### PR TITLE
Dashboard wave: board-only Beads, faster Runs, flat Agents table, Health diagnostics

### DIFF
--- a/backend/src/gc-supervisor-decoders.ts
+++ b/backend/src/gc-supervisor-decoders.ts
@@ -476,11 +476,24 @@ const StatusStoreHealthSchema = z.object({
   size_bytes: z.number().finite(),
   live_rows: z.number().finite().optional(),
   ratio_mb_per_row: z.number().finite().optional(),
+  threshold_mb_per_row: z.number().finite().optional(),
+  warning: z.boolean().optional(),
   last_gc_at: z.string().optional(),
+  last_gc_status: z.string().optional(),
+  path: z.string().optional(),
+}).passthrough();
+
+// gascity-dashboard-1cob: beads usage for the Health page, from status.work.
+const StatusWorkCountsSchema = z.object({
+  open: z.number().finite(),
+  ready: z.number().finite(),
+  in_progress: z.number().finite(),
 }).passthrough();
 
 const StatusSchema = z.object({
   store_health: StatusStoreHealthSchema.optional(),
+  work: StatusWorkCountsSchema.optional(),
+  version: z.string().optional(),
 }).passthrough();
 
 // izgc F3: every ListBody* envelope in the supervisor's OpenAPI declares

