### PR TITLE
fix(gc-client): accept supervisor RFC3339 datetimes with tz offsets

### DIFF
--- a/backend/src/gc-client.ts
+++ b/backend/src/gc-client.ts
@@ -112,6 +112,21 @@ export class GcClient {
       responseStyle: 'fields',
       throwOnError: false,
     });
+    // gascity-dashboard-9lvq: the supervisor (Go) emits RFC3339 datetimes with
+    // a numeric tz offset (e.g. `-04:00`), but the generated SDK validates
+    // them with Zod's `z.iso.datetime()`, which accepts only a `Z` suffix.
+    // One offset-bearing datetime rejected the whole listAgents/listBeads
+    // array (HTTP 502, blank panels). Normalize offset datetimes to the
+    // equivalent UTC `Z` instant at the transport edge, before validation, so
+    // valid supervisor data is accepted rather than discarded.
+    //
+    // The deprecated standalone @hey-api/client-fetch package ships
+    // `interceptors` typed as `unknown` in this project's resolution, so reach
+    // its documented response-interceptor API through a narrow typed view of
+    // the known runtime shape.
+    (this.supervisor.interceptors as SupervisorResponseInterceptors).response.use(
+      normalizeOffsetDatetimesInterceptor,
+    );
   }
 
   /** Base URL of the gc supervisor (no trailing slash). Used for non-city endpoints (e.g. /v0/health) + frontend CSP connect-src. */
@@ -931,4 +946,64 @@ function isGeneratedEmptyJsonBody(response: Response, data: unknown): boolean {
     return false;
   }
   return Object.keys(data).length === 0;
+}
+
+// Narrow view of the client-fetch response-interceptor registration API. The
+// generated client types `interceptors` as `unknown` in this project's
+// resolution (deprecated standalone package), so this captures only the one
+// method we call. The runtime invokes the interceptor as
+// `(response, request, options)`; the `...rest` keeps this faithful to that
+// arity even though our interceptor only reads `response`. See the constructor.
+type SupervisorResponseInterceptors = {
+  response: {
+    use(
+      fn: (response: Response, ...rest: unknown[]) => Response | Promise<Response>,
+    ): number;
+  };
+};
+
+// Matches an RFC3339 date-time string with a numeric tz offset (`+HH:MM` /
+// `-HH:MM`), as a JSON string literal. The `Z`-suffixed form is intentionally
+// NOT matched — it already passes `z.iso.datetime()` and needs no rewrite.
+const RFC3339_OFFSET_RE =
+  /"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?[+-]\d{2}:\d{2})"/g;
+
+// Rewrites offset-bearing RFC3339 datetimes in a JSON body to the equivalent
+// UTC `Z` instant. Conversion goes through `Date`, so sub-millisecond digits
+// (the supervisor occasionally emits nanoseconds) are truncated to ms — lossless
+// for the dashboard's display/sort use of these timestamps. A datetime `Date`
+// cannot parse is left verbatim so the downstream validator still reports it.
+function normalizeOffsetDatetimes(jsonText: string): string {
+  return jsonText.replace(RFC3339_OFFSET_RE, (match, value: string) => {
+    const ms = Date.parse(value);
+    if (Number.isNaN(ms)) return match;
+    return `"${new Date(ms).toISOString()}"`;
+  });
+}
+
+// Response interceptor: normalize offset datetimes in JSON bodies before the
+// generated SDK's offset-intolerant Zod validator runs. Non-JSON responses
+// (SSE streams, empty bodies) and bodies with no offset datetime pass through
+// untouched (no re-allocation). See gascity-dashboard-9lvq.
+async function normalizeOffsetDatetimesInterceptor(
+  response: Response,
+): Promise<Response> {
+  // Non-ok responses are turned into thrown errors by GcClient before the SDK
+  // validator runs (see fetchOnce), so they never reach Zod — skip them.
+  if (!response.ok) return response;
+  if (!response.headers.get('content-type')?.includes('application/json')) {
+    return response;
+  }
+  const body = await response.clone().text();
+  const normalized = normalizeOffsetDatetimes(body);
+  if (normalized === body) return response;
+  // Normalization shortens the body (e.g. `-04:00` -> `Z`), so the original
+  // Content-Length is now stale — drop it rather than advertise a wrong length.
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  return new Response(normalized, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }

--- a/backend/test/gc-client.test.ts
+++ b/backend/test/gc-client.test.ts
@@ -2301,6 +2301,130 @@ describe('GcClient.listCities', () => {
   });
 });
 
