### PR TITLE
feat: default install is core-only — Triage (maintainer) opt-in via MODULES_ENABLED

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -79,8 +79,10 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
     cityName,
     cityRoot: cityPath,
     useFixtures: config.useFixtures,
-    enabledModules:
-      config.enabledModules === null ? null : [...enabledFirstPartyIds],
+    // Always emit the explicit resolved firstParty id list (possibly empty)
+    // so the wire is unambiguous and the frontend filter never has to guess
+    // what an unset env meant. Core-only default (PR-D) surfaces as `[]`.
+    enabledModules: [...enabledFirstPartyIds],
     defaultView: config.defaultView,
   };
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -94,15 +94,15 @@ export interface AdminConfig {
   useFixtures: boolean;
   /**
    * Operator-enabled `firstParty` module ids (PRD §2, bead 9yj.5).
-   * `null` = unset, i.e. ALL firstParty modules mount (backwards-compat
-   * with pre-PR-C behaviour). An EMPTY set = no firstParty modules mount.
-   * Non-empty = exactly those `firstParty` ids mount. `core` modules
-   * ignore this filter entirely.
+   * `null` = unset, resolved to core-only — NO firstParty modules mount
+   * (PR-D: a default install is general-purpose, Triage et al. are opt-in).
+   * An EMPTY set = same effect, reached explicitly. Non-empty = exactly
+   * those `firstParty` ids mount. `core` modules ignore this filter.
    *
-   * The wire-shape `DashboardRuntimeConfig.enabledModules` mirrors this
-   * field as `string[] | null` so the frontend can apply the same filter
-   * to `ALL_VIEWS` (otherwise a backend-disabled module's path 404s in
-   * React Router).
+   * The wire-shape `DashboardRuntimeConfig.enabledModules` mirrors the
+   * RESOLVED firstParty id list (always an explicit array, never null) so
+   * the frontend applies the same membership filter to `ALL_VIEWS`
+   * (otherwise a backend-disabled module's path 404s in React Router).
    *
    * Env: `MODULES_ENABLED` (CSV — `MODULES_ENABLED=health,maintainer`).
    * Whitespace tolerated around each entry; empty entries dropped. Casing
@@ -123,9 +123,11 @@ export interface AdminConfig {
 
 /**
  * Parse `MODULES_ENABLED` CSV per the AdminConfig.enabledModules contract.
- * Returns `null` when the env is UNSET (preserves pre-PR-C behaviour);
- * returns an empty set when the env is the empty string (operator explicitly
- * disables all firstParty modules); returns a populated set otherwise.
+ * Returns `null` when the env is UNSET; returns an empty set when the env
+ * is the empty string; returns a populated set otherwise. Note: `null`
+ * (unset) and the empty set both resolve to core-only downstream (PR-D) —
+ * the distinction is kept here only so callers can tell "operator said
+ * nothing" from "operator explicitly cleared the list".
  *
  * Whitespace around each entry is trimmed; empty entries (from leading /
  * trailing / doubled commas) are dropped. Casing is preserved — module ids

--- a/backend/src/snapshot/fixtures/snapshot.ts
+++ b/backend/src/snapshot/fixtures/snapshot.ts
@@ -55,7 +55,11 @@ export const fixtureSnapshot = {
     cityName: 'example-city',
     cityRoot: '/tmp/example-city',
     useFixtures: true,
-    enabledModules: null,
+    // Fixtures explicitly opt the maintainer (Triage) module in so the
+    // fixture-driven dev/snapshot surface still exercises it after the
+    // core-only default flip (PR-D); a real install must opt in via
+    // MODULES_ENABLED.
+    enabledModules: ['maintainer'],
     defaultView: null,
   },
   headline: {

--- a/backend/src/views/enabled.ts
+++ b/backend/src/views/enabled.ts
@@ -13,8 +13,9 @@ import { LOG_COMPONENT, logWarn } from '../logging.js';
  * Given the registry's modules and the parsed `enabledModules` env value,
  * return the set of `firstParty` module ids that SHOULD mount.
  *
- *   - `enabled === null` (env unset): every `firstParty` id is enabled
- *     (preserves pre-PR-C behaviour).
+ *   - `enabled === null` (env unset): no `firstParty` ids are enabled —
+ *     a default install is core-only (PR-D). firstParty modules (e.g.
+ *     maintainer/Triage) require an explicit `MODULES_ENABLED` opt-in.
  *   - `enabled` is an empty set: no `firstParty` ids are enabled.
  *   - `enabled` is non-empty: every member that matches a `firstParty` id
  *     in the registry is enabled. Members that name a `core` id are
@@ -31,7 +32,7 @@ export function resolveEnabledFirstPartyIds(
   const firstPartyIds = new Set(
     registry.filter((m) => m.kind === 'firstParty').map((m) => m.id),
   );
-  if (enabled === null) return firstPartyIds;
+  if (enabled === null) return new Set();
 
   const coreIds = new Set(
     registry.filter((m) => m.kind === 'core').map((m) => m.id),

--- a/backend/test/config.test.ts
+++ b/backend/test/config.test.ts
@@ -195,7 +195,7 @@ describe('MAINTAINER_REPO deprecation warning is warn-once per process', () => {
 });
 
 describe('parseModulesEnabled (PR-C / bead 9yj.5)', () => {
-  test('returns null when env is unset — preserves "all firstParty enabled" default', () => {
+  test('returns null when env is unset — distinct from explicit-empty; both resolve core-only (PR-D)', () => {
     assert.equal(parseModulesEnabled(undefined), null);
   });
 

--- a/backend/test/views-enabled.test.ts
+++ b/backend/test/views-enabled.test.ts
@@ -29,9 +29,9 @@ const registry: ReadonlyArray<BackendModule<unknown>> = [
 ];
 
 describe('resolveEnabledFirstPartyIds', () => {
-  test('null env → every firstParty id enabled (backwards-compat default)', () => {
+  test('null env (unset) → no firstParty ids enabled — core-only default (PR-D)', () => {
     const enabled = resolveEnabledFirstPartyIds(registry, null);
-    assert.deepEqual([...enabled].sort(), ['maintainer', 'something']);
+    assert.equal(enabled.size, 0);
   });
 
   test('empty set env → no firstParty ids enabled', () => {

--- a/frontend/src/views/resolve.test.ts
+++ b/frontend/src/views/resolve.test.ts
@@ -63,9 +63,9 @@ const descriptorWithLegacyPaths = {
 void descriptorWithLegacyPaths;
 
 describe('filterEnabledViews', () => {
-  it('returns the full list when enabledModules is null (backwards-compat default)', () => {
+  it('keeps only core views when enabledModules is null (unset/not-yet-loaded → core-only, PR-D)', () => {
     const result = filterEnabledViews([core, maintainer], null);
-    expect(result.map((v) => v.id)).toEqual(['health', 'maintainer']);
+    expect(result.map((v) => v.id)).toEqual(['health']);
   });
 
   it('keeps core views even when enabledModules is the empty set', () => {

--- a/frontend/src/views/resolve.ts
+++ b/frontend/src/views/resolve.ts
@@ -21,16 +21,18 @@ import { NEEDS_YOU_VIEW_PARAM } from './modules/maintainer/needsYou';
  * Filter `ALL_VIEWS` down to what should mount in this deployment.
  *
  *   - `core` views always mount (operators cannot disable a core view).
- *   - When `enabledModules` is `null` (env unset), every `firstParty` view
- *     also mounts — preserves pre-PR-C behaviour.
+ *   - When `enabledModules` is `null` (config not yet loaded), only `core`
+ *     views mount — a default install is core-only (PR-D), so the
+ *     pre-load state matches the steady state and no firstParty nav
+ *     flashes in then disappears. The backend always sends an explicit
+ *     list, so `null` here only ever means "config still loading".
  *   - When `enabledModules` is a list, only those `firstParty` ids mount.
  */
 export function filterEnabledViews(
   views: ReadonlyArray<FrontendViewDescriptor>,
   enabledModules: ReadonlyArray<string> | null,
 ): ReadonlyArray<FrontendViewDescriptor> {
-  if (enabledModules === null) return views;
-  const enabled = new Set(enabledModules);
+  const enabled = new Set(enabledModules ?? []);
   return views.filter((v) => v.kind === 'core' || enabled.has(v.id));
 }
 

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -49,13 +49,14 @@ export interface DashboardRuntimeConfig {
   cityRoot: string;
   useFixtures: boolean;
   /**
-   * Operator-enabled `firstParty` module ids (PRD §2 / bead 9yj.5).
-   * `null` = unset, i.e. ALL firstParty modules are enabled (backwards-compat
-   * default — preserves pre-PR-C behaviour). `[]` = explicitly disabled all
-   * firstParty modules. A CSV-ish set like `['health','maintainer']` enables
-   * exactly those firstParty ids. `core` modules are ALWAYS mounted and never
-   * appear in this filter — operators cannot disable a core module by leaving
-   * it off this list.
+   * Resolved `firstParty` module ids that are mounted (PRD §2 / bead 9yj.5).
+   * The backend always emits an explicit array — `[]` for a core-only
+   * default install (PR-D), or e.g. `['maintainer']` when opted in via
+   * `MODULES_ENABLED`. `core` modules are ALWAYS mounted and never appear
+   * in this list — operators cannot disable a core module.
+   *
+   * `null` remains in the type only for the frontend's pre-load state
+   * (config not yet fetched), which the frontend treats as core-only.
    *
    * The frontend's view registry filters `ALL_VIEWS` by this set so a
    * backend-disabled module's route does not render a React Router 404; the


### PR DESCRIPTION
## What & why

PR-D from the modular-dashboard PRD (§G2). The maintainer (**Triage**) module is already a proper `firstParty`, `MODULES_ENABLED`-gated module — but its *default* shipped it **on**: an unset `MODULES_ENABLED` resolved to "all firstParty modules mount", so a fresh, general-purpose install rendered Triage out of the box.

This flips the default to **core-only**: firstParty modules (Triage et al.) require an explicit `MODULES_ENABLED` opt-in. The extension story is unchanged — adding a tab is still a `ViewDescriptor` + `ModuleDescriptor` registration (`specs/architecture/module-author-checklist.md`).

Operator decision (2026-06-01): core-only default. Resolves bead `gascity-dashboard-13li`.

## Changes

| File | Change |
|------|--------|
| `backend/src/views/enabled.ts` | `null` (unset) → empty set (core-only) instead of all-firstParty |
| `backend/src/city/runtime.ts` | Wire always emits the explicit resolved list (`[]` when core-only), never `null` |
| `frontend/src/views/resolve.ts` | `filterEnabledViews(null)` → core-only (also removes the nav flash-then-hide before config loads) |
| `backend/src/snapshot/fixtures/snapshot.ts` | Fixtures opt `['maintainer']` in explicitly so dev/snapshot still exercises Triage |
| `backend/src/config.ts`, `shared/src/snapshot/types.ts` | Doc comments updated to the new contract |
| `*.test.ts` (×3) | Behavior tests flipped to assert core-only (TDD) |

Drops the "unset = all firstParty" shorthand by design — explicit CSV is the opt-in.

## Behavior

- **Fresh install** (no `MODULES_ENABLED`): Health (core) only. No `/maintainer` nav, route, worker, or cache I/O.
- `MODULES_ENABLED=maintainer`: re-enables Triage.

## Test plan

All green locally (matches CI):

- [x] `npm run typecheck`
- [x] `typecheck:test` (backend + frontend)
- [x] backend tests
- [x] frontend tests
- [x] `npm run lint`
- [x] frontend `build`

## Follow-up

- `gascity-dashboard-nged` (blocked on this): close the `MAINTAINER_*` host-config leak — with maintainer disabled, the host still parses `MAINTAINER_*` and echoes `gastownhall/gascity` as `githubRepo`.
- Context: bead `gascity-dashboard-xpf0` ("Revisit modular-dashboard audience hypothesis", target 2026-11-30) tracks the broader audience/Phase-2 question; this PR is the Phase-1 core-only default it anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)