### PR TITLE
feat(tui): terminal dashboard with live tmux peek

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "shared",
         "backend",
-        "frontend"
+        "frontend",
+        "tui"
       ],
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -71,6 +72,31 @@
         "typescript": "^5.6.3",
         "vite": "^5.4.10",
         "vitest": "^2.1.5"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -527,7 +553,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -545,7 +570,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -563,7 +587,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -581,7 +604,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -599,7 +621,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -617,7 +638,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -635,7 +655,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -653,7 +672,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -671,7 +689,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -689,7 +706,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -707,7 +723,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -725,7 +740,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -743,7 +757,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -761,7 +774,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -779,7 +791,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -797,7 +808,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -815,7 +825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -833,7 +842,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -851,7 +859,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -869,7 +876,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -887,7 +893,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -905,7 +910,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -923,7 +927,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -941,7 +944,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -959,7 +961,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,7 +978,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2018,7 +2018,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2039,7 +2039,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2587,6 +2587,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2864,6 +2879,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -3330,6 +3357,89 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3423,6 +3533,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -3490,7 +3609,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3811,6 +3930,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -3831,6 +3956,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -4013,6 +4150,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -4790,6 +4937,10 @@
       "resolved": "shared",
       "link": true
     },
+    "node_modules/gas-city-dashboard-tui": {
+      "resolved": "tui",
+      "link": true
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -4808,6 +4959,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5166,11 +5329,95 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5385,6 +5632,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -5416,6 +5675,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-in-ssh": {
@@ -6060,6 +6334,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6332,6 +6615,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
@@ -6453,6 +6751,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -6976,6 +7283,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7139,6 +7462,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -7575,6 +7914,55 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7583,6 +7971,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stackback": {
@@ -7620,6 +8029,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -7718,6 +8144,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -8087,6 +8540,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -9101,6 +9566,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9111,11 +9591,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9186,6 +9694,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -9213,6 +9727,24 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "typescript": "^5.6.3"
+      }
+    },
+    "tui": {
+      "name": "gas-city-dashboard-tui",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "gas-city-dashboard-shared": "*",
+        "ink": "^5.0.1",
+        "react": "^18.3.1"
+      },
+      "bin": {
+        "gc-tui": "src/index.tsx"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "tsx": "^4.19.2",
         "typescript": "^5.6.3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "workspaces": [
     "shared",
     "backend",
-    "frontend"
+    "frontend",
+    "tui"
   ],
   "scripts": {
     "build:shared": "npm --workspace shared run build",

--- a/shared/src/context-window.ts
+++ b/shared/src/context-window.ts
@@ -6,6 +6,7 @@ import type { GcSession } from './gc-client-types.js';
  */
 export const TRUE_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
   'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-8': 1_000_000,
   'claude-sonnet-4-5': 1_000_000,
   'claude-sonnet-4-6': 1_000_000,
 };

--- a/specs/architecture/awaiting-decision-signal-feasibility.md
+++ b/specs/architecture/awaiting-decision-signal-feasibility.md
@@ -1,0 +1,31 @@
+# Spike finding: "agent awaiting human decision" signal
+
+Exit artifact for the awaiting-decision feasibility spike in `prd_incorporate-tmai-amux-components.md`. Verified against committed repo artifacts on 2026-06-01.
+
+## Verdict
+
+**EXISTS in the supervisor API — as BOTH a REST snapshot field AND an SSE event — but the dashboard does NOT consume it.** The signal is the supervisor's **`PendingInteraction`** (tool-approval / prompt-for-input). It is dashboard-local work to surface it; **no upstream change is required for the per-session case.**
+
+## Evidence (all in `backend/openapi/gc-supervisor.openapi.json` unless noted)
+
+- **Wire shape** — `PendingInteraction` (:4607): `{ request_id (req), kind (req), prompt?, options?: string[]|null, metadata? }`.
+- **REST snapshot** — `GET /v0/city/{cityName}/session/{id}/pending` (:23301) → `SessionPendingResponse` (:6016): `{ supported: bool, pending?: PendingInteraction }`.
+- **Write-back** — `POST /v0/city/{cityName}/session/{id}/respond` (:23574) ← `SessionRespondInputBody`: `{ action (req), request_id?, text?, metadata? }`. This is the real target for the decision-gate's accept/decline POST.
+- **SSE event** — the per-session stream `GET .../session/{id}/stream` (:23730) emits a `{ event: "pending", data: PendingInteraction }` variant (:23856).
+- **Not a session state** — `SessionResponse.state` is a free-form string with no enum (:6197); session activity is only `idle`/`in-turn`. Awaiting-decision is a separate `pending` channel, not a state value.
+- **Not on the city-wide stream** — `TypedEventStreamEnvelope` (:7298) lists ~50 city event types (`bead.*`, `session.crashed/idle_killed/...`); none is `pending`/`awaiting`/`decision`.
+
+## Why the dashboard doesn't see it today
+
+- The live-refresh hook subscribes only to `bead.` and `session.` prefixes (`shared/src/operator.ts` `GC_EVENT_PREFIX`) on the **city** stream (`/api/events/stream`, proxied verbatim by `backend/src/routes/events.ts`) — which does not carry `pending`. And `useGcEventRefresh` is refresh-only (reads `event.type`, refetches), not payload-carrying.
+- The **per-session** stream that *does* carry `pending` is proxied verbatim (`backend/src/routes/session-stream.ts`), so frames reach the browser — but the sole consumer `frontend/src/hooks/useSessionStream.ts` recognizes only `turn`/`snapshot` (`parseStreamPayload`, useSessionStream.ts:158–177); a `pending` frame falls through to `{ kind: 'invalid' }` and degrades the stream.
+- The `blocked` values in `shared/src/gc-beads.ts` (BeadStatus) and `shared/src/run-detail.ts` (RunNodeStatus) are **work-graph** blocked (dependency), unrelated to awaiting-human-input.
+
+## Path to surface it
+
+1. **Dashboard-owned, no upstream issue (basic case):** extend `useSessionStream`/`parseStreamPayload` to handle the `pending` variant (not `invalid`), and/or poll `GET .../session/{id}/pending`; render an editorial "awaiting decision" affordance; wire accept/decline to `POST .../respond`. The write-action constraint in the PRD maps directly: read `pending` over SSE → `POST .../respond` (carry `request_id`) → re-render from the next pushed resolution. The existing `request_id` is the idempotency key.
+2. **Optional upstream `gc` ask (city-wide case only):** to flag *which* agents across the city are blocked on a human without opening one SSE per session, the supervisor would need to emit a city-stream event (e.g. `session.pending` carrying `{session_id, request_id, kind}`) in `TypedEventStreamEnvelope`. That — and only that — is a legitimate `gastownhall/gascity` request.
+
+## RFC-target adjudication (corrects the premortem)
+
+The premortem's "RFC drafts target demo-dash" claim is **TRUE** for all four `.claude/rfc-drafts/` files (each is `gh issue create --repo gastownhall/demo-dash`). But its implication that those RFCs cover the decision signal is **FALSE** — they concern aimux **vendor quota** (rfc-1), tokscale **token windows** (rfc-2), and two dashboard-alignment discussions (rfc-3, rfc-4). **None addresses awaiting-human-decision.** This signal needs no demo-dash change and (per above) no `gc` change for the per-session case.

--- a/specs/architecture/cost-token-feasibility.md
+++ b/specs/architecture/cost-token-feasibility.md
@@ -1,0 +1,34 @@
+# Spike finding: per-run / per-session token & cost data
+
+Exit artifact for the cost/token feasibility spike in `prd_incorporate-tmai-amux-components.md`. Verified against committed repo artifacts on 2026-06-01.
+
+## Verdict
+
+**PARTIAL — the contract EXISTS, the data does not flow yet.** The committed supervisor OpenAPI snapshot defines five cost/token fields on `WorkerOperationEventPayload` (a `worker.operation` SSE event payload), every one documented "best-effort, currently always absent." Transport is over `GcClient` HTTP (the supervisor event stream) — **not** a `tokscale` subprocess. The dashboard does not decode these fields today (the event payload is decoded as an opaque record).
+
+## Evidence
+
+- `backend/openapi/gc-supervisor.openapi.json:12835–12893` — `cache_creation_tokens`, `cache_read_tokens`, `completion_tokens` (`int64`), `cost_usd_estimate` (`double`), `prompt_tokens` (`int64`), all "currently always absent." `cost_usd_estimate` references upstream **#1255** (pricing seam); `prompt_sha`/`prompt_version` reference **#1256**.
+- No `spend`/`price`/`dollars`/`cents` keys anywhere in the spec.
+- Generated (backend-only) client carries them: `backend/src/generated/gc-supervisor-client/zod.gen.ts` (`zWorkerOperationEventPayload`) and `types.gen.ts` (`cost_usd_estimate?: number`, token fields).
+- The dashboard's hand-written edge decodes the event payload as opaque `UnknownRecordSchema` (`backend/src/gc-supervisor-decoders.ts:282`); grep for the cost/token field names across `shared/src`, `backend/src`, `frontend/src` returns nothing translated.
+- Transport is `GcClient` HTTP: `backend/src/gc-client.ts` `listEvents`/events-stream paths (`/v0/city/.../events`, `.../events/stream`).
+
+## Wire-shape determination (corrects the PRD's a-priori worry)
+
+Cost lands as a **NUMBER**, not a wire string. `cost_usd_estimate` is `type: number`/`format: double`; tokens are `int64` integers. The wire-string precedent the PRD cited (`duration_ms`/`exit_code`/`signal` as `z.string()`) is confined to a **different** schema — `OrderHistoryEntry` (`backend/src/gc-supervisor-decoders.ts:433–451`) — and does not govern `WorkerOperationEventPayload`. **Do not string-coerce cost.**
+
+## `tokscale` claim adjudication
+
+**TRUE for the competing `demo-dash` repo, FALSE/irrelevant for this dashboard.** `tokscale` / `/data/projects` appear only in `.claude/rfc-drafts/rfc-2-tokens-endpoint.md` and `rfc-4` prose (describing demo-dash's `src/server/collectors/tokens.ts`), never in `backend/`, `frontend/`, or `shared/`. This dashboard's path to cost is the supervisor's HTTP SSE event, so the PRD's "absent if the only source is the subprocess" exit condition is **not triggered**.
+
+## Recommended decoder approach (when fields are populated)
+
+1. Narrow `worker.operation` events to a typed payload schema (discriminate on `type`) instead of widening the opaque record.
+2. Decode as **optional, non-fatal, number-typed**: `cost_usd_estimate: z.number().finite().optional()`, tokens `z.number().int().nonnegative().optional()`. Never a required field that throws and takes down the whole snapshot.
+3. Honor the "zero ≠ free" warning (openapi:12888): surface absent/`undefined` as "not measured," distinct from `0` — do not coalesce `undefined → 0`.
+4. Translate to a dashboard-owned `shared` DTO before it reaches the frontend.
+
+## Upstream ask (if wanted sooner)
+
+Against the supervisor (`gastownhall/gascity`, which owns `gc-supervisor.openapi.json`): **populate the existing `WorkerOperationEventPayload` cost/token fields** (refs #1255 pricing seam, #1256 prompt_sha/version). No new field or namespace needed — activation of an existing contract that already flows over `GcClient` HTTP. Do **not** conflate this with rfc-2's separate `GET .../tokens` (tokscale rolling-window) proposal targeted at demo-dash.

--- a/tui/README.md
+++ b/tui/README.md
@@ -18,30 +18,43 @@ split instead of alt-tabbing to the SSH-forwarded browser tab.
   defence, and break the 127.0.0.1-only posture. Session content reaches the
   operator through the backend, not by attaching to panes.
 
-## Views
+## Views (full-screen toggles)
 
-- **List** (default): agents grouped `failed → active → idle`, one line each as
-  `rig · agent · ctx% · activity · model · last-active`. Greyscale-first, with a
-  single red mark for the things worth a glance (failed agents, runs needing an
-  operator), honouring DESIGN.md's behavioural rules (words before colour, one
-  mark of alarm) — its typographic rules are web-only.
-- **Peek** (`enter` or `p`): detail for the selected agent — ids, model/context,
-  the **peek commands** to run in another pane (`gc session peek <id>`,
-  `tmux attach -t <session_name>`, `tmux capture-pane …`), the active run lanes
-  (formulas) on its rig, and that rig's beads (best-effort, beads carry no
-  session field so the match is by id prefix).
-- **Health** (`h`): system resources (load / vcpu / memory), headline counts,
-  runs needing an operator, context-pressure agents (≥75%), and a
-  never-active-by-rig rollup — the "why are these idle agents here, could the
-  mayor reallocate them?" view. Costs are shown as *not measured* (the
-  supervisor exposes no per-run cost yet — see
-  `specs/architecture/cost-token-feasibility.md`); they are not faked.
+Each is a full-screen toggle over the same navigable area; the selection
+persists across the live refresh. `enter` drills the selected row into a single
+reused tmux split (see Peek).
+
+- **Agents** (default): grouped by rig (orchestration layer first; within a rig,
+  active before idle), one line each as `agent · ctx% · activity · model ·
+  last-active`. Dormant agents show their transition reason (e.g. `city-stop`).
+  Greyscale-first, one red mark for what's worth a glance.
+- **Beads** (`b`): grouped by status (open → in_progress → blocked → closed),
+  priority-ordered. `enter` opens `gc bd show <id>` in the split — the bead's
+  instructions/description/labels.
+- **Formula runs** (`f`): run lanes grouped by rig, needs-operator first (one red
+  mark). `enter` opens the run's bead (`gc bd show`) plus its code diff in the
+  split.
+- **Health** (`h`): host resources, headline counts, runs needing an operator,
+  context-pressure agents (≥75%), and a never-active-by-rig reallocation rollup.
+  Costs are shown as *not measured* (the supervisor exposes none yet — see
+  `specs/architecture/cost-token-feasibility.md`); never faked.
+- **Detail** (`p`, agents only): in-TUI detail for the selected agent — ids, the
+  peek commands, that rig's beads and active run lanes.
+
+## Peek (tmux split)
+
+`enter` on a row opens **one reused** tmux split beside the dashboard and points
+it at the selected row's drill-in (agent → live `session logs -f`; bead →
+`bd show`; run → `bd show` + diff). `enter` retargets that pane to a new
+selection (no pile-up); `enter` on the row it's already showing, or `x`, closes
+it. Quitting (`q`) tears the peek pane down. All drill-ins READ (logs/show/diff)
+— none attaches as a tmux client, so peeking can't resize or disturb an agent.
 
 ## Controls
 
 `↑`/`↓` or `j`/`k` move the selection · **mouse wheel** scrolls · `PageUp`/`PageDown`
