### PR TITLE
test: backfill SSE/maintainer coverage + align strip-non-printable OSC_RE (wave td3)

### DIFF
--- a/backend/src/lib/strip-non-printable.test.ts
+++ b/backend/src/lib/strip-non-printable.test.ts
@@ -44,10 +44,6 @@ describe('stripNonPrintable — CVE-2021-42574 bidi codepoints', () => {
     0x2067, 0x2068, 0x2069,
   ];
 
-  test('lists exactly the 12 CVE codepoints', () => {
-    assert.equal(BIDI_CODEPOINTS.length, 12);
-  });
-
   for (const cp of BIDI_CODEPOINTS) {
     const label = `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
     test(`strips ${label}`, () => {

--- a/backend/src/lib/strip-non-printable.test.ts
+++ b/backend/src/lib/strip-non-printable.test.ts
@@ -1,0 +1,58 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripNonPrintable } from './strip-non-printable.js';
+
+// gascity-dashboard-vibg: stripNonPrintable must mirror
+// exec.ts::sanitiseTerminalOutput's OSC handling. An OSC sequence can be
+// terminated either by BEL (\x07, the xterm-legacy form) or by ST as
+// ESC \\ (\x1b\\, the spec form most modern terminals emit). Only matching
+// the BEL form left ST-terminated payloads as visible bracketed text once
+// CTRL_RE stripped the bounding ESC bytes — a defense-in-depth gap if
+// CTRL_RE were ever weakened.
+
+describe('stripNonPrintable — OSC termination forms', () => {
+  test('strips BEL-terminated OSC (ESC ] ... BEL)', () => {
+    const dirty = 'before\x1b]0;evil-title\x07after';
+    assert.equal(stripNonPrintable(dirty), 'beforeafter');
+  });
+
+  test('strips ST-terminated OSC (ESC ] ... ESC \\)', () => {
+    const dirty = 'before\x1b]0;evil-title\x1b\\after';
+    assert.equal(stripNonPrintable(dirty), 'beforeafter');
+  });
+
+  test('an unterminated OSC does not consume a following ANSI escape', () => {
+    // The OSC char-class excludes \x1b, so an unterminated OSC payload does
+    // not swallow the trailing CSI: OSC_RE fails to match (no terminator),
+    // CTRL_RE then strips both ESC bytes, and CSI_RE removes the [31m. The
+    // bracket text is left as inert, non-interpretable plain text — the
+    // defense-in-depth property is that no ESC survives and the CSI is still
+    // stripped on its own, not swallowed by a greedy OSC match.
+    const out = stripNonPrintable('before\x1b]0;no-terminator\x1b[31mred');
+    assert.ok(!out.includes('\x1b'), 'no ESC byte may survive');
+    assert.ok(!out.includes('[31m'), 'the trailing CSI must still be stripped');
+    assert.equal(out, 'before]0;no-terminatorred');
+  });
+});
+
+describe('stripNonPrintable — CVE-2021-42574 bidi codepoints', () => {
+  // All 12 Unicode bidi / RTL control codepoints from the trojan-source
+  // CVE (Boucher/Anderson 2021): U+061C (ALM), U+200E (LRM), U+200F (RLM),
+  // U+202A-202E (LRE/RLE/PDF/LRO/RLO), U+2066-2069 (LRI/RLI/FSI/PDI).
+  const BIDI_CODEPOINTS = [
+    0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066,
+    0x2067, 0x2068, 0x2069,
+  ];
+
+  test('lists exactly the 12 CVE codepoints', () => {
+    assert.equal(BIDI_CODEPOINTS.length, 12);
+  });
+
+  for (const cp of BIDI_CODEPOINTS) {
+    const label = `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+    test(`strips ${label}`, () => {
+      const ch = String.fromCodePoint(cp);
+      assert.equal(stripNonPrintable(`a${ch}b`), 'ab');
+    });
+  }
+});

--- a/backend/src/lib/strip-non-printable.ts
+++ b/backend/src/lib/strip-non-printable.ts
@@ -13,7 +13,11 @@
 // control bytes. Stripping all control bytes up front keeps the invariant
 // uniform regardless of which control class the input carries.
 
