### PR TITLE
fix(maintainer): decouple contributor-stats failure from triage ingest (wplw)

### DIFF
--- a/backend/src/views/modules/maintainer/triage-contributor-decouple.test.ts
+++ b/backend/src/views/modules/maintainer/triage-contributor-decouple.test.ts
@@ -1,0 +1,132 @@
+import { test, describe, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ContributorStat, MaintainerTriage } from 'gas-city-dashboard-shared';
+import type { ExecResult } from '../../../exec-core.js';
+import { fetchTriage, collectItems } from './triage.js';
+
+// gascity-dashboard-wplw: a contributor-stats failure is optional
+// enrichment and must NOT take down the cheap, still-valid open-issue /
+// open-PR ingest. computeContributorStats throws hard on a 2MB-cap
+// truncation or any `gh` non-zero exit; previously it was awaited in the
+// SAME Promise.all as the primary ingest, so any such failure rejected
+// fetchTriage entirely. The fix decouples it: a stats failure degrades to
+// an empty Map (authors keep defaultContributor) and is logged loudly
+// (Don't Swallow Errors), instead of rejecting fetchTriage.
+
+const OK = (stdout: string): ExecResult => ({
+  exitCode: 0,
+  stdout,
+  stderr: '',
+  truncated: false,
+  durationMs: 1,
+});
+
+const ISSUES_JSON = JSON.stringify([
+  {
+    number: 1,
+    title: 'an open issue',
+    createdAt: '2026-05-24T00:00:00.000Z',
+    updatedAt: '2026-05-24T00:00:00.000Z',
+    author: { login: 'alice' },
+    labels: [{ name: 'kind/bug' }],
+    url: 'https://github.com/o/r/issues/1',
+  },
+]);
+
+const PRS_JSON = JSON.stringify([
+  {
+    number: 2,
+    title: 'an open pr',
+    createdAt: '2026-05-24T00:00:00.000Z',
+    updatedAt: '2026-05-24T00:00:00.000Z',
+    author: { login: 'bob' },
+    labels: [],
+    url: 'https://github.com/o/r/pull/2',
+    body: '',
+    additions: 1,
+    deletions: 0,
+    files: [],
+  },
+]);
+
+function okStubs() {
+  return {
+    fetchIssues: async (): Promise<ExecResult> => OK(ISSUES_JSON),
+    fetchPrs: async (): Promise<ExecResult> => OK(PRS_JSON),
+  };
+}
+
+describe('fetchTriage — contributor-stats failure is decoupled from ingest', () => {
+  test('a thrown contributor-stats failure does not reject fetchTriage; items still ingest with defaultContributor', async () => {
+    const warnSpy = mock.method(console, 'error', () => undefined);
+    try {
+      const envelope: MaintainerTriage = await fetchTriage('owner/repo', {
+        ...okStubs(),
+        computeStats: async (): Promise<Map<string, ContributorStat>> => {
+          throw new Error(
+            'contributor history exceeded 2MB cap — repo grew beyond ingest budget',
+          );
+        },
+      });
+
+      // The cheap ingest is intact: both the open issue and open PR landed.
+      const items = collectItems(envelope);
+      const numbers = items.map((i) => i.number).sort((a, b) => a - b);
+      assert.deepEqual(numbers, [1, 2], 'both ingested items must survive a stats failure');
+      assert.equal(envelope.totals.issues_open, 1);
+      assert.equal(envelope.totals.prs_open, 1);
+
+      // Authors fall back to defaultContributor (tier 'regular', null rates),
+      // not to a thrown rejection.
+      for (const item of items) {
+        assert.equal(item.author.tier, 'regular');
+        assert.equal(item.author.prs_merged, null);
+        assert.equal(item.author.computed_at, null);
+      }
+    } finally {
+      warnSpy.mock.restore();
+    }
+  });
+
+  test('the contributor-stats failure is logged loudly, not swallowed silently', async () => {
+    const errorSpy = mock.method(console, 'error', () => undefined);
+    try {
+      await fetchTriage('owner/repo', {
+        ...okStubs(),
+        computeStats: async (): Promise<Map<string, ContributorStat>> => {
+          throw new Error('gh pr list (all) exited 1: rate limit exceeded');
+        },
+      });
+
+      const logged = errorSpy.mock.calls.map((c) => String(c.arguments[0]));
+      assert.ok(
+        logged.some((line) => line.includes('rate limit exceeded')),
+        `expected the contributor-stats failure to be logged; saw: ${JSON.stringify(logged)}`,
+      );
+    } finally {
+      errorSpy.mock.restore();
+    }
+  });
+
+  test('when contributor stats succeed, computed tiers are still spliced onto items', async () => {
+    const computed: ContributorStat = {
+      login: 'alice',
+      tier: 'core',
+      issues_accepted: 5,
+      issues_opened: 8,
+      prs_merged: 25,
+      prs_opened: 30,
+      computed_at: '2026-05-24T00:00:00.000Z',
+    };
+    const envelope = await fetchTriage('owner/repo', {
+      ...okStubs(),
+      computeStats: async (): Promise<Map<string, ContributorStat>> =>
+        new Map([['alice', computed]]),
+    });
+    const items = collectItems(envelope);
+    const alice = items.find((i) => i.author.login === 'alice');
+    assert.ok(alice, 'alice item present');
+    assert.equal(alice.author.tier, 'core', 'computed tier must splice onto the author');
+    assert.equal(alice.author.prs_merged, 25);
+  });
+});