+// gascity-dashboard-9lvq: the gc supervisor (Go) emits RFC3339 datetimes
+// with a numeric timezone offset (e.g. `-04:00`) on some records, but the
+// generated SDK response validator uses Zod's offset-intolerant
+// `z.iso.datetime()` (accepts only a `Z` suffix). A single offset-bearing
+// datetime rejected the WHOLE listAgents/listBeads array -> /api/agents and
+// /api/beads 502 -> dashboard panels blank. GcClient normalizes offset
+// datetimes to UTC `Z` at the client edge before validation so valid
+// supervisor data is accepted instead of discarded.
+describe('GcClient RFC3339 offset datetime normalization', () => {
+  let fake: Fake;
+  beforeEach(async () => {
+    fake = await startFake();
+  });
+  afterEach(async () => {
+    await fake.close();
+  });
+
+  test('accepts list items whose datetime carries a numeric tz offset', async () => {
+    const offsetBead = {
+      ...validBead('td-offset'),
+      created_at: '2026-05-09T22:13:38.653-04:00',
+    };
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ items: [offsetBead], total: 1 }));
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 5_000,
+    });
+    const out = await gc.listBeads(undefined, { limit: 10 });
+    assert.equal(out.items.length, 1, 'offset datetime must not blank the list');
+    assert.equal(out.items[0]?.id, 'td-offset');
+    // Normalized to the equivalent UTC instant (-04:00 -> +00:00 = +4h).
+    assert.equal(out.items[0]?.created_at, '2026-05-10T02:13:38.653Z');
+  });
+
+  test('leaves already-UTC (Z) datetimes untouched', async () => {
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ items: [validBead('td-utc')], total: 1 }));
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 5_000,
+    });
+    const out = await gc.listBeads(undefined, { limit: 10 });
+    assert.equal(out.items[0]?.created_at, '2026-01-01T00:00:00.000Z');
+  });
+
+  test('truncates sub-millisecond (nanosecond) precision to ms', async () => {
+    // The Go supervisor emits nanoseconds; Date parses ms only, so the
+    // normalized value is the ms-truncated UTC instant.
+    const nsBead = {
+      ...validBead('td-ns'),
+      created_at: '2026-05-09T22:13:38.653177770-04:00',
+    };
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ items: [nsBead], total: 1 }));
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 5_000,
+    });
+    const out = await gc.listBeads(undefined, { limit: 10 });
+    assert.equal(out.items[0]?.created_at, '2026-05-10T02:13:38.653Z');
+  });
+
+  test('normalizes a mix of offset and Z datetimes without cross-contamination', async () => {
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          items: [
+            { ...validBead('td-z'), created_at: '2026-01-01T00:00:00.000Z' },
+            { ...validBead('td-off'), created_at: '2026-05-09T22:13:38.653-04:00' },
+          ],
+          total: 2,
+        }),
+      );
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 5_000,
+    });
+    const out = await gc.listBeads(undefined, { limit: 10 });
+    assert.equal(out.items[0]?.created_at, '2026-01-01T00:00:00.000Z');
+    assert.equal(out.items[1]?.created_at, '2026-05-10T02:13:38.653Z');
+  });
+
+  test('leaves an unparseable datetime verbatim for the validator to reject', async () => {
+    // A datetime-shaped-but-invalid value (month 99) must NOT be silently
+    // rewritten; the NaN guard passes it through so the decoder reports it.
+    const badBead = {
+      ...validBead('td-bad'),
+      created_at: '2026-99-09T22:13:38-04:00',
+    };
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ items: [badBead], total: 1 }));
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 5_000,
+    });
+    await assert.rejects(
+      gc.listBeads(undefined, { limit: 10 }),
+      /created_at/,
+      'an unparseable datetime must surface as a decoder error, not be normalized away',
+    );
+  });
+});
+
 function validBead(id: string) {
   return {
     id,


### PR DESCRIPTION
## Problem

The gc supervisor (Go) emits RFC3339 datetimes with a **numeric timezone offset** (e.g. `2026-05-31T18:13:47-04:00`), but the generated SDK validates responses with Zod's `z.iso.datetime()`, which accepts **only** a `Z` suffix. A single offset-bearing datetime — the `mayor` agent's `session.last_activity`, older beads' `created_at` — caused the **entire** `listAgents` / `listBeads` array to be rejected, so:

- `GET /api/city/<city>/agents` → **502**
- `GET /api/city/<city>/beads` → **502**
- snapshot headline `activeAgents` → `unavailable`

i.e. the Agents and Beads panels rendered blank while the dashboard itself reported "live". The supervisor's data was **valid**; the dashboard's validator was wrongly strict.

## Fix

Normalize offset datetimes to the equivalent **UTC `Z`** instant at the client transport edge, via a `@hey-api/client-fetch` response interceptor, **before** the generated Zod validator runs. Valid supervisor data is accepted instead of discarded. Unparseable datetimes are left verbatim so the decoder still reports them (no silent normalization of genuinely-bad data).

Rejected approaches: dropping the offending item (would silently discard valid data — the mayor agent, real beads); hand-editing the generated `zod.gen.ts` (no-hand-edit artifact); the `@hey-api` zod plugin hardcodes `z.iso.datetime()` with no offset option.

### Changes
- **`backend/src/gc-client.ts`** — `normalizeOffsetDatetimes` + response interceptor; drops stale `Content-Length` on rewrite; narrow typed view of the interceptor API (`interceptors` resolves to `unknown` for the deprecated standalone `@hey-api/client-fetch`).
- **`backend/test/gc-client.test.ts`** — offset accepted, `Z` untouched, nanosecond→ms truncation, mixed offset+`Z` array, unparseable rejected.

## Review
3-agent review (code / security / typescript): 0 CRITICAL/HIGH. ReDoS-clear regex, correct clone/header/firing-order semantics. Applied: faithful cast arity, stale `Content-Length` drop, non-ok-bail comment, +3 tests.

## Test plan
- [x] `npm run typecheck` clean (source + test)
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npm --workspace backend test` — 849/849
- [x] Live: `/api/city/ds-research/{agents,beads}` → 200, `activeAgents` → `available`

Fixes gascity-dashboard-9lvq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)