-· `g`/`G` top/bottom · `enter`/`p` toggle peek · `h` toggle health · `q` (or
-`esc`) quit. The selection persists across the live refresh so peeking stays put.
+· `g`/`G` top/bottom · `enter` drill into split · `x` close split · `b` beads ·
+`f` runs · `h` health · `p` agent detail · `q` (or `esc`) quit.
 
 ## Run
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,74 @@
+# gas-city-dashboard-tui (prototype)
+
+A terminal glance surface for the Gas City dashboard — the smallest viable
+prototype to prove or kill the idea of a TUI an operator leaves open in a tmux
+split instead of alt-tabbing to the SSH-forwarded browser tab.
+
+## What it is (and is not)
+
+- **Thin client of the backend `/api/*`.** It reuses the `shared` DTOs directly
+  (`gas-city-dashboard-shared`), so a contract drift is a compile error here,
+  not a runtime `undefined`. It talks only to the backend — never to the gc
+  supervisor — so it inherits edge translation, sanitisation, timeouts, CSRF and
+  audit for free (`backend/src/gc-client.ts` is the only supervisor seam).
+- **Read-only.** No writes (claim/close/sling/respond) — those need the CSRF
+  double-submit the web client does; out of scope for the prototype.
+- **No tmux pane-attach.** Deliberately rejected: raw `capture-pane` bytes would
+  bypass the server-side ANSI/OSC sanitisation that is the load-bearing XSS
+  defence, and break the 127.0.0.1-only posture. Session content reaches the
+  operator through the backend, not by attaching to panes.
+
+## Views
+
+- **List** (default): agents grouped `failed → active → idle`, one line each as
+  `rig · agent · ctx% · activity · model · last-active`. Greyscale-first, with a
+  single red mark for the things worth a glance (failed agents, runs needing an
+  operator), honouring DESIGN.md's behavioural rules (words before colour, one
+  mark of alarm) — its typographic rules are web-only.
+- **Peek** (`enter` or `p`): detail for the selected agent — ids, model/context,
+  the **peek commands** to run in another pane (`gc session peek <id>`,
+  `tmux attach -t <session_name>`, `tmux capture-pane …`), the active run lanes
+  (formulas) on its rig, and that rig's beads (best-effort, beads carry no
+  session field so the match is by id prefix).
+- **Health** (`h`): system resources (load / vcpu / memory), headline counts,
+  runs needing an operator, context-pressure agents (≥75%), and a
+  never-active-by-rig rollup — the "why are these idle agents here, could the
+  mayor reallocate them?" view. Costs are shown as *not measured* (the
+  supervisor exposes no per-run cost yet — see
+  `specs/architecture/cost-token-feasibility.md`); they are not faked.
+
+## Controls
+
+`↑`/`↓` or `j`/`k` move the selection · **mouse wheel** scrolls · `PageUp`/`PageDown`
+· `g`/`G` top/bottom · `enter`/`p` toggle peek · `h` toggle health · `q` (or
+`esc`) quit. The selection persists across the live refresh so peeking stays put.
+
+## Run
+
+The backend must be running (`npm run dev:backend`) against a live supervisor.
+
+```bash
+# from repo root, after `npm install`
+set -a; . ./.env.local; set +a   # defines GC_CITY_NAME
+npm --workspace tui run start     # or: npm --workspace tui run start -- --city=<name>
+```
+
+### Launch inside tmux (so `enter`-peek works)
+
+The live-peek split (`enter`) needs the TUI to be running inside tmux. If you're
+already in a tmux session, the command above is enough. From a plain terminal,
+use the launcher, which creates/attaches a dedicated `gc-tui` session:
+
+```bash
+npm --workspace tui run start:tmux -- <city>     # or ./tui/start-tmux.sh <city>
+```
+
+Env: `DASHBOARD_URL` (default `http://127.0.0.1:8081`), `GC_CITY_NAME` or
+`--city=<name>` (required — no silent fallback to a default city). Press `q` to
+quit.
+
+## Status
+
+Prototype, not yet wired into root CI `typecheck`. If it graduates, add
+`npm --workspace tui run typecheck` to the root `typecheck:src` chain so
+shared-DTO changes can't silently break this third consumer.

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "gas-city-dashboard-tui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Prototype terminal glance surface for the Gas City dashboard — a thin client of the backend /api/* (reuses shared DTOs, no supervisor coupling).",
+  "bin": {
+    "gc-tui": "src/index.tsx"
+  },
+  "scripts": {
+    "start": "tsx src/index.tsx",
+    "start:tmux": "bash ./start-tmux.sh",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "gas-city-dashboard-shared": "*",
+    "ink": "^5.0.1",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  },
+  "license": "MIT"
+}

--- a/tui/peek-agent.sh
+++ b/tui/peek-agent.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Live agent peek for the TUI. Follows the conversation transcript when one
+# exists (Claude agents); otherwise watches live pane snapshots — which works
+# for non-transcript sessions like control-dispatchers, where `session logs`
+# fails with "no exact transcript found ... workdir fallback is ambiguous".
+#   peek-agent.sh <cityRoot> <id>
+set -uo pipefail
+root="${1:?cityRoot}"; id="${2:?id}"
+
+if gc --city "$root" session logs "$id" --tail 1 >/dev/null 2>&1; then
+  gc --city "$root" session logs "$id" -f
+else
+  # No conversation transcript (e.g. a control-dispatcher). Show live pane
+  # snapshots instead; the header is reprinted each refresh so the pane never
+  # looks frozen, even when a controller process has no visible output.
+  while true; do
+    printf '\033[H\033[2J'
+    echo "live pane of $id — no transcript (controller?); refreshing every 2s, Ctrl-C to stop"
+    echo
+    out="$(gc --city "$root" session peek "$id" --lines 200 2>&1)" || break
+    if [ -n "$out" ]; then echo "$out"; else echo "(no visible pane output)"; fi
+    sleep 2
+  done
+fi
+exec "$SHELL"

--- a/tui/peek-run.sh
+++ b/tui/peek-run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Drill into a formula run for the TUI peek pane: show the run's bead (formula,
+# status, owner, description), then its code diff. Read-only.
+#   peek-run.sh <cityRoot> <city> <baseUrl> <runId>
+set -uo pipefail
+root="${1:?cityRoot}"; city="${2:?city}"; base="${3:?baseUrl}"; rid="${4:?runId}"
+
+printf '\033[1m== run %s ==\033[0m\n' "$rid"
+gc --city "$root" bd show "$rid" 2>&1 || echo "(bd show failed)"
+
+printf '\n\033[1m== diff ==\033[0m\n'
+curl -s "$base/api/city/$city/runs/$rid/diff" 2>/dev/null \
+  | python3 -c 'import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("(diff unavailable)"); raise SystemExit
+print(d.get("patch") or d.get("error") or "(no changes)")' 2>/dev/null \
+  || echo "(diff unavailable)"
+
+echo
+exec "$SHELL"

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -2,36 +2,123 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Text, useApp, useInput, useStdout } from 'ink';
 import { useCity } from './useCity.ts';
 import { useMouseWheel } from './useMouseWheel.ts';
-import { AgentRow, DetailPane, HealthPane } from './panes.tsx';
-import { closePeek, insideTmux, openPeek, paneExists, replacePeek } from './peek.ts';
+import { AgentRow, BeadRow, DetailPane, HealthPane, RunRow } from './panes.tsx';
+import {
+  buildCommand,
+  closePeek,
+  openPeek,
+  paneExists,
+  replacePeek,
+  type PeekKind,
+} from './peek.ts';
 import {
   beadsForRig,
   categorize,
   contextPressure,
+  groupBeads,
   groupByRig,
+  groupRuns,
   lanesForRig,
+  laneNeedsOperator,
   neverActiveByRig,
   systemHealth,
   type AgentView,
   type Category,
-  type RigGroup,
 } from './derive.ts';
+import type { GcBead, GcSession, RunLane } from './api.ts';
 
 interface AppProps {
   readonly baseUrl: string;
   readonly city: string;
 }
 
+type ViewMode = 'list' | 'beads' | 'runs' | 'detail' | 'health';
+
+type Entry =
+  | { readonly kind: 'agent'; readonly id: string; readonly agent: AgentView }
+  | { readonly kind: 'bead'; readonly id: string; readonly bead: GcBead }
+  | { readonly kind: 'run'; readonly id: string; readonly lane: RunLane };
+
+interface GroupInfo {
+  readonly label: string;
+  readonly sub: string;
+  readonly alert: boolean;
+}
+
 type Row =
-  | { readonly kind: 'heading'; readonly group: RigGroup }
+  | { readonly kind: 'heading'; readonly group: GroupInfo }
   | {
-      readonly kind: 'agent';
-      readonly view: AgentView;
-      readonly agentIndex: number;
-      readonly group: RigGroup;
+      readonly kind: 'entry';
+      readonly entry: Entry;
+      readonly index: number;
+      readonly dim: boolean;
+      readonly group: GroupInfo;
     };
 