--- a/backend/src/views/modules/maintainer/triage.ts
+++ b/backend/src/views/modules/maintainer/triage.ts
@@ -7,7 +7,9 @@ import type {
   TriageTierSection,
 } from 'gas-city-dashboard-shared';
 import { execGhIssueList, execGhPrList, ExecError } from '../../../exec.js';
+import type { ExecResult } from '../../../exec-core.js';
 import { parseJsonArray } from '../../../lib/parse-json.js';
+import { LOG_COMPONENT, errorMessage, logError } from '../../../logging.js';
 import { classifyItem } from './classifier.js';
 import { computeContributorStats } from './contributor.js';
 import { buildClusters, inheritIssueFiles } from './blast-radius.js';
@@ -74,16 +76,37 @@ interface GhPr {
   files?: GhPrFile[];
 }
 
-export async function fetchTriage(repo: string): Promise<MaintainerTriage> {
-  // Four parallel gh calls: two for the open lists (361 ingest), two for
-  // the full lifetime history that drives contributor stats (alh). The
-  // contributor fetches are by far the biggest payloads but they're
-  // bounded by the repo's total history, not the number of unique
-  // authors — much cheaper than per-login round-trips would be.
+/**
+ * Seams for fetchTriage, mirroring the injected-fetchTriage pattern in
+ * router.ts / worker.ts. Defaults are the real implementations; tests
+ * override to drive the ingest and the (optional) contributor-stats
+ * enrichment independently. Optional, so existing callers keep fetchTriage(repo).
+ */
+interface FetchTriageDeps {
+  fetchIssues: (repo: string, limit: number) => Promise<ExecResult>;
+  fetchPrs: (repo: string, limit: number) => Promise<ExecResult>;
+  computeStats: (repo: string) => Promise<Map<string, ContributorStat>>;
+}
+
+export async function fetchTriage(
+  repo: string,
+  deps: FetchTriageDeps = {
+    fetchIssues: execGhIssueList,
+    fetchPrs: execGhPrList,
+    computeStats: computeContributorStats,
+  },
+): Promise<MaintainerTriage> {
+  // The two open-list gh calls (361 ingest) are the primary, cheap, and
+  // always-valid payload. Contributor stats (alh) are OPTIONAL enrichment
+  // on top — authors without a computed stat keep defaultContributor by
+  // design. computeContributorStats throws hard on a 2MB-cap truncation or
+  // any gh non-zero exit, so it runs on its own footing (loadContributorStats)
+  // and degrades to an empty Map rather than rejecting the whole refresh
+  // (gascity-dashboard-wplw). All three still run concurrently.
   const [issuesRaw, prsRaw, contributorStats] = await Promise.all([
-    execGhIssueList(repo, ITEM_FETCH_LIMIT),
-    execGhPrList(repo, ITEM_FETCH_LIMIT),
-    computeContributorStats(repo),
+    deps.fetchIssues(repo, ITEM_FETCH_LIMIT),
+    deps.fetchPrs(repo, ITEM_FETCH_LIMIT),
+    loadContributorStats(repo, deps.computeStats),
   ]);
 
   if (issuesRaw.truncated) {
@@ -150,6 +173,29 @@ export async function fetchTriage(repo: string): Promise<MaintainerTriage> {
   }
 
   return composeEnvelope(repo, [...issueItems, ...prItems]);
+}
+
+/**
+ * Run the optional contributor-stats enrichment on its own footing so a
+ * failure (2MB-cap truncation, gh non-zero exit, network) degrades to an
+ * empty Map and the cheap open-issue / open-PR ingest still renders —
+ * authors just keep defaultContributor (gascity-dashboard-wplw). The failure
+ * is logged loudly (Don't Swallow Errors), not swallowed silently: it's a
+ * real degradation the operator should see, just not a page-blackout.
+ */
+async function loadContributorStats(
+  repo: string,
+  computeStats: (repo: string) => Promise<Map<string, ContributorStat>>,
+): Promise<Map<string, ContributorStat>> {
+  try {
+    return await computeStats(repo);
+  } catch (err: unknown) {
+    logError(
+      LOG_COMPONENT.maintainer,
+      `contributor-stats enrichment failed for ${repo}, continuing with defaultContributor: ${errorMessage(err)}`,
+    );
+    return new Map<string, ContributorStat>();
+  }
 }
 
 function mapIssue(it: GhIssue): TriageItem {


### PR DESCRIPTION
## Summary
Fixes a triage-refresh blackout (bead gascity-dashboard-wplw, audit verified high).

`computeContributorStats` (optional enrichment) was awaited inside the **same** `Promise.all` as the primary open-issue/PR ingest in `fetchTriage`. It throws hard on a 2MB-cap truncation or any `gh` non-zero exit — so a single repo blowing the cap rejected `fetchTriage` entirely, taking down the cheap, still-valid issue/PR ingest even though items render fine without contributor tiers.

## Fix
Added a `loadContributorStats` wrapper that degrades a stats failure to an empty `Map` and **logs loudly** (`logError`, per Don't-Swallow-Errors) instead of rejecting. The three ingest calls still run concurrently; authors with no stat naturally keep `defaultContributor`. `contributor.ts` is intentionally left throwing — the correct resilience boundary is the caller, where optionality is known.

## Test plan
- New `triage-contributor-decouple.test.ts` (3 cases): a contributor-stats failure no longer rejects `fetchTriage` (issues/PRs still ingest, authors fall back), and the failure is logged not swallowed. **RED before, GREEN after (3/3).**
- Verified on branch: backend `test` 0 fail, `typecheck:test` + `lint` clean.
- Reviewed by code-reviewer: **approve**, 0 CRITICAL/HIGH; 1 LOW (a test spy var named `warnSpy` actually targets `console.error` — cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)