### PR TITLE
perf(snapshot): stale-while-revalidate in SourceCache.get()

### DIFF
--- a/backend/src/snapshot/cache.ts
+++ b/backend/src/snapshot/cache.ts
@@ -111,12 +111,33 @@ export class SourceCache<T> {
   }
 
   async get(options: { force?: boolean } = {}): Promise<SourceState<T>> {
+    if (options.force) {
+      return await this.refresh();
+    }
+
     const current = this.currentState();
 
-    if (!options.force && current && current.status !== 'stale') {
+    // Fresh (within TTL) or fixture fallback — serve as-is, no fetch.
+    if (current && current.status !== 'stale') {
       return current;
     }
 
+    // Stale-while-revalidate (gascity-dashboard-rqv0): we still hold prior
+    // live data whose TTL has lapsed. Serve it immediately and kick off a
+    // single-flighted background refresh instead of blocking the caller on
+    // the upstream supervisor scan (~seconds). The snapshot is polled by the
+    // frontend (visible-poll + SSE), so the refreshed entry lands on the next
+    // cycle; `stale` is already a first-class wire status the UI renders.
+    if (current) {
+      void this.refresh().catch(() => {
+        // refresh() resolves even on load failure (refreshUnshared catches
+        // and records lastError); this guard only prevents an unexpected
+        // throw from surfacing as an unhandled rejection on the bg path.
+      });
+      return current;
+    }
+
+    // Cold cache — nothing to serve, so the caller must wait for the first load.
     return await this.refresh();
   }
 

--- a/backend/test/snapshot-cache.test.ts
+++ b/backend/test/snapshot-cache.test.ts
@@ -41,10 +41,60 @@ describe('SourceCache', () => {
     assert.equal(stillFresh.status, 'fresh');
     assert.equal(loadCount, 1);
 
-    // Past TTL boundary — .get() should refresh (and succeed again).
+    // Past TTL boundary — stale-while-revalidate: .get() serves the prior
+    // value immediately with status 'stale' and fires a background refresh
+    // (load() already invoked), rather than blocking the caller.
     nowMs += 600;
+    const stale = await cache.get();
+    assert.equal(stale.status, 'stale');
+    assert.deepEqual(stale.data, { value: 'live' });
+    assert.equal(loadCount, 2, 'background refresh load() fired');
+
+    // Once the background refresh settles the cache is fresh again, with no
+    // additional load.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const refreshed = await cache.get();
     assert.equal(refreshed.status, 'fresh');
+    assert.equal(loadCount, 2);
+  });
+
+  test('stale-while-revalidate: past-TTL .get() serves stale immediately while the refresh is still in flight', async () => {
+    let nowMs = Date.parse('2026-05-22T12:00:00.000Z');
+    let loadCount = 0;
+    let release: (() => void) | undefined;
+    const cache = new SourceCache({
+      source: 'runs',
+      ttlMs: 1_000,
+      now: () => new Date(nowMs),
+      load: async () => {
+        loadCount += 1;
+        if (loadCount >= 2) {
+          // Hold the background refresh open so the assertion below proves
+          // the stale read returned WITHOUT waiting on the upstream fetch.
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+        return { value: `live-${loadCount}` };
+      },
+    });
+
+    const fresh = await cache.get();
+    assert.equal(fresh.status, 'fresh');
+    assert.equal(loadCount, 1);
+
+    nowMs += 1_500; // past TTL
+    const stale = await cache.get();
+    assert.equal(stale.status, 'stale');
+    assert.deepEqual(stale.data, { value: 'live-1' }, 'serves prior value, not the in-flight refresh');
+    assert.equal(loadCount, 2, 'background refresh started');
+
+    // Release the background refresh; the next read is fresh with no extra load.
+    release?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const refreshed = await cache.get();
+    assert.equal(refreshed.status, 'fresh');
+    assert.deepEqual(refreshed.data, { value: 'live-2' });
     assert.equal(loadCount, 2);
   });
 
@@ -116,9 +166,13 @@ describe('SourceCache', () => {
     assert.equal(fresh.status, 'fresh');
     assert.deepEqual(fresh.data, { value: 'live' });
 
-    // Advance past TTL so the next .get() triggers a refresh.
+    // Advance past TTL and force a blocking refresh so the failing load is
+    // surfaced synchronously. (A plain get() now serves stale immediately and
+    // refreshes in the background — the SWR path — so the error would land a
+    // cycle later; `force` is the deterministic probe of the stale-while-error
+    // contract: data preserved, error surfaced.)
     nowMs += 1_500;
-    const stale = await cache.get();
+    const stale = await cache.get({ force: true });
     assert.equal(stale.status, 'stale');
     assert.deepEqual(stale.error, { kind: 'message', message: 'collector failed' });
     assert.deepEqual(stale.data, { value: 'live' });


### PR DESCRIPTION
## Why

Follow-up to the slow formula-view investigation. The latency on the runs/history page is **not** that the runs collector is under-parallelized (it already `Promise.all`-fans its supervisor calls). It's the cache: `SourceCache.get()` **blocks on `refresh()` whenever the entry is past its 60s TTL**, so every ~60s the next snapshot load eats the full supervisor store-scan (~5s on ds-research). The scan itself is supervisor-side and irreducible; the dashboard's job is to stop making the user wait on it.

## Change

`get()` now does **stale-while-revalidate**:

```ts
if (options.force) return await this.refresh();        // explicit /snapshot/refresh
const current = this.currentState();
if (current && current.status !== 'stale') return current;   // fresh / fixture
if (current) {                                          // stale (TTL lapsed, have data)
  void this.refresh().catch(() => {});                  // single-flighted background refresh
  return current;                                       // serve stale NOW
}
return await this.refresh();                            // cold cache — must block once
```

So after the first load, the snapshot endpoint returns **immediately** with at-most-one-cycle-stale data and revalidates in the background. The frontend already polls (visible-interval + SSE), so fresh data lands on the next cycle. `stale` is an existing first-class wire status the UI renders, so nothing new leaks to the user.

## Tradeoff (intentional, ambient-appropriate)

A failed *background* refresh surfaces its error **one cycle later** rather than synchronously. The stale-while-error contract (data preserved + error surfaced) is otherwise unchanged — `refreshUnshared` is untouched, and `force: true` still blocks and surfaces errors synchronously.

## Scope

- Applies to all snapshot sources (city / runs / resources) — the whole snapshot-driven UI gets instant-after-first-load.
- Does **not** touch the uncached run-detail route (`/runs/:runId`), which calls `getRun` live on every click. That's a separate path — caching it (or deferring `getRunFormulaDetail`) is a follow-up.

## Test plan
- [x] TTL-boundary test updated: post-TTL `get()` now asserts serve-stale + background-refresh
- [x] stale-while-error test uses `force` to probe the blocking path deterministically
- [x] new test: in-flight refresh held open proves the stale read returns without waiting
- [x] backend `typecheck` + `typecheck:test`
- [x] backend tests (965 pass)
- [x] eslint on changed files

Bug: gascity-dashboard-rqv0

🤖 Generated with [Claude Code](https://claude.com/claude-code)