### PR TITLE
fix(runs): resolve formula name + diff for rig-store routed roots via gc.routed_to

### DIFF
--- a/backend/src/runs/execution-path.ts
+++ b/backend/src/runs/execution-path.ts
@@ -12,6 +12,13 @@ export function resolveRunExecutionPath(
   const candidates = [
     ...executionWorkDirs(root),
     ...beads.flatMap((bead) => executionWorkDirs(bead)),
+    // gascity-dashboard-tqus: gc.routed_to is the supervisor's canonical
+    // routing dir for rig-store roots. It ranks BELOW every explicit
+    // cwd/work_dir (a child session's real work_dir must win over the
+    // root's canonical-but-maybe-uninstantiated routed_to) but ABOVE the
+    // generic rig roots, since it is more specific than a rig checkout.
+    routedToWorkDir(root),
+    ...beads.map((bead) => routedToWorkDir(bead)),
     ...rigRoots(root),
     ...beads.flatMap((bead) => rigRoots(bead)),
     nonEmpty(rigRoot),
@@ -29,6 +36,15 @@ function executionWorkDirs(bead: GcRunBead | undefined): Array<string | undefine
     meta(bead, 'gc.work_dir'),
     meta(bead, 'work_dir'),
   ];
+}
+
+// gascity-dashboard-tqus: the supervisor marks routed rig-store workflow
+// roots with gc.routed_to (the agent's working directory) when no explicit
+// work_dir is recorded. Only an absolute path is a usable git cwd —
+// gc.routed_to can also hold an agent alias, which must never become a path.
+function routedToWorkDir(bead: GcRunBead | undefined): string | undefined {
+  const routedTo = meta(bead, 'gc.routed_to');
+  return routedTo !== undefined && routedTo.startsWith('/') ? routedTo : undefined;
 }
 
 function rigRoots(bead: GcRunBead | undefined): Array<string | undefined> {

--- a/backend/src/runs/formula-name.ts
+++ b/backend/src/runs/formula-name.ts
@@ -57,10 +57,12 @@ export interface ResolvedRunFormulaName {
  * missing a formula, collapsing every graph.v2 run-detail page to an
  * empty `formula_detail_unavailable` state.
  *
- * The gate on `gc.run_target` is what keeps the fallback honest: only
- * fully-instantiated runnable roots set both `gc.formula_contract` and
- * `gc.run_target`. Operator-edited descriptive titles on closed roots
- * without a target won't be mis-surfaced as formula names.
+ * The routing gate is what keeps the fallback honest: only fully-
+ * instantiated runnable roots set `gc.formula_contract` together with a
+ * supervisor routing signal — `gc.run_target` (legacy) or `gc.routed_to`
+ * (gascity-dashboard-tqus, the current rig-store shape). Operator-edited
+ * descriptive titles on closed or unrouted roots won't be mis-surfaced as
+ * formula names.
  *
  * gascity-dashboard-xfb7 (sadp follow-up): closed graph.v2 roots are
  * additionally excluded from the title fallback even when they retain
@@ -90,7 +92,7 @@ export function resolveRunFormulaName(
   if (explicit !== undefined) return { name: explicit, source: 'metadata' };
   if (
     meta(root, 'gc.formula_contract') === 'graph.v2' &&
-    meta(root, 'gc.run_target') !== undefined &&
+    hasRunRoutingSignal(root) &&
     root.status !== 'closed'
   ) {
     const title = root.title.trim();
@@ -140,9 +142,14 @@ function runFormulaTitleFallback(
   root: RunFormulaRootLike | undefined,
 ): string | null {
   if (root === undefined) return null;
+  // The runnable-root gate: only a routed, non-closed graph.v2 root gets the
+  // title fallback. gascity-dashboard-tqus — the supervisor now marks routed
+  // rig-store roots with gc.routed_to instead of gc.run_target, so either
+  // routing signal qualifies (both are supervisor-set; an operator-edited
+  // title alone never is).
   if (
     rootMeta(root, 'gc.formula_contract') !== 'graph.v2' ||
-    rootMeta(root, 'gc.run_target') === undefined ||
+    !hasRunRoutingSignal(root) ||
     root.status === 'closed'
   ) {
     return null;
@@ -158,6 +165,20 @@ function runFormulaTarget(root: RunFormulaRootLike | undefined): string | null {
     rootMeta(root, 'gc.routed_to') ??
     nonEmpty(root?.assignee) ??
     null
+  );
+}
+
+/**
+ * True when the supervisor has routed this root to a run target — via the
+ * legacy `gc.run_target` or the newer `gc.routed_to` (gascity-dashboard-tqus).
+ * The assignee is deliberately NOT a routing signal here: any bead can carry
+ * an assignee, so it would loosen the title-fallback gate past "runnable
+ * root". `runFormulaTarget` keeps the assignee fallback for display only.
+ */
+function hasRunRoutingSignal(root: RunFormulaRootLike | undefined): boolean {
+  return (
+    rootMeta(root, 'gc.run_target') !== undefined ||
+    rootMeta(root, 'gc.routed_to') !== undefined
   );
 }
 

--- a/backend/test/run-execution-path.test.ts
+++ b/backend/test/run-execution-path.test.ts
@@ -55,6 +55,62 @@ describe('run execution path resolution', () => {
   // is unknown" — rather than a known-but-useless path. The function still
   // honors an explicit rig_root in supervisor metadata (test above).
 
+  test('resolves gc.routed_to as the work dir for rig-store routed roots (tqus)', () => {
+    // gascity-dashboard-tqus: the supervisor marks routed rig-store workflow
+    // roots with gc.routed_to (an absolute work-dir path) instead of
+    // gc.cwd/gc.work_dir, so the diff resolver must accept it.
+    const root = runBead({
+      metadata: { 'gc.routed_to': ' /home/ds/gascity-packs/gascity-packs-polecat ' },
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root], undefined), {
+      kind: 'known',
+      path: '/home/ds/gascity-packs/gascity-packs-polecat',
+    });
+  });
+
+  test('a child work_dir outranks the root gc.routed_to (real worktree beats canonical routing dir)', () => {
+    // gascity-dashboard-tqus: rig-store roots often carry a canonical
+    // gc.routed_to that may not be the instantiated worktree, while the
+    // child session records the real gc.work_dir. The real worktree must win.
+    const root = runBead({
+      metadata: { 'gc.routed_to': '/home/ds/gascity-packs/gascity-packs-polecat' },
+    });
+    const child = runBead({
+      id: 'session-step',
+      metadata: { 'gc.work_dir': '/home/ds/gascity-packs-worktrees/polecat-2' },
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root, child], undefined), {
+      kind: 'known',
+      path: '/home/ds/gascity-packs-worktrees/polecat-2',
+    });
+  });
+
+  test('prefers an explicit gc.cwd over gc.routed_to', () => {
+    const root = runBead({
+      metadata: { 'gc.cwd': '/runs/explicit', 'gc.routed_to': '/home/ds/packs/x' },
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root], undefined), {
+      kind: 'known',
+      path: '/runs/explicit',
+    });
+  });
+
+  test('ignores a non-path gc.routed_to (agent alias) so it cannot shadow a rig root', () => {
+    // gc.routed_to is sometimes an agent alias rather than a path; only an
+    // absolute path is a usable git cwd. A non-path value must fall through.
+    const root = runBead({
+      metadata: { 'gc.routed_to': 'polecat', 'gc.rig_root': '/rig/from-root' },
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root], undefined), {
+      kind: 'known',
+      path: '/rig/from-root',
+    });
+  });
+
   test('returns an explicit unavailable state when no execution path is available', () => {
     assert.deepEqual(resolveRunExecutionPath(runBead({}), [], '  '), {
       kind: 'unavailable',

--- a/backend/test/run-formula-name.test.ts
+++ b/backend/test/run-formula-name.test.ts
@@ -55,10 +55,29 @@ describe('resolveRunFormulaName', () => {
     });
   });
 
-  test('does NOT fall back to title for graph.v2 roots without gc.run_target', () => {
-    // Without a target the formula can't be fetched anyway; surfacing the
-    // title as a "known" name would be a silent fallback that masks the
-    // actual missing-config failure mode.
+  test('tags the title fallback for graph.v2 roots gated by gc.routed_to (no gc.run_target) — rig-store routed roots (tqus)', () => {
+    // gascity-dashboard-tqus: the supervisor marks routed rig-store workflow
+    // roots with gc.routed_to (a work-dir path) instead of gc.run_target.
+    // The runnable-root gate must accept it or every rig-store run collapses
+    // to 'metadata missing'.
+    const root = makeRoot(
+      {
+        'gc.kind': 'workflow',
+        'gc.formula_contract': 'graph.v2',
+        'gc.routed_to': '/home/ds/gascity-packs/gascity-packs-polecat',
+      },
+      'mol-focus-review',
+    );
+    assert.deepEqual(resolveRunFormulaName(root), {
+      name: 'mol-focus-review',
+      source: 'title_fallback',
+    });
+  });
+
+  test('does NOT fall back to title for graph.v2 roots without gc.run_target or gc.routed_to', () => {
+    // Without any routing signal the formula can't be fetched anyway;
+    // surfacing the title as a "known" name would be a silent fallback that
+    // masks the actual missing-config failure mode.
     const root = makeRoot(
       { 'gc.kind': 'workflow', 'gc.formula_contract': 'graph.v2' },
       'mol-fixture-formula',
@@ -200,6 +219,31 @@ describe('resolveRunFormulaIdentity', () => {
       name: 'mol-from-detail',
       source: 'formula_detail',
       target: '/fixture/run/target',
+    });
+  });
+
+  test('state + lane modes resolve title_fallback for a gc.routed_to-gated rig-store root (tqus)', () => {
+    // The live ds-research regression: rig-store roots carry gc.routed_to
+    // (a work-dir path) and a mol- title, but no gc.run_target. Both the
+    // run-detail (state) and the snapshot lane must surface the title.
+    const root = makeRoot(
+      {
+        'gc.kind': 'workflow',
+        'gc.formula_contract': 'graph.v2',
+        'gc.routed_to': '/home/ds/gascity-packs/gascity-packs-polecat',
+      },
+      'mol-focus-review',
+    );
+
+    assert.deepEqual(resolveRunFormulaIdentity('state', { root }), {
+      name: 'mol-focus-review',
+      source: 'title_fallback',
+      target: '/home/ds/gascity-packs/gascity-packs-polecat',
+    });
+    assert.deepEqual(resolveRunFormulaIdentity('lane', { root, issues: [root] }), {
+      name: 'mol-focus-review',
+      source: 'title_fallback',
+      target: '/home/ds/gascity-packs/gascity-packs-polecat',
     });
   });
 


### PR DESCRIPTION
## Symptom

On live ds-research the formula run detail showed **"metadata missing"** for the formula and an **empty diff panel**, and the view was **slow to load**. Every formula run there is now a rig-store root (`root_store_ref=rig:gascity-packs`).

## Root cause (one upstream change, two stale resolvers)

The supervisor evolved how it marks routed rig-store workflow roots. The root bead now carries:

```
gc.formula_contract: graph.v2
gc.routed_to: /home/ds/gascity-packs/gascity-packs-polecat   ← work-dir path (new)
gc.source_bead_id / gc.source_store_ref                       ← new
```

…and **no** `gc.run_target`, `gc.cwd`, `gc.work_dir`, or `gc.rig_root`. Two dashboard resolvers still keyed on the old names:

1. **`formula-name.ts`** — the title-fallback runnable-root gate required `gc.run_target`, so the title `mol-focus-review` (a valid formula name) fell through to `metadata missing`.
2. **`execution-path.ts`** — only looked for `gc.cwd`/`gc.work_dir`/`gc.rig_root`, so `executionPath = missing_cwd_and_rig_root` → diff `path_unknown`.

`runFormulaTarget` already fell back to `gc.routed_to`; these two gates just never got the same update.

## Fix (dashboard-side edge translation)

- **Gate** (`formula-name.ts`): accept `gc.run_target` **or** `gc.routed_to` as the routing signal via a new `hasRunRoutingSignal()` — assignee deliberately excluded so the gate stays "runnable root". `status != closed` + `graph.v2` gates unchanged (preserves the xfb7 honesty rationale). Both the live `resolveRunFormulaIdentity` and the dead-but-tested `resolveRunFormulaName` are synced so the duplicated heuristic can't drift.
- **Exec path** (`execution-path.ts`): `gc.routed_to` (absolute paths only — it can also hold an agent alias) added as a work-dir candidate ranked **below** every explicit `cwd`/`work_dir` (a child session's real worktree must win over the root's canonical routing dir) and **above** generic rig roots.

## Verified live (tsx-watch hot-reload on ds-research)

| Run | Before | After |
|-----|--------|-------|
| `gpk-kyh8g` (pending, routed_to only) | `metadata missing`, no diff | formula `mol-focus-review` (title_fallback); diff honestly `not_git` (work dir not yet instantiated) |
| `gpk-4wtw2` (completed, has `gc.work_dir`) | `metadata missing` | formula `mol-focus-review`; **diff ok, 8 files / 35KB** |

## Scope notes

- **Slow load** is largely supervisor-side: `getRun`/diff scan the rig stores (3–10s); the route also awaits supervisor calls sequentially. Not addressed here — filed separately if we want to parallelize the independent fetches.
- Runs that carry **only** a `routed_to` pointing at a not-yet-instantiated dir still show no diff — that's correct (no work exists), and the deeper "supervisor doesn't record the worktree path for some rig-store roots" gap is the existing `gascity-dashboard-j7np`.

## Test plan
- [x] New unit tests: `routed_to` gate in `run-formula-name` (state + lane), `routed_to` work-dir + a-child-work_dir-outranks-root-routed_to + non-path-alias-ignored in `run-execution-path`
- [x] `npm run typecheck`, backend `typecheck:test`
- [x] backend tests (964 pass)
- [x] eslint on changed files

Bug: gascity-dashboard-tqus

🤖 Generated with [Claude Code](https://claude.com/claude-code)