### PR TITLE
perf(runs): parallelize independent supervisor fetches in run-detail route

### DIFF
--- a/backend/src/routes/runs.ts
+++ b/backend/src/routes/runs.ts
@@ -75,17 +75,16 @@ export function runsRouter(
       return;
     }
     try {
-      const { raw, partial: runtimePartial } = await getRunWithRuntimeState(
-        gc,
-        parsed.runId,
-        parsed.scope ?? defaultRunScope(gc.cityName),
-      );
-      const sessionsLookup = await getRunSessions(gc);
-      const formulaDetailLookup = await getRunFormulaDetail(
-        gc,
-        raw,
-        parsed.scope ?? defaultRunScope(gc.cityName),
-      );
+      const scope = parsed.scope ?? defaultRunScope(gc.cityName);
+      // getRunSessions is a city-wide listSessions independent of this run, so
+      // overlap it with the run+runtime-state fetch instead of serializing it
+      // after (gascity-dashboard-ey8i). getRunFormulaDetail genuinely depends
+      // on the run's raw root bead, so it stays sequential after the run fetch.
+      const [{ raw, partial: runtimePartial }, sessionsLookup] = await Promise.all([
+        getRunWithRuntimeState(gc, parsed.runId, scope),
+        getRunSessions(gc),
+      ]);
+      const formulaDetailLookup = await getRunFormulaDetail(gc, raw, scope);
       const detail = enrichFormulaRun(raw, enrichOptions(
         opts,
         sessionsLookup,


### PR DESCRIPTION
## Why

Follow-up to the slow formula-view investigation (#13 / `gascity-dashboard-tqus`). The run-detail route `GET /city/:city/runs/:runId` made three supervisor round-trips **sequentially**:

```
await getRunWithRuntimeState(...)   // getRun + bead fan-out
await getRunSessions(gc)            // city-wide listSessions — independent of the run
await getRunFormulaDetail(raw,...)  // depends on raw root bead
```

`getRunSessions` is a city-wide `listSessions` with no dependency on the run, so serializing it after the run fetch added its round-trip to the critical path for nothing.

## Change

Overlap the run+runtime-state fetch with the sessions fetch via `Promise.all`; keep `getRunFormulaDetail` sequential since it genuinely needs the run's `raw` root bead:

```ts
const [{ raw, partial }, sessionsLookup] = await Promise.all([
  getRunWithRuntimeState(gc, runId, scope),
  getRunSessions(gc),
]);
const formulaDetailLookup = await getRunFormulaDetail(gc, raw, scope);
```

Saves one `listSessions` round-trip off run-detail latency.

## Safety

- Same response shape and `completeness` reasons.
- `getRunSessions` never throws (returns an `unavailable` lookup on error), so `Promise.all` only rejects on a real run-fetch failure — identical to prior behavior, still caught by the route's `try/catch`. Sessions has no side effects, so a discarded result on rejection is fine.
- The `/diff` route is left sequential — its `git` read genuinely depends on the resolved execution path.

## Scope note

The dominant remaining latency is supervisor-side: `getRun` scans the rig stores (observed 3–10s on ds-research). That's not addressable here.

## Test plan
- [x] backend `typecheck` + `typecheck:test`
- [x] backend tests (958 pass)
- [x] eslint on changed file

Bug: gascity-dashboard-ey8i

🤖 Generated with [Claude Code](https://claude.com/claude-code)