### PR TITLE
fix(beads): strip control/escape/bidi chars from close-reason before exec + audit (htrz)

### DIFF
--- a/backend/src/lib/strip-non-printable.ts
+++ b/backend/src/lib/strip-non-printable.ts
@@ -1,0 +1,32 @@
+// Strip ANSI escape sequences (OSC + CSI), C0/DEL/C1 control characters, and
+// Unicode bidi/RTL controls from operator-influenced strings before they reach
+// a subprocess argument or the audit log. The shared helper for any path that
+// embeds attacker-influenced text into a single-line operator/audit record.
+//
+// Threat model: log-injection / terminal-escape forgery. A browser-supplied
+// string carrying `\x1b[31m... [admin] CRITICAL ...\x1b[0m`, bidi overrides, or
+// embedded newlines could otherwise forge a fake operator log line or audit
+// row, or smuggle a trojan-source sequence (CVE-2021-42574) into a stored
+// record. Mirrors backend/src/exec.ts::sanitiseTerminalOutput, but this strip
+// is total: \t/\n/\r are dropped too, because these consumers (close-reason
+// argv, audit JSON values) are single-line and never want embedded whitespace
+// control bytes. Stripping all control bytes up front keeps the invariant
+// uniform regardless of which control class the input carries.
+
+const OSC_RE = /\x1b\][^\x07]*\x07/g;
+const CSI_RE = /\x1b\[[?0-9;]*[a-zA-Z]/g;
+// All control chars: C0 (<0x20, incl. \t/\n/\r), DEL (\x7f), and C1
+// (\x80-\x9f). C1 are legacy 8-bit controls some terminals still interpret as
+// alternative escape introducers — same threat class as C0.
+const CTRL_RE = /[\x00-\x1f\x7f-\x9f]/g;
+// All 12 Unicode bidi/RTL control codepoints from CVE-2021-42574
+// (Boucher/Anderson 2021): U+061C, U+200E, U+200F, U+202A-202E, U+2066-2069.
+const BIDI_RE = /[؜‎‏‪-‮⁦-⁩]/g;
+
+export function stripNonPrintable(value: string): string {
+  return value
+    .replace(OSC_RE, '')
+    .replace(CSI_RE, '')
+    .replace(CTRL_RE, '')
+    .replace(BIDI_RE, '');
+}

--- a/backend/src/routes/beads.ts
+++ b/backend/src/routes/beads.ts
@@ -14,6 +14,7 @@ import {
 import { GcClient } from '../gc-client.js';
 import { HTTP_STATUS } from '../lib/http-status.js';
 import { writeExecError } from '../lib/sanitise-error.js';
+import { stripNonPrintable } from '../lib/strip-non-printable.js';
 import { errorMessage, LOG_COMPONENT, logWarn } from '../logging.js';
 import {
   routeInternalError,
@@ -230,12 +231,19 @@ async function runBeadAction(
     writeRouteError(res, routeValidationError('invalid bead id'));
     return;
   }
+  // gascity-dashboard-htrz: the close-reason is the only operator-controlled
+  // free-text that reaches a subprocess arg (`bd close --reason`) and the
+  // audit log. Strip control/escape/bidi bytes here, BEFORE both sinks, so a
+  // browser-supplied reason cannot forge a terminal-escape sequence into the
+  // `gc bd` output or inject a fake line/row into .gc/events.jsonl.
+  const safeReason =
+    reason !== undefined ? stripNonPrintable(reason) : undefined;
   try {
-    const result = await execBeadAction(beadId, action, reason, cityPath);
+    const result = await execBeadAction(beadId, action, safeReason, cityPath);
     await recordAudit({
       type: 'dashboard.exec',
       endpoint: `POST /api/beads/:id/${action}`,
-      parsed_args: { bead_id: beadId, ...(reason ? { reason } : {}) },
+      parsed_args: { bead_id: beadId, ...(safeReason ? { reason: safeReason } : {}) },
       exit_code: result.exitCode,
       duration_ms: result.durationMs,
     });

--- a/backend/src/routes/client-errors.ts
+++ b/backend/src/routes/client-errors.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { ClientErrorReport } from 'gas-city-dashboard-shared';
 import { HTTP_STATUS } from '../lib/http-status.js';
+import { stripNonPrintable } from '../lib/strip-non-printable.js';
 import type { LogComponent } from '../logging.js';
 import { LOG_COMPONENT, logWarn } from '../logging.js';
 import {
@@ -14,35 +15,6 @@ interface ClientErrorsRouterOptions {
 }
 
 const MAX_FIELD_LENGTH = 240;
-
-// Strip ANSI escape sequences (OSC + CSI) and control characters before
-// whitespace normalization. Otherwise a browser-supplied error string
-// containing `\x1b[31m... [admin] CRITICAL ...\x1b[0m` would survive the
-// `\s+ → ' '` collapse below and forge a fake `[component] message`
-// operator log line. Mirrors backend/src/exec.ts::sanitiseTerminalOutput;
-// the threat model here is browser-originated input rather than
-// supervisor output, but the same control-char surface applies.
-const OSC_RE = /\x1b\][^\x07]*\x07/g;
-const CSI_RE = /\x1b\[[?0-9;]*[a-zA-Z]/g;
-// All control chars: C0 (<0x20), DEL (\x7f), and C1 (\x80-\x9f). \t/\n/\r
-// are dropped here too because the whitespace normalize below would
-// collapse them anyway, and dropping them up front makes the
-// strip-before-normalize ordering invariant uniform regardless of which
-// control bytes the input carries. gascity-dashboard-3sxy added the C1
-// range (\x80-\x9f) — legacy 8-bit controls some terminals still
-// interpret as alternative escape introducers, same threat class as C0.
-const CTRL_RE = /[\x00-\x1f\x7f-\x9f]/g;
-// See exec.ts BIDI_RE — same 12-codepoint trojan-source set from
-// CVE-2021-42574 (U+061C, U+200E, U+200F, U+202A-202E, U+2066-2069).
-const BIDI_RE = /[؜‎‏‪-‮⁦-⁩]/g;
-
-function stripNonPrintable(value: string): string {
-  return value
-    .replace(OSC_RE, '')
-    .replace(CSI_RE, '')
-    .replace(CTRL_RE, '')
-    .replace(BIDI_RE, '');
-}
 
 export function clientErrorsRouter(opts: ClientErrorsRouterOptions = {}): Router {
   const router = Router();

--- a/backend/test/beads-nudge.test.ts
+++ b/backend/test/beads-nudge.test.ts
@@ -267,6 +267,52 @@ describe('POST /api/beads/:id/{claim,close,nudge}', { concurrency: false }, () =
     assert.equal(parsed.reason, 'shipped via pf2');
   });
 
+  // gascity-dashboard-htrz: the close-reason is operator-controlled free text
+  // that reaches BOTH a subprocess arg (`bd close --reason`) and the audit log.
+  // Control chars (ANSI/OSC escapes, C0/C1, newlines) + bidi/RTL overrides must
+  // be stripped before EITHER sink — otherwise a browser-supplied reason could
+  // forge a terminal-escape sequence in the gc output or inject a fake row into
+  // .gc/events.jsonl (log injection).
+  test('close reason: control/escape/bidi chars stripped before exec AND audit', async () => {
+    h = await buildApp();
+    // A reason carrying every stripped class: a CSI escape (\x1b[7m reverse),
+    // an OSC title set (\x1b]0;title BEL), an embedded newline + a forged JSON
+    // fragment that would inject a fake row into events.jsonl, a C1 control
+    // (\x9b), DEL (\x7f), and a bidi RLO override (‮). After sanitisation NONE
+    // of these byte classes may survive into either sink.
+    const dirty =
+      'safe\x1b[7m\x1b]0;evil\x07inject\n"type":"fake"\x9b\x7f‮rtl';
+    const res = await postJson(`${h.url}/api/beads/td-wisp-abc123/close`, {
+      reason: dirty,
+    });
+    assert.equal(res.status, 200);
+
+    // Property assertions (the contract): no control byte (C0/C1/DEL), no ESC,
+    // and no bidi override may reach EITHER the exec arg or the audit row.
+    const CONTROL_OR_BIDI = /[\x00-\x1f\x7f-\x9f‮]/;
+
+    assert.equal(h.calls.length, 1);
+    const sentReason = h.calls[0]!.reason!;
+    assert.ok(
+      !CONTROL_OR_BIDI.test(sentReason),
+      `exec reason still carries control/bidi bytes: ${JSON.stringify(sentReason)}`,
+    );
+    // The visible text survives; only the dangerous bytes are removed.
+    assert.ok(sentReason.includes('safe') && sentReason.includes('rtl'));
+
+    // The audit file stays exactly one well-formed row (the embedded newline +
+    // forged JSON did not split it) and its reason carries no dangerous bytes.
+    const rows = await readAudit(h.auditPath);
+    assert.equal(rows.length, 1);
+    const auditedReason = (rows[0]!.parsed_args as Record<string, string>)
+      .reason;
+    assert.equal(auditedReason, sentReason, 'exec + audit must see the same sanitized reason');
+    assert.ok(
+      !CONTROL_OR_BIDI.test(auditedReason),
+      `audit reason still carries control/bidi bytes: ${JSON.stringify(auditedReason)}`,
+    );
+  });
+
   test('invalid bead id returns 400 before reaching exec', async () => {
     h = await buildApp();
     const res = await postJson(`${h.url}/api/beads/bad%20id%20!!/nudge`);


### PR DESCRIPTION
## Summary
Fixes a log-injection / terminal-escape vulnerability (bead gascity-dashboard-htrz, security audit verified high).

The operator-supplied bead **close-reason** flowed unsanitized into **two sinks**: `execBeadAction` (a `bd close --reason <…>` subprocess arg) and the durable audit log (`recordAudit`). A crafted reason could inject ANSI/OSC terminal-escape sequences, embedded newlines + forged audit rows, C0/C1 control bytes, and CVE-2021-42574 bidi/RTL overrides into the audit trail and any terminal rendering it.

## Fix
- Hoisted the previously-private `stripNonPrintable` out of `routes/client-errors.ts` into a shared `backend/src/lib/strip-non-printable.ts` (strips OSC+CSI ANSI escapes, the full C0/DEL/C1 control range, and the 12 CVE-2021-42574 bidi codepoints). `client-errors.ts` now imports it — no duplicate definition.
- `routes/beads.ts` sanitizes the reason **once** into `safeReason` and passes that single value to **both** `execBeadAction` and `recordAudit`, so neither sink can ever see a raw control/escape/bidi byte.

## Test plan
- New regression in `beads-nudge.test.ts`: posts a close-reason laden with CSI, OSC, embedded newline + forged JSON row, C1, DEL, and a bidi RLO override, then asserts the exec arg and audit row carry no control/bidi/ESC bytes and the audit file stays exactly one well-formed row. **RED before the fix, GREEN after.**
- Verified on branch: backend `test` 0 fail, `typecheck:test` + `lint` clean.
- Reviewed by security-reviewer: **approve**, 0 CRITICAL/HIGH. Two LOW follow-ups filed (OSC regex misses the ST-terminated form — currently inert; bidi test covers 1 of 12 codepoints — prod strips all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)