--- a/backend/src/routes/health-diagnostics.test.ts
+++ b/backend/src/routes/health-diagnostics.test.ts
@@ -1,0 +1,199 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { GcStatus } from 'gas-city-dashboard-shared';
+import {
+  parseVersion,
+  buildDiagnostics,
+  type VersionProbe,
+} from './health-diagnostics.js';
+
+// gascity-dashboard-1cob: the diagnostics builder is pure — supervisor status
+// and the two version probes are injected, so every branch is testable
+// without spawning a process or touching a real supervisor.
+
+describe('parseVersion', () => {
+  test('extracts the semver from `dolt version` output', () => {
+    assert.equal(parseVersion('dolt version 2.0.7\n'), '2.0.7');
+  });
+
+  test('extracts the semver from `bd version` output', () => {
+    assert.equal(
+      parseVersion('bd version 1.0.4 (ce242a879: HEAD@ce242a879678)\n'),
+      '1.0.4',
+    );
+  });
+
+  test('returns null when no version token is present', () => {
+    assert.equal(parseVersion('command not found'), null);
+  });
+
+  test('returns null on empty output', () => {
+    assert.equal(parseVersion(''), null);
+  });
+});
+
+function okProbe(version: string): VersionProbe {
+  return async () => ({ kind: 'ok', version });
+}
+
+function failProbe(reason: string): VersionProbe {
+  return async () => ({ kind: 'error', reason });
+}
+
+const fullStatus: GcStatus = {
+  version: '0.42.0',
+  work: { open: 10, ready: 4, in_progress: 2 },
+  store_health: {
+    size_bytes: 1_000_000,
+    live_rows: 2000,
+    ratio_mb_per_row: 0.5,
+    threshold_mb_per_row: 1.0,
+    warning: false,
+    last_gc_status: 'success',
+    path: '/data/store',
+  },
+};
+
+describe('buildDiagnostics', () => {
+  test('surfaces dolt + beads versions from successful probes', async () => {
+    const d = await buildDiagnostics({
+      status: fullStatus,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.deepEqual(d.doltVersion, {
+      status: 'available',
+      value: '2.0.7',
+      source: 'local probe: dolt version',
+    });
+    assert.deepEqual(d.beadsVersion, {
+      status: 'available',
+      value: '1.0.4',
+      source: 'local probe: bd version',
+    });
+  });
+
+  test('surfaces probe failure as unavailable with the reason (no fabrication)', async () => {
+    const d = await buildDiagnostics({
+      status: fullStatus,
+      doltProbe: failProbe('dolt not on PATH'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.doltVersion.status, 'unavailable');
+    assert.equal(
+      d.doltVersion.status === 'unavailable' ? d.doltVersion.reason : '',
+      'dolt not on PATH',
+    );
+  });
+
+  test('translates store_health into dolt usage', async () => {
+    const d = await buildDiagnostics({
+      status: fullStatus,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.doltUsage.status, 'available');
+    if (d.doltUsage.status === 'available') {
+      assert.equal(d.doltUsage.value.size_bytes, 1_000_000);
+      assert.equal(d.doltUsage.value.live_rows, 2000);
+      assert.equal(d.doltUsage.value.threshold_mb_per_row, 1.0);
+    }
+  });
+
+  test('translates work counts into beads usage', async () => {
+    const d = await buildDiagnostics({
+      status: fullStatus,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.deepEqual(
+      d.beadsUsage.status === 'available' ? d.beadsUsage.value : null,
+      { open: 10, ready: 4, in_progress: 2 },
+    );
+  });
+
+  test('builds a recommended-vs-loaded row from the dolt maintenance threshold', async () => {
+    const d = await buildDiagnostics({
+      status: fullStatus,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.configComparison.status, 'available');
+    if (d.configComparison.status === 'available') {
+      const row = d.configComparison.value.find((r) =>
+        r.label.toLowerCase().includes('ratio'),
+      );
+      assert.ok(row, 'expected a Dolt ratio comparison row');
+      assert.equal(row?.withinRecommendation, true);
+    }
+  });
+
+  test('flags an over-threshold ratio as not within recommendation', async () => {
+    const overStatus: GcStatus = {
+      ...fullStatus,
+      store_health: {
+        size_bytes: 5_000_000,
+        ratio_mb_per_row: 2.5,
+        threshold_mb_per_row: 1.0,
+        warning: true,
+      },
+    };
+    const d = await buildDiagnostics({
+      status: overStatus,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.configComparison.status, 'available');
+    if (d.configComparison.status === 'available') {
+      const row = d.configComparison.value.find((r) =>
+        r.label.toLowerCase().includes('ratio'),
+      );
+      assert.equal(row?.withinRecommendation, false);
+    }
+  });
+
+  test('marks usage + comparison unavailable when store_health is absent', async () => {
+    const d = await buildDiagnostics({
+      status: { version: '0.42.0' },
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.doltUsage.status, 'unavailable');
+    assert.equal(d.configComparison.status, 'unavailable');
+  });
+
+  test('marks beads usage unavailable when status.work is absent', async () => {
+    const d = await buildDiagnostics({
+      status: { store_health: { size_bytes: 1 } },
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.beadsUsage.status, 'unavailable');
+  });
+
+  test('marks everything supervisor-sourced unavailable when status is null (supervisor offline)', async () => {
+    const d = await buildDiagnostics({
+      status: null,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.doltUsage.status, 'unavailable');
+    assert.equal(d.beadsUsage.status, 'unavailable');
+    assert.equal(d.configComparison.status, 'unavailable');
+    // Local probes are independent of supervisor reachability.
+    assert.equal(d.doltVersion.status, 'available');
+  });
+
+  test('omits the ratio comparison row when the supervisor reports no threshold', async () => {
+    const d = await buildDiagnostics({
+      status: {
+        store_health: { size_bytes: 1, ratio_mb_per_row: 0.5 },
+        work: { open: 1, ready: 1, in_progress: 1 },
+      },
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    // No threshold => no recommended baseline => unavailable, not a fake row.
+    assert.equal(d.configComparison.status, 'unavailable');
+  });
+});

--- a/backend/src/routes/health-diagnostics.test.ts
+++ b/backend/src/routes/health-diagnostics.test.ts
@@ -100,6 +100,34 @@ describe('buildDiagnostics', () => {
     }
   });
 
+  test('carries last_gc_at and strips unknown passthrough wire keys from dolt usage', async () => {
+    // store_health is Zod-decoded with passthrough(), so unknown keys ride
+    // along on the wire object at runtime. The edge mapping must surface the
+    // known last_gc_at field and drop unknown keys rather than forwarding them
+    // into the client DTO (serialization-at-the-edges invariant).
+    const status = {
+      ...fullStatus,
+      store_health: {
+        ...fullStatus.store_health,
+        last_gc_at: '2026-05-30T08:00:00Z',
+        unexpected_wire_key: 'leak',
+      },
+    } as unknown as GcStatus;
+    const d = await buildDiagnostics({
+      status,
+      doltProbe: okProbe('2.0.7'),
+      beadsProbe: okProbe('1.0.4'),
+    });
+    assert.equal(d.doltUsage.status, 'available');
+    if (d.doltUsage.status === 'available') {
+      assert.equal(d.doltUsage.value.last_gc_at, '2026-05-30T08:00:00Z');
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(d.doltUsage.value, 'unexpected_wire_key'),
+        'unknown passthrough key must not leak into the DTO',
+      );
+    }
+  });
+
   test('translates work counts into beads usage', async () => {
     const d = await buildDiagnostics({
       status: fullStatus,

--- a/backend/src/routes/health-diagnostics.ts
+++ b/backend/src/routes/health-diagnostics.ts
@@ -1,0 +1,127 @@
+import type {
+  BeadsUsage,
+  ConfigComparisonRow,
+  DiagnosticValue,
+  DoltUsage,
+  GcStatus,
+  HealthDiagnostics,
+} from 'gas-city-dashboard-shared';
+
+// gascity-dashboard-1cob: pure translation of supervisor status + local
+// version probes into the Health page's diagnostics bundle. No IO lives here —
+// the route injects the probes and the (already-fetched) supervisor status, so
+// every branch is unit-testable. Per the data-sourcing rule, a datum the
+// backend cannot obtain is surfaced as `unavailable` with a reason, never
+// fabricated.
+
+const DOLT_VERSION_SOURCE = 'local probe: dolt version';
+const BEADS_VERSION_SOURCE = 'local probe: bd version';
+const STATUS_SOURCE = 'supervisor status.store_health';
+const WORK_SOURCE = 'supervisor status.work';
+const COMPARISON_SOURCE = 'supervisor status.store_health (threshold vs actual)';
+
+const STATUS_UNAVAILABLE_REASON =
+  'supervisor did not report store_health';
+const WORK_UNAVAILABLE_REASON = 'supervisor did not report work counts';
+const NO_THRESHOLD_REASON =
+  'supervisor reports no recommended baseline to compare against';
+
+/** Result of a single local CLI version probe. */
+export type VersionProbeResult =
+  | { kind: 'ok'; version: string }
+  | { kind: 'error'; reason: string };
+
+export type VersionProbe = () => Promise<VersionProbeResult>;
+
+export interface BuildDiagnosticsInput {
+  /** Supervisor city status, or null when the supervisor is unreachable. */
+  status: GcStatus | null;
+  doltProbe: VersionProbe;
+  beadsProbe: VersionProbe;
+}
+
+const SEMVER_RE = /(\d+\.\d+\.\d+)/;
+
+/**
+ * Pulls the first dotted version token out of a CLI's version output. Both
+ * `dolt version` ("dolt version 2.0.7") and `bd version` ("bd version 1.0.4
+ * (sha…)") put the semver first, so one parser covers both.
+ */
+export function parseVersion(stdout: string): string | null {
+  return SEMVER_RE.exec(stdout)?.[1] ?? null;
+}
+
+function fromProbe(
+  result: VersionProbeResult,
+  source: string,
+): DiagnosticValue<string> {
+  return result.kind === 'ok'
+    ? { status: 'available', value: result.version, source }
+    : { status: 'unavailable', reason: result.reason };
+}
+
+function doltUsageOf(status: GcStatus | null): DiagnosticValue<DoltUsage> {
+  const sh = status?.store_health;
+  if (sh === undefined) {
+    return { status: 'unavailable', reason: STATUS_UNAVAILABLE_REASON };
+  }
+  return { status: 'available', value: { ...sh }, source: STATUS_SOURCE };
+}
+
+function beadsUsageOf(status: GcStatus | null): DiagnosticValue<BeadsUsage> {
+  const work = status?.work;
+  if (work === undefined) {
+    return { status: 'unavailable', reason: WORK_UNAVAILABLE_REASON };
+  }
+  const value: BeadsUsage = {
+    open: work.open,
+    ready: work.ready,
+    in_progress: work.in_progress,
+  };
+  return { status: 'available', value, source: WORK_SOURCE };
+}
+
+function configComparisonOf(
+  status: GcStatus | null,
+): DiagnosticValue<ConfigComparisonRow[]> {
+  const sh = status?.store_health;
+  // The only recommended-vs-actual signal the supervisor exposes today is the
+  // Dolt maintenance ratio threshold. Without both the threshold (recommended)
+  // and the actual ratio there is no baseline to diff — surface unavailable
+  // rather than inventing a recommended value (see gascity-dashboard-1cob.2).
+  if (
+    sh === undefined ||
+    sh.threshold_mb_per_row === undefined ||
+    sh.ratio_mb_per_row === undefined
+  ) {
+    return { status: 'unavailable', reason: NO_THRESHOLD_REASON };
+  }
+  const row: ConfigComparisonRow = {
+    label: 'Dolt MB-per-row ratio',
+    recommended: `≤ ${sh.threshold_mb_per_row}`,
+    loaded: String(sh.ratio_mb_per_row),
+    // The supervisor owns the verdict: prefer its `warning` flag when present,
+    // otherwise compare against the threshold it reported.
+    withinRecommendation:
+      sh.warning !== undefined
+        ? !sh.warning
+        : sh.ratio_mb_per_row <= sh.threshold_mb_per_row,
+  };
+  return { status: 'available', value: [row], source: COMPARISON_SOURCE };
+}
+
+export async function buildDiagnostics(
+  input: BuildDiagnosticsInput,
+): Promise<HealthDiagnostics> {
+  const [doltVersion, beadsVersion] = await Promise.all([
+    input.doltProbe(),
+    input.beadsProbe(),
+  ]);
+  return {
+    doltVersion: fromProbe(doltVersion, DOLT_VERSION_SOURCE),
+    beadsVersion: fromProbe(beadsVersion, BEADS_VERSION_SOURCE),
+    doltUsage: doltUsageOf(input.status),
+    beadsUsage: beadsUsageOf(input.status),
+    configComparison: configComparisonOf(input.status),
+  };
+}

--- a/backend/src/routes/health-diagnostics.ts
+++ b/backend/src/routes/health-diagnostics.ts
@@ -65,7 +65,24 @@ function doltUsageOf(status: GcStatus | null): DiagnosticValue<DoltUsage> {
   if (sh === undefined) {
     return { status: 'unavailable', reason: STATUS_UNAVAILABLE_REASON };
   }
-  return { status: 'available', value: { ...sh }, source: STATUS_SOURCE };
+  // Map known fields explicitly rather than spreading `sh` directly: store_health
+  // is decoded with a passthrough() schema, so `{ ...sh }` would leak unknown wire
+  // keys into the client DTO and violate the serialization-at-the-edges invariant
+  // (review). Optional keys are spread conditionally so absent fields stay absent
+  // under exactOptionalPropertyTypes rather than becoming present-with-undefined.
+  const value: DoltUsage = {
+    size_bytes: sh.size_bytes,
+    ...(sh.live_rows !== undefined && { live_rows: sh.live_rows }),
+    ...(sh.ratio_mb_per_row !== undefined && { ratio_mb_per_row: sh.ratio_mb_per_row }),
+    ...(sh.threshold_mb_per_row !== undefined && {
+      threshold_mb_per_row: sh.threshold_mb_per_row,
+    }),
+    ...(sh.warning !== undefined && { warning: sh.warning }),
+    ...(sh.last_gc_at !== undefined && { last_gc_at: sh.last_gc_at }),
+    ...(sh.last_gc_status !== undefined && { last_gc_status: sh.last_gc_status }),
+    ...(sh.path !== undefined && { path: sh.path }),
+  };
+  return { status: 'available', value, source: STATUS_SOURCE };
 }
 
 function beadsUsageOf(status: GcStatus | null): DiagnosticValue<BeadsUsage> {

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,10 +1,16 @@
 import { Router } from 'express';
 import os from 'node:os';
-import type { SupervisorHealthState, SystemHealth } from 'gas-city-dashboard-shared';
+import type {
+  GcStatus,
+  SupervisorHealthState,
+  SystemHealth,
+} from 'gas-city-dashboard-shared';
 import { GcClient } from '../gc-client.js';
 import { recordAudit } from '../audit.js';
 import { HTTP_STATUS } from '../lib/http-status.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
+import { buildDiagnostics, type VersionProbe } from './health-diagnostics.js';
+import { probeBeadsVersion, probeDoltVersion } from './version-probe.js';
 
 // Health uses a tighter window than the global GcClient timeout (5s default)
 // because /v0/city/{name}/health is a cheap localhost ping. 2.5s is plenty
@@ -44,6 +50,12 @@ export interface HealthRouterOptions {
    * time, not re-read per request.
    */
   supervisorTimeoutMs?: number;
+  /**
+   * Local CLI version probes. Defaults to the real `dolt version` / `bd
+   * version` exec probes; tests inject deterministic stand-ins.
+   */
+  doltProbe?: VersionProbe;
+  beadsProbe?: VersionProbe;
 }
 
 /**
@@ -56,6 +68,8 @@ export interface HealthRouterOptions {
 export function healthRouter(gc: GcClient, opts: HealthRouterOptions = {}): Router {
   const router = Router();
   const supervisorTimeoutMs = opts.supervisorTimeoutMs ?? resolveHealthTimeoutMs();
+  const doltProbe = opts.doltProbe ?? probeDoltVersion;
+  const beadsProbe = opts.beadsProbe ?? probeBeadsVersion;
 
   router.get('/system', async (_req, res) => {
     const mem = process.memoryUsage();
@@ -85,6 +99,19 @@ export function healthRouter(gc: GcClient, opts: HealthRouterOptions = {}): Rout
         error: 'supervisor health unavailable',
       };
     }
+    // Diagnostics (gascity-dashboard-1cob): supervisor status carries Dolt +
+    // Beads usage and the recommended-vs-actual threshold; the binary versions
+    // are probed locally. A status fetch failure does NOT 504 the route — the
+    // local version probes are still useful — so it degrades to null status and
+    // the builder surfaces the supervisor-sourced fields as unavailable.
+    let status: GcStatus | null;
+    try {
+      status = await gc.getStatus();
+    } catch (err) {
+      logWarn(LOG_COMPONENT.health, `supervisor status fetch failed: ${errorMessage(err)}`);
+      status = null;
+    }
+    const diagnostics = await buildDiagnostics({ status, doltProbe, beadsProbe });
     const payload: SystemHealth = {
       admin: {
         pid: process.pid,
@@ -103,6 +130,7 @@ export function healthRouter(gc: GcClient, opts: HealthRouterOptions = {}): Rout
         uptime_sec: Math.round(os.uptime()),
       },
       supervisor,
+      diagnostics,
     };
     await recordAudit({
       type: 'dashboard.fetch',

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -74,13 +74,21 @@ export function healthRouter(gc: GcClient, opts: HealthRouterOptions = {}): Rout
   router.get('/system', async (_req, res) => {
     const mem = process.memoryUsage();
     const load = os.loadavg();
+    // The health probe and the status fetch are independent supervisor calls —
+    // neither result feeds the other — so they ride one parallel wave bounded
+    // to the same timeout window instead of stacking serially (gascity-dashboard-1cob
+    // review). getStatus takes an AbortSignal rather than a timeoutMs option, so
+    // it is bounded with AbortSignal.timeout to match supervisorTimeoutMs.
+    const [healthSettled, statusSettled] = await Promise.allSettled([
+      gc.health({ timeoutMs: supervisorTimeoutMs }),
+      gc.getStatus(AbortSignal.timeout(supervisorTimeoutMs)),
+    ]);
+
     let supervisor: SupervisorHealthState;
-    try {
-      supervisor = {
-        status: 'available',
-        data: await gc.health({ timeoutMs: supervisorTimeoutMs }),
-      };
-    } catch (err) {
+    if (healthSettled.status === 'fulfilled') {
+      supervisor = { status: 'available', data: healthSettled.value };
+    } else {
+      const err = healthSettled.reason;
       // gascity-dashboard-mek: distinguish hung supervisor (504) from
       // broken supervisor (200 + explicit unavailable state). Generic fetch
       // failures (connection refused, 5xx, JSON parse error) still keep the
@@ -99,16 +107,20 @@ export function healthRouter(gc: GcClient, opts: HealthRouterOptions = {}): Rout
         error: 'supervisor health unavailable',
       };
     }
+
     // Diagnostics (gascity-dashboard-1cob): supervisor status carries Dolt +
     // Beads usage and the recommended-vs-actual threshold; the binary versions
     // are probed locally. A status fetch failure does NOT 504 the route — the
     // local version probes are still useful — so it degrades to null status and
     // the builder surfaces the supervisor-sourced fields as unavailable.
     let status: GcStatus | null;
-    try {
-      status = await gc.getStatus();
-    } catch (err) {
-      logWarn(LOG_COMPONENT.health, `supervisor status fetch failed: ${errorMessage(err)}`);
+    if (statusSettled.status === 'fulfilled') {
+      status = statusSettled.value;
+    } else {
+      logWarn(
+        LOG_COMPONENT.health,
+        `supervisor status fetch failed: ${errorMessage(statusSettled.reason)}`,
+      );
       status = null;
     }
     const diagnostics = await buildDiagnostics({ status, doltProbe, beadsProbe });

--- a/backend/src/routes/version-probe.ts
+++ b/backend/src/routes/version-probe.ts
@@ -1,0 +1,37 @@
+import { runExec } from '../exec-core.js';
+import { errorMessage } from '../logging.js';
+import {
+  parseVersion,
+  type VersionProbe,
+  type VersionProbeResult,
+} from './health-diagnostics.js';
+
+// gascity-dashboard-1cob: the gc supervisor API exposes no Dolt or Beads
+// binary version (see gascity-dashboard-1cob.1), so the dashboard probes them
+// locally on the 127.0.0.1 backend host via `dolt version` / `bd version`.
+// This is the IO edge; parsing + diagnostics translation are pure (see
+// health-diagnostics.ts). A failed probe is surfaced as `error` with a reason,
+// never swallowed into a fake version string.
+
+const VERSION_PROBE_TIMEOUT_MS = 3_000;
+
+async function probeVersion(cmd: string): Promise<VersionProbeResult> {
+  try {
+    const result = await runExec(cmd, ['version'], VERSION_PROBE_TIMEOUT_MS);
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || 'no output';
+      return { kind: 'error', reason: `${cmd} version exited ${result.exitCode}: ${detail}` };
+    }
+    const version = parseVersion(result.stdout);
+    if (version === null) {
+      return { kind: 'error', reason: `${cmd} version output had no recognizable version` };
+    }
+    return { kind: 'ok', version };
+  } catch (err) {
+    return { kind: 'error', reason: `${cmd} version probe failed: ${errorMessage(err)}` };
+  }
+}
+
+export const probeDoltVersion: VersionProbe = () => probeVersion('dolt');
+
+export const probeBeadsVersion: VersionProbe = () => probeVersion('bd');

--- a/backend/src/snapshot/collectors/runs/discovery.ts
+++ b/backend/src/snapshot/collectors/runs/discovery.ts
@@ -22,31 +22,29 @@ export async function loadRunBeads(
   gc: GcClient,
   limit: number,
 ): Promise<LoadedRunBeads> {
+  // The city-molecule query has static city-scoped params and no dependency on
+  // feed discovery, so it rides the first parallel wave alongside the city
+  // listBeads and the feed fetch — never serialized behind them (wbe9). Only
+  // the per-rig queries depend on the discovered rig set, so they form a second
+  // wave once rig names are known.
+  const moleculeFetch = settledRecentFetch(gc, {
+    label: 'city molecule list',
+    params: { limit: RECENT_RUN_FETCH_LIMIT, type: 'molecule', all: true },
+  });
   const [active, feedDiscovery] = await Promise.all([
     gc.listBeads(undefined, { limit }),
     discoverFromFeed(gc),
   ]);
   const rigNames = unionRigNames(runRigNames(active.items), feedDiscovery.rigNames);
-  const sources: Array<{ label: string; params: Parameters<GcClient['listBeads']>[1] }> = [
-    ...rigNames.map((rig) => ({
-      label: `rig '${rig}'`,
-      params: { limit: RECENT_RUN_FETCH_LIMIT, type: 'task' as const, rig, all: true },
-    })),
-    {
-      label: 'city molecule list',
-      params: { limit: RECENT_RUN_FETCH_LIMIT, type: 'molecule' as const, all: true },
-    },
-  ];
 
-  const settled = await Promise.all(
-    sources.map(async ({ label, params }) => {
-      try {
-        return { ok: true as const, items: (await gc.listBeads(undefined, params)).items };
-      } catch (error) {
-        return { ok: false as const, label, error };
-      }
+  const rigFetches = rigNames.map((rig) =>
+    settledRecentFetch(gc, {
+      label: `rig '${rig}'`,
+      params: { limit: RECENT_RUN_FETCH_LIMIT, type: 'task', rig, all: true },
     }),
   );
+
+  const settled = await Promise.all([moleculeFetch, ...rigFetches]);
 
   const recentItems: GcBead[] = [];
   let partial = false;
@@ -67,6 +65,21 @@ export async function loadRunBeads(
     feedScopes: feedDiscovery.scopes,
     partial,
   };
+}
+
+type RecentFetchOutcome =
+  | { ok: true; items: GcBead[] }
+  | { ok: false; label: string; error: unknown };
+
+async function settledRecentFetch(
+  gc: GcClient,
+  source: { label: string; params: Parameters<GcClient['listBeads']>[1] },
+): Promise<RecentFetchOutcome> {
+  try {
+    return { ok: true, items: (await gc.listBeads(undefined, source.params)).items };
+  } catch (error) {
+    return { ok: false, label: source.label, error };
+  }
 }
 
 interface FeedDiscovery {

--- a/backend/test/snapshot-runs.test.ts
+++ b/backend/test/snapshot-runs.test.ts
@@ -1128,20 +1128,29 @@ describe('createRunsSourceCache', () => {
     const result = await cache.get();
 
     assert.equal(result.status, 'fresh');
-    assert.deepEqual(seenParams, [
-      { limit: 77 },
-      {
-        limit: RECENT_RUN_FETCH_LIMIT,
-        type: 'task',
-        rig: 'todo-app',
-        all: true,
-      },
-      {
-        limit: RECENT_RUN_FETCH_LIMIT,
-        type: 'molecule',
-        all: true,
-      },
-    ]);
+    // wbe9: the molecule query rides the first parallel wave with the city
+    // discovery query, and the rig query follows once rig names are known — so
+    // the three may be observed in any order. Assert the exact set rather than
+    // a sequence.
+    const byJson = (a: unknown, b: unknown) =>
+      JSON.stringify(a).localeCompare(JSON.stringify(b));
+    assert.deepEqual(
+      [...seenParams].sort(byJson),
+      [
+        { limit: 77 },
+        {
+          limit: RECENT_RUN_FETCH_LIMIT,
+          type: 'task',
+          rig: 'todo-app',
+          all: true,
+        },
+        {
+          limit: RECENT_RUN_FETCH_LIMIT,
+          type: 'molecule',
+          all: true,
+        },
+      ].sort(byJson),
+    );
     assert.equal(
       seenParams.some((params) => params.all === true && params.type === undefined),
       false,
@@ -1184,14 +1193,23 @@ describe('createRunsSourceCache', () => {
     const result = await cache.get();
 
     assert.equal(result.status, 'fresh');
-    assert.deepEqual(seenParams, [
-      { limit: 77 },
-      {
-        limit: RECENT_RUN_FETCH_LIMIT,
-        type: 'molecule',
-        all: true,
-      },
-    ]);
+    // wbe9: the molecule recent-run query now rides the first parallel wave
+    // alongside the city discovery query, so the two may be observed in either
+    // order — assert membership, not sequence.
+    assert.equal(seenParams.length, 2);
+    assert.deepEqual(
+      [...seenParams].sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b)),
+      ),
+      [
+        { limit: 77 },
+        {
+          limit: RECENT_RUN_FETCH_LIMIT,
+          type: 'molecule',
+          all: true,
+        },
+      ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
+    );
     if (result.status === 'fresh') {
       // yh5i: completed runs land in historicalLanes (toggle-visible).
       assert.equal(result.data.historicalLanes[0]?.id, 'done-root');
@@ -1747,5 +1765,57 @@ describe('createRunsSourceCache', () => {
         error: 'run scope metadata unavailable',
       });
     }
+  });
+
+  // wbe9: the city-molecule listBeads query has static city-scoped params and
+  // no data dependency on feed discovery, so it must NOT be serialized behind
+  // listFormulaRuns. Pinning this prevents a regression back to the
+  // two-sequential-phase shape that paid an extra serial supervisor round-trip
+  // on every uncached runs load. The deferred feed promise stays UNRESOLVED
+  // until after we observe the molecule query fire — if the collector awaited
+  // the feed before issuing the molecule query, the test would deadlock-time
+  // out, not pass.
+  test('wbe9: city-molecule listBeads is not serialized behind feed discovery', async () => {
+    let moleculeQueried = false;
+    let releaseFeed: (() => void) | undefined;
+    const feedGate = new Promise<void>((resolve) => {
+      releaseFeed = resolve;
+    });
+
+    const cache = createRunsSourceCache({
+      gc: {
+        listBeads: async (_signal: AbortSignal | undefined, params: ListBeadsParams) => {
+          assert.ok(params, 'collector must always pass an explicit params arg');
+          // Initial city-scoped discovery query.
+          if (params.rig === undefined && params.type === undefined && params.all !== true) {
+            return { items: [], total: 0 };
+          }
+          if (params.type === 'molecule' && params.all === true) {
+            // The molecule query fired before the feed resolved — release the
+            // feed so the load can complete instead of hanging.
+            moleculeQueried = true;
+            releaseFeed?.();
+            return { items: [], total: 0 };
+          }
+          assert.fail(`unexpected listBeads params: ${JSON.stringify(params)}`);
+        },
+        listFormulaRuns: async () => {
+          // Block feed discovery until the molecule query is observed. If the
+          // collector serialized the molecule query after the feed, this never
+          // releases and the test times out (a failing RED signal).
+          await feedGate;
+          return { items: [], partial: false };
+        },
+        cityName: 'test',
+      } satisfies GcClientMock as unknown as GcClient,
+      limit: 1000,
+    });
+
+    const result = await cache.get();
+    assert.equal(result.status, 'fresh');
+    assert.ok(
+      moleculeQueried,
+      'city-molecule listBeads must be issued concurrently with feed discovery, not after it',
+    );
   });
 });

--- a/frontend/src/routes/Agents.chips.test.ts
+++ b/frontend/src/routes/Agents.chips.test.ts
@@ -1,25 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { GcAgent } from 'gas-city-dashboard-shared';
-import { AGENT_CHIPS, buildAgentSynopsis, stateTone } from './Agents';
+import { buildAgentSynopsis, stateTone } from './Agents';
 
 // gascity-dashboard-ay6: the Agents view consumes the supervisor's
 // first-class agent roster (GcAgent), not the session list. These tests
-// pin the chip-coverage invariant on the agent shape: every state the
-// supervisor reports must match at least one chip, otherwise agents in
-// that state vanish silently when any chip is active (parallels the bug
-// from gascity-dashboard-9yb on the session side).
-
-// AgentResponse.state is a free `string` in the OpenAPI; this is the set
-// observed in this deployment + the named states the supervisor commits
-// to today. Same conservative posture as the previous NAMED_STATES list.
-const NAMED_STATES = [
-  'creating',
-  'active',
-  'asleep',
-  'detached',
-  'failed',
-  'closed',
-] as const;
+// pin the state→tone and synopsis-count contracts the table still relies
+// on for the State column and the page synopsis line.
 
 function mkAgent(state: string, overrides: Partial<GcAgent> = {}): GcAgent {
   return {
@@ -31,63 +17,6 @@ function mkAgent(state: string, overrides: Partial<GcAgent> = {}): GcAgent {
     ...overrides,
   };
 }
-
-describe('AGENT_CHIPS', () => {
-  it('every named agent state matches at least one chip', () => {
-    for (const state of NAMED_STATES) {
-      const agent = mkAgent(state);
-      const matched = AGENT_CHIPS.some((chip) => chip.match(agent));
-      expect(
-        matched,
-        `state "${state}" must match at least one chip, otherwise it disappears when any chip is active`,
-      ).toBe(true);
-    }
-  });
-
-  it('exposes a "detached" chip so detached agents stay visible under chip filters', () => {
-    const detached = mkAgent('detached');
-    const detachedChip = AGENT_CHIPS.find((chip) => chip.id === 'detached');
-    expect(detachedChip, 'detached chip should exist').toBeDefined();
-    expect(detachedChip?.match(detached)).toBe(true);
-  });
-
-  it('detached agents match only the detached chip when not running', () => {
-    const detached = mkAgent('detached');
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(detached)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toEqual(['detached']);
-  });
-
-  it('a detached agent whose process is still running matches BOTH the running and detached chips', () => {
-    // gc can report state='detached' (tmux disconnected) while the
-    // underlying process is still running. The running chip keys on
-    // a.running===true; the detached chip keys on a.state==='detached'.
-    // Detached-but-running must surface under both filters so an
-    // operator scanning for 'what is alive right now' doesn't lose it
-    // just because the tmux attachment is gone. Mirrors the session-side
-    // invariant from gascity-dashboard-bi9.
-    const detachedAndRunning = mkAgent('detached', { running: true });
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(detachedAndRunning)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toContain('running');
-    expect(matchingIds).toContain('detached');
-    // Bound the match set: only those two chips, no spurious third match.
-    expect(matchingIds).toHaveLength(2);
-  });
-
-  it('suspended agents match the suspended chip regardless of state', () => {
-    // Suspended is a roster-side signal the session list never carried
-    // (a suspended agent has no session). The dedicated chip lets the
-    // operator slice the new agent surface by it.
-    const suspended = mkAgent('asleep', { suspended: true });
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(suspended)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toContain('suspended');
-  });
-});
 
 describe('stateTone', () => {
   it('classifies detached agents explicitly (not via default fallthrough)', () => {

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -47,10 +47,6 @@ function stubFetch() {
           // bound live session. AgentDetail will show "no session
           // matches" for these; the name-link in this view must
           // pre-empt the confusion with a distinct title tooltip.
-          // Uses `control-dispatcher` so the agent lands in the
-          // non-collapsible Orchestration group (otherwise the row
-          // would be hidden behind a collapsed `(no rig)` header in
-          // the test render).
           {
             name: 'control-dispatcher',
             available: true,
@@ -162,6 +158,11 @@ describe('AgentsPage (post-ay6 regressions)', () => {
         </NowProvider>
       </MemoryRouter>,
     );
+
+    // The orphan agent (asleep, no session) is hidden by the active-only
+    // default; toggle "Running only" off to bring the full roster into view.
+    const runningToggle = await screen.findByRole('checkbox', { name: /running/i });
+    fireEvent.click(runningToggle);
 
     // Both rows render their alias as a Link, but the title must
     // differ — session-bound agents promise a real drilldown; orphan

--- a/frontend/src/routes/Agents.test.tsx
+++ b/frontend/src/routes/Agents.test.tsx
@@ -1,0 +1,179 @@
+import { cleanup, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GcAgent } from 'gas-city-dashboard-shared';
+import { AgentsPage, isActivelyRunning } from './Agents';
+import { NowProvider } from '../contexts/NowContext';
+
+// The SSE refresh hook opens an EventSource; stub it so tests run in jsdom
+// without a live supervisor. We only assert on rendered roster, not on the
+// live-update plumbing (covered by useGcEvents' own tests).
+vi.mock('../hooks/useGcEvents', () => ({
+  useGcEventRefresh: () => 'open',
+}));
+
+const listAgents = vi.fn();
+const listSessions = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: {
+    listAgents: () => listAgents(),
+    listSessions: () => listSessions(),
+  },
+}));
+
+function agent(partial: Partial<GcAgent> & Pick<GcAgent, 'name'>): GcAgent {
+  return {
+    available: true,
+    running: false,
+    suspended: false,
+    state: 'asleep',
+    ...partial,
+  };
+}
+
+const ROSTER: GcAgent[] = [
+  agent({
+    name: 'alpha/worker',
+    rig: 'alpha',
+    state: 'active',
+    running: true,
+    session: { name: 'gc-1', attached: false, last_activity: '2026-06-01T10:00:00Z' },
+  }),
+  agent({
+    name: 'beta/worker',
+    rig: 'beta',
+    state: 'running',
+    running: true,
+    session: { name: 'gc-2', attached: false, last_activity: '2026-06-01T12:00:00Z' },
+  }),
+  agent({
+    name: 'alpha/sleeper',
+    rig: 'alpha',
+    state: 'asleep',
+    running: false,
+  }),
+  agent({
+    name: 'beta/stopped',
+    rig: 'beta',
+    state: 'failed',
+    running: false,
+  }),
+];
+
+function renderAgents() {
+  return render(
+    <NowProvider intervalMs={1_000_000}>
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <AgentsPage />
+      </MemoryRouter>
+    </NowProvider>,
+  );
+}
+
+function bodyRows(): HTMLElement[] {
+  const table = screen.getByRole('table');
+  const body = table.querySelector('tbody');
+  if (!body) throw new Error('table has no tbody');
+  // Rows that carry an agent (have a link cell). Skip the empty-state row.
+  return Array.from(body.querySelectorAll('tr')).filter(
+    (tr) => tr.querySelector('a') !== null,
+  );
+}
+
+beforeEach(() => {
+  listAgents.mockResolvedValue({ items: ROSTER });
+  listSessions.mockResolvedValue({ items: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('isActivelyRunning', () => {
+  it('treats active/running state or running flag as actively running', () => {
+    expect(isActivelyRunning(agent({ name: 'a', state: 'active' }))).toBe(true);
+    expect(isActivelyRunning(agent({ name: 'a', state: 'running' }))).toBe(true);
+    expect(isActivelyRunning(agent({ name: 'a', state: 'asleep', running: true }))).toBe(true);
+  });
+
+  it('excludes suspended agents even when otherwise running', () => {
+    expect(
+      isActivelyRunning(agent({ name: 'a', state: 'active', suspended: true })),
+    ).toBe(false);
+  });
+
+  it('treats idle/asleep/failed agents as not actively running', () => {
+    expect(isActivelyRunning(agent({ name: 'a', state: 'asleep' }))).toBe(false);
+    expect(isActivelyRunning(agent({ name: 'a', state: 'failed' }))).toBe(false);
+  });
+});
+
+describe('AgentsPage', () => {
+  it('renders a single flat table with no expandable/group rows', async () => {
+    renderAgents();
+    await waitFor(() => expect(screen.getAllByRole('table')).toHaveLength(1));
+    // No collapsible group headers (those carry a chevron / group toggle).
+    expect(screen.queryByRole('button', { name: /toggle|collapse|expand/i })).toBeNull();
+  });
+
+  it('has a Rig column with the agent rig value', async () => {
+    renderAgents();
+    await waitFor(() => screen.getByRole('table'));
+    expect(screen.getByRole('columnheader', { name: /rig/i })).toBeTruthy();
+    // Active-only default: alpha/worker + beta/worker are visible; their rigs render.
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('alpha')).toBeTruthy();
+    expect(within(table).getByText('beta')).toBeTruthy();
+  });
+
+  it('defaults to showing only actively-running agents', async () => {
+    renderAgents();
+    await waitFor(() => screen.getByRole('table'));
+    await waitFor(() => expect(bodyRows()).toHaveLength(2));
+    expect(screen.getByText('alpha/worker')).toBeTruthy();
+    expect(screen.getByText('beta/worker')).toBeTruthy();
+    expect(screen.queryByText('alpha/sleeper')).toBeNull();
+    expect(screen.queryByText('beta/stopped')).toBeNull();
+  });
+
+  it('filters the table by rig via the rig dropdown', async () => {
+    renderAgents();
+    await waitFor(() => screen.getByRole('table'));
+    const rigSelect = screen.getByRole('combobox', { name: /rig/i });
+    fireEvent.change(rigSelect, { target: { value: 'alpha' } });
+    await waitFor(() => expect(bodyRows()).toHaveLength(1));
+    expect(screen.getByText('alpha/worker')).toBeTruthy();
+    expect(screen.queryByText('beta/worker')).toBeNull();
+  });
+
+  it('can show all agents (not just running) and sort by rig', async () => {
+    renderAgents();
+    await waitFor(() => screen.getByRole('table'));
+    // Turn off the active-only default so all four rows show.
+    const runningToggle = screen.getByRole('checkbox', { name: /running/i });
+    fireEvent.click(runningToggle);
+    await waitFor(() => expect(bodyRows()).toHaveLength(4));
+
+    // Sort by rig ascending: alpha rows precede beta rows.
+    const rigHeader = screen.getByRole('button', { name: /rig/i });
+    fireEvent.click(rigHeader);
+    const namesAsc = bodyRows().map((r) => r.querySelector('a')?.textContent ?? '');
+    const firstBetaIdx = namesAsc.findIndex((n) => n.startsWith('beta'));
+    const lastAlphaIdx = namesAsc.map((n) => n.startsWith('alpha')).lastIndexOf(true);
+    expect(lastAlphaIdx).toBeLessThan(firstBetaIdx);
+  });
+
+  it('sorts by activity', async () => {
+    renderAgents();
+    await waitFor(() => screen.getByRole('table'));
+    // beta/worker has the later last_activity than alpha/worker.
+    const activityHeader = screen.getByRole('button', { name: /^last active/i });
+    fireEvent.click(activityHeader); // asc
+    const namesAsc = bodyRows().map((r) => r.querySelector('a')?.textContent ?? '');
+    fireEvent.click(activityHeader); // desc
+    const namesDesc = bodyRows().map((r) => r.querySelector('a')?.textContent ?? '');
+    expect(namesDesc).toEqual([...namesAsc].reverse());
+  });
+});

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -7,27 +7,19 @@ import {
 } from 'gas-city-dashboard-shared';
 import { api } from '../api/client';
 import { Button } from '../components/Button';
-import { FilterChips } from '../components/FilterChips';
-import { GroupedTable } from '../components/GroupedTable';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { PartialDataNotice } from '../components/PartialDataNotice';
 import { LiveSessionPeek, isAgentStreamable } from '../components/LiveSessionPeek';
-import { SortToggle } from '../components/SortToggle';
 import { SseIndicator } from '../components/SseIndicator';
 import { StatusBadge, type StatusTone } from '../components/StatusBadge';
-import { type TableColumn } from '../components/Table';
+import { Table, type TableColumn } from '../components/Table';
 import { useNow } from '../contexts/NowContext';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
-import { useListFilters, type FilterChip, type SortMode } from '../hooks/useListFilters';
 import { formatRelative } from '../hooks/time';
-import {
-  ORCHESTRATION_PROJECT,
-  agentProject,
-  isPerRigDispatcherAgent,
-} from '../hooks/projectOf';
+import { agentProject, isPerRigDispatcherAgent } from '../hooks/projectOf';
 import { agentSlug } from '../hooks/sessionSlug';
 
 // gascity-dashboard-ay6: the Agents view consumes the supervisor's
@@ -39,87 +31,41 @@ import { agentSlug } from '../hooks/sessionSlug';
 // The cityStatus snapshot collector continues to aggregate over sessions
 // for now — sessionsByProvider migration is sd4's territory.
 
-const PINNED_PROJECTS = [ORCHESTRATION_PROJECT];
-const NON_COLLAPSIBLE_PROJECTS = new Set([ORCHESTRATION_PROJECT]);
-
-// Activity ordering uses the agent's bound session's last_activity. Agents
-// with no session (orphans) return undefined so the list-filter sink sends
-// them to the bottom under activity-sort rather than ranking them at the
-// epoch.
-function agentActivity(a: GcAgent): number | undefined {
-  const raw = a.session?.last_activity;
-  if (!raw) return undefined;
-  const t = Date.parse(raw);
-  return Number.isFinite(t) ? t : undefined;
+// "Actively running" is the dashboard's single definition of an agent
+// the operator should see by default: not suspended, and either the gc
+// supervisor reports an active/running lifecycle state or the underlying
+// process flag is set. Exported so the test asserts the contract directly
+// rather than re-encoding a magic state string.
+export function isActivelyRunning(a: GcAgent): boolean {
+  return (
+    !a.suspended &&
+    (a.state === 'active' || a.state === 'running' || a.running === true)
+  );
 }
 
-const SORT_OPTIONS: ReadonlyArray<{ id: SortMode; label: string }> = [
-  { id: 'activity', label: 'activity' },
-  { id: 'alpha', label: 'alphabetical' },
-];
+// Sentinel for the rig dropdown's "all rigs" option. Empty string can't
+// collide with a real rig key because agentProject() never returns one.
+const RIG_FILTER_ALL = '';
 
-// Agent state chips collapse the gc supervisor's many states into buckets
-// the operator actually filters by. Every state an agent can carry must
-// match at least one chip — otherwise agents in that state vanish silently
-// when any chip is active (parallels gascity-dashboard-9yb's invariant for
-// sessions). Exported so tests can assert full state coverage.
-// Non-suspended chips all gate on `!a.suspended` so the chip filter
-// matches `stateBucket`'s priority order — `stateBucket` returns
-// 'suspended' before checking state, so a suspended-asleep agent is
-// counted in the suspended bucket only. Without the guard, the idle
-// chip would also surface suspended-asleep agents and the operator's
-// "what's idle?" filter would be over-broad. Same reasoning applies
-// to running/detached/stopped (a suspended agent that also reads as
-// running/detached/stopped via raw state should still only count as
-// suspended).
-export const AGENT_CHIPS: ReadonlyArray<FilterChip<GcAgent>> = [
-  {
-    id: 'running',
-    label: 'running',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'active' || a.state === 'running' || a.running === true),
-  },
-  {
-    id: 'idle',
-    label: 'idle',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'asleep' || a.state === 'idle' || a.state === 'creating'),
-  },
-  {
-    id: 'detached',
-    label: 'detached',
-    match: (a) => !a.suspended && a.state === 'detached',
-  },
-  {
-    id: 'stopped',
-    label: 'stopped',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'failed' ||
-        a.state === 'closed' ||
-        a.state === 'errored' ||
-        a.state === 'stuck'),
-  },
-  {
-    id: 'suspended',
-    label: 'suspended',
-    // The agent roster surfaces suspended agents that the session list
-    // never did — a distinct chip lets the operator slice by them
-    // without conflating with stopped/idle.
-    match: (a) => a.suspended === true,
-  },
-];
+// Display label + stable key for a row's rig, reusing agentProject so the
+// Rig column, dropdown, and sort all agree (folds case/separator drift and
+// lifts cross-rig agents into the Orchestration bucket).
+function agentRigLabel(a: GcAgent): string {
+  return agentProject(a).label;
+}
 
-const AGENT_SEARCH_FIELDS = (a: GcAgent): ReadonlyArray<string | undefined> => [
-  a.name,
-  a.display_name,
-  a.pool,
-  a.rig,
-  a.provider,
-  a.model,
-];
+function agentRigKey(a: GcAgent): string {
+  return agentProject(a).key;
+}
+
+function matchesSearch(a: GcAgent, needle: string): boolean {
+  if (needle.length === 0) return true;
+  const fields = [a.name, a.display_name, a.pool, a.rig, a.provider, a.model];
+  for (const field of fields) {
+    if (field && field.toLowerCase().includes(needle)) return true;
+  }
+  return false;
+}
 
 export function AgentsPage() {
   const { data, loading, error, refresh } = useCachedData(
@@ -159,18 +105,30 @@ export function AgentsPage() {
 
   const synopsis = useMemo(() => buildAgentSynopsis(rows), [rows]);
 
-  const filters = useListFilters<GcAgent>({
-    viewKey: 'agents',
-    rows,
-    projectOf: agentProject,
-    searchOf: AGENT_SEARCH_FIELDS,
-    chips: AGENT_CHIPS,
-    defaultCollapsed: true,
-    activityOf: agentActivity,
-    defaultSortMode: 'activity',
-    pinnedProjects: PINNED_PROJECTS,
-    nonCollapsibleProjects: NON_COLLAPSIBLE_PROJECTS,
-  });
+  const [search, setSearch] = useState('');
+  // Default to actively-running only — the operator's "what's working right
+  // now?" view. Toggling off reveals the full roster (idle/stopped/orphans).
+  const [runningOnly, setRunningOnly] = useState(true);
+  const [rigFilter, setRigFilter] = useState<string>(RIG_FILTER_ALL);
+
+  // Rig options for the dropdown: every rig present in the roster, by stable
+  // key with its display label, sorted alphabetically by label.
+  const rigOptions = useMemo(() => {
+    const byKey = new Map<string, string>();
+    for (const a of rows) byKey.set(agentRigKey(a), agentRigLabel(a));
+    return Array.from(byKey, ([key, label]) => ({ key, label })).sort((a, b) =>
+      a.label.localeCompare(b.label),
+    );
+  }, [rows]);
+
+  const visibleRows = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return rows.filter((a) => {
+      if (runningOnly && !isActivelyRunning(a)) return false;
+      if (rigFilter !== RIG_FILTER_ALL && agentRigKey(a) !== rigFilter) return false;
+      return matchesSearch(a, needle);
+    });
+  }, [rows, search, runningOnly, rigFilter]);
 
   const columns = useMemo<ReadonlyArray<TableColumn<GcAgent>>>(() => [
     {
@@ -228,6 +186,16 @@ export function AgentsPage() {
           </div>
         );
       },
+    },
+    {
+      key: 'rig',
+      label: 'Rig',
+      sortable: true,
+      // Sort by the display label so the column's visual order matches the
+      // sort order (the key is lowercased/normalized and would diverge).
+      sortValue: (r) => agentRigLabel(r),
+      render: (r) => <span className="text-fg-muted">{agentRigLabel(r)}</span>,
+      className: 'w-40',
     },
     {
       key: 'state',
@@ -356,41 +324,54 @@ export function AgentsPage() {
 
       <div className="mb-6 space-y-3">
         <ListSearchBar
-          value={filters.search}
-          onChange={filters.setSearch}
+          value={search}
+          onChange={setSearch}
           placeholder="Search agents by alias, rig, pool, provider"
-          matchCount={filters.totalMatches}
+          matchCount={visibleRows.length}
           totalCount={rows.length}
           ariaLabel="Search agents"
         />
         <div className="flex flex-wrap items-baseline gap-x-8 gap-y-3">
-          <FilterChips
-            chips={AGENT_CHIPS}
-            activeIds={filters.activeChipIds}
-            onToggle={filters.toggleChip}
-            legend="State"
-          />
-          <SortToggle<SortMode>
-            value={filters.sortMode}
-            options={SORT_OPTIONS}
-            onChange={filters.setSortMode}
-            legend="Sort"
-          />
+          <label className="flex items-baseline gap-2 text-label">
+            <span className="uppercase tracking-wider text-fg-muted">Rig</span>
+            <select
+              value={rigFilter}
+              onChange={(e) => setRigFilter(e.target.value)}
+              aria-label="Filter by rig"
+              className="text-label uppercase tracking-wider text-fg-muted bg-transparent border-0 focus-mark cursor-pointer hover:text-fg transition-colors duration-150 ease-out-quart"
+            >
+              <option value={RIG_FILTER_ALL}>all rigs</option>
+              {rigOptions.map((opt) => (
+                <option key={opt.key} value={opt.key}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-baseline gap-2 text-label">
+            <input
+              type="checkbox"
+              checked={runningOnly}
+              onChange={(e) => setRunningOnly(e.target.checked)}
+              className="focus-mark cursor-pointer"
+            />
+            <span className="uppercase tracking-wider text-fg-muted">
+              Running only
+            </span>
+          </label>
         </div>
       </div>
 
-      <GroupedTable
-        groups={filters.groups}
+      <Table
         columns={columns}
+        rows={visibleRows}
         rowKey={(r) => r.name}
-        onToggleProject={filters.toggleProject}
-        emptyMessage={
-          filters.search.length > 0 || filters.activeChipIds.size > 0
+        initialSort={{ key: 'last_active', dir: 'desc' }}
+        empty={
+          search.length > 0 || rigFilter !== RIG_FILTER_ALL || runningOnly
             ? 'No agents match the current search or filter.'
             : 'No agents configured.'
         }
-        perProjectEmpty="No agents in this project."
-        initialSort={{ key: 'last_active', dir: 'desc' }}
       />
 
       <Modal

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   GC_EVENT_PREFIX,
@@ -120,6 +120,16 @@ export function AgentsPage() {
       a.label.localeCompare(b.label),
     );
   }, [rows]);
+
+  // If the selected rig leaves the roster (its agents all stopped and were
+  // pruned on an SSE/manual refresh), the controlled <select> would keep
+  // filtering against a rig with no rows and strand the table empty with no
+  // visible cause. Reset to "all rigs" when the selection is no longer present.
+  useEffect(() => {
+    if (rigFilter !== RIG_FILTER_ALL && !rigOptions.some((o) => o.key === rigFilter)) {
+      setRigFilter(RIG_FILTER_ALL);
+    }
+  }, [rigOptions, rigFilter]);
 
   const visibleRows = useMemo(() => {
     const needle = search.trim().toLowerCase();

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BeadsPage } from './Beads';
+import { NowProvider } from '../contexts/NowContext';
+import { invalidate } from '../api/cache';
+import type { GcBead } from 'gas-city-dashboard-shared';
+
+// gascity-dashboard-lcnb: the Beads tab is board-only — the list view and
+// the board/list selector are gone. These tests assert (a) the kanban board
+// renders by default with no toggle, and (b) there is no "View" radiogroup
+// (the SortToggle that used to switch views).
+
+const PROJECT = 'gascity';
+
+beforeEach(() => {
+  // The board implies "show all", so the page only ever reads the
+  // showAll=1 cache key plus the sessions feed.
+  invalidate('beads:all');
+  invalidate('sessions');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/city/test-city/beads')) {
+        return jsonResponse(beadListPayload([sampleBead()]));
+      }
+      if (url === '/api/city/test-city/sessions') {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('BeadsPage', () => {
+  it('renders the kanban board by default', async () => {
+    renderPage();
+
+    await screen.findByRole('heading', { name: /^beads$/i });
+    // The board renders one <section aria-label={project}> per project
+    // group; the list view rendered a <table> instead.
+    const board = await screen.findByRole('region', { name: PROJECT });
+    expect(board).not.toBeNull();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('does not render a board/list view selector', async () => {
+    renderPage();
+
+    await screen.findByRole('heading', { name: /^beads$/i });
+    // The removed selector was a SortToggle rendered as a radiogroup
+    // labelled "View".
+    expect(screen.queryByRole('radiogroup', { name: /view/i })).toBeNull();
+    expect(screen.queryByRole('radio', { name: /list/i })).toBeNull();
+    expect(screen.queryByRole('radio', { name: /board/i })).toBeNull();
+  });
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/beads']}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <NowProvider intervalMs={1_000_000}>
+        <BeadsPage />
+      </NowProvider>
+    </MemoryRouter>,
+  );
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function beadListPayload(items: ReadonlyArray<GcBead>): {
+  items: ReadonlyArray<GcBead>;
+  total: number;
+} {
+  return { items, total: items.length };
+}
+
+function sampleBead(): GcBead {
+  return {
+    id: `${PROJECT}-0001`,
+    title: 'Sample bead',
+    status: 'open',
+    priority: 0,
+    issue_type: 'task',
+    labels: [],
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -3,29 +3,17 @@ import { GC_EVENT_PREFIX, type GcBead } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { BeadBoardSection } from '../components/beads/BeadBoardSection';
 import { BeadDetailRail } from '../components/beads/BeadDetailRail';
-import { BeadDetailModal } from '../components/BeadDetailModal';
 import { Button } from '../components/Button';
 import { FilterChips } from '../components/FilterChips';
-import { GroupedTable } from '../components/GroupedTable';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
-import { SortToggle } from '../components/SortToggle';
-import { beadStatusTone, StatusBadge } from '../components/StatusBadge';
-import { type TableColumn } from '../components/Table';
+import { StatusBadge } from '../components/StatusBadge';
 import { buildBeadGraph } from '../lib/beadGraph';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
 import { useListFilters, type FilterChip } from '../hooks/useListFilters';
 import { beadProject } from '../hooks/projectOf';
-import { formatDate } from '../lib/format';
-
-type BeadView = 'board' | 'list';
-
-const VIEW_OPTIONS: ReadonlyArray<{ id: BeadView; label: string }> = [
-  { id: 'board', label: 'Board' },
-  { id: 'list', label: 'List' },
-];
 
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 
@@ -45,15 +33,11 @@ const BEAD_SEARCH_FIELDS = (b: GcBead): ReadonlyArray<string | undefined> => [
 
 export function BeadsPage() {
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
-  const [showAll, setShowAll] = useState(false);
-  const [view, setView] = useState<BeadView>('board');
-  // The board is a kanban: its in-progress / blocked / done columns are
-  // empty under the open-only default, so Board implies "show all". List
-  // keeps the manual toggle.
-  const showAllEffective = view === 'board' || showAll;
+  // The board is a kanban: its in-progress / blocked / done columns need
+  // the full status set, so it always fetches every bead.
   const { data, loading, error, refresh } = useCachedData(
-    showAllEffective ? 'beads:all' : 'beads:open',
-    () => api.listBeads(showAllEffective),
+    'beads:all',
+    () => api.listBeads(true),
   );
   const rows = useMemo(() => data?.items ?? [], [data]);
   const totalShown = data?.total ?? 0;
@@ -65,11 +49,9 @@ export function BeadsPage() {
   const [closeReason, setCloseReason] = useState('');
   const [actionInFlight, setActionInFlight] = useState<{ id: string; action: string } | null>(null);
   const [actionResult, setActionResult] = useState<string | null>(null);
-  const [viewing, setViewing] = useState<GcBead | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  // Sessions back the board's bead -> live-run resolution. Only the board
-  // view reads them; the list view leaves the cache cold.
+  // Sessions back the board's bead -> live-run resolution.
   const sessions = useCachedData('sessions', () => api.listSessions());
   const sessionItems = useMemo(
     () => sessions.data?.items ?? [],
@@ -91,10 +73,10 @@ export function BeadsPage() {
 
   useGcEventRefresh([GC_EVENT_PREFIX.bead], () => void refresh());
 
-  // The board operates on the same search/chip/label-filtered set the list
-  // does, flattened across project groups. The dependency graph (columns +
-  // needs/blocks edges) is rebuilt from that set; edges pointing outside it
-  // render unresolved rather than fabricated.
+  // The board operates on the search/chip/label-filtered set, flattened
+  // across project groups. The dependency graph (columns + needs/blocks
+  // edges) is rebuilt from that set; edges pointing outside it render
+  // unresolved rather than fabricated.
   const matched = useMemo(
     () => filters.groups.flatMap((g) => g.rows),
     [filters.groups],
@@ -142,134 +124,6 @@ export function BeadsPage() {
     [filteredRows, totalShown, labelFilter],
   );
 
-  const columns = useMemo<ReadonlyArray<TableColumn<GcBead>>>(() => [
-    {
-      key: 'id',
-      label: 'ID',
-      sortable: true,
-      sortValue: (r) => r.id,
-      render: (r) => <span className="text-fg-muted tnum">{r.id}</span>,
-      className: 'w-32',
-    },
-    {
-      key: 'title',
-      label: 'Title',
-      sortable: true,
-      sortValue: (r) => r.title,
-      render: (r) => (
-        <div className="min-w-0">
-          <button
-            type="button"
-            onClick={() => setViewing(r)}
-            className="text-fg truncate hover:text-accent focus-mark text-left"
-            title={`Open ${r.id}`}
-          >
-            {r.title}
-          </button>
-          <p className="text-label uppercase tracking-wider text-fg-faint mt-1 truncate">
-            {r.issue_type}
-            {r.assignee ? ` · ${r.assignee}` : ''}
-          </p>
-          {Array.isArray(r.labels) && r.labels.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
-              {r.labels.slice(0, 8).map((l) => (
-                <button
-                  key={l}
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLabelFilter((cur) => (cur === l ? null : l));
-                  }}
-                  className={`text-label uppercase tracking-wider transition-colors duration-150 ease-out-quart focus-mark rounded-sm ${labelTone(l)}`}
-                  title={`Filter to label "${l}"`}
-                >
-                  {l}
-                </button>
-              ))}
-              {r.labels.length > 8 && (
-                <span className="text-label uppercase tracking-wider text-fg-faint italic">
-                  +{r.labels.length - 8} more
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      ),
-    },
-    {
-      key: 'priority',
-      label: 'P',
-      sortable: true,
-      // Sort null priority to the bottom (sentinel > any P-value the supervisor uses).
-      sortValue: (r) => r.priority ?? Number.POSITIVE_INFINITY,
-      render: (r) => (
-        <span className={`tnum font-medium ${priorityColor(r.priority)}`}>
-          {r.priority === null ? 'P—' : `P${r.priority}`}
-        </span>
-      ),
-      align: 'right',
-      className: 'w-12',
-    },
-    {
-      key: 'status',
-      label: 'Status',
-      sortable: true,
-      sortValue: (r) => r.status,
-      render: (r) => <StatusBadge tone={beadStatusTone(r.status)} label={r.status} />,
-      className: 'w-32',
-    },
-    {
-      // 6bv7 F16: OpenAPI Bead has no updated_at; the column reflects the
-      // only timestamp the supervisor actually emits — created_at.
-      key: 'created',
-      label: 'Created',
-      sortable: true,
-      sortValue: (r) => r.created_at,
-      render: (r) => (
-        <span className="text-fg-muted tnum">{formatDate(r.created_at)}</span>
-      ),
-      className: 'w-28',
-    },
-    {
-      key: 'actions',
-      label: '',
-      render: (r) => (
-        <div className="flex items-baseline justify-end gap-4">
-          <Button
-            size="sm"
-            tone="quiet"
-            disabled={r.status === 'in_progress' || actionInFlight !== null}
-            onClick={() => void runAction(r, 'claim')}
-          >
-            Claim
-          </Button>
-          <Button
-            size="sm"
-            tone="quiet"
-            disabled={r.status === 'closed' || actionInFlight !== null}
-            onClick={() => {
-              setCloseReason('');
-              setClosing(r);
-            }}
-          >
-            Close
-          </Button>
-          <Button
-            size="sm"
-            tone="quiet"
-            disabled={!r.assignee || actionInFlight !== null}
-            onClick={() => void runAction(r, 'nudge')}
-            title={r.assignee ? `nudge ${r.assignee}` : 'no assignee'}
-          >
-            Nudge
-          </Button>
-        </div>
-      ),
-      align: 'right',
-      className: 'w-56',
-    },
-  ], [actionInFlight, runAction]);
-
   const isTruncated =
     typeof upstreamTotal === 'number' &&
     typeof upstreamFetched === 'number' &&
@@ -287,21 +141,9 @@ export function BeadsPage() {
                 {error}
               </span>
             )}
-            {view === 'board' ? (
-              <span className="text-label uppercase tracking-wider text-fg-faint">
-                All statuses
-              </span>
-            ) : (
-              <label className="flex items-baseline gap-2 text-label uppercase tracking-wider text-fg-muted cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={showAll}
-                  onChange={(e) => setShowAll(e.target.checked)}
-                  className="accent-accent translate-y-0.5"
-                />
-                Show all
-              </label>
-            )}
+            <span className="text-label uppercase tracking-wider text-fg-faint">
+              All statuses
+            </span>
             <Button size="sm" onClick={() => void refresh()} disabled={loading}>
               {loading ? 'Refreshing' : 'Refresh'}
             </Button>
@@ -342,80 +184,47 @@ export function BeadsPage() {
           totalCount={filteredRows.length}
           ariaLabel="Search beads"
         />
-        <div className="flex items-baseline justify-between gap-4">
-          <FilterChips
-            chips={BEAD_CHIPS}
-            activeIds={filters.activeChipIds}
-            onToggle={filters.toggleChip}
-            legend="Status"
-          />
-          <SortToggle<BeadView>
-            value={view}
-            options={VIEW_OPTIONS}
-            onChange={setView}
-            legend="View"
-          />
-        </div>
+        <FilterChips
+          chips={BEAD_CHIPS}
+          activeIds={filters.activeChipIds}
+          onToggle={filters.toggleChip}
+          legend="Status"
+        />
       </div>
 
-      {view === 'board' ? (
-        matched.length === 0 ? (
-          <p className="text-body text-fg-muted italic">
-            {filters.search.length > 0 || filters.activeChipIds.size > 0
-              ? 'No beads match the current search or filter.'
-              : labelFilter !== null
-                ? `No beads match label "${labelFilter}".`
-                : 'Nothing on the queue right now.'}
-          </p>
-        ) : (
-          <div className="grid grid-cols-1 xl:grid-cols-[2fr_1fr] gap-x-10 gap-y-8">
-            <div className="space-y-12">
-              {filters.groups.map((g) => (
-                <BeadBoardSection
-                  key={g.projectKey}
-                  label={g.project}
-                  count={g.totalInProject}
-                  graph={graph}
-                  ids={groupIds.get(g.projectKey) ?? EMPTY_IDS}
-                  selectedId={selectedId}
-                  onSelect={setSelectedId}
-                />
-              ))}
-            </div>
-            <div className="xl:sticky xl:top-6 xl:self-start">
-              <BeadDetailRail
-                beadId={selectedId}
-                initialBead={selectedBead}
-                sessions={sessionItems}
-                onOpenBead={setSelectedId}
-              />
-            </div>
-          </div>
-        )
+      {matched.length === 0 ? (
+        <p className="text-body text-fg-muted italic">
+          {filters.search.length > 0 || filters.activeChipIds.size > 0
+            ? 'No beads match the current search or filter.'
+            : labelFilter !== null
+              ? `No beads match label "${labelFilter}".`
+              : 'Nothing on the queue right now.'}
+        </p>
       ) : (
-        <GroupedTable
-          groups={filters.groups}
-          columns={columns}
-          rowKey={(r) => r.id}
-          onToggleProject={filters.toggleProject}
-          emptyMessage={
-            filters.search.length > 0 || filters.activeChipIds.size > 0
-              ? 'No beads match the current search or filter.'
-              : labelFilter !== null
-                ? `No beads match label "${labelFilter}".`
-                : 'Nothing on the queue right now.'
-          }
-          perProjectEmpty="No beads in this project."
-          initialSort={{ key: 'updated', dir: 'desc' }}
-        />
+        <div className="grid grid-cols-1 xl:grid-cols-[2fr_1fr] gap-x-10 gap-y-8">
+          <div className="space-y-12">
+            {filters.groups.map((g) => (
+              <BeadBoardSection
+                key={g.projectKey}
+                label={g.project}
+                count={g.totalInProject}
+                graph={graph}
+                ids={groupIds.get(g.projectKey) ?? EMPTY_IDS}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+              />
+            ))}
+          </div>
+          <div className="xl:sticky xl:top-6 xl:self-start">
+            <BeadDetailRail
+              beadId={selectedId}
+              initialBead={selectedBead}
+              sessions={sessionItems}
+              onOpenBead={setSelectedId}
+            />
+          </div>
+        </div>
       )}
-
-      <BeadDetailModal
-        open={viewing !== null}
-        onClose={() => setViewing(null)}
-        beadId={viewing?.id ?? null}
-        initialBead={viewing}
-      />
 
       <Modal
         open={closing !== null}
@@ -459,24 +268,6 @@ export function BeadsPage() {
       </Modal>
     </section>
   );
-}
-
-function labelTone(label: string): string {
-  // Pipeline-state labels carry the load. Approval = ok, needs- = warn,
-  // blocked = stuck. Scope / gc: / agent: are quiet structural prefixes.
-  if (label === 'approved' || label.endsWith('-approved')) return 'text-ok hover:opacity-80';
-  if (label === 'needs-review' || label.startsWith('needs-review-')) return 'text-warn hover:opacity-80';
-  if (label.startsWith('needs-impl:') || label.startsWith('needs-')) return 'text-warn hover:opacity-80';
-  if (label === 'blocked' || label === 'mayor-skip' || label === 'mayor-needs-human') return 'text-accent hover:opacity-80';
-  if (label.startsWith('scope:')) return 'text-fg-muted hover:text-fg';
-  if (label.startsWith('gc:') || label.startsWith('agent:')) return 'text-fg-faint hover:text-fg-muted';
-  return 'text-fg-muted hover:text-fg';
-}
-
-function priorityColor(p: number | null): string {
-  if (p === 0) return 'text-accent';
-  if (p === 1) return 'text-warn';
-  return 'text-fg-muted';
 }
 
 function buildSynopsis(filtered: ReadonlyArray<GcBead>, totalShown: number, labelFilter: string | null): string {

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -5,6 +5,7 @@ import { HealthPage } from './Health';
 import { invalidate } from '../api/cache';
 import type {
   DoltNomsTrend,
+  HealthDiagnostics,
   SupervisorHealth,
   SystemHealth,
 } from 'gas-city-dashboard-shared';
@@ -109,6 +110,102 @@ describe('HealthPage', () => {
   });
 });
 
+// gascity-dashboard-1cob: Health diagnostics — Dolt/Beads versions + usage,
+// recommended-vs-loaded config comparison. Every datum sources from the
+// backend (never hardcoded); unavailable data surfaces explicitly.
+describe('HealthPage diagnostics', () => {
+  it('renders Dolt and Beads versions from the backend', async () => {
+    const { container } = renderPage();
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    expect(valueFor(container, 'Dolt version')?.textContent).toBe('2.0.7');
+    expect(valueFor(container, 'Beads version')?.textContent).toBe('1.0.4');
+  });
+
+  it('surfaces a failed version probe explicitly rather than blank', async () => {
+    currentHealth = {
+      ...baseHealth(),
+      diagnostics: {
+        ...baseDiagnostics(),
+        doltVersion: { status: 'unavailable', reason: 'dolt not on PATH' },
+      },
+    };
+    const { container } = renderPage();
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    const value = valueFor(container, 'Dolt version');
+    expect(value?.textContent).toMatch(/unavailable|dolt not on PATH/i);
+    expect(value?.className).toMatch(/text-warn/);
+  });
+
+  it('renders Dolt + Beads usage from the backend', async () => {
+    const { container } = renderPage();
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    expect(valueFor(container, 'Live rows')?.textContent).toMatch(/2,?000/);
+    expect(valueFor(container, 'Open')?.textContent).toBe('10');
+    expect(valueFor(container, 'Ready')?.textContent).toBe('4');
+    expect(valueFor(container, 'In progress')?.textContent).toBe('2');
+  });
+
+  it('renders the recommended-vs-loaded comparison row, in-bounds', async () => {
+    const { container } = renderPage();
+    await screen.findByRole('heading', { name: /recommended/i });
+
+    const row = rowFor(container, 'Dolt MB-per-row ratio');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain('≤ 1');
+    expect(row?.textContent).toContain('0.5');
+    // In-bounds row is not warn-toned.
+    expect(row?.className ?? '').not.toMatch(/text-warn/);
+  });
+
+  it('flags an over-threshold comparison row with a warn tone', async () => {
+    currentHealth = {
+      ...baseHealth(),
+      diagnostics: {
+        ...baseDiagnostics(),
+        configComparison: {
+          status: 'available',
+          source: 's',
+          value: [
+            {
+              label: 'Dolt MB-per-row ratio',
+              recommended: '≤ 1',
+              loaded: '2.5',
+              withinRecommendation: false,
+            },
+          ],
+        },
+      },
+    };
+    const { container } = renderPage();
+    await screen.findByRole('heading', { name: /recommended/i });
+
+    const row = rowFor(container, 'Dolt MB-per-row ratio');
+    expect(row?.className ?? '').toMatch(/text-warn/);
+  });
+
+  it('shows comparison unavailable copy when the supervisor reports no baseline', async () => {
+    currentHealth = {
+      ...baseHealth(),
+      diagnostics: {
+        ...baseDiagnostics(),
+        configComparison: {
+          status: 'unavailable',
+          reason: 'supervisor reports no recommended baseline to compare against',
+        },
+      },
+    };
+    renderPage();
+    await screen.findByRole('heading', { name: /recommended/i });
+
+    expect(
+      screen.getByText(/no recommended baseline/i),
+    ).toBeTruthy();
+  });
+});
+
 function renderPage() {
   return render(
     <MemoryRouter
@@ -133,6 +230,14 @@ function valueFor(container: HTMLElement, label: string): HTMLElement | null {
   );
   if (terms.length !== 1) return null;
   return terms[0]?.nextElementSibling as HTMLElement | null;
+}
+
+function rowFor(container: HTMLElement, label: string): HTMLElement | null {
+  // The comparison table renders one element per row carrying a
+  // data-comparison-row attribute set to the row label.
+  return container.querySelector(
+    `[data-comparison-row="${label}"]`,
+  ) as HTMLElement | null;
 }
 
 function synopsisFor(heading: HTMLElement): HTMLElement | null {
@@ -191,6 +296,44 @@ function baseHealth(): SystemHealth {
     supervisor: {
       status: 'available',
       data: presentLocator(),
+    },
+    diagnostics: baseDiagnostics(),
+  };
+}
+
+function baseDiagnostics(): HealthDiagnostics {
+  return {
+    doltVersion: { status: 'available', value: '2.0.7', source: 'local probe: dolt version' },
+    beadsVersion: { status: 'available', value: '1.0.4', source: 'local probe: bd version' },
+    doltUsage: {
+      status: 'available',
+      source: 'supervisor status.store_health',
+      value: {
+        size_bytes: 1_000_000,
+        live_rows: 2000,
+        ratio_mb_per_row: 0.5,
+        threshold_mb_per_row: 1.0,
+        warning: false,
+        last_gc_status: 'success',
+        path: '/data/store',
+      },
+    },
+    beadsUsage: {
+      status: 'available',
+      source: 'supervisor status.work',
+      value: { open: 10, ready: 4, in_progress: 2 },
+    },
+    configComparison: {
+      status: 'available',
+      source: 'supervisor status.store_health (threshold vs actual)',
+      value: [
+        {
+          label: 'Dolt MB-per-row ratio',
+          recommended: '≤ 1',
+          loaded: '0.5',
+          withinRecommendation: true,
+        },
+      ],
     },
   };
 }

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from 'react';
-import type { DoltNomsTrend, SystemHealth } from 'gas-city-dashboard-shared';
+import type {
+  ConfigComparisonRow,
+  DiagnosticValue,
+  DoltNomsTrend,
+  HealthDiagnostics,
+  SystemHealth,
+} from 'gas-city-dashboard-shared';
 import { api } from '../api/client';
 import { Button } from '../components/Button';
 import { PageHeader } from '../components/PageHeader';
@@ -115,6 +121,21 @@ export function HealthPage() {
             </KvList>
           </Section>
 
+          <Section title="Diagnostics">
+            <div className="space-y-8">
+              <KvList>
+                <DiagnosticKv label="Dolt version" datum={health.diagnostics.doltVersion} />
+                <DiagnosticKv label="Beads version" datum={health.diagnostics.beadsVersion} />
+              </KvList>
+              <DoltUsageBlock usage={health.diagnostics.doltUsage} />
+              <BeadsUsageBlock usage={health.diagnostics.beadsUsage} />
+            </div>
+          </Section>
+
+          <Section title="Recommended vs loaded">
+            <ConfigComparison comparison={health.diagnostics.configComparison} />
+          </Section>
+
           <Section
             title="Dolt-noms · 24 h"
             meta={trend && trend.samples.length > 0 ? `${trend.samples.length} samples` : undefined}
@@ -194,6 +215,129 @@ function Kv({
       <dt className="text-body text-fg-muted">{label}</dt>
       <dd className={`text-body tnum font-medium ${valueColor}`}>{value}</dd>
     </>
+  );
+}
+
+// gascity-dashboard-1cob: a diagnostic datum renders its value when available
+// and an explicit "unavailable — <reason>" in warn tone otherwise, so a
+// missing source (failed probe, supervisor offline) reads as a state rather
+// than a blank. Pairs color with a word per DESIGN.md's Greyscale Test.
+function DiagnosticKv({
+  label,
+  datum,
+}: {
+  label: string;
+  datum: DiagnosticValue<string>;
+}) {
+  return datum.status === 'available' ? (
+    <Kv label={label} value={datum.value} />
+  ) : (
+    <Kv label={label} value={`unavailable — ${datum.reason}`} tone="warn" />
+  );
+}
+
+function DoltUsageBlock({
+  usage,
+}: {
+  usage: HealthDiagnostics['doltUsage'];
+}) {
+  if (usage.status === 'unavailable') {
+    return (
+      <UnavailableNote heading="Dolt usage" reason={usage.reason} />
+    );
+  }
+  const u = usage.value;
+  return (
+    <div className="space-y-2">
+      <h3 className="text-label uppercase tracking-wider text-fg-muted">Dolt usage</h3>
+      <KvList>
+        <Kv label="On-disk size" value={formatHumanSize(u.size_bytes)} />
+        {u.live_rows !== undefined && (
+          <Kv label="Live rows" value={u.live_rows.toLocaleString()} />
+        )}
+        {u.ratio_mb_per_row !== undefined && (
+          <Kv label="MB per row" value={u.ratio_mb_per_row.toString()} />
+        )}
+        {u.last_gc_status !== undefined && (
+          <Kv
+            label="Last maintenance"
+            value={u.last_gc_status}
+            {...(u.last_gc_status !== 'success' ? { tone: 'warn' as const } : {})}
+          />
+        )}
+        {u.path !== undefined && <Kv label="Store path" value={u.path} />}
+      </KvList>
+    </div>
+  );
+}
+
+function BeadsUsageBlock({
+  usage,
+}: {
+  usage: HealthDiagnostics['beadsUsage'];
+}) {
+  if (usage.status === 'unavailable') {
+    return <UnavailableNote heading="Beads usage" reason={usage.reason} />;
+  }
+  const u = usage.value;
+  return (
+    <div className="space-y-2">
+      <h3 className="text-label uppercase tracking-wider text-fg-muted">Beads usage</h3>
+      <KvList>
+        <Kv label="Open" value={u.open.toString()} />
+        <Kv label="Ready" value={u.ready.toString()} />
+        <Kv label="In progress" value={u.in_progress.toString()} />
+      </KvList>
+    </div>
+  );
+}
+
+function ConfigComparison({
+  comparison,
+}: {
+  comparison: DiagnosticValue<ConfigComparisonRow[]>;
+}) {
+  if (comparison.status === 'unavailable') {
+    return (
+      <p className="text-body text-fg-muted italic">
+        Comparison unavailable: {comparison.reason}.
+      </p>
+    );
+  }
+  return (
+    <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
+      <div className="text-label uppercase tracking-wider text-fg-muted">Setting</div>
+      <div className="text-label uppercase tracking-wider text-fg-muted text-right">Recommended</div>
+      <div className="text-label uppercase tracking-wider text-fg-muted text-right">Loaded</div>
+      {comparison.value.map((row) => (
+        <ComparisonRow key={row.label} row={row} />
+      ))}
+    </div>
+  );
+}
+
+function ComparisonRow({ row }: { row: ConfigComparisonRow }) {
+  const tone = row.withinRecommendation ? 'text-fg' : 'text-warn';
+  return (
+    <div className={`contents ${tone}`} data-comparison-row={row.label}>
+      <div className={`text-body ${tone}`}>
+        {row.label}
+        {!row.withinRecommendation && (
+          <span className="text-label uppercase tracking-wider text-warn"> · over</span>
+        )}
+      </div>
+      <div className="text-body tnum text-fg-muted text-right">{row.recommended}</div>
+      <div className={`text-body tnum font-medium text-right ${tone}`}>{row.loaded}</div>
+    </div>
+  );
+}
+
+function UnavailableNote({ heading, reason }: { heading: string; reason: string }) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-label uppercase tracking-wider text-fg-muted">{heading}</h3>
+      <p className="text-body text-fg-muted italic">Unavailable: {reason}.</p>
+    </div>
   );
 }
 

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -13,6 +13,7 @@ import { StatusBadge, type StatusTone } from '../components/StatusBadge';
 import { useCachedData } from '../hooks/useCachedData';
 import { useVisibleRefresh } from '../hooks/useVisibleRefresh';
 import { formatHumanSize } from '../lib/format';
+import { formatShortDate } from '../hooks/time';
 
 // Health page fetches the two slow paths in parallel through the
 // stale-while-revalidate cache so re-entering this view (or polling
@@ -264,6 +265,9 @@ function DoltUsageBlock({
             value={u.last_gc_status}
             {...(u.last_gc_status !== 'success' ? { tone: 'warn' as const } : {})}
           />
+        )}
+        {u.last_gc_at !== undefined && (
+          <Kv label="Last maintenance at" value={formatShortDate(u.last_gc_at)} />
         )}
         {u.path !== undefined && <Kv label="Store path" value={u.path} />}
       </KvList>

--- a/shared/src/gc-health.ts
+++ b/shared/src/gc-health.ts
@@ -23,6 +23,83 @@ export interface SystemHealth {
   };
   /** gc supervisor's own city health probe. */
   supervisor: SupervisorHealthState;
+  /**
+   * Diagnostic detail for troubleshooting: Dolt/Beads versions and usage,
+   * plus recommended-vs-loaded config comparison. Each datum carries its own
+   * availability so a missing source (supervisor omitted a field, or a local
+   * version probe failed) surfaces explicitly rather than as a fake value.
+   */
+  diagnostics: HealthDiagnostics;
+}
+
+/**
+ * A single diagnostic value paired with its provenance. `status:'available'`
+ * carries the value; `status:'unavailable'` carries a human-readable reason so
+ * the UI can show *why* it is missing rather than coalescing to a blank.
+ */
+export type DiagnosticValue<T> =
+  | { status: 'available'; value: T; source: string }
+  | { status: 'unavailable'; reason: string };
+
+/**
+ * Dolt store usage, sourced from the supervisor's `status.store_health`
+ * (`GET /v0/city/{name}/status`). All numeric fields except `size_bytes` are
+ * optional on the wire — a degraded supervisor may omit them.
+ */
+export interface DoltUsage {
+  size_bytes: number;
+  live_rows?: number;
+  ratio_mb_per_row?: number;
+  /** Recommended ceiling for ratio_mb_per_row; a ratio above this trips a warning. */
+  threshold_mb_per_row?: number;
+  /** True when the supervisor considers Dolt maintenance overdue. */
+  warning?: boolean;
+  last_gc_at?: IsoTimestamp;
+  last_gc_status?: string;
+  path?: string;
+}
+
+/**
+ * Beads (work-item) usage, sourced from the supervisor's `status.work`
+ * (`GET /v0/city/{name}/status`).
+ */
+export interface BeadsUsage {
+  open: number;
+  ready: number;
+  in_progress: number;
+}
+
+/**
+ * Recommended-vs-loaded comparison for one configuration datum. `recommended`
+ * is the supervisor-reported baseline (e.g. the Dolt maintenance ratio
+ * threshold); `loaded` is the currently-active value. `withinRecommendation`
+ * is the supervisor's own verdict, not a dashboard heuristic.
+ */
+export interface ConfigComparisonRow {
+  label: string;
+  recommended: string;
+  loaded: string;
+  withinRecommendation: boolean;
+}
+
+/**
+ * Troubleshooting bundle for the Health page. Versions that the supervisor API
+ * does not expose are probed locally on the backend host (see
+ * gascity-dashboard-1cob.1); the comparison rows are sourced from whatever
+ * recommended-vs-actual signal the supervisor reports (today: the Dolt
+ * maintenance ratio threshold — see gascity-dashboard-1cob.2).
+ */
+export interface HealthDiagnostics {
+  doltVersion: DiagnosticValue<string>;
+  beadsVersion: DiagnosticValue<string>;
+  doltUsage: DiagnosticValue<DoltUsage>;
+  beadsUsage: DiagnosticValue<BeadsUsage>;
+  /**
+   * Recommended-vs-loaded config rows. `unavailable` when the supervisor
+   * exposes no recommended baseline to compare against; when `available` it
+   * always carries at least one row.
+   */
+  configComparison: DiagnosticValue<ConfigComparisonRow[]>;
 }
 
 export interface SupervisorHealth {
@@ -52,12 +129,26 @@ export interface StatusStoreHealth {
   size_bytes: number;
   live_rows?: number;
   ratio_mb_per_row?: number;
+  threshold_mb_per_row?: number;
+  warning?: boolean;
   last_gc_at?: IsoTimestamp;
+  last_gc_status?: string;
+  path?: string;
+}
+
+/** Work-item counts under `status.work`. */
+export interface StatusWorkCounts {
+  open: number;
+  ready: number;
+  in_progress: number;
 }
 
 /** `GET /v0/city/{name}/status` — only the fields the dashboard reads. */
 export interface GcStatus {
   store_health?: StatusStoreHealth;
+  work?: StatusWorkCounts;
+  /** Server (gc) version. Optional per OpenAPI. */
+  version?: string;
 }
 
 export interface DoltNomsSample {


### PR DESCRIPTION
## Summary

Four dashboard work items landed as one reviewed wave (parallel `/focus`): three P0 UI/perf fixes plus a P2 Health-diagnostics feature. Each was implemented in an isolated worktree, then merged onto this branch and put through a single unified review pass.

| Bead | P | Change |
|---|---|---|
| `lcnb` | P0 | **Beads tab:** removed the list view + view selector — board (kanban) is the only view now. Dead `BeadDetailModal` path dropped (~190 lines net). |
| `wbe9` | P0 | **Formula Runs perf:** root cause was the city-molecule `listBeads` fetch serialized behind feed discovery in `runs/discovery.ts`; hoisted it into the first parallel wave. Other run surfaces audited and already parallel. |
| `c2gr` | P0 | **Agents page:** rebuilt from an expandable rig-grouped `GroupedTable` into a flat `Table` — Rig column, **Running-only** default, rig dropdown filter, sortable by rig/activity. `GroupedTable` untouched (shared with Beads/Mail). |
| `1cob` | P2 | **Health diagnostics:** dolt/beads binary versions (local probe), Dolt/Beads usage, and recommended-vs-loaded Dolt maintenance threshold sourced from supervisor status. No hardcoding/fabrication — unobtainable data surfaces as `unavailable`. |

## Review fixes (commit `22f797c`)

Unified review (code + security + typescript reviewers) on the combined diff — 0 critical. Addressed:

- **HIGH** — Health route fired `gc.health()` then `gc.getStatus()` serially (~7.5s worst case). Now one `Promise.allSettled` wave bounded to `supervisorTimeoutMs` via `AbortSignal.timeout`; the 504-on-health-timeout / degrade-on-status-failure contract is preserved.
- **MEDIUM** — Agents `rigFilter` could strand an empty table if the selected rig left the roster → auto-resets to "all rigs". `last_gc_at` was in the DTO but never rendered → now shown. `{ ...sh }` passthrough spread leaked unknown wire keys → explicit field mapping at the edge (+ regression test).

**By design / no action:** the new `version-probe` subprocess is injection-safe (`shell:false`, static argv, hardened env); dolt-path/stderr exposure is acceptable for a 127.0.0.1 single-operator tool.

## Test plan

- [x] `npm run typecheck` (src + test) — CI parity
- [x] `npm run lint`
- [x] `npm --workspace backend test` — 980 pass
- [x] `npm --workspace frontend test` — 511 pass
- [x] `npm --workspace frontend run build`
- [ ] Manual: Beads tab (board-only, no toggle), Runs load time, Agents flat table + rig filter/sort, Health diagnostics sections

## Follow-ups filed (beads)

- `1cob.1` — gc supervisor API exposes no Dolt/Beads binary versions (drives the local-probe workaround)
- `1cob.2` — gc supervisor API exposes no canonical recommended-config baseline
- `9d77` — upgrade dev-only `vitest` to clear GHSA-5xrq-8626-4rwp (not exploitable here — needs `--ui`, not used)
