### PR TITLE
fix(maintainer): serialize writeCache via a write-chain mutex (xk8x)

### DIFF
--- a/backend/src/views/modules/maintainer/storage.ts
+++ b/backend/src/views/modules/maintainer/storage.ts
@@ -47,10 +47,30 @@ export async function readCache(cachePath: string): Promise<CacheReadResult> {
   return { status: 'ready', envelope: parsed };
 }
 
+// Serialise concurrent writers in this process. The background runRefresh
+// worker and the route POST /api/maintainer/refresh are two real writers; a
+// shared `${cachePath}.tmp-${pid}-${Date.now()}` can collide within one
+// millisecond, so atomic rename alone (which only guards readers from a
+// half-written tmp) is not enough. Single chain mirrors slung-state.ts: each
+// writer waits for the prior write+rename to finish before starting its own,
+// so no two writers ever share a tmp path or interleave their fs.writeFile.
+let writeChain: Promise<void> = Promise.resolve();
+
 export async function writeCache(
   cachePath: string,
   envelope: MaintainerTriage,
 ): Promise<void> {
+  const next = writeChain.then(() => persistAtomic(cachePath, envelope));
+  // Keep the chain alive after a failed write so the next enqueued writer
+  // still runs, but never swallow the failure — surface it to the awaiting
+  // caller below and log it for the operator (mirrors slung-state.ts).
+  writeChain = next.catch((err: unknown) => {
+    logWarn(LOG_COMPONENT.maintainer, `cache write failed: ${errorMessage(err)}`);
+  });
+  await next;
+}
+
+async function persistAtomic(cachePath: string, envelope: MaintainerTriage): Promise<void> {
   await fs.mkdir(path.dirname(cachePath), { recursive: true });
   const tmp = `${cachePath}.tmp-${process.pid}-${Date.now()}`;
   await fs.writeFile(tmp, JSON.stringify(envelope, null, 2), 'utf-8');

--- a/backend/test/maintainer-storage.test.ts
+++ b/backend/test/maintainer-storage.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { MaintainerTriage } from 'gas-city-dashboard-shared';
+
+import { readCache, writeCache } from '../src/views/modules/maintainer/storage.js';
+
+// gascity-dashboard-xk8x: writeCache must serialise concurrent writers the
+// same way the sibling slung-state.ts does. The background runRefresh worker
+// and the route POST /api/maintainer/refresh are two real concurrent writers;
+// without a mutex they can land on the same `${cachePath}.tmp-${pid}-${Date.now()}`
+// within one millisecond, interleave fs.writeFile (torn tmp), and both rename.
+
+function makeEnvelope(repo: string): MaintainerTriage {
+  return {
+    computed_at: null,
+    repo,
+    tiers: [],
+    totals: { issues_open: 0, prs_open: 0 },
+  };
+}
+
+describe('maintainer storage writeCache', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'maintainer-storage-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test('concurrent writers serialise: never share a tmp path, never overlap writeFile', async () => {
+    const cachePath = path.join(dir, 'maintainer-cache.json');
+
+    const realWriteFile = fs.writeFile.bind(fs);
+    const tmpPaths: string[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    // Wrap fs.writeFile to (a) record each tmp path written and (b) hold the
+    // write open briefly so two unserialised writers would visibly overlap.
+    // With the mutex, the second writer's writeFile cannot start until the
+    // first writer's rename has completed, so maxInFlight stays 1.
+    const writeFileSpy = (async (file: unknown, ...rest: unknown[]) => {
+      tmpPaths.push(String(file));
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        // @ts-expect-error spy forwards the original variadic signature
+        return await realWriteFile(file, ...rest);
+      } finally {
+        inFlight -= 1;
+      }
+    }) as typeof fs.writeFile;
+
+    (fs as { writeFile: typeof fs.writeFile }).writeFile = writeFileSpy;
+    try {
+      await Promise.all([
+        writeCache(cachePath, makeEnvelope('owner/a')),
+        writeCache(cachePath, makeEnvelope('owner/b')),
+      ]);
+    } finally {
+      (fs as { writeFile: typeof fs.writeFile }).writeFile = realWriteFile;
+    }
+
+    assert.equal(tmpPaths.length, 2, 'both writers should have written a tmp file');
+    assert.notEqual(tmpPaths[0], tmpPaths[1], 'concurrent writers must not share a tmp path');
+    assert.equal(maxInFlight, 1, 'writes must be serialised — only one writeFile in flight at a time');
+
+    // No leftover tmp files: every tmp was renamed away, nothing torn behind.
+    const leftovers = (await fs.readdir(dir)).filter((name) => name.includes('.tmp-'));
+    assert.deepEqual(leftovers, [], `no tmp files should remain, found: ${leftovers.join(', ')}`);
+  });
+
+  test('final file is a clean, parseable envelope after concurrent writes', async () => {
+    const cachePath = path.join(dir, 'maintainer-cache.json');
+
+    await Promise.all([
+      writeCache(cachePath, makeEnvelope('owner/a')),
+      writeCache(cachePath, makeEnvelope('owner/b')),
+    ]);
+
+    const result = await readCache(cachePath);
+    assert.equal(result.status, 'ready');
+    if (result.status === 'ready') {
+      assert.ok(
+        result.envelope.repo === 'owner/a' || result.envelope.repo === 'owner/b',
+        'final envelope must be exactly one of the two writers, not a torn mix',
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a cache write race (bead gascity-dashboard-xk8x, audit verified high).

`writeCache` built its tmp path as `<cachePath>.tmp-<pid>-<ms>` with no mutex. Two real concurrent writers — the background `runRefresh` and route `POST /api/maintainer/refresh` — can collide on one tmp path within the same millisecond, interleave `fs.writeFile` (torn tmp) and both `rename`. Atomic rename only guards readers from a half-write, not two writers sharing a tmp path. The sibling `slung-state.ts` already solved this with a module-scoped write-chain mutex; `storage.ts` never got it.

## Fix
Gave `writeCache` the same module-scoped `writeChain` Promise mutex, mirroring `slung-state.ts:77-95,116-119` — serializing writers so they never share a tmp path or interleave.

## Test plan
- New `maintainer-storage.test.ts`: two concurrent `writeCache` calls no longer share a tmp path / tear the file. **RED before the fix, GREEN after.**
- Verified on branch: backend `test` 0 fail, `typecheck:test` + `lint` clean.
- Reviewed by code-reviewer: **approve**, 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)