### PR TITLE
feat(runs): expand-in-place history — show-more toggle instead of "N more not shown"

### DIFF
--- a/backend/src/snapshot/collectors/runs/constants.ts
+++ b/backend/src/snapshot/collectors/runs/constants.ts
@@ -3,10 +3,11 @@ export const RUNS_FETCH_LIMIT = 1_000;
 export const RECENT_RUN_FETCH_LIMIT = 80;
 
 /**
- * gascity-dashboard-yh5i: active and historical lanes have independent caps
- * so complete lanes can never crowd active work out of the visible window.
+ * gascity-dashboard-yh5i: active lanes are capped so they can't crowd the
+ * ambient window. Historical lanes ship uncapped (gascity-dashboard-l9q9) —
+ * the frontend owns the historical preview/expand count — so there is no
+ * MAX_VISIBLE_HISTORICAL_LANES here anymore.
  */
 export const MAX_VISIBLE_ACTIVE_LANES = 8;
-export const MAX_VISIBLE_HISTORICAL_LANES = 5;
 
 export const RECENT_CHANGES_CAP = 12;

--- a/backend/src/snapshot/collectors/runs/grouping.ts
+++ b/backend/src/snapshot/collectors/runs/grouping.ts
@@ -6,10 +6,7 @@ import {
 
 import { fromRootMetadataScope } from '../../../lib/run-scope.js';
 import { resolveRunFormulaIdentity } from '../../../runs/formula-name.js';
-import {
-  MAX_VISIBLE_ACTIVE_LANES,
-  MAX_VISIBLE_HISTORICAL_LANES,
-} from './constants.js';
+import { MAX_VISIBLE_ACTIVE_LANES } from './constants.js';
 import type { RunFeedScopeMap } from './types.js';
 import {
   activeAssignees,
@@ -59,14 +56,17 @@ export function buildRunSummary(
   const activeLanes = sortedLanes.filter((lane) => lane.phase !== 'complete');
   const historicalLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
   const visibleActive = activeLanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
-  const visibleHistorical = historicalLanes.slice(0, MAX_VISIBLE_HISTORICAL_LANES);
 
   const summary: RunSummary = {
     totalActive: activeLanes.length,
     totalHistorical: historicalLanes.length,
     runCounts: runCounts(activeLanes, visibleActive.length),
     lanes: visibleActive,
-    historicalLanes: visibleHistorical,
+    // Historical lanes ship uncapped (gascity-dashboard-l9q9): the frontend
+    // renders a preview and reveals the rest in place via a show-more toggle,
+    // so the wire must carry the full completed set (bounded by the run-fetch
+    // limit). Active lanes stay capped — they're the live, ambient surface.
+    historicalLanes,
     recentChanges: recentChanges(laneIssues),
     census: runCensusUnavailable(),
   };

--- a/backend/test/snapshot-runs.test.ts
+++ b/backend/test/snapshot-runs.test.ts
@@ -8,7 +8,6 @@ import {
   createRunsSourceCache,
   fromGcBead,
   MAX_VISIBLE_ACTIVE_LANES,
-  MAX_VISIBLE_HISTORICAL_LANES,
   RECENT_RUN_FETCH_LIMIT,
   runBeadFilter,
 } from '../src/snapshot/collectors/runs.js';
@@ -1010,11 +1009,11 @@ describe('buildRunSummary', () => {
     assert.deepEqual(summary.historicalLanes, []);
   });
 
-  test('yh5i: independent caps — historical overflow does not steal active slots', () => {
-    // Build 10 active + 7 historical lanes (each cap is 8 + 5 respectively).
-    // Active cap = MAX_VISIBLE_ACTIVE_LANES (8), historical cap = MAX_VISIBLE_HISTORICAL_LANES (5).
-    // Expect: lanes.length === 8 (cap), historicalLanes.length === 5 (cap),
-    // totalActive === 10 (raw count), totalHistorical === 7 (raw count).
+  test('yh5i/l9q9: active stays capped while historical ships uncapped', () => {
+    // Build 10 active + 7 historical lanes. Active cap = MAX_VISIBLE_ACTIVE_LANES
+    // (8); historical is no longer capped on the wire (l9q9 — the frontend owns
+    // the preview/expand). Expect: lanes.length === 8 (cap), historicalLanes
+    // carries all 7, totalActive === 10, totalHistorical === 7.
     const issues = [];
     for (let i = 0; i < 10; i += 1) {
       issues.push(issue({
@@ -1042,7 +1041,7 @@ describe('buildRunSummary', () => {
     assert.equal(summary.totalActive, 10, 'raw active count');
     assert.equal(summary.totalHistorical, 7, 'raw historical count');
     assert.equal(summary.lanes.length, MAX_VISIBLE_ACTIVE_LANES, 'active cap');
-    assert.equal(summary.historicalLanes.length, MAX_VISIBLE_HISTORICAL_LANES, 'historical cap');
+    assert.equal(summary.historicalLanes.length, 7, 'historical uncapped — all sent');
     // Crucially: no historical lane leaks into active and vice versa.
     for (const lane of summary.lanes) {
       assert.notEqual(lane.phase, 'complete', `lane ${lane.id} must not be complete`);

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { RunLane, RunSummary, SourceState } from "gas-city-dashboard-shared";
 import { LaneCard } from "./LaneCard";
 
@@ -27,6 +28,11 @@ const COUNT_LABELS: Array<[keyof RunSummary["runCounts"], string]> = [
 ];
 
 const HISTORICAL_SECTION_ID = 'runs-historical-section';
+const HISTORICAL_LIST_ID = 'runs-historical-list';
+// How many completed runs show before the operator opts into the rest.
+// The wire carries every historical lane (gascity-dashboard-l9q9); this
+// preview keeps the section ambient by default per DESIGN.md.
+const HISTORICAL_PREVIEW = 5;
 
 export function RunMap({ source, now, showHistory }: RunMapProps) {
   if (source.status === "error") {
@@ -122,6 +128,11 @@ function rigLabel(rig: string): string {
 }
 
 function HistoricalSection({ summary, now }: { summary: RunSummary; now: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const lanes = summary.historicalLanes;
+  const hasOverflow = lanes.length > HISTORICAL_PREVIEW;
+  const shown = expanded ? lanes : lanes.slice(0, HISTORICAL_PREVIEW);
+
   return (
     <section
       id={HISTORICAL_SECTION_ID}
@@ -131,21 +142,27 @@ function HistoricalSection({ summary, now }: { summary: RunSummary; now: number 
       <h2 className="text-label uppercase tracking-wider text-fg-faint">
         Historical
       </h2>
-      {summary.historicalLanes.length === 0 ? (
+      {lanes.length === 0 ? (
         <p className="mt-3 text-body text-fg-muted italic">
           No completed runs in the current window.
         </p>
       ) : (
         <>
-          <ol className="mt-3 divide-y divide-rule">
-            {summary.historicalLanes.map((lane) => (
+          <ol id={HISTORICAL_LIST_ID} className="mt-3 divide-y divide-rule">
+            {shown.map((lane) => (
               <LaneCard key={lane.id} lane={lane} now={now} />
             ))}
           </ol>
-          {summary.totalHistorical > summary.historicalLanes.length && (
-            <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
-              {summary.totalHistorical - summary.historicalLanes.length} more not shown
-            </p>
+          {hasOverflow && (
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={expanded}
+              aria-controls={HISTORICAL_LIST_ID}
+              className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum hover:text-fg focus-mark"
+            >
+              {expanded ? 'Show fewer' : `Show ${lanes.length - HISTORICAL_PREVIEW} more`}
+            </button>
           )}
         </>
       )}


### PR DESCRIPTION
## Why

The runs **Historical** section capped completed runs at 5 on the wire and showed a static "N more not shown" footnote (`RunMap.tsx`), so the other runs were unreachable without a code change — you couldn't get at a run hidden in the "26 more".

## Change (expand-in-place)

- **Backend** ships **all** historical lanes (`grouping.ts`). They were already computed server-side and just sliced off; `totalHistorical` still carries the count. Active lanes stay capped (`MAX_VISIBLE_ACTIVE_LANES`) — they're the live ambient surface.
- **Frontend** (`RunMap.tsx`) renders a 5-run preview with a **"Show N more" / "Show fewer"** toggle that reveals the rest in place (`useState`). Collapsed by default keeps the section ambient per `DESIGN.md`; one click expands. The toggle is a real accessible button (`aria-expanded` + `aria-controls`), styled in the existing tracked-uppercase editorial register — no card chrome, consistent with the Flat Page Rule.

```
Historical
─────────────
  run A
  ...(5 shown)
  [ Show 26 more ]   ← click → reveals all inline, becomes "Show fewer"
```

## DESIGN.md note

This is progressive disclosure, not added density: the resting state is unchanged (5 + a quiet text toggle), so it stays within the "density is not insight" stance while making the full set reachable on intent.

## Notes
- Removed the now-frontend-owned `MAX_VISIBLE_HISTORICAL_LANES`; the preview count (`HISTORICAL_PREVIEW = 5`) lives in `RunMap`.
- Active lanes' own "N more not shown" footnote is unchanged (out of scope — you asked about history).

## Test plan
- [x] backend `typecheck` + `typecheck:test`; frontend `typecheck` + `typecheck:test`
- [x] backend tests (964) — independent-caps test now asserts historical ships uncapped
- [x] frontend tests
- [x] frontend `build`
- [x] eslint on changed files

Bug: gascity-dashboard-l9q9

🤖 Generated with [Claude Code](https://claude.com/claude-code)