-type ViewMode = 'list' | 'detail' | 'health';
+interface Nav {
+  readonly entries: readonly Entry[];
+  readonly renderRows: readonly Row[];
+}
+
+const EMPTY_NAV: Nav = { entries: [], renderRows: [] };
+
+function buildNav(
+  view: ViewMode,
+  sessions: readonly GcSession[],
+  beads: readonly GcBead[],
+  lanes: readonly RunLane[],
+): Nav {
+  const entries: Entry[] = [];
+  const renderRows: Row[] = [];
+  const push = (entry: Entry, dim: boolean, group: GroupInfo): void => {
+    renderRows.push({ kind: 'entry', entry, index: entries.length, dim, group });
+    entries.push(entry);
+  };
+
+  if (view === 'beads') {
+    for (const g of groupBeads(beads)) {
+      const group: GroupInfo = { label: g.status, sub: `${g.beads.length}`, alert: false };
+      renderRows.push({ kind: 'heading', group });
+      const dim = g.status === 'closed' || g.status === 'deferred';
+      for (const b of g.beads) push({ kind: 'bead', id: b.id, bead: b }, dim, group);
+    }
+    return { entries, renderRows };
+  }
+
+  if (view === 'runs') {
+    for (const g of groupRuns(lanes)) {
+      const needs = g.lanes.filter(laneNeedsOperator).length;
+      const group: GroupInfo = {
+        label: g.rig,
+        sub: needs > 0 ? `${g.lanes.length} · ${needs} need operator` : `${g.lanes.length}`,
+        alert: needs > 0,
+      };
+      renderRows.push({ kind: 'heading', group });
+      for (const l of g.lanes) push({ kind: 'run', id: l.id, lane: l }, false, group);
+    }
+    return { entries, renderRows };
+  }
+
+  // list (and detail, which navigates the same agent list underneath)
+  for (const g of groupByRig(sessions)) {
+    const group: GroupInfo = {
+      label: g.rig,
+      sub: `${g.failed > 0 ? `${g.failed} failed · ` : ''}${g.active} active · ${g.idle} idle`,
+      alert: g.failed > 0,
+    };
+    renderRows.push({ kind: 'heading', group });
+    for (const v of g.agents) {
+      push({ kind: 'agent', id: v.session.id, agent: v }, v.category === 'idle', group);
+    }
+  }
+  return { entries, renderRows };
+}
+
+function entryLabel(e: Entry): string {
+  if (e.kind === 'agent') return e.agent.agent;
+  if (e.kind === 'bead') return e.bead.id;
+  return e.lane.title;
+}
 
 function useTerminalRows(): number {
   const { stdout } = useStdout();
@@ -55,73 +142,97 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
   const [cursorId, setCursorId] = useState<string | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [status, setStatus] = useState<string | null>(null);
-  // A single reused peek pane: its tmux id, and which agent it's showing.
+  // A single reused peek pane: its tmux id, and "<kind>:<id>" it's showing.
   const [peekPaneId, setPeekPaneId] = useState<string | null>(null);
-  const [peekAgentId, setPeekAgentId] = useState<string | null>(null);
+  const [peekTarget, setPeekTarget] = useState<string | null>(null);
   const now = Date.now();
 
-  // Grouped by rig; within a rig, active before idle (groupByRig owns the sort).
-  const { agents, renderRows } = useMemo(() => {
-    const groups = groupByRig(sessions);
-    const agentList: AgentView[] = [];
-    const rowList: Row[] = [];
-    for (const g of groups) {
-      rowList.push({ kind: 'heading', group: g });
-      for (const view of g.agents) {
-        rowList.push({ kind: 'agent', view, agentIndex: agentList.length, group: g });
-        agentList.push(view);
-      }
-    }
-    return { agents: agentList, renderRows: rowList };
-  }, [sessions]);
-
-  const cursorIndex = Math.max(
-    0,
-    agents.findIndex((a) => a.session.id === cursorId),
+  const health = useMemo(() => systemHealth(snapshot), [snapshot]);
+  // detail navigates the same agent list as 'list' underneath.
+  const navView: ViewMode = view === 'detail' ? 'list' : view;
+  const { entries, renderRows } = useMemo(
+    () => (navView === 'health' ? EMPTY_NAV : buildNav(navView, sessions, beads, health.lanes)),
+    [navView, sessions, beads, health.lanes],
   );
-  const selected: AgentView | undefined = agents[cursorIndex];
 
-  // Keep cursor pointed at a real agent as the list churns.
+  const cursorIndex = Math.max(0, entries.findIndex((e) => e.id === cursorId));
+  const selected: Entry | undefined = entries[cursorIndex];
+  const selectedAgent: AgentView | undefined =
+    selected && selected.kind === 'agent' ? selected.agent : undefined;
+
+  // Keep the cursor on a real entry as lists churn / views switch.
   useEffect(() => {
-    if (agents.length === 0) return;
-    const exists = cursorId !== null && agents.some((a) => a.session.id === cursorId);
-    if (!exists) setCursorId(agents[0]?.session.id ?? null);
-  }, [agents, cursorId]);
+    if (entries.length === 0) return;
+    if (cursorId === null || !entries.some((e) => e.id === cursorId)) {
+      setCursorId(entries[0]?.id ?? null);
+    }
+  }, [entries, cursorId]);
 
-  // Refs so the wheel callback stays stable (re-subscribing would re-emit the
-  // mouse-enable escape sequence on every render).
-  const agentsRef = useRef(agents);
-  agentsRef.current = agents;
+  // Refs so the wheel callback stays stable (re-subscribing re-emits the
+  // mouse-enable escape sequence every render).
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
   const cursorIndexRef = useRef(cursorIndex);
   cursorIndexRef.current = cursorIndex;
 
   const moveCursor = useCallback((delta: number) => {
-    const list = agentsRef.current;
+    const list = entriesRef.current;
     if (list.length === 0) return;
     const next = Math.min(Math.max(cursorIndexRef.current + delta, 0), list.length - 1);
-    setCursorId(list[next]?.session.id ?? null);
+    setCursorId(list[next]?.id ?? null);
   }, []);
 
   useMouseWheel(useCallback((dir: -1 | 1) => moveCursor(dir * 3), [moveCursor]));
 
-  // Tear down our peek pane on the way out so quitting doesn't leave an orphan
-  // shell pane behind in the tmux session.
+  const closeActivePeek = (): void => {
+    if (peekPaneId !== null && paneExists(peekPaneId)) closePeek(peekPaneId);
+    setPeekPaneId(null);
+    setPeekTarget(null);
+  };
+
   const quit = (): void => {
     if (peekPaneId !== null && paneExists(peekPaneId)) closePeek(peekPaneId);
     exit();
   };
 
-  // Every render row is exactly ONE line (no per-heading blank line), so the
-  // window's row count equals its line count. chrome = header + sticky line +
-  // footer (+ error line). Keeping this exact is what prevents the content
-  // from overflowing the screen and scrolling the top off.
+  const drill = (entry: Entry): void => {
+    const kind: PeekKind = entry.kind;
+    const built = buildCommand({
+      kind,
+      id: entry.id,
+      cityRoot: snapshot?.config.cityRoot ?? null,
+      city,
+      baseUrl,
+    });
+    if (typeof built !== 'string') {
+      setStatus(`peek: ${built.error}`);
+      return;
+    }
+    const target = `${kind}:${entry.id}`;
+    const live = peekPaneId !== null && paneExists(peekPaneId);
+    if (live && peekTarget === target) {
+      closeActivePeek();
+      setStatus('peek closed');
+      return;
+    }
+    const r = live ? replacePeek(peekPaneId, built) : openPeek(built);
+    if (r.ok) {
+      if (!live) setPeekPaneId(r.paneId ?? null);
+      setPeekTarget(target);
+      setStatus(`peeking ${entryLabel(entry)} →`);
+    } else {
+      setStatus(`peek: ${r.error}`);
+    }
+  };
+
+  // Exact one-line-per-row accounting prevents screen overflow. chrome =
+  // header + sticky line + footer (+ error line).
   const chrome = error ? 4 : 3;
   const viewport = Math.max(3, rows - chrome);
   const maxTop = Math.max(0, renderRows.length - viewport);
 
