### PR TITLE
fix(runs): confine run-detail git reads to a sanctioned cwd allowlist (k2b8)

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -112,7 +112,11 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
   // and not a git repo — injecting it made runs with no worktree metadata render
   // the misleading "Execution folder is not a git work tree" instead of the
   // honest "Execution folder is unknown for this run."
-  router.use('/runs', runsRouter(gc));
+  // gascity-dashboard-k2b8: pass the configured cwd allowlist so the run-diff
+  // git reads are confined to sanctioned roots. Empty (default) keeps the
+  // prior shape-only validation. cityPath is deliberately NOT a member of this
+  // allowlist (a9yi: it's the city config dir, not a run worktree).
+  router.use('/runs', runsRouter(gc, { runCwdAllowedRoots: config.runCwdAllowedRoots }));
   router.use('/links', linksRouter(gc));
   router.use('/agents', agentsRouter({ cityPath, gc }));
   router.use('/beads', beadsRouter(gc, cityPath));

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -3,7 +3,8 @@
 
 import { AGENT_ALIAS_RE } from './exec.js';
 import { isValidCityName } from './lib/cityName.js';
-import { LOG_COMPONENT, logWarn } from './logging.js';
+import { isValidHostPath } from './lib/hostPath.js';
+import { LOG_COMPONENT, logWarn, sanitizeForLog } from './logging.js';
 
 /**
  * Per-module configuration slices, scoped under AdminConfig.modules.<id>.
@@ -54,6 +55,19 @@ export interface AdminConfig {
    * for headless / systemd contexts where cwd is unrelated to the city tree.
    */
   cityPath: string;
+  /**
+   * Opt-in path-prefix allowlist for run-detail git reads (gascity-dashboard-k2b8).
+   * The run cwd fed to `git -C <cwd>` originates from supervisor run metadata
+   * (gc.cwd / gc.work_dir / gc.rig_root); when this list is non-empty the cwd
+   * must live under one of these absolute roots or the read is refused, so a
+   * buggy/compromised supervisor value cannot target an arbitrary host repo.
+   * Empty (the default) preserves the prior shape-only validation — no
+   * regression for deployments that don't configure it.
+   *
+   * Env: `RUN_CWD_ALLOWED_ROOTS` (colon-separated absolute paths, PATH-style).
+   * Whitespace tolerated; empty / relative / `..`-bearing entries are dropped.
+   */
+  runCwdAllowedRoots: ReadonlyArray<string>;
   /** Path to .gc/events.jsonl for audit-log append. */
   auditLogPath: string;
   /** Path to the dist/ of the frontend build, served by express.static. */
@@ -128,6 +142,44 @@ export function parseModulesEnabled(raw: string | undefined): ReadonlySet<string
   return new Set(ids);
 }
 