-const OSC_RE = /\x1b\][^\x07]*\x07/g;
+// OSC terminates with BEL (\x07, xterm-legacy) or ST as ESC \\ (\x1b\\, the
+// spec form modern terminals emit). The single-byte C1 ST (\x9c) is covered by
+// CTRL_RE. The char-class excludes \x1b so an unterminated OSC cannot consume a
+// following ANSI escape. Kept exactly in step with exec.ts::sanitiseTerminalOutput.
+const OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 const CSI_RE = /\x1b\[[?0-9;]*[a-zA-Z]/g;
 // All control chars: C0 (<0x20, incl. \t/\n/\r), DEL (\x7f), and C1
 // (\x80-\x9f). C1 are legacy 8-bit controls some terminals still interpret as

--- a/backend/src/views/modules/maintainer/classifier.test.ts
+++ b/backend/src/views/modules/maintainer/classifier.test.ts
@@ -1,0 +1,243 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyItem, isMarkCandidate } from './classifier.js';
+import { makeIssue, makePr } from './fixtures/triage-item.js';
+
+// gascity-dashboard-z9sj: direct unit coverage for the priority classifier.
+// classifyTier + computeTriageScore are module-private, so they are pinned
+// through the exported classifyItem (which surfaces both `tier` and
+// `triage_score`). isMarkCandidate is exported and tested directly.
+//
+// These pin the scoring bands and tier mapping so a band boundary or label
+// mapping regression fails loudly instead of silently re-ordering the page.
+
+describe('classifyItem — tier mapping from labels', () => {
+  test('kind/bug + priority/p0 → regression_breaking', () => {
+    const item = makeIssue({ number: 1, labels: ['kind/bug', 'priority/p0'] });
+    assert.equal(classifyItem(item).tier, 'regression_breaking');
+  });
+
+  test('kind/bug + priority/p1 → regression_breaking', () => {
+    const item = makeIssue({ number: 2, labels: ['kind/bug', 'priority/p1'] });
+    assert.equal(classifyItem(item).tier, 'regression_breaking');
+  });
+
+  test('kind/bug + priority/p2 → regression (p2 is not a breaking priority)', () => {
+    const item = makeIssue({ number: 3, labels: ['kind/bug', 'priority/p2'] });
+    assert.equal(classifyItem(item).tier, 'regression');
+  });
+
+  test('kind/bug alone → regression', () => {
+    const item = makeIssue({ number: 4, labels: ['kind/bug'] });
+    assert.equal(classifyItem(item).tier, 'regression');
+  });
+
+  test('priority/p0 without kind/bug → stability (breaking priority alone is not a bug)', () => {
+    const item = makeIssue({ number: 5, labels: ['priority/p0'] });
+    assert.equal(classifyItem(item).tier, 'stability');
+  });
+
+  test('no kind label → stability', () => {
+    const item = makeIssue({ number: 6, labels: ['kind/feature', 'area/beads'] });
+    assert.equal(classifyItem(item).tier, 'stability');
+  });
+
+  test('empty labels → stability', () => {
+    const item = makeIssue({ number: 7, labels: [] });
+    assert.equal(classifyItem(item).tier, 'stability');
+  });
+});
+
+describe('classifyItem — triage_score severity base by tier', () => {
+  // Severity base: regression_breaking 300, regression 200, stability 100.
+  // Use an issue with no friction labels and no linked PRs so simplicityBonus
+  // is exactly 0 and the base is observable.
+  test('regression_breaking issue, no bonus → 300', () => {
+    const item = makeIssue({ number: 1, labels: ['kind/bug', 'priority/p0'] });
+    assert.equal(classifyItem(item).triage_score, 300);
+  });
+
+  test('regression issue, no bonus → 200', () => {
+    const item = makeIssue({ number: 2, labels: ['kind/bug'] });
+    assert.equal(classifyItem(item).triage_score, 200);
+  });
+
+  test('stability issue, no bonus → 100', () => {
+    const item = makeIssue({ number: 3, labels: [] });
+    assert.equal(classifyItem(item).triage_score, 100);
+  });
+});
+
+describe('classifyItem — PR simplicity bonus by lines_changed band', () => {
+  // Bands: <50 +50, <200 +35, <500 +20, <1000 +10, >=1000 +0.
+  // Use status 'open' (no status delta) on a regression_breaking PR (base 300).
+  function scoreForLines(lines: number): number {
+    const pr = makePr({
+      number: 1,
+      labels: ['kind/bug', 'priority/p0'],
+      status: 'open',
+      lines_changed: lines,
+    });
+    return classifyItem(pr).triage_score;
+  }
+
+  test('0 lines → +50 (300+50=350)', () => assert.equal(scoreForLines(0), 350));
+  test('49 lines (just under 50) → +50', () => assert.equal(scoreForLines(49), 350));
+  test('50 lines (band boundary) → +35 (300+35=335)', () => assert.equal(scoreForLines(50), 335));
+  test('199 lines → +35', () => assert.equal(scoreForLines(199), 335));
+  test('200 lines (boundary) → +20 (300+20=320)', () => assert.equal(scoreForLines(200), 320));
+  test('499 lines → +20', () => assert.equal(scoreForLines(499), 320));
+  test('500 lines (boundary) → +10 (300+10=310)', () => assert.equal(scoreForLines(500), 310));
+  test('999 lines → +10', () => assert.equal(scoreForLines(999), 310));
+  test('1000 lines (boundary) → +0 (300)', () => assert.equal(scoreForLines(1000), 300));
+  test('5000 lines → +0', () => assert.equal(scoreForLines(5000), 300));
+
+  test('null lines_changed treated as 0 → +50', () => {
+    const pr = makePr({
+      number: 9,
+      labels: ['kind/bug', 'priority/p0'],
+      status: 'open',
+      lines_changed: null,
+    });
+    assert.equal(classifyItem(pr).triage_score, 350);
+  });
+});
+
+describe('classifyItem — PR status delta', () => {
+  // Small (<50 lines, +50) regression_breaking PR base = 350 before status.
+  function scoreForStatus(status: Parameters<typeof makePr>[0]['status']): number {
+    const pr = makePr({
+      number: 1,
+      labels: ['kind/bug', 'priority/p0'],
+      status,
+      lines_changed: 10,
+    });
+    return classifyItem(pr).triage_score;
+  }
+
+  test('approved → +15 (350+15=365)', () => assert.equal(scoreForStatus('approved'), 365));
+  test('needs_review → +10 (350+10=360)', () => assert.equal(scoreForStatus('needs_review'), 360));
+  test('open → +0 (350)', () => assert.equal(scoreForStatus('open'), 350));
+  test('draft → -15 (350-15=335)', () => assert.equal(scoreForStatus('draft'), 335));
+  test('changes_requested → -10 (350-10=340)', () => assert.equal(scoreForStatus('changes_requested'), 340));
+});
+
+describe('classifyItem — issue simplicity bonus', () => {
+  // Stability issue base = 100.
+  test('linked open PR (linked_numbers non-empty) → +40 (140)', () => {
+    const item = makeIssue({ number: 1, labels: [], linked_numbers: [42] });
+    assert.equal(classifyItem(item).triage_score, 140);
+  });
+
+  test('status/needs-info → -25 (75)', () => {
+    const item = makeIssue({ number: 2, labels: ['status/needs-info'] });
+    assert.equal(classifyItem(item).triage_score, 75);
+  });
+
+  test('status/needs-repro → -25 (75)', () => {
+    const item = makeIssue({ number: 3, labels: ['status/needs-repro'] });
+    assert.equal(classifyItem(item).triage_score, 75);
+  });
+
+  test('status/stale → -30 (70)', () => {
+    const item = makeIssue({ number: 4, labels: ['status/stale'] });
+    assert.equal(classifyItem(item).triage_score, 70);
+  });
+
+  test('status/help-wanted → -15 (85)', () => {
+    const item = makeIssue({ number: 5, labels: ['status/help-wanted'] });
+    assert.equal(classifyItem(item).triage_score, 85);
+  });
+
+  test('friction labels stack: needs-info + stale → -55 (45)', () => {
+    const item = makeIssue({
+      number: 6,
+      labels: ['status/needs-info', 'status/stale'],
+    });
+    assert.equal(classifyItem(item).triage_score, 45);
+  });
+
+  test('linked PR + friction: +40 -25 → 115', () => {
+    const item = makeIssue({
+      number: 7,
+      labels: ['status/needs-info'],
+      linked_numbers: [99],
+    });
+    assert.equal(classifyItem(item).triage_score, 115);
+  });
+});
+
+describe('isMarkCandidate — truth table', () => {
+  // A mark candidate is: kind==='pr' AND tier==='regression_breaking'
+  //   AND slung == null AND status NOT in {draft, changes_requested}.
+  test('PR, regression_breaking, open, not slung → candidate', () => {
+    const pr = makePr({ number: 1, status: 'open', slung: null });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), true);
+  });
+
+  test('issue is never a candidate (kind gate)', () => {
+    const issue = makeIssue({ number: 2, status: 'open' });
+    assert.equal(isMarkCandidate(issue, 'regression_breaking'), false);
+  });
+
+  test('regression tier → not a candidate', () => {
+    const pr = makePr({ number: 3, status: 'open' });
+    assert.equal(isMarkCandidate(pr, 'regression'), false);
+  });
+
+  test('stability tier → not a candidate', () => {
+    const pr = makePr({ number: 4, status: 'open' });
+    assert.equal(isMarkCandidate(pr, 'stability'), false);
+  });
+
+  test('draft PR → not a candidate', () => {
+    const pr = makePr({ number: 5, status: 'draft' });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), false);
+  });
+
+  test('changes_requested PR → not a candidate', () => {
+    const pr = makePr({ number: 6, status: 'changes_requested' });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), false);
+  });
+
+  test('approved PR → candidate', () => {
+    const pr = makePr({ number: 7, status: 'approved' });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), true);
+  });
+
+  test('needs_review PR → candidate', () => {
+    const pr = makePr({ number: 8, status: 'needs_review' });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), true);
+  });
+
+  test('already-slung PR → not a candidate (mark moves to next unhandled)', () => {
+    const pr = makePr({
+      number: 9,
+      status: 'open',
+      slung: {
+        slung_at: '2026-05-24T00:00:00.000Z',
+        target: 'mayor',
+        bead_id: null,
+        resolved_session_name: null,
+      },
+    });
+    assert.equal(isMarkCandidate(pr, 'regression_breaking'), false);
+  });
+});
+
+describe('classifyItem — provisional is_marked mirrors isMarkCandidate', () => {
+  test('candidate PR carries provisional is_marked=true', () => {
+    const pr = makePr({
+      number: 1,
+      labels: ['kind/bug', 'priority/p0'],
+      status: 'open',
+      slung: null,
+    });
+    assert.equal(classifyItem(pr).is_marked, true);
+  });
+
+  test('non-candidate issue carries is_marked=false', () => {
+    const issue = makeIssue({ number: 2, labels: ['kind/bug', 'priority/p0'] });
+    assert.equal(classifyItem(issue).is_marked, false);
+  });
+});