-  // Cursor's row index (heading rows shift it), used to keep it on screen.
   const cursorRowIndex = renderRows.findIndex(
-    (r) => r.kind === 'agent' && r.agentIndex === cursorIndex,
+    (r) => r.kind === 'entry' && r.index === cursorIndex,
   );
   useEffect(() => {
     if (cursorRowIndex < 0) return;
@@ -136,83 +247,72 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
   const visible = renderRows.slice(effectiveTop, effectiveTop + viewport);
   const above = effectiveTop;
   const below = Math.max(0, renderRows.length - (effectiveTop + viewport));
-  // When the window opens mid-rig (its heading scrolled off), show that rig as
-  // a dim sticky label so the top rows are never orphaned/untitled.
   const firstVisible = visible[0];
-  const stickyGroup: RigGroup | null =
-    firstVisible && firstVisible.kind === 'agent' ? firstVisible.group : null;
+  const stickyGroup: GroupInfo | null =
+    firstVisible && firstVisible.kind === 'entry' ? firstVisible.group : null;
+
+  const toggle = (target: ViewMode): void => {
+    setView((v) => (v === target ? 'list' : target));
+    setScrollTop(0);
+  };
 
   useInput(
     (input, key) => {
-      if (input === 'q') {
-        quit();
-        return;
-      }
-      if (key.escape) {
-        if (view === 'list') quit();
-        else setView('list');
-        return;
-      }
-      if (input === 'h') {
-        setView((v) => (v === 'health' ? 'list' : 'health'));
-        return;
-      }
-      if (key.return) {
-        // One reused peek pane: open it, retarget it to the selected agent, or
-        // (if it's already showing this agent) toggle it closed.
-        if (!selected) return;
-        if (!insideTmux()) {
-          setStatus('peek: not inside tmux — use `npm --workspace tui run start:tmux`');
-          return;
-        }
-        const root = snapshot?.config.cityRoot ?? null;
-        const live = peekPaneId !== null && paneExists(peekPaneId);
-        if (live && peekAgentId === selected.session.id) {
-          closePeek(peekPaneId);
-          setPeekPaneId(null);
-          setPeekAgentId(null);
-          setStatus('peek closed');
-        } else if (live) {
-          const r = replacePeek(peekPaneId, selected.session.id, root);
-          if (r.ok) setPeekAgentId(selected.session.id);
-          setStatus(r.ok ? `peeking ${selected.agent} →` : `peek: ${r.error}`);
-        } else {
-          const r = openPeek(selected.session.id, root);
-          if (r.ok) {
-            setPeekPaneId(r.paneId ?? null);
-            setPeekAgentId(selected.session.id);
-          }
-          setStatus(r.ok ? `peeking ${selected.agent} →` : `peek: ${r.error}`);
-        }
+      if (input === 'q') return quit();
+      if (key.escape) return view === 'list' ? quit() : (setView('list'), setScrollTop(0));
+      if (input === 'h') return toggle('health');
+      if (input === 'b') return toggle('beads');
+      if (input === 'f') return toggle('runs');
+      if (input === 'p') {
+        if (navView === 'list') setView((v) => (v === 'detail' ? 'list' : 'detail'));
         return;
       }
       if (input === 'x') {
-        // Close the peek pane.
-        if (peekPaneId !== null && paneExists(peekPaneId)) {
-          closePeek(peekPaneId);
-          setStatus('peek closed');
-        }
-        setPeekPaneId(null);
-        setPeekAgentId(null);
+        closeActivePeek();
+        setStatus('peek closed');
         return;
       }
-      if (input === 'p') {
-        setView((v) => (v === 'detail' ? 'list' : 'detail'));
+      if (key.return) {
+        if (selected) drill(selected);
         return;
       }
       if (key.downArrow || input === 'j') moveCursor(1);
       else if (key.upArrow || input === 'k') moveCursor(-1);
       else if (key.pageDown) moveCursor(viewport);
       else if (key.pageUp) moveCursor(-viewport);
-      else if (input === 'g') moveCursor(-agents.length);
-      else if (input === 'G') moveCursor(agents.length);
+      else if (input === 'g') moveCursor(-entries.length);
+      else if (input === 'G') moveCursor(entries.length);
     },
     { isActive: Boolean(process.stdin.isTTY) },
   );
 
   const counts: Record<Category, number> = { failed: 0, active: 0, idle: 0 };
   for (const s of sessions) counts[categorize(s)] += 1;
-  const health = systemHealth(snapshot);
+  const openBeads = beads.filter((b) => b.status === 'open').length;
+  const needsOpRuns = health.lanes.filter(laneNeedsOperator).length;
+
+  const summary =
+    view === 'beads' ? (
+      <Text dimColor>
+        beads · {openBeads} open · {beads.length} total
+      </Text>
+    ) : view === 'runs' ? (
+      <Text dimColor>
+        runs · {health.lanes.length} active
+        {needsOpRuns > 0 ? <Text color="red"> · {needsOpRuns} need operator</Text> : null}
+      </Text>
+    ) : (
+      <Text>
+        {counts.failed > 0 ? (
+          <Text>
+            <Text color="red">{counts.failed} failed</Text>
+            <Text dimColor> · </Text>
+          </Text>
+        ) : null}
+        <Text>{counts.active} active</Text>
+        <Text dimColor> · {counts.idle} idle · {sessions.length} agents</Text>
+      </Text>
+    );
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -220,17 +320,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
         <Text>
           <Text bold>{city}</Text>
           <Text dimColor>  </Text>
-          {counts.failed > 0 ? (
-            <Text>
-              <Text color="red">{counts.failed} failed</Text>
-              <Text dimColor> · </Text>
-            </Text>
-          ) : null}
-          <Text>{counts.active} active</Text>
-          <Text dimColor> · {counts.idle} idle · {sessions.length} agents</Text>
-          {health.activeRuns !== null ? (
-            <Text dimColor> · {health.activeRuns} runs</Text>
-          ) : null}
+          {summary}
         </Text>
         <Text dimColor>{conn === 'open' ? 'live' : conn === 'closed' ? 'reconnecting…' : conn}</Text>
       </Box>
@@ -250,25 +340,23 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
             now={now}
           />
         </Box>
-      ) : view === 'detail' && selected ? (
+      ) : view === 'detail' && selectedAgent ? (
         <Box marginTop={1}>
           <DetailPane
-            view={selected}
-            beads={beadsForRig(beads, selected.rig)}
-            lanes={lanesForRig(health.lanes, selected.rig)}
+            view={selectedAgent}
+            beads={beadsForRig(beads, selectedAgent.rig)}
+            lanes={lanesForRig(health.lanes, selectedAgent.rig)}
             now={now}
           />
         </Box>
       ) : (
         <>
-          {/* Sticky rig context (or a spacer) so the top of the list keeps a
-              title even when its heading has scrolled above the window. */}
           {stickyGroup ? (
             <Box>
-              <Text dimColor>{stickyGroup.rig}</Text>
+              <Text dimColor>{stickyGroup.label}</Text>
               <Text dimColor>
                 {'  '}
-                {stickyGroup.active} active · {stickyGroup.idle} idle ↑
+                {stickyGroup.sub} ↑
               </Text>
             </Box>
           ) : (
@@ -277,29 +365,28 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
             </Box>
           )}
           <Box flexDirection="column">
-            {renderRows.length === 0 && !error ? (
-              <Text dimColor>no sessions</Text>
+            {renderRows.length === 0 ? (
+              <Text dimColor>{emptyLabel(view)}</Text>
             ) : (
-              visible.map((row) =>
+              visible.map((row, i) =>
                 row.kind === 'heading' ? (
-                  <Box key={`h:${row.group.rig}`}>
-                    {row.group.failed > 0 ? (
-                      <Text bold color="red">{row.group.rig}</Text>
+                  <Box key={`h:${row.group.label}:${effectiveTop + i}`}>
+                    {row.group.alert ? (
+                      <Text bold color="red">{row.group.label}</Text>
                     ) : (
-                      <Text bold>{row.group.rig}</Text>
+                      <Text bold>{row.group.label}</Text>
                     )}
                     <Text dimColor>
                       {'  '}
-                      {row.group.failed > 0 ? `${row.group.failed} failed · ` : ''}
-                      {row.group.active} active · {row.group.idle} idle
+                      {row.group.sub}
                     </Text>
                   </Box>
                 ) : (
-                  <AgentRow
-                    key={row.view.session.id}
-                    view={row.view}
-                    selected={row.agentIndex === cursorIndex}
-                    dim={row.view.category === 'idle'}
+                  <EntryRow
+                    key={`${row.entry.kind}:${row.entry.id}`}
+                    entry={row.entry}
+                    selected={row.index === cursorIndex}
+                    dim={row.dim}
                     now={now}
                   />
                 ),
@@ -315,10 +402,33 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
                 {below > 0 ? `↓ ${below}` : ''}
               </Text>
             )}
-            <Text dimColor>↑↓/wheel · enter peek · x close · p detail · h health · q quit</Text>
+            <Text dimColor>↑↓ · enter drill · x close · b/f/h views · p detail · q quit</Text>
           </Box>
         </>
       )}
     </Box>
   );
+}
+
+function emptyLabel(view: ViewMode): string {
+  if (view === 'beads') return 'no beads';
+  if (view === 'runs') return 'no active runs';
+  return 'no sessions';
+}
+
+interface EntryRowProps {
+  readonly entry: Entry;
+  readonly selected: boolean;
+  readonly dim: boolean;
+  readonly now: number;
+}
+
+function EntryRow({ entry, selected, dim, now }: EntryRowProps): React.JSX.Element {
+  if (entry.kind === 'agent') {
+    return <AgentRow view={entry.agent} selected={selected} dim={dim} now={now} />;
+  }
+  if (entry.kind === 'bead') {
+    return <BeadRow bead={entry.bead} selected={selected} dim={dim} />;
+  }
+  return <RunRow lane={entry.lane} selected={selected} />;
 }

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -1,0 +1,324 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, useApp, useInput, useStdout } from 'ink';
+import { useCity } from './useCity.ts';
+import { useMouseWheel } from './useMouseWheel.ts';
+import { AgentRow, DetailPane, HealthPane } from './panes.tsx';
+import { closePeek, insideTmux, openPeek, paneExists, replacePeek } from './peek.ts';
+import {
+  beadsForRig,
+  categorize,
+  contextPressure,
+  groupByRig,
+  lanesForRig,
+  neverActiveByRig,
+  systemHealth,
+  type AgentView,
+  type Category,
+  type RigGroup,
+} from './derive.ts';
+
+interface AppProps {
+  readonly baseUrl: string;
+  readonly city: string;
+}
+
+type Row =
+  | { readonly kind: 'heading'; readonly group: RigGroup }
+  | {
+      readonly kind: 'agent';
+      readonly view: AgentView;
+      readonly agentIndex: number;
+      readonly group: RigGroup;
+    };
+
+type ViewMode = 'list' | 'detail' | 'health';
+
+function useTerminalRows(): number {
+  const { stdout } = useStdout();
+  const [rows, setRows] = useState(stdout.rows ?? 24);
+  useEffect(() => {
+    const onResize = (): void => setRows(stdout.rows ?? 24);
+    stdout.on('resize', onResize);
+    return () => {
+      stdout.off('resize', onResize);
+    };
+  }, [stdout]);
+  return rows;
+}
+
+export function App({ baseUrl, city }: AppProps): React.JSX.Element {
+  const { exit } = useApp();
+  const { sessions, snapshot, beads, error, conn } = useCity(baseUrl, city);
+  const rows = useTerminalRows();
+
+  const [view, setView] = useState<ViewMode>('list');
+  const [cursorId, setCursorId] = useState<string | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [status, setStatus] = useState<string | null>(null);
+  // A single reused peek pane: its tmux id, and which agent it's showing.
+  const [peekPaneId, setPeekPaneId] = useState<string | null>(null);
+  const [peekAgentId, setPeekAgentId] = useState<string | null>(null);
+  const now = Date.now();
+
+  // Grouped by rig; within a rig, active before idle (groupByRig owns the sort).
+  const { agents, renderRows } = useMemo(() => {
+    const groups = groupByRig(sessions);
+    const agentList: AgentView[] = [];
+    const rowList: Row[] = [];
+    for (const g of groups) {
+      rowList.push({ kind: 'heading', group: g });
+      for (const view of g.agents) {
+        rowList.push({ kind: 'agent', view, agentIndex: agentList.length, group: g });
+        agentList.push(view);
+      }
+    }
+    return { agents: agentList, renderRows: rowList };
+  }, [sessions]);
+
+  const cursorIndex = Math.max(
+    0,
+    agents.findIndex((a) => a.session.id === cursorId),
+  );
+  const selected: AgentView | undefined = agents[cursorIndex];
+
+  // Keep cursor pointed at a real agent as the list churns.
+  useEffect(() => {
+    if (agents.length === 0) return;
+    const exists = cursorId !== null && agents.some((a) => a.session.id === cursorId);
+    if (!exists) setCursorId(agents[0]?.session.id ?? null);
+  }, [agents, cursorId]);
+
+  // Refs so the wheel callback stays stable (re-subscribing would re-emit the
+  // mouse-enable escape sequence on every render).
+  const agentsRef = useRef(agents);
+  agentsRef.current = agents;
+  const cursorIndexRef = useRef(cursorIndex);
+  cursorIndexRef.current = cursorIndex;
+
+  const moveCursor = useCallback((delta: number) => {
+    const list = agentsRef.current;
+    if (list.length === 0) return;
+    const next = Math.min(Math.max(cursorIndexRef.current + delta, 0), list.length - 1);
+    setCursorId(list[next]?.session.id ?? null);
+  }, []);
+
+  useMouseWheel(useCallback((dir: -1 | 1) => moveCursor(dir * 3), [moveCursor]));
+
+  // Tear down our peek pane on the way out so quitting doesn't leave an orphan
+  // shell pane behind in the tmux session.
+  const quit = (): void => {
+    if (peekPaneId !== null && paneExists(peekPaneId)) closePeek(peekPaneId);
+    exit();
+  };
+
+  // Every render row is exactly ONE line (no per-heading blank line), so the
+  // window's row count equals its line count. chrome = header + sticky line +
+  // footer (+ error line). Keeping this exact is what prevents the content
+  // from overflowing the screen and scrolling the top off.
+  const chrome = error ? 4 : 3;
+  const viewport = Math.max(3, rows - chrome);
+  const maxTop = Math.max(0, renderRows.length - viewport);
+
+  // Cursor's row index (heading rows shift it), used to keep it on screen.
+  const cursorRowIndex = renderRows.findIndex(
+    (r) => r.kind === 'agent' && r.agentIndex === cursorIndex,
+  );
+  useEffect(() => {
+    if (cursorRowIndex < 0) return;
+    setScrollTop((top) => {
+      if (cursorRowIndex < top) return cursorRowIndex;
+      if (cursorRowIndex >= top + viewport) return cursorRowIndex - viewport + 1;
+      return Math.min(top, maxTop);
+    });
+  }, [cursorRowIndex, viewport, maxTop]);
+
+  const effectiveTop = Math.min(scrollTop, maxTop);
+  const visible = renderRows.slice(effectiveTop, effectiveTop + viewport);
+  const above = effectiveTop;
+  const below = Math.max(0, renderRows.length - (effectiveTop + viewport));
+  // When the window opens mid-rig (its heading scrolled off), show that rig as
+  // a dim sticky label so the top rows are never orphaned/untitled.
+  const firstVisible = visible[0];
+  const stickyGroup: RigGroup | null =
+    firstVisible && firstVisible.kind === 'agent' ? firstVisible.group : null;
+
+  useInput(
+    (input, key) => {
+      if (input === 'q') {
+        quit();
+        return;
+      }
+      if (key.escape) {
+        if (view === 'list') quit();
+        else setView('list');
+        return;
+      }
+      if (input === 'h') {
+        setView((v) => (v === 'health' ? 'list' : 'health'));
+        return;
+      }
+      if (key.return) {
+        // One reused peek pane: open it, retarget it to the selected agent, or
+        // (if it's already showing this agent) toggle it closed.
+        if (!selected) return;
+        if (!insideTmux()) {
+          setStatus('peek: not inside tmux — use `npm --workspace tui run start:tmux`');
+          return;
+        }
+        const root = snapshot?.config.cityRoot ?? null;
+        const live = peekPaneId !== null && paneExists(peekPaneId);
+        if (live && peekAgentId === selected.session.id) {
+          closePeek(peekPaneId);
+          setPeekPaneId(null);
+          setPeekAgentId(null);
+          setStatus('peek closed');
+        } else if (live) {
+          const r = replacePeek(peekPaneId, selected.session.id, root);
+          if (r.ok) setPeekAgentId(selected.session.id);
+          setStatus(r.ok ? `peeking ${selected.agent} →` : `peek: ${r.error}`);
+        } else {
+          const r = openPeek(selected.session.id, root);
+          if (r.ok) {
+            setPeekPaneId(r.paneId ?? null);
+            setPeekAgentId(selected.session.id);
+          }
+          setStatus(r.ok ? `peeking ${selected.agent} →` : `peek: ${r.error}`);
+        }
+        return;
+      }
+      if (input === 'x') {
+        // Close the peek pane.
+        if (peekPaneId !== null && paneExists(peekPaneId)) {
+          closePeek(peekPaneId);
+          setStatus('peek closed');
+        }
+        setPeekPaneId(null);
+        setPeekAgentId(null);
+        return;
+      }
+      if (input === 'p') {
+        setView((v) => (v === 'detail' ? 'list' : 'detail'));
+        return;
+      }
+      if (key.downArrow || input === 'j') moveCursor(1);
+      else if (key.upArrow || input === 'k') moveCursor(-1);
+      else if (key.pageDown) moveCursor(viewport);
+      else if (key.pageUp) moveCursor(-viewport);
+      else if (input === 'g') moveCursor(-agents.length);
+      else if (input === 'G') moveCursor(agents.length);
+    },
+    { isActive: Boolean(process.stdin.isTTY) },
+  );
+
+  const counts: Record<Category, number> = { failed: 0, active: 0, idle: 0 };
+  for (const s of sessions) counts[categorize(s)] += 1;
+  const health = systemHealth(snapshot);
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box justifyContent="space-between">
+        <Text>
+          <Text bold>{city}</Text>
+          <Text dimColor>  </Text>
+          {counts.failed > 0 ? (
+            <Text>
+              <Text color="red">{counts.failed} failed</Text>
+              <Text dimColor> · </Text>
+            </Text>
+          ) : null}
+          <Text>{counts.active} active</Text>
+          <Text dimColor> · {counts.idle} idle · {sessions.length} agents</Text>
+          {health.activeRuns !== null ? (
+            <Text dimColor> · {health.activeRuns} runs</Text>
+          ) : null}
+        </Text>
+        <Text dimColor>{conn === 'open' ? 'live' : conn === 'closed' ? 'reconnecting…' : conn}</Text>
+      </Box>
+
+      {error ? (
+        <Box>
+          <Text color="red">! {error}</Text>
+        </Box>
+      ) : null}
+
+      {view === 'health' ? (
+        <Box marginTop={1}>
+          <HealthPane
+            health={health}
+            idle={neverActiveByRig(sessions)}
+            pressure={contextPressure(sessions)}
+            now={now}
+          />
+        </Box>
+      ) : view === 'detail' && selected ? (
+        <Box marginTop={1}>
+          <DetailPane
+            view={selected}
+            beads={beadsForRig(beads, selected.rig)}
+            lanes={lanesForRig(health.lanes, selected.rig)}
+            now={now}
+          />
+        </Box>
+      ) : (
+        <>
+          {/* Sticky rig context (or a spacer) so the top of the list keeps a
+              title even when its heading has scrolled above the window. */}
+          {stickyGroup ? (
+            <Box>
+              <Text dimColor>{stickyGroup.rig}</Text>
+              <Text dimColor>
+                {'  '}
+                {stickyGroup.active} active · {stickyGroup.idle} idle ↑
+              </Text>
+            </Box>
+          ) : (
+            <Box>
+              <Text> </Text>
+            </Box>
+          )}
+          <Box flexDirection="column">
+            {renderRows.length === 0 && !error ? (
+              <Text dimColor>no sessions</Text>
+            ) : (
+              visible.map((row) =>
+                row.kind === 'heading' ? (
+                  <Box key={`h:${row.group.rig}`}>
+                    {row.group.failed > 0 ? (
+                      <Text bold color="red">{row.group.rig}</Text>
+                    ) : (
+                      <Text bold>{row.group.rig}</Text>
+                    )}
+                    <Text dimColor>
+                      {'  '}
+                      {row.group.failed > 0 ? `${row.group.failed} failed · ` : ''}
+                      {row.group.active} active · {row.group.idle} idle
+                    </Text>
+                  </Box>
+                ) : (
+                  <AgentRow
+                    key={row.view.session.id}
+                    view={row.view}
+                    selected={row.agentIndex === cursorIndex}
+                    dim={row.view.category === 'idle'}
+                    now={now}
+                  />
+                ),
+              )
+            )}
+          </Box>
+          <Box justifyContent="space-between">
+            {status ? (
+              <Text dimColor>{status}</Text>
+            ) : (
+              <Text dimColor>
+                {above > 0 ? `↑ ${above} ` : '   '}
+                {below > 0 ? `↓ ${below}` : ''}
+              </Text>
+            )}
+            <Text dimColor>↑↓/wheel · enter peek · x close · p detail · h health · q quit</Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -10,9 +10,10 @@ import type {
   GcSessionList,
   GcBead,
   DashboardSnapshot,
+  RunLane,
 } from 'gas-city-dashboard-shared';
 
-export type { GcSession, GcBead, DashboardSnapshot };
+export type { GcSession, GcBead, DashboardSnapshot, RunLane };
 
 function cityBase(baseUrl: string, city: string): string {
   return `${baseUrl}/api/city/${encodeURIComponent(city)}`;

--- a/tui/src/api.ts
+++ b/tui/src/api.ts
@@ -1,0 +1,64 @@
+// Thin read client of the backend /api/*. The TUI never talks to the gc
+// supervisor directly — it inherits edge translation, sanitisation, timeouts
+// and audit from the backend GcClient (backend/src/gc-client.ts) for free.
+// Consumes the dashboard-owned DTOs; shared/ remains the single source of
+// truth for the shapes, so a contract drift is a compile error here, not a
+// runtime undefined.
+
+import type {
+  GcSession,
+  GcSessionList,
+  GcBead,
+  DashboardSnapshot,
+} from 'gas-city-dashboard-shared';
+
+export type { GcSession, GcBead, DashboardSnapshot };
+
+function cityBase(baseUrl: string, city: string): string {
+  return `${baseUrl}/api/city/${encodeURIComponent(city)}`;
+}
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, signal ? { signal } : {});
+  if (!res.ok) {
+    throw new Error(`GET ${new URL(url).pathname} failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** GET /api/city/:cityName/sessions → GcSessionList. */
+export function fetchSessions(
+  baseUrl: string,
+  city: string,
+  signal?: AbortSignal,
+): Promise<GcSessionList> {
+  return getJson<GcSessionList>(`${cityBase(baseUrl, city)}/sessions`, signal);
+}
+
+/** GET /api/city/:cityName/snapshot → DashboardSnapshot (system health + run lanes). */
+export function fetchSnapshot(
+  baseUrl: string,
+  city: string,
+  signal?: AbortSignal,
+): Promise<DashboardSnapshot> {
+  return getJson<DashboardSnapshot>(`${cityBase(baseUrl, city)}/snapshot`, signal);
+}
+
+interface BeadList {
+  readonly items: GcBead[];
+}
+
+/** GET /api/city/:cityName/beads → bead list (associated to rigs by id prefix). */
+export async function fetchBeads(
+  baseUrl: string,
+  city: string,
+  signal?: AbortSignal,
+): Promise<GcBead[]> {
+  const list = await getJson<BeadList>(`${cityBase(baseUrl, city)}/beads`, signal);
+  return list.items;
+}
+
+/** City-scoped SSE endpoint the backend proxies verbatim from the supervisor. */
+export function eventsStreamUrl(baseUrl: string, city: string): string {
+  return `${cityBase(baseUrl, city)}/events/stream`;
+}

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -1,0 +1,40 @@
+// Resolves the TUI's runtime target from env/argv. Mirrors the web client's
+// no-silent-fallback stance (frontend/src/api/cityBase.ts): a city-scoped
+// surface with no city is a bug, not a default-to-first-city fallback.
+
+import { CITY_NAME_RE } from 'gas-city-dashboard-shared';
+
+export interface TuiConfig {
+  /** Backend origin, e.g. http://127.0.0.1:8081 (the backend binds 127.0.0.1). */
+  readonly baseUrl: string;
+  /** Active city; every read/stream rides /api/city/:cityName/*. */
+  readonly city: string;
+}
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:8081';
+
+/** Reads `--city=<name>` from argv, falling back to GC_CITY_NAME. */
+function resolveCity(argv: readonly string[], env: NodeJS.ProcessEnv): string {
+  const flag = argv.find((a) => a.startsWith('--city='));
+  const city = flag ? flag.slice('--city='.length) : env.GC_CITY_NAME;
+  if (!city) {
+    throw new Error(
+      'No city resolved. Pass --city=<name> or set GC_CITY_NAME ' +
+        '(source .env.local first: `set -a; . ./.env.local; set +a`).',
+    );
+  }
+  if (!CITY_NAME_RE.test(city)) {
+    throw new Error(`Invalid city name: ${city}`);
+  }
+  return city;
+}
+
+export function resolveConfig(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): TuiConfig {
+  return {
+    baseUrl: (env.DASHBOARD_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, ''),
+    city: resolveCity(argv, env),
+  };
+}

--- a/tui/src/derive.ts
+++ b/tui/src/derive.ts
@@ -192,6 +192,71 @@ export function lanesForRig(lanes: readonly RunLane[], rig: string): RunLane[] {
   });
 }
 
+// ── beads grouping (by status, kanban-style) ────────────────────────────────
+
+export interface BeadGroup {
+  readonly status: string;
+  readonly beads: readonly GcBead[];
+}
+
+const BEAD_STATUS_ORDER = ['open', 'in_progress', 'blocked', 'deferred', 'closed'];
+
+function beadStatusRank(status: string): number {
+  const i = BEAD_STATUS_ORDER.indexOf(status);
+  return i < 0 ? BEAD_STATUS_ORDER.length : i;
+}
+
+/** Groups beads by status (open → in_progress → blocked → deferred → closed);
+ *  within a status, higher priority (lower number) first, then newest. */
+export function groupBeads(beads: readonly GcBead[]): BeadGroup[] {
+  const byStatus = new Map<string, GcBead[]>();
+  for (const b of beads) {
+    const arr = byStatus.get(b.status) ?? [];
+    arr.push(b);
+    byStatus.set(b.status, arr);
+  }
+  return [...byStatus.entries()]
+    .map(([status, list]) => ({
+      status,
+      beads: list.slice().sort((a, b) => {
+        const pa = a.priority ?? 99;
+        const pb = b.priority ?? 99;
+        if (pa !== pb) return pa - pb;
+        return (b.created_at ?? '').localeCompare(a.created_at ?? '');
+      }),
+    }))
+    .sort((a, b) => beadStatusRank(a.status) - beadStatusRank(b.status));
+}
+
+// ── run lanes grouping (by rig) ─────────────────────────────────────────────
+
+export interface RunGroup {
+  readonly rig: string;
+  readonly lanes: readonly RunLane[];
+}
+
+/** Groups run lanes by rig; within a rig, needs-operator first, then by title. */
+export function groupRuns(lanes: readonly RunLane[]): RunGroup[] {
+  const byRig = new Map<string, RunLane[]>();
+  for (const l of lanes) {
+    const rig = laneRig(l) ?? ORCHESTRATION;
+    const arr = byRig.get(rig) ?? [];
+    arr.push(l);
+    byRig.set(rig, arr);
+  }
+  return [...byRig.entries()]
+    .map(([rig, list]) => ({
+      rig,
+      lanes: list.slice().sort((a, b) => {
+        const na = laneNeedsOperator(a) ? 0 : 1;
+        const nb = laneNeedsOperator(b) ? 0 : 1;
+        if (na !== nb) return na - nb;
+        return a.title.localeCompare(b.title);
+      }),
+    }))
+    .sort((a, b) => a.rig.localeCompare(b.rig));
+}
+
 // ── snapshot accessors (collapse the Avail/SourceState unions) ───────────────
 
 export interface SystemHealth {

--- a/tui/src/derive.ts
+++ b/tui/src/derive.ts
@@ -1,0 +1,288 @@
+// Pure view-derivation over the dashboard DTOs. No IO, no React — so it can be
+// reasoned about and (later) unit-tested in isolation. shared/ owns the wire
+// shapes; this module only projects them into what the operator scans.
+
+import {
+  effectiveContextPct,
+  type GcSession,
+  type GcBead,
+  type DashboardSnapshot,
+  type RunLane,
+} from 'gas-city-dashboard-shared';
+
+/**
+ * Context usage as a percent of the model's TRUE window. gc reports
+ * `context_pct` against a hardcoded 200k denominator, so 1M-window models
+ * read a misleading saturated 100; this rescales (and matches the web UI).
+ */
+export function ctxPct(s: GcSession): number | undefined {
+  return effectiveContextPct(s);
+}
+
+export type Category = 'failed' | 'active' | 'idle';
+
+export interface AgentView {
+  readonly session: GcSession;
+  /** Rig basename, e.g. `gascity` from `/home/ds/gascity`. */
+  readonly rig: string;
+  /** Agent basename, e.g. `polecat-4` or `oversight-rig.project-lead`. */
+  readonly agent: string;
+  readonly category: Category;
+}
+
+export function basename(path: string | null | undefined): string {
+  if (!path) return '';
+  const trimmed = path.replace(/\/+$/, '');
+  const seg = trimmed.slice(trimmed.lastIndexOf('/') + 1);
+  return seg || trimmed;
+}
+
+export function categorize(s: GcSession): Category {
+  if (s.state === 'failed') return 'failed';
+  if (s.state === 'active' || s.state === 'creating') return 'active';
+  return 'idle';
+}
+
+/** Label for the city-level (rig-less) agents: mayor, city control-dispatcher. */
+export const ORCHESTRATION = 'orchestration';
+
+/**
+ * Canonical rig label. The supervisor reports a rig inconsistently — sometimes
+ * a filesystem path (`/home/ds/projects/scix_experiments`), sometimes a name
+ * (`scix-experiments`), with varying case — which split one project across two
+ * groups. Normalise (basename · `_`→`-` · lowercase) so a project is one group.
+ */
+export function rigLabel(rig: string | null | undefined): string {
+  const base = basename(rig);
+  if (!base) return ORCHESTRATION;
+  return base.replace(/_/g, '-').toLowerCase();
+}
+
+export function toAgentView(s: GcSession): AgentView {
+  return {
+    session: s,
+    rig: rigLabel(s.rig),
+    agent: basename(s.title ?? s.alias ?? s.id) || s.id,
+    category: categorize(s),
+  };
+}
+
+// ── rig grouping (top-level rigs; within rig: active before idle) ───────────
+
+export interface RigGroup {
+  readonly rig: string;
+  readonly agents: readonly AgentView[];
+  readonly failed: number;
+  readonly active: number;
+  readonly idle: number;
+}
+
+const CATEGORY_RANK: Record<Category, number> = { failed: 0, active: 1, idle: 2 };
+
+/**
+ * Groups agents by rig. Within a rig: failed → active → idle, each by recency.
+ * Rigs ordered by (has-failed, active-count desc, name) so the rigs an operator
+ * should look at sit at the top.
+ */
+export function groupByRig(sessions: readonly GcSession[]): RigGroup[] {
+  const byRig = new Map<string, AgentView[]>();
+  for (const s of sessions) {
+    const view = toAgentView(s);
+    const arr = byRig.get(view.rig) ?? [];
+    arr.push(view);
+    byRig.set(view.rig, arr);
+  }
+
+  const groups: RigGroup[] = [...byRig.entries()].map(([rig, list]) => {
+    const agents = list.slice().sort((a, b) => {
+      const rank = CATEGORY_RANK[a.category] - CATEGORY_RANK[b.category];
+      if (rank !== 0) return rank;
+      return Date.parse(b.session.last_active ?? '') - Date.parse(a.session.last_active ?? '');
+    });
+    return {
+      rig,
+      agents,
+      failed: list.filter((v) => v.category === 'failed').length,
+      active: list.filter((v) => v.category === 'active').length,
+      idle: list.filter((v) => v.category === 'idle').length,
+    };
+  });
+
+  return groups.sort((a, b) => {
+    // Orchestration (mayor + city dispatcher) always leads — it directs the rest.
+    if (a.rig === ORCHESTRATION) return -1;
+    if (b.rig === ORCHESTRATION) return 1;
+    const af = a.failed > 0 ? 1 : 0;
+    const bf = b.failed > 0 ? 1 : 0;
+    if (af !== bf) return bf - af;
+    if (b.active !== a.active) return b.active - a.active;
+    return a.rig.localeCompare(b.rig);
+  });
+}
+
+export function relativeTime(iso: string | undefined, now: number): string {
+  if (!iso) return 'never';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '—';
+  const secs = Math.max(0, Math.round((now - then) / 1000));
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+/** "claude-opus-4-8" → "opus-4-8"; trims the vendor prefix for column width. */
+export function shortModel(model: string | undefined): string {
+  if (!model) return '';
+  return model.replace(/^claude-/, '');
+}
+
+// ── peek commands (surfaced, not executed — read-only) ──────────────────────
+
+export interface PeekCommands {
+  readonly gcPeek: string;
+  readonly tmuxAttach: string;
+  readonly tmuxCapture: string;
+}
+
+export function peekCommands(s: GcSession): PeekCommands {
+  return {
+    gcPeek: `gc session peek ${s.id}`,
+    tmuxAttach: `tmux attach -t ${s.session_name}`,
+    tmuxCapture: `tmux capture-pane -t ${s.session_name} -p`,
+  };
+}
+
+// ── bead ↔ rig association (best-effort: beads carry no session field) ───────
+
+/** `agent-diagnostics-x0i` → `agent-diagnostics`. */
+export function beadRigPrefix(beadId: string): string {
+  return beadId.replace(/-[^-]+$/, '');
+}
+
+export function beadsForRig(beads: readonly GcBead[], rig: string): GcBead[] {
+  if (!rig || rig === ORCHESTRATION) return [];
+  return beads.filter((b) => {
+    const prefix = beadRigPrefix(b.id);
+    return prefix === rig || prefix.startsWith(rig) || rig.startsWith(prefix);
+  });
+}
+
+// ── run lanes (formulas) ────────────────────────────────────────────────────
+
+/** `scope.rootStoreRef` "rig:gascity" → "gascity". */
+export function laneRig(lane: RunLane): string | null {
+  if (lane.scope.status !== 'available') return null;
+  const ref = lane.scope.rootStoreRef;
+  if (typeof ref !== 'string') return null;
+  return ref.startsWith('rig:') ? ref.slice('rig:'.length) : null;
+}
+
+export function laneNeedsOperator(lane: RunLane): boolean {
+  return lane.health.status === 'available' && lane.health.data.needsOperator;
+}
+
+export function lanesForRig(lanes: readonly RunLane[], rig: string): RunLane[] {
+  if (!rig || rig === ORCHESTRATION) return [];
+  return lanes.filter((l) => {
+    const lr = laneRig(l);
+    return lr !== null && (lr === rig || lr.startsWith(rig) || rig.startsWith(lr));
+  });
+}
+
+// ── snapshot accessors (collapse the Avail/SourceState unions) ───────────────
+
+export interface SystemHealth {
+  readonly activeAgents: number | null;
+  readonly activeSessions: number | null;
+  readonly activeRuns: number | null;
+  readonly maxAgents: number | null;
+  readonly vcpu: number | null;
+  readonly load1: number | null;
+  readonly loadPerVcpu: number | null;
+  readonly memUtil: number | null;
+  readonly lanes: readonly RunLane[];
+}
+
+function metric(m: { status: string; value?: number } | undefined): number | null {
+  return m && m.status === 'available' && typeof m.value === 'number' ? m.value : null;
+}
+
+export function systemHealth(snap: DashboardSnapshot | null): SystemHealth {
+  if (!snap) {
+    return {
+      activeAgents: null,
+      activeSessions: null,
+      activeRuns: null,
+      maxAgents: null,
+      vcpu: null,
+      load1: null,
+      loadPerVcpu: null,
+      memUtil: null,
+      lanes: [],
+    };
+  }
+  const res = snap.sources.resources;
+  const runs = snap.sources.runs;
+  // SourceState is unavailable only when status === 'error'; otherwise it
+  // carries data (fresh/stale/fixture).
+  const resData = res.status !== 'error' ? res.data : null;
+  const lanes = runs.status !== 'error' ? runs.data.lanes : [];
+  return {
+    activeAgents: metric(snap.headline.activeAgents),
+    activeSessions: metric(snap.headline.activeSessions),
+    activeRuns: metric(snap.headline.activeRuns),
+    maxAgents: metric(snap.headline.maxAgents),
+    vcpu: resData?.vcpuCount ?? null,
+    load1: resData?.loadAverage[0] ?? null,
+    loadPerVcpu: resData?.loadPerVcpu ?? null,
+    memUtil: resData?.memory.utilization ?? null,
+    lanes,
+  };
+}
+
+// ── idle / reallocation analysis (the operator's "why are these here?") ──────
+
+export interface IdleRollup {
+  readonly rig: string;
+  readonly neverActive: number;
+  readonly total: number;
+}
+
+/**
+ * Per-rig count of sessions that have NEVER emitted activity (no last_active).
+ * These are the pool/role agents an operator may want to reclaim for busier
+ * rigs. Sorted by never-active count desc.
+ */
+export function neverActiveByRig(sessions: readonly GcSession[]): IdleRollup[] {
+  const byRig = new Map<string, { never: number; total: number }>();
+  for (const s of sessions) {
+    const rig = rigLabel(s.rig);
+    const entry = byRig.get(rig) ?? { never: 0, total: 0 };
+    entry.total += 1;
+    if (!s.last_active) entry.never += 1;
+    byRig.set(rig, entry);
+  }
+  return [...byRig.entries()]
+    .map(([rig, v]) => ({ rig, neverActive: v.never, total: v.total }))
+    .filter((r) => r.neverActive > 0)
+    .sort((a, b) => b.neverActive - a.neverActive);
+}
+
+export interface ContextPressureEntry {
+  readonly session: GcSession;
+  readonly pct: number;
+}
+
+/** Agents under context pressure (>= threshold% of TRUE window), worst first. */
+export function contextPressure(
+  sessions: readonly GcSession[],
+  thresholdPct = 75,
+): ContextPressureEntry[] {
+  return sessions
+    .map((s) => ({ session: s, pct: ctxPct(s) }))
+    .filter((e): e is ContextPressureEntry => e.pct !== undefined && e.pct >= thresholdPct)
+    .sort((a, b) => b.pct - a.pct);
+}

--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -1,0 +1,38 @@
+#!/usr/bin/env -S npx tsx
+import { render } from 'ink';
+import { App } from './App.tsx';
+import { resolveConfig } from './config.ts';
+
+// Alternate screen buffer (what vim/less/htop use): the app owns one clean
+// screen, so frames never leak into the terminal's scrollback and "the top" is
+// always the live top. Restored on exit so the prior terminal contents return.
+const ALT_ENTER = '\x1b[?1049h';
+const ALT_LEAVE = '\x1b[?1049l';
+
+function main(): void {
+  let config;
+  try {
+    config = resolveConfig();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+
+  const useAlt = Boolean(process.stdout.isTTY);
+  if (useAlt) process.stdout.write(ALT_ENTER);
+
+  let restored = false;
+  const restore = (): void => {
+    if (restored) return;
+    restored = true;
+    if (useAlt) process.stdout.write(ALT_LEAVE);
+  };
+
+  const app = render(<App baseUrl={config.baseUrl} city={config.city} />);
+  app.waitUntilExit().then(restore, restore);
+  // Belt-and-suspenders: leave the alt screen even on an abrupt exit so the
+  // user's terminal is never left in the alternate buffer.
+  process.on('exit', restore);
+}
+
+main();

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -72,6 +72,69 @@ export function AgentRow({ view, selected, dim, now }: AgentRowProps): React.JSX
   );
 }
 
+// ── one bead row (beads view) ───────────────────────────────────────────────
+
+interface BeadRowProps {
+  readonly bead: GcBead;
+  readonly selected: boolean;
+  readonly dim: boolean;
+}
+
+export function BeadRow({ bead, selected, dim }: BeadRowProps): React.JSX.Element {
+  const prio = typeof bead.priority === 'number' ? `P${bead.priority}` : '';
+  return (
+    <Box>
+      <Box width={2}>{selected ? <Text color="cyan">▸</Text> : <Text> </Text>}</Box>
+      <Box width={3} marginRight={1}>
+        <Text dimColor>{prio}</Text>
+      </Box>
+      <Box flexGrow={1} marginRight={1}>
+        <Text wrap="truncate-end" bold={selected} inverse={selected} dimColor={dim && !selected}>
+          {bead.title}
+        </Text>
+      </Box>
+      <Box width={8} marginRight={1}>
+        <Text wrap="truncate-end" dimColor>
+          {bead.issue_type}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── one run-lane row (formula runs view) ─────────────────────────────────────
+
+interface RunRowProps {
+  readonly lane: RunLane;
+  readonly selected: boolean;
+}
+
+export function RunRow({ lane, selected }: RunRowProps): React.JSX.Element {
+  const needsOp = laneNeedsOperator(lane);
+  return (
+    <Box>
+      <Box width={2}>
+        {needsOp ? <Text color="red">●</Text> : selected ? <Text color="cyan">▸</Text> : <Text> </Text>}
+      </Box>
+      <Box flexGrow={1} marginRight={1}>
+        <Text wrap="truncate-end" bold={selected} inverse={selected}>
+          {lane.title}
+        </Text>
+      </Box>
+      <Box width={14} marginRight={1}>
+        <Text wrap="truncate-end" dimColor>
+          {lane.phaseLabel}
+        </Text>
+      </Box>
+      <Box width={12}>
+        <Text wrap="truncate-end" dimColor>
+          {needsOp ? 'needs operator' : ''}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
 // ── detail / peek pane for the selected agent ───────────────────────────────
 
 interface DetailPaneProps {

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -1,0 +1,238 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { RunLane } from 'gas-city-dashboard-shared';
+import type { GcBead } from './api.ts';
+import {
+  ctxPct,
+  laneNeedsOperator,
+  laneRig,
+  peekCommands,
+  relativeTime,
+  shortModel,
+  type AgentView,
+  type ContextPressureEntry,
+  type IdleRollup,
+  type SystemHealth,
+} from './derive.ts';
+
+function pct(n: number | null | undefined, scale01 = false): string {
+  if (n === null || n === undefined) return '—';
+  return `${Math.round(scale01 ? n * 100 : n)}%`;
+}
+
+// ── one agent row in the list ───────────────────────────────────────────────
+
+interface AgentRowProps {
+  readonly view: AgentView;
+  readonly selected: boolean;
+  readonly dim: boolean;
+  readonly now: number;
+}
+
+export function AgentRow({ view, selected, dim, now }: AgentRowProps): React.JSX.Element {
+  const s = view.session;
+  const pct = ctxPct(s);
+  const ctx = pct !== undefined ? `${pct}%` : '';
+  // Active agents show live activity; dormant agents show WHY they're idle
+  // (the supervisor's transition reason, e.g. "city-stop"/"drained") rather
+  // than a bare "asleep", so "I thought we suspended that" is answerable.
+  const activity =
+    view.category === 'active'
+      ? (s.activity ?? '')
+      : s.attached
+        ? 'attached'
+        : (s.reason ?? s.state);
+  return (
+    <Box>
+      <Box width={2}>
+        {selected ? <Text color="cyan">▸</Text> : <Text> </Text>}
+      </Box>
+      <Box width={40} marginRight={2}>
+        <Text wrap="truncate-end" bold={selected} inverse={selected} dimColor={dim && !selected}>
+          {view.agent}
+        </Text>
+      </Box>
+      <Box width={4} marginRight={1} justifyContent="flex-end">
+        <Text dimColor>{ctx}</Text>
+      </Box>
+      <Box width={9} marginRight={1}>
+        <Text wrap="truncate-end" dimColor>
+          {activity}
+        </Text>
+      </Box>
+      <Box width={10} marginRight={1}>
+        <Text wrap="truncate-end" dimColor>
+          {shortModel(s.model) || s.provider}
+        </Text>
+      </Box>
+      <Box width={5} justifyContent="flex-end">
+        <Text dimColor>{relativeTime(s.last_active, now)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── detail / peek pane for the selected agent ───────────────────────────────
+
+interface DetailPaneProps {
+  readonly view: AgentView;
+  readonly beads: readonly GcBead[];
+  readonly lanes: readonly RunLane[];
+  readonly now: number;
+}
+
+export function DetailPane({ view, beads, lanes, now }: DetailPaneProps): React.JSX.Element {
+  const s = view.session;
+  const cmds = peekCommands(s);
+  const pct = ctxPct(s);
+  const ctx = pct !== undefined ? `${pct}%` : '—';
+  return (
+    <Box flexDirection="column">
+      <Text bold>
+        {view.rig} · {view.agent}
+      </Text>
+      <Text dimColor>
+        {s.state}
+        {s.reason ? ` (${s.reason})` : ''} · {s.provider}
+        {s.model ? ` · ${shortModel(s.model)}` : ''} · ctx {ctx} · last {relativeTime(s.last_active, now)}
+        {s.attached ? ' · attached' : ''}
+      </Text>
+      <Text dimColor>
+        id {s.id} · pool {s.pool ?? '—'} · kind {s.agent_kind ?? '—'}
+      </Text>
+
+      <Box marginTop={1}>
+        <Text bold>peek</Text>
+      </Box>
+      <Text>  {cmds.gcPeek}</Text>
+      <Text>  {cmds.tmuxAttach}</Text>
+      <Text dimColor>  {cmds.tmuxCapture}</Text>
+
+      <Box marginTop={1}>
+        <Text bold>formulas </Text>
+        <Text dimColor>(active run lanes on this rig)</Text>
+      </Box>
+      {lanes.length === 0 ? (
+        <Text dimColor>  none</Text>
+      ) : (
+        lanes.slice(0, 6).map((l) => (
+          <Box key={l.id}>
+            <Text>  {laneNeedsOperator(l) ? <Text color="red">● </Text> : '  '}</Text>
+            <Text>{l.title}</Text>
+            <Text dimColor> — {l.phaseLabel}</Text>
+            {laneNeedsOperator(l) ? <Text color="red"> — needs operator</Text> : null}
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text bold>beads </Text>
+        <Text dimColor>(this rig, best-effort match)</Text>
+      </Box>
+      {beads.length === 0 ? (
+        <Text dimColor>  none</Text>
+      ) : (
+        beads.slice(0, 8).map((b) => (
+          <Box key={b.id}>
+            <Text dimColor>  [{b.status}] </Text>
+            <Text wrap="truncate-end">{b.title}</Text>
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text dimColor>↑↓ change agent · enter peek · x close peek · p close · q quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── system health / observability pane ──────────────────────────────────────
+
+interface HealthPaneProps {
+  readonly health: SystemHealth;
+  readonly idle: readonly IdleRollup[];
+  readonly pressure: readonly ContextPressureEntry[];
+  readonly now: number;
+}
+
+export function HealthPane({ health, idle, pressure }: HealthPaneProps): React.JSX.Element {
+  const needsOp = health.lanes.filter(laneNeedsOperator);
+  return (
+    <Box flexDirection="column">
+      <Text bold>system</Text>
+      <Text dimColor>
+        {'  '}load {health.load1?.toFixed(2) ?? '—'} / {health.vcpu ?? '—'} vcpu (
+        {health.loadPerVcpu?.toFixed(2) ?? '—'} per-vcpu) · mem {pct(health.memUtil, true)}
+      </Text>
+      <Text dimColor>
+        {'  '}agents {health.activeAgents ?? '—'} active · sessions {health.activeSessions ?? '—'} · runs{' '}
+        {health.activeRuns ?? '—'} active · max {health.maxAgents ?? '—'}
+      </Text>
+
+      <Box marginTop={1}>
+        <Text bold>runs needing operator </Text>
+        <Text dimColor>({needsOp.length})</Text>
+      </Box>
+      {needsOp.length === 0 ? (
+        <Text dimColor>  none</Text>
+      ) : (
+        needsOp.slice(0, 8).map((l) => (
+          <Box key={l.id}>
+            <Text color="red">  ● </Text>
+            <Text>{l.title}</Text>
+            <Text dimColor>
+              {' '}({laneRig(l) ?? '—'}) — {l.phaseLabel}
+            </Text>
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text bold>context pressure </Text>
+        <Text dimColor>(≥75%)</Text>
+      </Box>
+      {pressure.length === 0 ? (
+        <Text dimColor>  none</Text>
+      ) : (
+        pressure.slice(0, 8).map((e) => (
+          <Box key={e.session.id}>
+            <Text color="red">  {e.pct}% </Text>
+            <Text wrap="truncate-end">{e.session.title}</Text>
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text bold>idle / reallocation </Text>
+        <Text dimColor>(agents never active, by rig)</Text>
+      </Box>
+      {idle.length === 0 ? (
+        <Text dimColor>  none</Text>
+      ) : (
+        idle.slice(0, 10).map((r) => (
+          <Box key={r.rig}>
+            <Text dimColor>{'  '}</Text>
+            <Text>{r.rig}</Text>
+            <Text dimColor>
+              {'  '}
+              {r.neverActive} never / {r.total}
+            </Text>
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text bold>costs</Text>
+      </Box>
+      <Text dimColor>
+        {'  '}not measured — supervisor exposes no per-run cost yet
+      </Text>
+      <Text dimColor>  (see specs/architecture/cost-token-feasibility.md)</Text>
+
+      <Box marginTop={1}>
+        <Text dimColor>h close · q quit</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/tui/src/peek.ts
+++ b/tui/src/peek.ts
@@ -1,13 +1,26 @@
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-// gc session ids / aliases are conservative tokens; validate before any value
+// Ids / aliases / city paths are conservative tokens; validate before any value
 // reaches a shell-interpreted tmux command (defence in depth — no injection).
 const SAFE_ID = /^[A-Za-z0-9._-]+$/;
-// City root is a filesystem path; allow path chars only.
 const SAFE_PATH = /^[A-Za-z0-9._/-]+$/;
+
+// peek-run.sh lives next to this workspace's src/ (tui/peek-run.sh).
+const RUN_SCRIPT = fileURLToPath(new URL('../peek-run.sh', import.meta.url));
 
 export function insideTmux(): boolean {
   return Boolean(process.env.TMUX);
+}
+
+export type PeekKind = 'agent' | 'bead' | 'run';
+
+export interface PeekRequest {
+  readonly kind: PeekKind;
+  readonly id: string;
+  readonly cityRoot: string | null;
+  readonly city: string;
+  readonly baseUrl: string;
 }
 
 export interface PeekResult {
@@ -18,21 +31,30 @@ export interface PeekResult {
 }
 
 /**
- * Builds the follow command. READS the agent's log (`gc session logs -f`) — it
- * does NOT attach as a second tmux client, so it cannot resize or disturb the
- * running agent. `--city` is explicit because the pane inherits the TUI's cwd,
- * which is usually not a city directory.
+ * Builds the shell command for a peek, by kind. All commands READ
+ * (logs/show/diff) — none attaches as a tmux client, so peeking can't resize or
+ * disturb a running agent. `--city`/explicit paths are passed because the pane
+ * inherits the TUI's cwd, which is usually not a city directory. `; exec $SHELL`
+ * keeps the pane open so output/errors stay readable.
  */
-function buildCommand(sessionId: string, cityRoot: string | null): string | { error: string } {
+export function buildCommand(req: PeekRequest): string | { error: string } {
   if (!insideTmux()) {
     return { error: 'not inside tmux — launch with `npm --workspace tui run start:tmux`' };
   }
-  if (!SAFE_ID.test(sessionId)) return { error: `unsafe session id: ${sessionId}` };
-  if (!cityRoot) return { error: 'city path not loaded yet — retry in a moment' };
-  if (!SAFE_PATH.test(cityRoot)) return { error: `unsafe city path: ${cityRoot}` };
-  // `; exec $SHELL` keeps the pane open if the follow exits, so an error stays
-  // readable instead of the pane vanishing.
-  return `gc --city ${cityRoot} session logs ${sessionId} -f; exec $SHELL`;
+  if (!req.cityRoot) return { error: 'city path not loaded yet — retry in a moment' };
+  if (!SAFE_PATH.test(req.cityRoot)) return { error: `unsafe city path: ${req.cityRoot}` };
+  if (!SAFE_ID.test(req.id)) return { error: `unsafe id: ${req.id}` };
+  const root = req.cityRoot;
+  switch (req.kind) {
+    case 'agent':
+      return `gc --city ${root} session logs ${req.id} -f; exec $SHELL`;
+    case 'bead':
+      return `gc --city ${root} bd show ${req.id}; exec $SHELL`;
+    case 'run':
+      // peek-run.sh prints `bd show <run>` then the code diff; args are
+      // single-quoted (all validated/owned, no quotes) for the sh -c tmux runs.
+      return `bash '${RUN_SCRIPT}' '${root}' '${req.city}' '${req.baseUrl}' '${req.id}'`;
+  }
 }
 
 function tmuxFail(r: ReturnType<typeof spawnSync>): string {
@@ -49,13 +71,11 @@ export function paneExists(paneId: string): boolean {
 }
 
 /** Opens the peek pane beside the dashboard (focus stays on the dashboard). */
-export function openPeek(sessionId: string, cityRoot: string | null): PeekResult {
-  const built = buildCommand(sessionId, cityRoot);
-  if (typeof built !== 'string') return { ok: false, error: built.error };
+export function openPeek(command: string): PeekResult {
   // -d: don't move focus. -P -F prints the new pane's id so we can retarget it.
   const r = spawnSync(
     'tmux',
-    ['split-window', '-d', '-h', '-l', '45%', '-P', '-F', '#{pane_id}', built],
+    ['split-window', '-d', '-h', '-l', '45%', '-P', '-F', '#{pane_id}', command],
     { encoding: 'utf8' },
   );
   if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
@@ -64,11 +84,9 @@ export function openPeek(sessionId: string, cityRoot: string | null): PeekResult
   return { ok: true, paneId: (r.stdout ?? '').trim() };
 }
 
-/** Retargets the existing peek pane to a different agent (reuses one pane). */
-export function replacePeek(paneId: string, sessionId: string, cityRoot: string | null): PeekResult {
-  const built = buildCommand(sessionId, cityRoot);
-  if (typeof built !== 'string') return { ok: false, error: built.error };
-  const r = spawnSync('tmux', ['respawn-pane', '-k', '-t', paneId, built], { encoding: 'utf8' });
+/** Retargets the existing peek pane (reuses one pane instead of stacking). */
+export function replacePeek(paneId: string, command: string): PeekResult {
+  const r = spawnSync('tmux', ['respawn-pane', '-k', '-t', paneId, command], { encoding: 'utf8' });
   if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
     return { ok: false, error: tmuxFail(r) };
   }

--- a/tui/src/peek.ts
+++ b/tui/src/peek.ts
@@ -6,8 +6,9 @@ import { fileURLToPath } from 'node:url';
 const SAFE_ID = /^[A-Za-z0-9._-]+$/;
 const SAFE_PATH = /^[A-Za-z0-9._/-]+$/;
 
-// peek-run.sh lives next to this workspace's src/ (tui/peek-run.sh).
+// Helper scripts live next to this workspace's src/ (tui/*.sh).
 const RUN_SCRIPT = fileURLToPath(new URL('../peek-run.sh', import.meta.url));
+const AGENT_SCRIPT = fileURLToPath(new URL('../peek-agent.sh', import.meta.url));
 
 export function insideTmux(): boolean {
   return Boolean(process.env.TMUX);
@@ -47,7 +48,9 @@ export function buildCommand(req: PeekRequest): string | { error: string } {
   const root = req.cityRoot;
   switch (req.kind) {
     case 'agent':
-      return `gc --city ${root} session logs ${req.id} -f; exec $SHELL`;
+      // peek-agent.sh follows the transcript if one exists, else watches pane
+      // snapshots (works for non-transcript sessions like dispatchers).
+      return `bash '${AGENT_SCRIPT}' '${root}' '${req.id}'`;
     case 'bead':
       return `gc --city ${root} bd show ${req.id}; exec $SHELL`;
     case 'run':

--- a/tui/src/peek.ts
+++ b/tui/src/peek.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+
+// gc session ids / aliases are conservative tokens; validate before any value
+// reaches a shell-interpreted tmux command (defence in depth — no injection).
+const SAFE_ID = /^[A-Za-z0-9._-]+$/;
+// City root is a filesystem path; allow path chars only.
+const SAFE_PATH = /^[A-Za-z0-9._/-]+$/;
+
+export function insideTmux(): boolean {
+  return Boolean(process.env.TMUX);
+}
+
+export interface PeekResult {
+  readonly ok: boolean;
+  /** tmux pane id of the peek pane (e.g. "%7"), set on a successful open. */
+  readonly paneId?: string;
+  readonly error?: string;
+}
+
+/**
+ * Builds the follow command. READS the agent's log (`gc session logs -f`) — it
+ * does NOT attach as a second tmux client, so it cannot resize or disturb the
+ * running agent. `--city` is explicit because the pane inherits the TUI's cwd,
+ * which is usually not a city directory.
+ */
+function buildCommand(sessionId: string, cityRoot: string | null): string | { error: string } {
+  if (!insideTmux()) {
+    return { error: 'not inside tmux — launch with `npm --workspace tui run start:tmux`' };
+  }
+  if (!SAFE_ID.test(sessionId)) return { error: `unsafe session id: ${sessionId}` };
+  if (!cityRoot) return { error: 'city path not loaded yet — retry in a moment' };
+  if (!SAFE_PATH.test(cityRoot)) return { error: `unsafe city path: ${cityRoot}` };
+  // `; exec $SHELL` keeps the pane open if the follow exits, so an error stays
+  // readable instead of the pane vanishing.
+  return `gc --city ${cityRoot} session logs ${sessionId} -f; exec $SHELL`;
+}
+
+function tmuxFail(r: ReturnType<typeof spawnSync>): string {
+  if (r.error) return r.error.message;
+  const detail = (r.stderr?.toString() ?? '').trim();
+  return `tmux: ${detail || `exit ${r.status}`}`;
+}
+
+/** True if a pane with this id currently exists anywhere in the server. */
+export function paneExists(paneId: string): boolean {
+  const r = spawnSync('tmux', ['list-panes', '-a', '-F', '#{pane_id}'], { encoding: 'utf8' });
+  if (r.status !== 0 || typeof r.stdout !== 'string') return false;
+  return r.stdout.split('\n').includes(paneId);
+}
+
+/** Opens the peek pane beside the dashboard (focus stays on the dashboard). */
+export function openPeek(sessionId: string, cityRoot: string | null): PeekResult {
+  const built = buildCommand(sessionId, cityRoot);
+  if (typeof built !== 'string') return { ok: false, error: built.error };
+  // -d: don't move focus. -P -F prints the new pane's id so we can retarget it.
+  const r = spawnSync(
+    'tmux',
+    ['split-window', '-d', '-h', '-l', '45%', '-P', '-F', '#{pane_id}', built],
+    { encoding: 'utf8' },
+  );
+  if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
+    return { ok: false, error: tmuxFail(r) };
+  }
+  return { ok: true, paneId: (r.stdout ?? '').trim() };
+}
+
+/** Retargets the existing peek pane to a different agent (reuses one pane). */
+export function replacePeek(paneId: string, sessionId: string, cityRoot: string | null): PeekResult {
+  const built = buildCommand(sessionId, cityRoot);
+  if (typeof built !== 'string') return { ok: false, error: built.error };
+  const r = spawnSync('tmux', ['respawn-pane', '-k', '-t', paneId, built], { encoding: 'utf8' });
+  if (r.error || (typeof r.status === 'number' && r.status !== 0)) {
+    return { ok: false, error: tmuxFail(r) };
+  }
+  return { ok: true, paneId };
+}
+
+/** Closes the peek pane. */
+export function closePeek(paneId: string): void {
+  spawnSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore' });
+}

--- a/tui/src/useCity.ts
+++ b/tui/src/useCity.ts
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react';
+import {
+  eventsStreamUrl,
+  fetchBeads,
+  fetchSessions,
+  fetchSnapshot,
+  type DashboardSnapshot,
+  type GcBead,
+  type GcSession,
+} from './api.ts';
+
+export type ConnState = 'connecting' | 'open' | 'degraded' | 'closed';
+
+export interface CityState {
+  readonly sessions: readonly GcSession[];
+  readonly snapshot: DashboardSnapshot | null;
+  readonly beads: readonly GcBead[];
+  readonly error: string | null;
+  readonly conn: ConnState;
+}
+
+const INITIAL: CityState = {
+  sessions: [],
+  snapshot: null,
+  beads: [],
+  error: null,
+  conn: 'connecting',
+};
+
+// Same coalescing window as the web hook (frontend/src/hooks/useGcEvents.ts):
+// a busy city emits many events per second; refetching per-event would hammer
+// the backend (and the snapshot is the heaviest read). Leading + trailing
+// throttle → at most one refresh per window, plus one after the burst settles.
+const COALESCE_MS = 2_500;
+// Any of these prefixes means the operator-visible state may have moved.
+const REFRESH_PREFIXES = ['session.', 'bead.', 'run.', 'agent.'];
+
+/**
+ * Loads sessions + snapshot + beads for a city and refreshes them (coalesced)
+ * on SSE activity. Read-only; no writes, no supervisor coupling.
+ */
+export function useCity(baseUrl: string, city: string): CityState {
+  const [state, setState] = useState<CityState>(INITIAL);
+
+  useEffect(() => {
+    let cancelled = false;
+    let es: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryDelayMs = 1_000;
+    let lastFire = 0;
+    let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Each feed updates its own slice as it lands — sessions are fast, the
+    // snapshot is slow; waiting for all three would stall the fast paint.
+    const refresh = (): void => {
+      void fetchSessions(baseUrl, city)
+        .then((list) => {
+          if (!cancelled) setState((p) => ({ ...p, sessions: list.items, error: null }));
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) setState((p) => ({ ...p, error: reason(err) }));
+        });
+      void fetchSnapshot(baseUrl, city)
+        .then((snap) => {
+          if (!cancelled) setState((p) => ({ ...p, snapshot: snap }));
+        })
+        .catch(() => {
+          /* snapshot is supplementary (health pane); don't clobber the list */
+        });
+      void fetchBeads(baseUrl, city)
+        .then((beads) => {
+          if (!cancelled) setState((p) => ({ ...p, beads }));
+        })
+        .catch(() => {
+          /* beads are supplementary (peek pane) */
+        });
+    };
+
+    const scheduleRefresh = (): void => {
+      const elapsed = Date.now() - lastFire;
+      if (elapsed >= COALESCE_MS) {
+        if (coalesceTimer) {
+          clearTimeout(coalesceTimer);
+          coalesceTimer = null;
+        }
+        lastFire = Date.now();
+        refresh();
+      } else if (coalesceTimer === null) {
+        coalesceTimer = setTimeout(() => {
+          coalesceTimer = null;
+          if (cancelled) return;
+          lastFire = Date.now();
+          refresh();
+        }, COALESCE_MS - elapsed);
+      }
+    };
+
+    const connect = (): void => {
+      const EventSourceCtor = globalThis.EventSource;
+      if (typeof EventSourceCtor !== 'function') {
+        setState((prev) => ({ ...prev, conn: 'closed' }));
+        return;
+      }
+      es = new EventSourceCtor(eventsStreamUrl(baseUrl, city));
+      setState((prev) => ({ ...prev, conn: 'connecting' }));
+      es.onopen = () => {
+        if (cancelled) return;
+        retryDelayMs = 1_000;
+        setState((prev) => ({ ...prev, conn: 'open' }));
+      };
+      const handle = (msg: MessageEvent<string>): void => {
+        if (cancelled) return;
+        let parsed: unknown = null;
+        try {
+          parsed = JSON.parse(msg.data);
+        } catch {
+          setState((prev) => ({ ...prev, conn: 'degraded' }));
+          return;
+        }
+        const type =
+          parsed && typeof parsed === 'object' && 'type' in parsed
+            ? (parsed as { type: unknown }).type
+            : null;
+        if (typeof type !== 'string') {
+          setState((prev) => ({ ...prev, conn: 'degraded' }));
+          return;
+        }
+        setState((prev) => ({ ...prev, conn: 'open' }));
+        if (REFRESH_PREFIXES.some((p) => type.startsWith(p))) scheduleRefresh();
+      };
+      es.onmessage = handle;
+      es.addEventListener('event', handle as EventListener);
+      es.onerror = () => {
+        if (cancelled) return;
+        es?.close();
+        es = null;
+        setState((prev) => ({ ...prev, conn: 'closed' }));
+        retryTimer = setTimeout(() => {
+          retryDelayMs = Math.min(retryDelayMs * 2, 30_000);
+          connect();
+        }, retryDelayMs);
+      };
+    };
+
+    refresh();
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (coalesceTimer) clearTimeout(coalesceTimer);
+      es?.close();
+    };
+  }, [baseUrl, city]);
+
+  return state;
+}
+
+function reason(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tui/src/useMouseWheel.ts
+++ b/tui/src/useMouseWheel.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useStdin, useStdout } from 'ink';
+
+// Enable/disable SGR mouse reporting. 1000 = button events (includes wheel),
+// 1006 = SGR extended coordinates (so we get a clean `ESC [ < b ; x ; y M`
+// frame instead of the legacy byte-packed form). We deliberately do NOT enable
+// motion tracking (1003) — only discrete wheel ticks are wanted, and motion
+// would flood stdin and fight terminal text selection.
+const ENABLE = '\x1b[?1000h\x1b[?1006h';
+const DISABLE = '\x1b[?1000l\x1b[?1006l';
+
+// SGR wheel buttons: 64 = wheel up, 65 = wheel down.
+const SGR_MOUSE = /\x1b\[<(\d+);\d+;\d+[Mm]/g;
+
+/**
+ * Calls `onWheel(-1)` on wheel-up and `onWheel(1)` on wheel-down. No-op when
+ * the terminal can't do raw mode (piped output) — keyboard nav still works.
+ */
+export function useMouseWheel(onWheel: (direction: -1 | 1) => void): void {
+  const { stdin, setRawMode, isRawModeSupported } = useStdin();
+  const { stdout } = useStdout();
+
+  useEffect(() => {
+    if (!isRawModeSupported || !stdin) return;
+    setRawMode(true);
+    stdout.write(ENABLE);
+
+    const onData = (chunk: Buffer | string): void => {
+      const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      SGR_MOUSE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = SGR_MOUSE.exec(s)) !== null) {
+        const button = Number.parseInt(match[1] ?? '', 10);
+        if (button === 64) onWheel(-1);
+        else if (button === 65) onWheel(1);
+      }
+    };
+
+    stdin.on('data', onData);
+    return () => {
+      stdin.off('data', onData);
+      stdout.write(DISABLE);
+    };
+    // onWheel is captured fresh each render via the dependency.
+  }, [stdin, stdout, setRawMode, isRawModeSupported, onWheel]);
+}

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Launch the Gas City TUI inside tmux so the live-peek split (enter) works.
+#
+#   ./tui/start-tmux.sh <city>        # or set GC_CITY_NAME
+#   npm --workspace tui run start:tmux -- <city>
+#
+# If you are already inside tmux, it runs directly (peek splits the current
+# window). Otherwise it creates/attaches a dedicated `gc-tui` session so the
+# TUI has a tmux to split into.
+set -euo pipefail
+
+city="${1:-${GC_CITY_NAME:-}}"
+city_flag=""
+[ -n "$city" ] && city_flag="-- --city=$city"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+run="cd '$root' && npm --workspace tui run start $city_flag"
+
+if [ -n "${TMUX:-}" ]; then
+  # Already in tmux — run directly; enter-peek splits the current window.
+  eval "$run"
+else
+  # Not in tmux — start a CLEAN dedicated session: kill any stale `gc-tui`
+  # (orphan peek panes from a previous run) first, then create fresh.
+  tmux kill-session -t gc-tui 2>/dev/null || true
+  exec tmux new-session -s gc-tui "$run"
+fi

--- a/tui/tsconfig.json
+++ b/tui/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Adds a `tui` npm workspace — an [Ink](https://github.com/vadimdemedes/ink) (React-for-CLI) **read-only terminal surface** for the Gas City dashboard, as a terminal-native companion to the web app. It is a thin client of the backend `/api/*` and reuses the `shared` DTOs and SSE event model directly (no supervisor coupling, no new wire shapes), so a contract drift is a compile error, not a runtime `undefined`.

Plus a one-line `shared` fix discovered while building it, and the two feasibility-spike findings the dashboard relies on.

## Why

An operator who lives in tmux wants an ambient glance at run/agent health without alt-tabbing to a browser — and a frictionless way to peek a specific agent's progress in a split.

## Highlights

- **Rig-grouped glance view** — orchestration layer (mayor + city dispatcher) pinned first; within a rig, active before idle. Shows corrected context%, model, activity, and the transition reason (e.g. `city-stop`) for dormant agents. Rig labels are normalised so path/name/case variants collapse to one group.
- **Health pane (`h`)** — host resources, headline counts, runs needing an operator, context pressure, and a never-active-by-rig reallocation rollup. Cost shows *not measured* (the supervisor exposes none yet — see spike below); never faked.
- **Detail pane (`p`)** — ids, peek commands, rig beads, and active run lanes.
- **Live agent peek (`enter`)** — a **single reused** tmux split running `gc --city <root> session logs <id> -f`. It *reads* the agent's log, so it can't resize or disturb the agent (unlike attaching a second tmux client). `enter` retargets the pane, `enter`-on-same or `x` closes it, and quitting tears it down. Clean launch resets a dedicated `gc-tui` session.
- Mouse-wheel + keyboard nav, scroll window with a sticky rig header, and the alternate-screen buffer so it owns one clean page.

### `fix(shared)`
`claude-opus-4-8` was missing from `TRUE_CONTEXT_WINDOWS`, so `effectiveContextPct()` fell back to gc's `context_pct` (reported against a hardcoded 200k denominator, saturating at 100) — making 1M-window agents like the mayor read a false 100% context pressure instead of ~20%. Also fixes the web UI.

### Spike findings (`specs/architecture/`)
- `cost-token-feasibility.md` — cost/token fields exist on `WorkerOperationEventPayload` but are "always absent"; arrive over `GcClient` (not a `tokscale` subprocess); typed `number`.
- `awaiting-decision-signal-feasibility.md` — `PendingInteraction` already exists (REST + per-session SSE + `respond`); surfacing it is dashboard-local work.

## Run

```bash
npm --workspace tui run start:tmux -- <city>   # launches inside tmux so enter-peek works
```

## Test plan / notes

- `tui` typecheck passes (`npm --workspace tui run typecheck`); peek open→retarget→close verified end-to-end in a real tmux (single pane reused, no pile-up).
- Root gate green on this branch: `npm run lint`, `npm --workspace shared test`, `npm run typecheck` (src + test).
- **Known follow-up:** the `tui` workspace is **not yet in the root CI `typecheck` chain** (and is outside the eslint scope), so a `shared`-DTO change can't currently fail it. Adding `npm --workspace tui run typecheck` to `typecheck:src` is the graduation step (noted in `tui/README.md`). Happy to fold that into this PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)