+/**
+ * Parse `RUN_CWD_ALLOWED_ROOTS` per the AdminConfig.runCwdAllowedRoots
+ * contract (gascity-dashboard-k2b8). Colon-separated, PATH-style. Each entry
+ * is trimmed; only safe, non-root absolute roots survive — empty, relative,
+ * NUL-bearing, and `..`-bearing entries are dropped via the shared
+ * isValidHostPath gate, and a bare `/` is rejected because it would make the
+ * prefix check admit every absolute path (defeating the allowlist). So a
+ * typo'd allowlist can never widen the prefix check beyond a real host root.
+ *
+ * Per "Don't Swallow Errors": when the env is SET but one or more entries are
+ * dropped, that is logged — a silently-emptied allowlist would leave the
+ * operator believing enforcement is active when it has degraded to shape-only.
+ * Returns `[]` when unset (shape-only validation, no regression).
+ */
+export function parseRunCwdAllowedRoots(raw: string | undefined): readonly string[] {
+  if (raw === undefined) return [];
+  const entries = raw
+    .split(':')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const roots = entries.filter((s) => isValidHostPath(s) && s !== '/');
+  if (roots.length < entries.length) {
+    // sanitizeForLog each dropped entry: these are operator env values and
+    // could carry CR/LF that would otherwise forge a second structured log
+    // line (matches the logging discipline used across routes/collectors).
+    const dropped = entries.filter((s) => !roots.includes(s)).map(sanitizeForLog);
+    logWarn(
+      LOG_COMPONENT.admin,
+      `RUN_CWD_ALLOWED_ROOTS: dropped ${dropped.length} invalid root(s) [${dropped.join(', ')}]; ` +
+        `only safe absolute non-root paths are honored` +
+        (roots.length === 0
+          ? '. No valid roots remain — run cwd validation has degraded to shape-only.'
+          : `. Enforcing ${roots.length} root(s).`),
+    );
+  }
+  return roots;
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): AdminConfig {
   const portRaw = env.PORT ?? '8081';
   const port = Number.parseInt(portRaw, 10);
@@ -157,6 +209,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AdminConfig {
     gcSupervisorUrl: (env.GC_SUPERVISOR_URL ?? 'http://127.0.0.1:8372').replace(/\/+$/, ''),
     cityName,
     cityPath: env.GC_CITY_PATH ?? '',
+    runCwdAllowedRoots: parseRunCwdAllowedRoots(env.RUN_CWD_ALLOWED_ROOTS),
     auditLogPath: env.ADMIN_AUDIT_LOG_PATH ?? defaultAuditLogPath(env),
     frontendDistPath: env.ADMIN_FRONTEND_DIST ?? '../frontend/dist',
     disabled: env.ADMIN_DASHBOARD_DISABLED === '1',

--- a/backend/src/exec.ts
+++ b/backend/src/exec.ts
@@ -256,11 +256,17 @@ const RUN_GIT_VIEWS: Record<RunGitView, string[]> = {
  * comes from supervisor-owned run metadata, not a browser parameter, but it is
  * still validated here so every subprocess boundary remains in this file.
  */
+// gascity-dashboard-k2b8: `allowedRoots` is REQUIRED on the run-git boundary
+// functions (not defaulted) so a caller cannot silently skip the cwd
+// prefix gate by omitting it. Pass `[]` only to deliberately opt into
+// shape-only validation — the single opt-in seam lives in readRunGitDiff /
+// RunsRouterOptions, sourced from config.runCwdAllowedRoots.
 export async function execRunGit(
   cwd: string,
   view: RunGitView,
+  allowedRoots: readonly string[],
 ): Promise<ExecResult> {
-  if (!isValidRunCwd(cwd)) {
+  if (!isValidRunCwd(cwd, allowedRoots)) {
     throw new ExecError('invalid run cwd', 'validation');
   }
   const args = RUN_GIT_VIEWS[view];
@@ -275,8 +281,9 @@ export async function execRunGit(
 export async function execRunGitDiffFrom(
   cwd: string,
   baseRevision: string,
+  allowedRoots: readonly string[],
 ): Promise<ExecResult> {
-  if (!isValidRunCwd(cwd) || !/^[0-9a-f]{40,64}$/i.test(baseRevision)) {
+  if (!isValidRunCwd(cwd, allowedRoots) || !/^[0-9a-f]{40,64}$/i.test(baseRevision)) {
     throw new ExecError('invalid run git diff args', 'validation');
   }
   return runExec(
@@ -290,8 +297,9 @@ export async function execRunGitDiffFrom(
 export async function execRunGitNameStatusFrom(
   cwd: string,
   baseRevision: string,
+  allowedRoots: readonly string[],
 ): Promise<ExecResult> {
-  if (!isValidRunCwd(cwd) || !/^[0-9a-f]{40,64}$/i.test(baseRevision)) {
+  if (!isValidRunCwd(cwd, allowedRoots) || !/^[0-9a-f]{40,64}$/i.test(baseRevision)) {
     throw new ExecError('invalid run git name-status args', 'validation');
   }
   return runExec(
@@ -313,9 +321,10 @@ export async function execRunGitNameStatusFrom(
 export async function execRunGitNewFileDiff(
   cwd: string,
   filePath: string,
+  allowedRoots: readonly string[],
   maxBytes = MAX_RUN_DIFF_BYTES,
 ): Promise<ExecResult> {
-  if (!isValidRunCwd(cwd) || !isValidRunRelativePath(filePath)) {
+  if (!isValidRunCwd(cwd, allowedRoots) || !isValidRunRelativePath(filePath)) {
     throw new ExecError('invalid run git diff path', 'validation');
   }
   return runExec(
@@ -326,8 +335,39 @@ export async function execRunGitNewFileDiff(
   );
 }
 
-function isValidRunCwd(cwd: string): boolean {
-  return cwd.startsWith('/') && !cwd.includes('\0') && !cwd.split('/').includes('..');
+/**
+ * Validate a run cwd before it is handed to `git -C <cwd>`. The cwd comes
+ * from supervisor run metadata (gc.cwd / gc.work_dir / gc.rig_root), so this
+ * is the dashboard's last shell-read gate (gascity-dashboard-k2b8).
+ *
+ * Two layers:
+ *  1. Shape — reuse the shared isValidHostPath gate (absolute, no NUL, no `..`
+ *     traversal segment), the same rule applied to supervisor host paths
+ *     elsewhere.
+ *  2. Prefix allowlist — when `allowedRoots` is non-empty the cwd must sit at
+ *     or under one sanctioned root, so a buggy/compromised supervisor value
+ *     cannot point git at an arbitrary host repo. An empty list (the default)
+ *     keeps the shape-only behavior, preserving deployments that don't
+ *     configure RUN_CWD_ALLOWED_ROOTS.
+ */
+export function isValidRunCwd(
+  cwd: string,
+  allowedRoots: readonly string[] = [],
+): boolean {
+  if (!isValidHostPath(cwd)) return false;
+  if (allowedRoots.length === 0) return true;
+  return allowedRoots.some((root) => isPathUnderRoot(cwd, root));
+}
+
+/**
+ * True when `cwd` equals `root` or is nested under it, matching on path
+ * SEGMENT boundaries — `/home/ds/gascity` admits `/home/ds/gascity/x` but not
+ * the sibling `/home/ds/gascity-evil`, which a naive startsWith would wrongly
+ * accept.
+ */
+function isPathUnderRoot(cwd: string, root: string): boolean {
+  const normalizedRoot = root.endsWith('/') ? root.slice(0, -1) : root;
+  return cwd === normalizedRoot || cwd.startsWith(`${normalizedRoot}/`);
 }
 
 function isValidRunRelativePath(filePath: string): boolean {

--- a/backend/src/routes/runs.ts
+++ b/backend/src/routes/runs.ts
@@ -32,6 +32,13 @@ import { mergeRunRuntimeState } from '../runs/runtime-state.js';
 
 export interface RunsRouterOptions {
   rigRoot?: string;
+  /**
+   * Opt-in path-prefix allowlist for run-detail git reads
+   * (gascity-dashboard-k2b8). Threaded into readRunGitDiff so the cwd fed to
+   * `git -C` must live under a sanctioned root. Empty / omitted preserves the
+   * prior shape-only validation. Sourced from config.runCwdAllowedRoots.
+   */
+  runCwdAllowedRoots?: readonly string[];
 }
 
 export function runsRouter(
@@ -53,7 +60,7 @@ export function runsRouter(
         parsed.scope ?? defaultRunScope(gc.cityName),
       );
       const detail = enrichFormulaRun(raw, baseEnrichOptions(opts));
-      const diff = await readRunGitDiff(detail.executionPath);
+      const diff = await readRunGitDiff(detail.executionPath, opts.runCwdAllowedRoots ?? []);
       res.json(diff);
     } catch (err) {
       writeRunError(res, err, 'failed to fetch run diff');

--- a/backend/src/runs/diff.ts
+++ b/backend/src/runs/diff.ts
@@ -21,6 +21,7 @@ const CONTROL_PLANE_PATH_PREFIXES = ['.beads', '.gc'] as const;
 
 export async function readRunGitDiff(
   executionPath: RunExecutionPath,
+  allowedRoots: readonly string[] = [],
 ): Promise<RunDiffResponse> {
   if (executionPath.kind === 'unavailable') {
     return emptyDiff('path_unknown', unavailableRoot('path_unknown'));
@@ -29,7 +30,7 @@ export async function readRunGitDiff(
 
   let rootPath: string;
   try {
-    const result = await runGit(cwd, 'root');
+    const result = await runGit(cwd, 'root', allowedRoots);
     rootPath = result.stdout.trim();
     if (rootPath.length === 0) return emptyDiff('not_git', unavailableRoot('not_git'));
   } catch (err) {
@@ -39,9 +40,9 @@ export async function readRunGitDiff(
 
   try {
     const [statusResult, untrackedResult, comparison] = await Promise.all([
-      runGit(cwd, 'status'),
-      runGit(cwd, 'untracked'),
-      resolveComparison(cwd),
+      runGit(cwd, 'status', allowedRoots),
+      runGit(cwd, 'untracked', allowedRoots),
+      resolveComparison(cwd, allowedRoots),
     ]);
     const status = statusResult.stdout
       .split('\n')
@@ -51,14 +52,15 @@ export async function readRunGitDiff(
     const untrackedPaths = parseNulList(untrackedResult.stdout)
       .filter(isReviewableRunDiffPath);
     const [trackedPatch, trackedChangedFiles] = await Promise.all([
-      readTrackedPatch(cwd, comparison),
-      readTrackedChangedFiles(cwd, comparison),
+      readTrackedPatch(cwd, comparison, allowedRoots),
+      readTrackedChangedFiles(cwd, comparison, allowedRoots),
     ]);
     const trackedPatchBody = filterReviewablePatch(trackedPatch.stdout);
     const untrackedPatch = await readUntrackedPatch(
       cwd,
       untrackedPaths,
       trackedPatchBody.length,
+      allowedRoots,
     );
     return {
       kind: 'ok',
@@ -115,8 +117,9 @@ function unavailableRoot(
 async function runGit(
   cwd: string,
   view: Parameters<typeof execRunGit>[1],
+  allowedRoots: readonly string[],
 ): Promise<{ stdout: string; stderr: string; truncated: boolean }> {
-  const result = await execRunGit(cwd, view);
+  const result = await execRunGit(cwd, view, allowedRoots);
   const cappedDiff = result.truncated && view === 'diff-head';
   if (result.exitCode !== 0 && !cappedDiff) {
     throw new Error(`git ${view} failed`);
@@ -124,12 +127,15 @@ async function runGit(
   return result;
 }
 
-async function resolveComparison(cwd: string): Promise<RunDiffComparison> {
-  const upstream = await execRunGit(cwd, 'upstream');
+async function resolveComparison(
+  cwd: string,
+  allowedRoots: readonly string[],
+): Promise<RunDiffComparison> {
+  const upstream = await execRunGit(cwd, 'upstream', allowedRoots);
   if (upstream.exitCode !== 0 || upstream.stdout.trim().length === 0) {
     return { kind: 'head', reason: 'no_upstream' };
   }
-  const mergeBase = await execRunGit(cwd, 'merge-base-upstream');
+  const mergeBase = await execRunGit(cwd, 'merge-base-upstream', allowedRoots);
   const mergeBaseHash = mergeBase.stdout.trim();
   if (mergeBase.exitCode !== 0 || !/^[0-9a-f]{40,64}$/i.test(mergeBaseHash)) {
     return { kind: 'head', reason: 'upstream_lookup_failed' };
@@ -144,16 +150,17 @@ async function resolveComparison(cwd: string): Promise<RunDiffComparison> {
 async function readTrackedPatch(
   cwd: string,
   comparison: RunDiffComparison,
+  allowedRoots: readonly string[],
 ): Promise<{ stdout: string; truncated: boolean }> {
   if (comparison.kind === 'upstream') {
-    const result = await execRunGitDiffFrom(cwd, comparison.mergeBase);
+    const result = await execRunGitDiffFrom(cwd, comparison.mergeBase, allowedRoots);
     if (result.exitCode !== 0 && !result.truncated) {
       throw new Error('git diff from upstream merge base failed');
     }
     return result;
   }
   if (comparison.kind === 'head') {
-    const result = await execRunGit(cwd, 'diff-head');
+    const result = await execRunGit(cwd, 'diff-head', allowedRoots);
     if (result.exitCode !== 0 && !result.truncated) {
       logWarn(
         LOG_COMPONENT.runs,
@@ -169,11 +176,12 @@ async function readTrackedPatch(
 async function readTrackedChangedFiles(
   cwd: string,
   comparison: RunDiffComparison,
+  allowedRoots: readonly string[],
 ): Promise<RunChangedFile[]> {
   const result = comparison.kind === 'upstream'
-    ? await execRunGitNameStatusFrom(cwd, comparison.mergeBase)
+    ? await execRunGitNameStatusFrom(cwd, comparison.mergeBase, allowedRoots)
     : comparison.kind === 'head'
-      ? await execRunGit(cwd, 'name-status-head')
+      ? await execRunGit(cwd, 'name-status-head', allowedRoots)
       : null;
   if (result === null) return [];
   if (result.exitCode !== 0) {
@@ -197,6 +205,7 @@ async function readUntrackedPatch(
   cwd: string,
   paths: string[],
   usedBytes: number,
+  allowedRoots: readonly string[],
 ): Promise<{ stdout: string; truncated: boolean }> {
   const orderedPaths = [...paths]
     .filter(isSafeRelativeGitPath)
@@ -213,6 +222,7 @@ async function readUntrackedPatch(
     const result = await execRunGitNewFileDiff(
       cwd,
       filePath,
+      allowedRoots,
       Math.max(1, Math.min(remaining, MAX_UNTRACKED_FILE_DIFF_BYTES)),
     );
     if (![0, 1].includes(result.exitCode) && !result.truncated) {

--- a/backend/test/app.test.ts
+++ b/backend/test/app.test.ts
@@ -15,6 +15,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     gcSupervisorUrl: 'http://127.0.0.1:1',
     cityName: 'test-city',
     cityPath: '',
+    runCwdAllowedRoots: [],
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,

--- a/backend/test/city-dispatch.test.ts
+++ b/backend/test/city-dispatch.test.ts
@@ -20,6 +20,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     gcSupervisorUrl: 'http://127.0.0.1:1',
     cityName: 'test-city',
     cityPath: '',
+    runCwdAllowedRoots: [],
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,

--- a/backend/test/config.test.ts
+++ b/backend/test/config.test.ts
@@ -59,6 +59,39 @@ describe('loadConfig', () => {
     assert.equal(loadConfig({ SNAPSHOT_USE_FIXTURES: '' }).useFixtures, false);
   });
 
+  test('runCwdAllowedRoots defaults to empty (shape-only, no regression) when unset', () => {
+    assert.deepEqual(loadConfig({}).runCwdAllowedRoots, []);
+  });
+
+  test('runCwdAllowedRoots parses a colon-separated list of absolute roots', () => {
+    const cfg = loadConfig({
+      RUN_CWD_ALLOWED_ROOTS: '/home/ds/gascity:/home/ds/gascity-dashboard',
+    });
+    assert.deepEqual(cfg.runCwdAllowedRoots, [
+      '/home/ds/gascity',
+      '/home/ds/gascity-dashboard',
+    ]);
+  });
+
+  test('runCwdAllowedRoots trims whitespace and drops empty/invalid entries', () => {
+    const cfg = loadConfig({
+      // leading/trailing space, an empty segment, a relative path, and a
+      // ..-bearing path are all dropped (only safe absolute roots survive).
+      RUN_CWD_ALLOWED_ROOTS: ' /home/ds/gascity : :relative/path:/a/../b:/srv/runs ',
+    });
+    assert.deepEqual(cfg.runCwdAllowedRoots, ['/home/ds/gascity', '/srv/runs']);
+  });
+
+  test('runCwdAllowedRoots drops a bare "/" root (would otherwise admit every path)', () => {
+    // A root of "/" passes the shape check but makes the prefix gate admit
+    // every absolute path — it is rejected so it can never defeat the allowlist.
+    assert.deepEqual(loadConfig({ RUN_CWD_ALLOWED_ROOTS: '/' }).runCwdAllowedRoots, []);
+    assert.deepEqual(
+      loadConfig({ RUN_CWD_ALLOWED_ROOTS: '/:/home/ds/gascity' }).runCwdAllowedRoots,
+      ['/home/ds/gascity'],
+    );
+  });
+
   test('maintainerTriageTarget defaults to mayor (always-present dispatcher)', () => {
     // gascity-dashboard-cus8: default was 'chief-of-staff' but that role
     // can be suspended in a deployment's agent roster (observed

--- a/backend/test/exec-run-cwd.test.ts
+++ b/backend/test/exec-run-cwd.test.ts
@@ -1,0 +1,78 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isValidRunCwd } from '../src/exec.js';
+
+// gascity-dashboard-k2b8: isValidRunCwd guards the cwd that the run-detail
+// diff path feeds to `git -C <cwd>`. The cwd originates from supervisor run
+// metadata (gc.cwd / gc.work_dir / gc.rig_root), so a buggy or compromised
+// supervisor value could otherwise point the dashboard's last shell-read at
+// any git repo on the host. The allowlist (RUN_CWD_ALLOWED_ROOTS) is the
+// defense-in-depth prefix gate; when empty the validator preserves the prior
+// shape-only behavior so existing deployments do not regress.
+
+describe('isValidRunCwd — shape (allowlist empty)', () => {
+  const noRoots: readonly string[] = [];
+
+  test('accepts a safe absolute path', () => {
+    assert.equal(isValidRunCwd('/home/ds/gascity/polecat-1', noRoots), true);
+  });
+
+  test('rejects a relative path', () => {
+    assert.equal(isValidRunCwd('home/ds/run', noRoots), false);
+  });
+
+  test('rejects a path with a .. traversal segment', () => {
+    assert.equal(isValidRunCwd('/home/ds/../etc', noRoots), false);
+  });
+
+  test('rejects a path containing a NUL byte', () => {
+    assert.equal(isValidRunCwd('/home/ds/run\0/x', noRoots), false);
+  });
+
+  test('rejects the empty string', () => {
+    assert.equal(isValidRunCwd('', noRoots), false);
+  });
+
+  test('defaults to shape-only when allowedRoots is omitted', () => {
+    assert.equal(isValidRunCwd('/anywhere/on/host'), true);
+  });
+});
+
+describe('isValidRunCwd — prefix allowlist (configured)', () => {
+  const roots = ['/home/ds/gascity', '/home/ds/gascity-dashboard'];
+
+  test('accepts a cwd that is exactly an allowed root', () => {
+    assert.equal(isValidRunCwd('/home/ds/gascity', roots), true);
+  });
+
+  test('accepts a cwd nested under an allowed root', () => {
+    assert.equal(isValidRunCwd('/home/ds/gascity/polecat-1', roots), true);
+  });
+
+  test('normalizes a trailing-slash root so nested cwds still match', () => {
+    // A PATH-style entry supplied with a trailing slash must behave identically.
+    assert.equal(isValidRunCwd('/home/ds/gascity/subdir', ['/home/ds/gascity/']), true);
+    assert.equal(isValidRunCwd('/home/ds/gascity', ['/home/ds/gascity/']), true);
+    assert.equal(isValidRunCwd('/home/ds/gascity-evil', ['/home/ds/gascity/']), false);
+  });
+
+  test('accepts a cwd under the second allowed root', () => {
+    assert.equal(isValidRunCwd('/home/ds/gascity-dashboard/backend', roots), true);
+  });
+
+  test('rejects a cwd outside every allowed root', () => {
+    assert.equal(isValidRunCwd('/etc', roots), false);
+    assert.equal(isValidRunCwd('/home/ds/other-project', roots), false);
+  });
+
+  test('rejects a sibling that only shares a string prefix (segment-boundary, not startsWith)', () => {
+    // /home/ds/gascity-evil must NOT be admitted by the /home/ds/gascity root.
+    assert.equal(isValidRunCwd('/home/ds/gascity-evil', roots), false);
+  });
+
+  test('still applies the shape check even when the prefix would match', () => {
+    // A .. segment is rejected before the prefix is ever considered.
+    assert.equal(isValidRunCwd('/home/ds/gascity/../../etc', roots), false);
+  });
+});

--- a/backend/test/run-diff-route.test.ts
+++ b/backend/test/run-diff-route.test.ts
@@ -177,6 +177,68 @@ describe('run diff route', () => {
     }
   });
 
+  // gascity-dashboard-k2b8: when RUN_CWD_ALLOWED_ROOTS is configured, a
+  // supervisor-supplied work_dir outside every sanctioned root must be
+  // refused before `git -C <cwd>` runs — defense-in-depth on the dashboard's
+  // last shell-read. The refusal surfaces as the existing not_git shape (the
+  // cwd validation throws and the root probe is the first git call).
+  test('k2b8: refuses a run cwd outside the configured allowlist', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'run-allowlist-deny-'));
+    await execFileAsync('git', ['-C', repo, 'init']);
+    await fs.writeFile(path.join(repo, 'README.md'), 'base\n');
+    await execFileAsync('git', ['-C', repo, 'add', 'README.md']);
+    await commit(repo);
+    await fs.writeFile(path.join(repo, 'README.md'), 'base\nnext\n');
+
+    fake.setHandler((_req, res) => {
+      json(res, graphV2Snapshot(repo));
+    });
+    // The repo is a REAL git tree, but the allowlist sanctions an unrelated
+    // root, so the diff must be refused. Because the cwd is a genuine repo,
+    // `not_git` can only arise from the cwd refusal (the validation throws
+    // before git runs) — were enforcement absent, the paired allow-test below
+    // shows this exact setup yields kind 'ok'.
+    const { url, close } = await startApp(
+      buildApp(fake.baseUrl, '', ['/var/empty/sanctioned-root']),
+    );
+    try {
+      const res = await fetch(`${url}/api/runs/gc-root/diff`);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.kind, 'not_git', 'an out-of-allowlist cwd must not be read');
+      assert.deepEqual(body.changedFiles, []);
+      assert.equal(body.patch, '');
+    } finally {
+      await close();
+      await fs.rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('k2b8: serves the diff when the run cwd is under a configured allowed root', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'run-allowlist-allow-'));
+    await execFileAsync('git', ['-C', repo, 'init']);
+    await fs.writeFile(path.join(repo, 'README.md'), 'base\n');
+    await execFileAsync('git', ['-C', repo, 'add', 'README.md']);
+    await commit(repo);
+    await fs.writeFile(path.join(repo, 'README.md'), 'base\nnext\n');
+
+    fake.setHandler((_req, res) => {
+      json(res, graphV2Snapshot(repo));
+    });
+    // The cwd equals the sanctioned root, so the read proceeds normally.
+    const { url, close } = await startApp(buildApp(fake.baseUrl, '', [repo]));
+    try {
+      const res = await fetch(`${url}/api/runs/gc-root/diff`);
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.kind, 'ok', 'an in-allowlist cwd must be served');
+      assert.match(body.patch, /^\+next$/m);
+    } finally {
+      await close();
+      await fs.rm(repo, { recursive: true, force: true });
+    }
+  });
+
   test('marks large local-change patches as truncated', async () => {
     const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'run-large-diff-'));
     await execFileAsync('git', ['-C', repo, 'init']);
@@ -217,7 +279,11 @@ async function commit(repo: string, message = 'base'): Promise<void> {
   ]);
 }
 
-function buildApp(fakeUrl: string, rigRoot = ''): express.Express {
+function buildApp(
+  fakeUrl: string,
+  rigRoot = '',
+  runCwdAllowedRoots: readonly string[] = [],
+): express.Express {
   const gc = new GcClient({
     baseUrl: fakeUrl,
     cityName: 'racoon-city',
@@ -225,7 +291,7 @@ function buildApp(fakeUrl: string, rigRoot = ''): express.Express {
   });
   const app = express();
   app.use(express.json());
-  app.use('/api/runs', runsRouter(gc, { rigRoot }));
+  app.use('/api/runs', runsRouter(gc, { rigRoot, runCwdAllowedRoots }));
   return app;
 }
 

--- a/backend/test/views-registry.test.ts
+++ b/backend/test/views-registry.test.ts
@@ -21,6 +21,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     gcSupervisorUrl: 'http://127.0.0.1:1',
     cityName: 'test-city',
     cityPath: '',
+    runCwdAllowedRoots: [],
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,


### PR DESCRIPTION
## What & why

Bead **gascity-dashboard-k2b8** (security, defense-in-depth). The run-detail diff view shells `git -C <cwd>` where `cwd` comes from supervisor run metadata (`gc.cwd` / `gc.work_dir` / `gc.rig_root`). `isValidRunCwd` validated **shape only** (absolute, no `..`, no NUL), so a buggy or compromised supervisor value could point the dashboard's last shell-read at **any** git repo on the host. Hardening this **before** the upstream `gc.work_dir` stamp starts feeding paths into local `git diff`.

## The fix — opt-in path-prefix allowlist

- **`config.ts`** — new env `RUN_CWD_ALLOWED_ROOTS` (colon-separated absolute roots), parsed by `parseRunCwdAllowedRoots`: each entry gated by the shared `isValidHostPath`, a bare `/` rejected (it would admit every path), and any dropped entry **logged** (Don't Swallow Errors — a silently-emptied allowlist must not masquerade as enforcement).
- **`exec.ts`** — `isValidRunCwd(cwd, allowedRoots)` reuses `isValidHostPath` for shape, then requires `cwd` at/under one root via a **segment-boundary** check (`/home/ds/gascity` does NOT admit the sibling `/home/ds/gascity-evil`). `allowedRoots` is **required** on the four `execRunGit*` boundary functions so a caller can't silently skip the gate; the single opt-in seam lives in `readRunGitDiff` / `RunsRouterOptions`.
- **`diff.ts` / `routes/runs.ts` / `city/runtime.ts`** — threaded through to the route, sourced from `config.runCwdAllowedRoots`.
- **Empty allowlist (default) = prior shape-only behavior — no regression.** `cityPath` is deliberately NOT a sanctioned root (a9yi: city config dir, not a worktree).

## Design note

There is no clean sanctioned root available by default (cityPath is excluded; prod passes no rigRoot), so the allowlist is operator-configured and **opt-in**: unset ⇒ today's shape-only check; set ⇒ confine to the listed roots. Reviewed via security-reviewer + code-reviewer; both surfaced the same footguns, all addressed (bare-`/` drop, silent-degradation warn, required boundary param, segment-boundary matching).

## Test plan / gates (all green locally, against current `main`)

- [x] `npm run typecheck`
- [x] `npm run -w backend typecheck:test` · `npm run -w frontend typecheck:test`
- [x] `npm run -w backend test` (798) · `npm run -w frontend test` (472)
- [x] `npm run -w frontend build`
- [x] security-reviewer + code-reviewer passes; findings applied

New tests: unit shape + prefix (sibling-prefix, `..`-interplay, bare-`/`), config parsing incl. dropped-`/` + whitespace, and two route-level integration cases (real git repo outside allowlist → refused; same repo under an allowed root → served).