--- a/backend/src/views/modules/maintainer/contributor.test.ts
+++ b/backend/src/views/modules/maintainer/contributor.test.ts
@@ -1,0 +1,184 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveTier, tally, type RawCounts, type GhListItem } from './contributor.js';
+
+// gascity-dashboard-z9sj: direct unit coverage for the contributor trust-tier
+// classifier and the in-memory tally aggregation. deriveTier's ordering is
+// load-bearing — spam_risk MUST be tested before regular so a contributor
+// with 5 unaccepted issues gets the warning, not the benefit of the doubt.
+
+function counts(overrides: Partial<RawCounts> = {}): RawCounts {
+  return {
+    issues_opened: 0,
+    issues_accepted: 0,
+    prs_opened: 0,
+    prs_merged: 0,
+    ...overrides,
+  };
+}
+
+describe('deriveTier — trust tier thresholds', () => {
+  test('>=20 merged PRs → core', () => {
+    assert.equal(deriveTier(counts({ prs_merged: 20, prs_opened: 20 })), 'core');
+  });
+
+  test('19 merged PRs (just under core) → trusted', () => {
+    assert.equal(deriveTier(counts({ prs_merged: 19, prs_opened: 19 })), 'trusted');
+  });
+
+  test('>=5 merged PRs → trusted', () => {
+    assert.equal(deriveTier(counts({ prs_merged: 5, prs_opened: 5 })), 'trusted');
+  });
+
+  test('>=10 issues_accepted (0 merged PRs) → trusted', () => {
+    assert.equal(
+      deriveTier(counts({ issues_accepted: 10, issues_opened: 12 })),
+      'trusted',
+    );
+  });
+
+  test('4 merged PRs (under trusted) but >=1 → regular', () => {
+    assert.equal(deriveTier(counts({ prs_merged: 4, prs_opened: 4 })), 'regular');
+  });
+
+  test('1 accepted issue, low total → regular', () => {
+    assert.equal(
+      deriveTier(counts({ issues_accepted: 1, issues_opened: 2 })),
+      'regular',
+    );
+  });
+});
+
+describe('deriveTier — spam_risk ordering (spam_risk before regular)', () => {
+  test('5 opened, 0 accepted/merged → spam_risk (lots of noise, nothing landed)', () => {
+    assert.equal(deriveTier(counts({ issues_opened: 5 })), 'spam_risk');
+  });
+
+  test('5 PRs opened, 0 merged → spam_risk', () => {
+    assert.equal(deriveTier(counts({ prs_opened: 5 })), 'spam_risk');
+  });
+
+  test('mixed 3 issues + 2 PRs opened, none accepted → spam_risk', () => {
+    assert.equal(
+      deriveTier(counts({ issues_opened: 3, prs_opened: 2 })),
+      'spam_risk',
+    );
+  });
+
+  test('4 opened, 0 accepted (under spam threshold) → new (total<=1 is false here, falls to regular)', () => {
+    // total=4, accepted=0 → not spam_risk (needs >=5), not regular (accepted<1),
+    // not new (total>1) → final fallback 'regular'.
+    assert.equal(deriveTier(counts({ issues_opened: 4 })), 'regular');
+  });
+
+  test('spam threshold met but one item accepted → NOT spam_risk → regular', () => {
+    // accepted===0 is required for spam_risk; one acceptance flips it.
+    assert.equal(
+      deriveTier(counts({ issues_opened: 5, issues_accepted: 1 })),
+      'regular',
+    );
+  });
+
+  test('spam_risk wins over new when both could apply (5 opened, 0 accepted)', () => {
+    // total>=5 means the new (total<=1) branch is never reached — confirms
+    // ordering: spam_risk is tested before new.
+    assert.equal(deriveTier(counts({ prs_opened: 5 })), 'spam_risk');
+  });
+});
+
+describe('deriveTier — new and fallback', () => {
+  test('0 contributions → new', () => {
+    assert.equal(deriveTier(counts()), 'new');
+  });
+
+  test('exactly 1 contribution, 0 accepted → new', () => {
+    assert.equal(deriveTier(counts({ issues_opened: 1 })), 'new');
+  });
+
+  test('2 opened, 0 accepted (total>1, under spam) → regular fallback', () => {
+    assert.equal(deriveTier(counts({ issues_opened: 2 })), 'regular');
+  });
+});
+
+describe('tally — per-author aggregation', () => {
+  const issue = (number: number, login: string | null, state: string): GhListItem => ({
+    number,
+    author: login === null ? null : { login },
+    state,
+  });
+
+  test('counts issues_opened and issues_accepted (CLOSED = accepted)', () => {
+    const issues: GhListItem[] = [
+      issue(1, 'alice', 'OPEN'),
+      issue(2, 'alice', 'CLOSED'),
+      issue(3, 'alice', 'CLOSED'),
+    ];
+    const out = tally(issues, []);
+    const alice = out.get('alice');
+    assert.ok(alice);
+    assert.equal(alice.issues_opened, 3);
+    assert.equal(alice.issues_accepted, 2);
+  });
+
+  test('counts prs_opened and prs_merged (MERGED = merged)', () => {
+    const prs: GhListItem[] = [
+      issue(10, 'bob', 'OPEN'),
+      issue(11, 'bob', 'MERGED'),
+      issue(12, 'bob', 'CLOSED'),
+    ];
+    const out = tally([], prs);
+    const bob = out.get('bob');
+    assert.ok(bob);
+    assert.equal(bob.prs_opened, 3);
+    // Only MERGED counts as merged — a CLOSED-not-merged PR does not.
+    assert.equal(bob.prs_merged, 1);
+  });
+
+  test('aggregates issues and PRs for the same author', () => {
+    const issues: GhListItem[] = [issue(1, 'carol', 'CLOSED')];
+    const prs: GhListItem[] = [issue(2, 'carol', 'MERGED')];
+    const out = tally(issues, prs);
+    const carol = out.get('carol');
+    assert.ok(carol);
+    assert.equal(carol.issues_opened, 1);
+    assert.equal(carol.issues_accepted, 1);
+    assert.equal(carol.prs_opened, 1);
+    assert.equal(carol.prs_merged, 1);
+  });
+
+  test('skips items with null author or empty login', () => {
+    const issues: GhListItem[] = [
+      issue(1, null, 'OPEN'),
+      issue(2, '', 'OPEN'),
+      issue(3, 'dave', 'OPEN'),
+    ];
+    const out = tally(issues, []);
+    assert.equal(out.size, 1);
+    assert.ok(out.has('dave'));
+  });
+
+  test('derives the correct tier on the aggregated ContributorStat', () => {
+    // 25 merged PRs → core.
+    const prs: GhListItem[] = Array.from({ length: 25 }, (_, i) =>
+      issue(i + 1, 'eve', 'MERGED'),
+    );
+    const out = tally([], prs);
+    const eve = out.get('eve');
+    assert.ok(eve);
+    assert.equal(eve.tier, 'core');
+    assert.equal(eve.prs_merged, 25);
+    assert.equal(eve.prs_opened, 25);
+  });
+
+  test('stamps a computed_at timestamp on every stat', () => {
+    const out = tally([issue(1, 'frank', 'OPEN')], []);
+    const frank = out.get('frank');
+    assert.ok(frank);
+    assert.equal(typeof frank.computed_at, 'string');
+    assert.equal(frank.login, 'frank');
+  });
+
+  test('empty inputs → empty map', () => {
+    assert.equal(tally([], []).size, 0);
+  });
+});

--- a/backend/src/views/modules/maintainer/contributor.test.ts
+++ b/backend/src/views/modules/maintainer/contributor.test.ts
@@ -79,9 +79,10 @@ describe('deriveTier — spam_risk ordering (spam_risk before regular)', () => {
     );
   });
 
-  test('spam_risk wins over new when both could apply (5 opened, 0 accepted)', () => {
-    // total>=5 means the new (total<=1) branch is never reached — confirms
-    // ordering: spam_risk is tested before new.
+  test('spam_risk is reached before the regular fallback (5 opened, 0 accepted)', () => {
+    // 5 unaccepted contributions: not core/trusted, not new (total>1). Without
+    // the spam_risk check this would fall through to the final 'regular'
+    // return — so this confirms spam_risk is tested before that fallback.
     assert.equal(deriveTier(counts({ prs_opened: 5 })), 'spam_risk');
   });
 });

--- a/backend/src/views/modules/maintainer/contributor.ts
+++ b/backend/src/views/modules/maintainer/contributor.ts
@@ -34,13 +34,13 @@ interface GhListItemAuthor {
   login?: string;
 }
 
-interface GhListItem {
+export interface GhListItem {
   number: number;
   author: GhListItemAuthor | null;
   state: string;
 }
 
-interface RawCounts {
+export interface RawCounts {
   issues_opened: number;
   issues_accepted: number;
   prs_opened: number;
@@ -83,7 +83,7 @@ export async function computeContributorStats(
   return tally(issues, prs);
 }
 
-function tally(issues: GhListItem[], prs: GhListItem[]): Map<string, ContributorStat> {
+export function tally(issues: GhListItem[], prs: GhListItem[]): Map<string, ContributorStat> {
 
   const counts = new Map<string, RawCounts>();
   for (const it of issues) {
@@ -160,7 +160,7 @@ function buildStat(
  * has to test BEFORE new so a contributor with 5 unaccepted issues
  * gets the warning, not the benefit of the doubt.
  */
-function deriveTier(c: RawCounts): ContributorTier {
+export function deriveTier(c: RawCounts): ContributorTier {
   if (c.prs_merged >= 20) return 'core';
   if (c.prs_merged >= 5 || c.issues_accepted >= 10) return 'trusted';
   const total = c.issues_opened + c.prs_opened;

--- a/backend/src/views/modules/maintainer/contributor.ts
+++ b/backend/src/views/modules/maintainer/contributor.ts
@@ -34,12 +34,14 @@ interface GhListItemAuthor {
   login?: string;
 }
 
+/** @internal Exported for unit testing; not part of this module's public contract. */
 export interface GhListItem {
   number: number;
   author: GhListItemAuthor | null;
   state: string;
 }
 
+/** @internal Exported for unit testing; not part of this module's public contract. */
 export interface RawCounts {
   issues_opened: number;
   issues_accepted: number;
@@ -83,6 +85,7 @@ export async function computeContributorStats(
   return tally(issues, prs);
 }
 
+/** @internal Exported for unit testing; not part of this module's public contract. */
 export function tally(issues: GhListItem[], prs: GhListItem[]): Map<string, ContributorStat> {
 
   const counts = new Map<string, RawCounts>();
@@ -159,6 +162,8 @@ function buildStat(
  * Order matters: tested top-to-bottom, first match wins. spam_risk
  * has to test BEFORE new so a contributor with 5 unaccepted issues
  * gets the warning, not the benefit of the doubt.
+ *
+ * @internal Exported for unit testing; not part of this module's public contract.
  */
 export function deriveTier(c: RawCounts): ContributorTier {
   if (c.prs_merged >= 20) return 'core';

--- a/backend/src/views/modules/maintainer/triage-mappers.test.ts
+++ b/backend/src/views/modules/maintainer/triage-mappers.test.ts
@@ -37,7 +37,7 @@ interface PrInput {
   files?: { path?: string; additions?: number; deletions?: number }[];
 }
 
-async function ingestPrs(prs: PrInput[], issues: unknown[] = []): Promise<TriageItem[]> {
+async function ingestPrs(prs: PrInput[], issues: object[] = []): Promise<TriageItem[]> {
   const envelope: MaintainerTriage = await fetchTriage('owner/repo', {
     fetchIssues: async (): Promise<ExecResult> => OK(JSON.stringify(issues)),
     fetchPrs: async (): Promise<ExecResult> =>

--- a/backend/src/views/modules/maintainer/triage-mappers.test.ts
+++ b/backend/src/views/modules/maintainer/triage-mappers.test.ts
@@ -1,0 +1,185 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ContributorStat, MaintainerTriage, TriageItem } from 'gas-city-dashboard-shared';
+import type { ExecResult } from '../../../exec-core.js';
+import { fetchTriage, collectItems } from './triage.js';
+
+// gascity-dashboard-z9sj: direct coverage for the ingest mappers
+// (extractLinkedIssueNumbers regex, derivePrStatus precedence, and the mapPr
+// field translation). These functions are module-private, so they are pinned
+// through the public fetchTriage injected-deps seam — the same seam the
+// triage-contributor-decouple suite uses. computeStats is stubbed to an empty
+// Map so authors keep defaultContributor and the assertions isolate the
+// mapping logic from the enrichment pass.
+
+const OK = (stdout: string): ExecResult => ({
+  exitCode: 0,
+  stdout,
+  stderr: '',
+  truncated: false,
+  durationMs: 1,
+});
+
+const NO_STATS = async (): Promise<Map<string, ContributorStat>> =>
+  new Map<string, ContributorStat>();
+
+const FIXED_ISO = '2026-05-24T00:00:00.000Z';
+
+interface PrInput {
+  number: number;
+  title?: string;
+  body?: string;
+  additions?: number;
+  deletions?: number;
+  reviewDecision?: string;
+  isDraft?: boolean;
+  labels?: { name?: string }[];
+  files?: { path?: string; additions?: number; deletions?: number }[];
+}
+
+async function ingestPrs(prs: PrInput[], issues: unknown[] = []): Promise<TriageItem[]> {
+  const envelope: MaintainerTriage = await fetchTriage('owner/repo', {
+    fetchIssues: async (): Promise<ExecResult> => OK(JSON.stringify(issues)),
+    fetchPrs: async (): Promise<ExecResult> =>
+      OK(
+        JSON.stringify(
+          prs.map((p) => ({
+            number: p.number,
+            title: p.title ?? `pr ${p.number}`,
+            createdAt: FIXED_ISO,
+            updatedAt: FIXED_ISO,
+            author: { login: 'someone' },
+            url: `https://example/pull/${p.number}`,
+            body: p.body,
+            additions: p.additions,
+            deletions: p.deletions,
+            reviewDecision: p.reviewDecision,
+            isDraft: p.isDraft,
+            labels: p.labels,
+            files: p.files,
+          })),
+        ),
+      ),
+    computeStats: NO_STATS,
+  });
+  return collectItems(envelope).filter((i) => i.kind === 'pr');
+}
+
+function onePr(input: PrInput): Promise<TriageItem> {
+  return ingestPrs([input]).then((prs) => {
+    const pr = prs.find((p) => p.number === input.number);
+    assert.ok(pr, `PR #${input.number} should be ingested`);
+    return pr;
+  });
+}
+
+describe('mapPr — derivePrStatus precedence', () => {
+  test('isDraft true wins over reviewDecision', async () => {
+    const pr = await onePr({ number: 1, isDraft: true, reviewDecision: 'APPROVED' });
+    assert.equal(pr.status, 'draft');
+  });
+
+  test('APPROVED → approved', async () => {
+    const pr = await onePr({ number: 2, reviewDecision: 'APPROVED' });
+    assert.equal(pr.status, 'approved');
+  });
+
+  test('CHANGES_REQUESTED → changes_requested', async () => {
+    const pr = await onePr({ number: 3, reviewDecision: 'CHANGES_REQUESTED' });
+    assert.equal(pr.status, 'changes_requested');
+  });
+
+  test('REVIEW_REQUIRED → needs_review', async () => {
+    const pr = await onePr({ number: 4, reviewDecision: 'REVIEW_REQUIRED' });
+    assert.equal(pr.status, 'needs_review');
+  });
+
+  test('no reviewDecision, not draft → open', async () => {
+    const pr = await onePr({ number: 5 });
+    assert.equal(pr.status, 'open');
+  });
+
+  test('unknown reviewDecision → open (fallthrough)', async () => {
+    const pr = await onePr({ number: 6, reviewDecision: 'SOMETHING_ELSE' });
+    assert.equal(pr.status, 'open');
+  });
+});
+
+describe('mapPr — field translation', () => {
+  test('lines_changed = additions + deletions', async () => {
+    const pr = await onePr({ number: 1, additions: 30, deletions: 12 });
+    assert.equal(pr.lines_changed, 42);
+  });
+
+  test('missing additions/deletions default to 0 → lines_changed 0', async () => {
+    const pr = await onePr({ number: 2 });
+    assert.equal(pr.lines_changed, 0);
+  });
+
+  test('blast_files extracted from files[].path, dropping empty/missing', async () => {
+    const pr = await onePr({
+      number: 3,
+      files: [{ path: 'a.ts' }, { path: '' }, {}, { path: 'b.ts' }],
+    });
+    assert.deepEqual(pr.blast_files, ['a.ts', 'b.ts']);
+  });
+
+  test('kind, number, title, html_url carried through', async () => {
+    const pr = await onePr({ number: 99, title: 'a fix' });
+    assert.equal(pr.kind, 'pr');
+    assert.equal(pr.number, 99);
+    assert.equal(pr.title, 'a fix');
+    assert.equal(pr.html_url, 'https://example/pull/99');
+  });
+});
+
+describe('extractLinkedIssueNumbers — closing-verb regex', () => {
+  async function linked(body: string | undefined): Promise<number[]> {
+    // fetchTriage's issue→PR reverse-map only rewrites issue.linked_numbers,
+    // never PR.linked_numbers, so a PR's parsed value is what we read here.
+    const pr = await onePr({ number: 1, body });
+    return [...pr.linked_numbers].sort((a, b) => a - b);
+  }
+
+  test('undefined body → []', async () => {
+    assert.deepEqual(await linked(undefined), []);
+  });
+
+  test('no closing verb → []', async () => {
+    assert.deepEqual(await linked('see #12 for context'), []);
+  });
+
+  test('"Fixes #12" → [12]', async () => {
+    assert.deepEqual(await linked('Fixes #12'), [12]);
+  });
+
+  test('"closes #3" lowercase → [3]', async () => {
+    assert.deepEqual(await linked('closes #3'), [3]);
+  });
+
+  test('all closing verbs: close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved', async () => {
+    const body =
+      'close #1 closes #2 closed #3 fix #4 fixes #5 fixed #6 resolve #7 resolves #8 resolved #9';
+    assert.deepEqual(await linked(body), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  test('case-insensitive verb match (FIXES)', async () => {
+    assert.deepEqual(await linked('FIXES #42'), [42]);
+  });
+
+  test('deduplicates repeated references', async () => {
+    assert.deepEqual(await linked('fixes #5 and also closes #5'), [5]);
+  });
+
+  test('word-boundary: "prefixes #9" must NOT match (no false "fixes")', async () => {
+    assert.deepEqual(await linked('prefixes #9'), []);
+  });
+
+  test('requires a space before the # — "fix#7" does not match', async () => {
+    assert.deepEqual(await linked('fix#7'), []);
+  });
+
+  test('multiple distinct issues across the body', async () => {
+    assert.deepEqual(await linked('fixes #100\n\nAlso resolves #200.'), [100, 200]);
+  });
+});

--- a/backend/test/beads-nudge.test.ts
+++ b/backend/test/beads-nudge.test.ts
@@ -276,20 +276,37 @@ describe('POST /api/beads/:id/{claim,close,nudge}', { concurrency: false }, () =
   test('close reason: control/escape/bidi chars stripped before exec AND audit', async () => {
     h = await buildApp();
     // A reason carrying every stripped class: a CSI escape (\x1b[7m reverse),
-    // an OSC title set (\x1b]0;title BEL), an embedded newline + a forged JSON
-    // fragment that would inject a fake row into events.jsonl, a C1 control
-    // (\x9b), DEL (\x7f), and a bidi RLO override (‮). After sanitisation NONE
-    // of these byte classes may survive into either sink.
+    // a BEL-terminated OSC title set (\x1b]0;title \x07), an ST-terminated OSC
+    // (\x1b]0;title \x1b\\ — the spec form modern terminals emit), an embedded
+    // newline + a forged JSON fragment that would inject a fake row into
+    // events.jsonl, a C1 control (\x9b), DEL (\x7f), and ALL 12
+    // CVE-2021-42574 bidi/RTL control codepoints. After sanitisation NONE of
+    // these byte classes may survive into either sink.
+    //
+    // gascity-dashboard-vibg: the bidi codepoints are exercised exhaustively
+    // (not just the RLO U+202E) so a future narrowing of BIDI_RE regresses
+    // here, and the ST-OSC form is included to lock in the BEL/ST parity with
+    // exec.ts::sanitiseTerminalOutput.
+    const BIDI_CHARS = [
+      0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066,
+      0x2067, 0x2068, 0x2069,
+    ]
+      .map((cp) => String.fromCodePoint(cp))
+      .join('');
     const dirty =
-      'safe\x1b[7m\x1b]0;evil\x07inject\n"type":"fake"\x9b\x7f‮rtl';
+      'safe\x1b[7m\x1b]0;belevil\x07\x1b]0;stevil\x1b\\inject\n"type":"fake"\x9b\x7f' +
+      BIDI_CHARS +
+      'rtl';
     const res = await postJson(`${h.url}/api/beads/td-wisp-abc123/close`, {
       reason: dirty,
     });
     assert.equal(res.status, 200);
 
     // Property assertions (the contract): no control byte (C0/C1/DEL), no ESC,
-    // and no bidi override may reach EITHER the exec arg or the audit row.
-    const CONTROL_OR_BIDI = /[\x00-\x1f\x7f-\x9f‮]/;
+    // and none of the 12 bidi control codepoints may reach EITHER the exec arg
+    // or the audit row.
+    const CONTROL_OR_BIDI =
+      /[\x00-\x1f\x7f-\x9f؜‎‏‪-‮⁦-⁩]/;
 
     assert.equal(h.calls.length, 1);
     const sentReason = h.calls[0]!.reason!;

--- a/backend/test/run-session-stream-route.test.ts
+++ b/backend/test/run-session-stream-route.test.ts
@@ -79,6 +79,66 @@ describe('session stream route', () => {
     }
   });
 
+  test('returns a 502 JSON error when the supervisor is unreachable before the stream opens', async () => {
+    // session-stream does not pass openImmediately, so a pre-open upstream
+    // failure must surface as a real HTTP 502 (not a 200 SSE error frame) —
+    // the client never saw a stream, so the status code is still meaningful.
+    const { url, close } = await startApp(buildApp('http://127.0.0.1:1'));
+    try {
+      const res = await fetch(`${url}/api/sessions/gc-session-b/stream`);
+      assert.equal(res.status, 502);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      const body = await res.json();
+      assert.equal(body.kind, 'upstream');
+      assert.match(body.error, /session stream unreachable/);
+    } finally {
+      await close();
+    }
+  });
+
+  test('returns a 502 JSON error when the supervisor responds non-200 before the stream opens', async () => {
+    fake.setHandler((_req, res) => {
+      res.statusCode = 503;
+      res.end('upstream down');
+    });
+    const { url, close } = await startApp(buildApp(fake.baseUrl));
+    try {
+      const res = await fetch(`${url}/api/sessions/gc-session-b/stream`);
+      assert.equal(res.status, 502);
+      const body = await res.json();
+      assert.equal(body.kind, 'upstream');
+      assert.match(body.error, /gc supervisor returned 503/);
+    } finally {
+      await close();
+    }
+  });
+
+  test('emits a post-open SSE error frame when the upstream stream fails after bytes flow', async () => {
+    // Once the proxy has piped at least one upstream chunk, the client-facing
+    // headers are already sent; a later upstream drop must arrive as an
+    // `event: error` frame on the open stream, not a (now impossible) status.
+    fake.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'text/event-stream');
+      res.flushHeaders();
+      res.write('event: turn\ndata: {"role":"assistant","text":"open"}\n\n');
+      // Drop the upstream connection abruptly mid-stream.
+      setTimeout(() => res.destroy(new Error('upstream reset')), 20);
+    });
+    const { url, close } = await startApp(buildApp(fake.baseUrl));
+    try {
+      const res = await fetch(`${url}/api/sessions/gc-session-b/stream`);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /text\/event-stream/);
+      // The proxy ends the client stream after the upstream drops; the body
+      // resolves with the bytes that were piped before the reset.
+      const text = await res.text();
+      assert.match(text, /event: turn/);
+    } finally {
+      await close();
+    }
+  });
+
   test('rejects invalid stream session ids before calling supervisor', async () => {
     const { url, close } = await startApp(buildApp(fake.baseUrl));
     try {

--- a/backend/test/sse-proxy-backpressure.test.ts
+++ b/backend/test/sse-proxy-backpressure.test.ts
@@ -37,11 +37,11 @@ interface FakeRes extends EventEmitter {
   acceptWrites: boolean;
   writes: string[];
   status(code: number): FakeRes;
-  setHeader(): void;
+  setHeader(name: string, value: string): void;
   flushHeaders(): void;
   write(chunk: string | Uint8Array): boolean;
   end(): void;
-  json(): void;
+  json(body: unknown): void;
 }
 
 function fakeRes(): FakeRes {

--- a/backend/test/sse-proxy-backpressure.test.ts
+++ b/backend/test/sse-proxy-backpressure.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import type { Request, Response } from 'express';
+
+import { proxySupervisorSse } from '../src/routes/sse-proxy.js';
+
+// gascity-dashboard-6taa: the drain-vs-close race in proxySupervisorSse.
+//
+// When a client reads slowly, res.write() returns false (backpressure) and the
+// proxy parks on a Promise that resolves on EITHER 'drain' OR 'close'. If the
+// client disconnects *during* that backpressured write, only the 'close'
+// listener can release the parked await — without it the await orphans forever,
+// leaking the upstream connection and the heartbeat timer. These tests drive
+// that exact path with fakes: a regression makes the proxy promise never
+// resolve, which the per-test deadline turns into an explicit failure instead
+// of a hung suite.
+
+interface FakeReq extends EventEmitter {
+  headers: Record<string, string>;
+  query: Record<string, string>;
+}
+
+function fakeReq(): FakeReq {
+  const req = new EventEmitter() as FakeReq;
+  req.headers = {};
+  req.query = {};
+  return req;
+}
+
+interface FakeRes extends EventEmitter {
+  headersSent: boolean;
+  writableEnded: boolean;
+  destroyed: boolean;
+  statusCode: number;
+  /** When false, the next write() reports backpressure (returns false). */
+  acceptWrites: boolean;
+  writes: string[];
+  status(code: number): FakeRes;
+  setHeader(): void;
+  flushHeaders(): void;
+  write(chunk: string | Uint8Array): boolean;
+  end(): void;
+  json(): void;
+}
+
+function fakeRes(): FakeRes {
+  const res = new EventEmitter() as FakeRes;
+  res.headersSent = false;
+  res.writableEnded = false;
+  res.destroyed = false;
+  res.statusCode = 0;
+  res.acceptWrites = true;
+  res.writes = [];
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.setHeader = () => undefined;
+  res.flushHeaders = () => {
+    res.headersSent = true;
+  };
+  res.write = (chunk: string | Uint8Array) => {
+    res.writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return res.acceptWrites;
+  };
+  res.end = () => {
+    res.writableEnded = true;
+  };
+  res.json = () => {
+    res.writableEnded = true;
+  };
+  return res;
+}
+
+/** A ReadableStream-backed upstream body whose chunks are pushed by the test. */
+function makeUpstream(): {
+  upstream: globalThis.Response;
+  push: (text: string) => void;
+  closeUpstream: () => void;
+} {
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    upstream: { ok: true, status: 200, body } as unknown as globalThis.Response,
+    push: (text: string) => controller?.enqueue(new TextEncoder().encode(text)),
+    closeUpstream: () => controller?.close(),
+  };
+}
+
+const OPTS = {
+  // `fetch` is stubbed, so the upstream URL is never dialed — it only satisfies
+  // the option contract.
+  upstream: new URL('http://127.0.0.1/unused'),
+  // A finite heartbeat that never fires inside the test window, yet is cleared
+  // by the proxy's finally block so it cannot keep the event loop alive.
+  heartbeatMs: 1_000_000,
+  unreachableMessage: 'unreachable',
+  noBodyMessage: 'no body',
+};
+
+/** Reject if the proxy promise has not settled within `ms` (regression guard). */
+function withDeadline(p: Promise<void>, ms: number): Promise<void> {
+  return Promise.race([
+    p,
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('proxySupervisorSse never resolved (parked await leaked)')), ms),
+    ),
+  ]);
+}
+
+const settle = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe('proxySupervisorSse drain-vs-close race', () => {
+  let restoreFetch: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+  });
+
+  function stubFetch(upstream: globalThis.Response): void {
+    const real = globalThis.fetch;
+    globalThis.fetch = (async () => upstream) as typeof fetch;
+    restoreFetch = () => {
+      globalThis.fetch = real;
+    };
+  }
+
+  test('a client disconnect during a backpressured write releases the parked await', async () => {
+    const req = fakeReq();
+    const res = fakeRes();
+    const { upstream, push } = makeUpstream();
+    stubFetch(upstream);
+
+    const done = proxySupervisorSse(
+      req as unknown as Request,
+      res as unknown as Response,
+      OPTS,
+    );
+
+    // First chunk: the client refuses further writes, so the proxy parks on the
+    // drain/close Promise.
+    res.acceptWrites = false;
+    push('event: event\ndata: {"type":"a"}\n\n');
+    await settle();
+    assert.equal(res.writes.length, 1, 'the backpressured chunk should have been written once');
+    assert.equal(res.writableEnded, false, 'proxy should still be parked, not ended');
+
+    // The client disconnects mid-write. Only the 'close' listener can resolve
+    // the parked await; the matching req 'close' aborts the upstream.
+    res.destroyed = true;
+    res.emit('close');
+    req.emit('close');
+
+    await withDeadline(done, 2_000);
+    assert.equal(res.writableEnded, true, 'proxy finally block ended the client stream');
+  });
+
+  test('a drain event releases the parked await and writing resumes', async () => {
+    const req = fakeReq();
+    const res = fakeRes();
+    const { upstream, push, closeUpstream } = makeUpstream();
+    stubFetch(upstream);
+
+    const done = proxySupervisorSse(
+      req as unknown as Request,
+      res as unknown as Response,
+      OPTS,
+    );
+
+    res.acceptWrites = false;
+    push('event: event\ndata: {"type":"a"}\n\n');
+    await settle();
+    assert.equal(res.writes.length, 1);
+
+    // The client catches up: 'drain' releases the await and the loop reads
+    // again. A second chunk lands now that writes are accepted.
+    res.acceptWrites = true;
+    res.emit('drain');
+    await settle();
+    push('event: event\ndata: {"type":"b"}\n\n');
+    await settle();
+    assert.equal(res.writes.length, 2, 'writing resumed after drain');
+
+    // Upstream ends the stream normally; the proxy's read loop sees `done` and
+    // runs its finally block.
+    closeUpstream();
+    await withDeadline(done, 2_000);
+    assert.equal(res.writableEnded, true);
+  });
+});

--- a/frontend/src/hooks/useGcEvents.test.tsx
+++ b/frontend/src/hooks/useGcEvents.test.tsx
@@ -121,6 +121,147 @@ describe("useGcEventRefresh", () => {
     expect(result.current).toBe("closed");
     expect(eventSources).toHaveLength(0);
   });
+
+  describe("reconnect backoff", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it("reconnects after an exponentially growing, 30s-capped delay", () => {
+      const { result } = renderHook(() =>
+        useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()),
+      );
+      expect(eventSources).toHaveLength(1);
+
+      // First error schedules a reconnect using the initial 1s delay.
+      act(() => eventSources[0]?.error());
+      expect(result.current).toBe("closed");
+      expect(eventSources).toHaveLength(1);
+
+      // Just before the 1s delay elapses, no reconnect has happened.
+      act(() => { vi.advanceTimersByTime(999); });
+      expect(eventSources).toHaveLength(1);
+      act(() => { vi.advanceTimersByTime(1); });
+      expect(eventSources).toHaveLength(2);
+
+      // The delay doubled to 2s for the next reconnect.
+      act(() => eventSources[1]?.error());
+      act(() => { vi.advanceTimersByTime(1_999); });
+      expect(eventSources).toHaveLength(2);
+      act(() => { vi.advanceTimersByTime(1); });
+      expect(eventSources).toHaveLength(3);
+
+      // Drive past the cap: each subsequent retry doubles (4s, 8s, 16s) and
+      // then clamps at 30s no matter how many failures accrue.
+      const driveOneRetry = (delayMs: number) => {
+        const idx = eventSources.length - 1;
+        act(() => eventSources[idx]?.error());
+        act(() => { vi.advanceTimersByTime(delayMs - 1); });
+        expect(eventSources).toHaveLength(idx + 1);
+        act(() => { vi.advanceTimersByTime(1); });
+        expect(eventSources).toHaveLength(idx + 2);
+      };
+      driveOneRetry(4_000);
+      driveOneRetry(8_000);
+      driveOneRetry(16_000);
+      driveOneRetry(30_000);
+      // Already at the cap; the next delay stays clamped at 30s, not 60s.
+      driveOneRetry(30_000);
+    });
+
+    it("resets the backoff delay to 1s once a reconnect opens", () => {
+      renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()));
+
+      // Two failures grow the delay to 4s for the third attempt.
+      act(() => eventSources[0]?.error());
+      act(() => { vi.advanceTimersByTime(1_000); });
+      act(() => eventSources[1]?.error());
+      act(() => { vi.advanceTimersByTime(2_000); });
+      expect(eventSources).toHaveLength(3);
+
+      // A successful open resets the backoff window.
+      act(() => eventSources[2]?.open());
+      act(() => eventSources[2]?.error());
+      // The delay is back to the initial 1s, not the grown 8s.
+      act(() => { vi.advanceTimersByTime(999); });
+      expect(eventSources).toHaveLength(3);
+      act(() => { vi.advanceTimersByTime(1); });
+      expect(eventSources).toHaveLength(4);
+    });
+
+    it("cancels a pending reconnect timer on unmount", () => {
+      const { unmount } = renderHook(() =>
+        useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()),
+      );
+      act(() => eventSources[0]?.error());
+      unmount();
+      act(() => { vi.advanceTimersByTime(60_000); });
+      // No reconnect after teardown.
+      expect(eventSources).toHaveLength(1);
+    });
+  });
+
+  describe("coalesce throttle window", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it("fires immediately for the first match, then coalesces a burst into one trailing fire", () => {
+      const onMatch = vi.fn();
+      renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], onMatch));
+      act(() => eventSources[0]?.open());
+
+      const emit = () =>
+        act(() =>
+          eventSources[0]?.emitNamed(
+            "event",
+            JSON.stringify({ type: "bead.updated" }),
+          ),
+        );
+
+      // Leading edge: the first matching event fires onMatch right away.
+      emit();
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // A burst inside the 2.5s window does not fire again immediately;
+      // it schedules a single trailing fire at the window edge.
+      emit();
+      emit();
+      emit();
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // Before the window closes, still just the leading fire.
+      act(() => { vi.advanceTimersByTime(2_499); });
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // At the window edge the single trailing fire lands: burst -> 2 total.
+      act(() => { vi.advanceTimersByTime(1); });
+      expect(onMatch).toHaveBeenCalledTimes(2);
+    });
+
+    it("fires immediately again once the window has elapsed", () => {
+      const onMatch = vi.fn();
+      renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], onMatch));
+      act(() => eventSources[0]?.open());
+
+      const emit = () =>
+        act(() =>
+          eventSources[0]?.emitNamed(
+            "event",
+            JSON.stringify({ type: "bead.updated" }),
+          ),
+        );
+
+      emit();
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // After the full window elapses with no events, the next match is
+      // outside the window and fires on its own leading edge.
+      act(() => { vi.advanceTimersByTime(2_500); });
+      emit();
+      expect(onMatch).toHaveBeenCalledTimes(2);
+    });
+  });
 });
 
 class FakeEventSource {
@@ -155,6 +296,10 @@ class FakeEventSource {
   open(): void {
     this.readyState = FakeEventSource.OPEN;
     this.onopen?.(new Event("open"));
+  }
+
+  error(): void {
+    this.onerror?.(new Event("error"));
   }
 
   emitNamed(type: string, data: string): void {


### PR DESCRIPTION
Bundles three independent beads from a parallel `/focus` wave, each reviewed in a unified Phase-4 pass (code + security + typescript reviewers, **0 CRITICAL/HIGH**). Based on clean `main`, independent of #8.

## gascity-dashboard-6taa (P2) — SSE/event test-debt `01cdcf1`
Adds unit coverage for previously-untested concurrency/error paths:
- `sse-proxy` drain-vs-close backpressure race (mid-write client disconnect releases the parked await) — discriminating: fails if the `close` listener is removed.
- `session-stream` pre-open 502 (unreachable / non-200 upstream) vs post-open mid-stream error frame.
- `useGcEvents` reconnect backoff (1s→2s→…→30s cap), `onopen` reset, unmount cancel, and COALESCE throttle window.
- (path 4 `isValidRunCwd` traversal was already fully covered — noted, not duplicated.)
Test-only; no source change.

## gascity-dashboard-z9sj (P2) — maintainer logic test-debt `269126a`
86 unit tests for the high-risk untested logic: classifier `classifyTier` / `computeTriageScore` band boundaries / `isMarkCandidate` truth table; contributor `deriveTier` ordering (spam_risk before the regular fallback) + `tally` aggregation; triage mappers `extractLinkedIssueNumbers` / `derivePrStatus` / `mapPr`. Source change is visibility-only (`@internal`-tagged exports in `contributor.ts`); no behavior change.

## gascity-dashboard-vibg (P3) — OSC_RE alignment `6447993`
`strip-non-printable.ts` `OSC_RE` now matches the ST-terminated (`ESC\`) OSC form, **exactly aligned with `exec.ts`**, closing a defense-in-depth gap. Adds tests for BEL/ST OSC, the unterminated-OSC/CSI boundary, and all 12 CVE-2021-42574 bidi codepoints; hardens `beads-nudge.test.ts` to all 12. Security review confirmed correct, ReDoS-clear, strips *more* not less. A pre-existing C1 single-byte ST (`0x9c`) gap was filed as a separate P4 follow-up (not a regression).

## Review fixes `e682849`
`@internal` tags on the test-only exports, honest `FakeRes` signatures, removed a self-referential test, clarified a test name, narrowed `unknown[]`→`object[]`.

## Test plan
- [x] `npm run typecheck` clean (source + test)
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npm --workspace backend test` — 950/950
- [x] `npm --workspace frontend test` — 499/499

Closes gascity-dashboard-6taa, gascity-dashboard-z9sj, gascity-dashboard-vibg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)