### PR TITLE
fix(runs): cache run detail (SWR) to stop the multi-second load hang

### DIFF
--- a/backend/src/routes/runs.ts
+++ b/backend/src/routes/runs.ts
@@ -5,6 +5,7 @@ import type {
   GcFormulaDetail,
   GcRunSnapshot,
   GcSession,
+  FormulaRunDetail,
   RunFormulaDetailFetchFailure,
   RunFormulaDetailState,
   FormulaRunPartialReason,
@@ -30,9 +31,24 @@ import {
   UnsupportedRunError,
 } from '../runs/enrich.js';
 import { mergeRunRuntimeState } from '../runs/runtime-state.js';
+import { KeyedSwrCache } from '../runs/run-detail-cache.js';
+
+// Run-detail reads are cached with stale-while-revalidate because the
+// supervisor's single-run endpoint scans every store in the city to assemble
+// one run (gascity-dashboard-wqsk). 30s mirrors the ambient-glance cadence of
+// the snapshot list (60s) while keeping the focused detail view fresher; SSE
+// bead events and the manual Refresh button bypass it via `?refresh=1`.
+const RUN_DETAIL_CACHE_TTL_MS = 30_000;
 
 export interface RunsRouterOptions {
   rigRoot?: string;
+  /**
+   * Stale-while-revalidate TTL for the run-detail cache, in ms. Defaults to
+   * RUN_DETAIL_CACHE_TTL_MS. Exposed for tests that exercise the stale path.
+   */
+  runDetailCacheTtlMs?: number;
+  /** Injectable clock for the run-detail cache (tests only). */
+  now?: () => number;
   /**
    * Opt-in path-prefix allowlist for run-detail git reads
    * (gascity-dashboard-k2b8). Threaded into readRunGitDiff so the cwd fed to
@@ -47,6 +63,10 @@ export function runsRouter(
   opts: RunsRouterOptions = {},
 ): Router {
   const router = Router();
+  const detailCache = new KeyedSwrCache<FormulaRunDetail>({
+    ttlMs: opts.runDetailCacheTtlMs ?? RUN_DETAIL_CACHE_TTL_MS,
+    ...(opts.now ? { now: opts.now } : {}),
+  });
 
   router.get('/:runId/diff', async (req, res) => {
     const parsed = parseRunRequest(req.params.runId, req.query);
@@ -76,35 +96,65 @@ export function runsRouter(
     }
     try {
       const scope = parsed.scope ?? defaultRunScope(gc.cityName);
-      // getRunSessions is a city-wide listSessions independent of this run, so
-      // overlap it with the run+runtime-state fetch instead of serializing it
-      // after (gascity-dashboard-ey8i). getRunFormulaDetail genuinely depends
-      // on the run's raw root bead, so it stays sequential after the run fetch.
-      const [{ raw, partial: runtimePartial }, sessionsLookup] = await Promise.all([
-        getRunWithRuntimeState(gc, parsed.runId, scope),
-        getRunSessions(gc),
-      ]);
-      const formulaDetailLookup = await getRunFormulaDetail(gc, raw, scope);
-      const detail = enrichFormulaRun(raw, enrichOptions(
-        opts,
-        sessionsLookup,
-        formulaDetailLookup,
-      ));
-      const completeness = formulaRunCompleteness([
-        ...runPartialReasons(detail.completeness),
-        ...(runtimePartial ? ['runtime_bead_read_failed' as const] : []),
-        ...(sessionsLookup.kind === 'unavailable' ? ['session_list_failed' as const] : []),
-        ...(formulaDetailLookup.kind === 'unavailable'
-          ? [formulaDetailPartialReason(formulaDetailLookup.state.reason)]
-          : []),
-      ]);
-      res.json({ ...detail, completeness });
+      // Cache the assembled detail keyed by run + scope: the supervisor scans
+      // every store to build one run (~seconds), so repeat navigations and
+      // concurrent clients would each re-pay it. `?refresh=1` (the manual
+      // Refresh button + SSE-driven refresh) forces a fresh assemble
+      // (gascity-dashboard-wqsk).
+      const force = req.query.refresh === '1';
+      const cacheKey = runDetailCacheKey(parsed.runId, scope);
+      const detail = await detailCache.get(
+        cacheKey,
+        () => assembleRunDetail(gc, parsed.runId, scope, opts),
+        { force },
+      );
+      res.json(detail);
     } catch (err) {
       writeRunError(res, err, 'failed to fetch run');
     }
   });
 
   return router;
+}
+
+// Cache key for one run's assembled detail. Scope is part of the identity:
+// the same runId resolves to different snapshots under different scopes. The
+// components are all identifiers (bead id, 'city'|'rig', scope name) with no
+// embedded spaces, so a space delimiter cannot collide.
+function runDetailCacheKey(
+  runId: string,
+  scope: { scopeKind: RunScopeKind; scopeRef: string },
+): string {
+  return [runId, scope.scopeKind, scope.scopeRef].join(' ');
+}
+
+// Assemble the full run-detail response from the supervisor. Extracted from
+// the route handler so it can be the cache's load() closure
+// (gascity-dashboard-wqsk). getRunSessions is a city-wide listSessions
+// independent of this run, so it overlaps the run+runtime-state fetch instead
+// of serializing after (gascity-dashboard-ey8i). getRunFormulaDetail genuinely
+// depends on the run's raw root bead, so it stays sequential after the run fetch.
+async function assembleRunDetail(
+  gc: GcClient,
+  runId: string,
+  scope: { scopeKind: RunScopeKind; scopeRef: string },
+  opts: RunsRouterOptions,
+): Promise<FormulaRunDetail> {
+  const [{ raw, partial: runtimePartial }, sessionsLookup] = await Promise.all([
+    getRunWithRuntimeState(gc, runId, scope),
+    getRunSessions(gc),
+  ]);
+  const formulaDetailLookup = await getRunFormulaDetail(gc, raw, scope);
+  const detail = enrichFormulaRun(raw, enrichOptions(opts, sessionsLookup, formulaDetailLookup));
+  const completeness = formulaRunCompleteness([
+    ...runPartialReasons(detail.completeness),
+    ...(runtimePartial ? ['runtime_bead_read_failed' as const] : []),
+    ...(sessionsLookup.kind === 'unavailable' ? ['session_list_failed' as const] : []),
+    ...(formulaDetailLookup.kind === 'unavailable'
+      ? [formulaDetailPartialReason(formulaDetailLookup.state.reason)]
+      : []),
+  ]);
+  return { ...detail, completeness };
 }
 
 async function getRunFormulaDetail(

--- a/backend/src/runs/run-detail-cache.ts
+++ b/backend/src/runs/run-detail-cache.ts
@@ -1,0 +1,87 @@
+// Per-key TTL + single-flight + stale-while-revalidate cache for run-detail
+// reads (gascity-dashboard-wqsk).
+//
+// The gc supervisor's single-run endpoint (GET /v0/city/{name}/workflow/{id})
+// scans every store in the city to assemble one run — 2–4s for a tiny run,
+// worse under load. The run-detail route paid that on every navigation. This
+// cache keys assembled detail by runId+scope and serves repeat reads from
+// memory, collapsing the supervisor scan to at most one per TTL per run.
+//
+// Why a bespoke cache and not SourceCache: SourceCache (snapshot/cache.ts) is
+// single-entry and bound to the fixed SourceName enum + SourceState wire shape.
+// Run detail is keyed by an unbounded (runId, scope) space, so it needs a Map.
+// The stale-while-revalidate + single-flight semantics mirror SourceCache.get()
+// deliberately so the two caches behave the same way under load.
+
+export interface KeyedSwrCacheOptions {
+  /** Entries older than this are stale and trigger a background revalidate. */
+  ttlMs: number;
+  /** Injectable clock for tests. Defaults to wall-clock epoch millis. */
+  now?: () => number;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  fetchedAtMs: number;
+}
+
+export class KeyedSwrCache<T> {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly entries = new Map<string, CacheEntry<T>>();
+  // Single-flight per key: concurrent loads (or a stale read's background
+  // revalidate racing a forced read) share one in-flight promise so the
+  // supervisor is hit once, not once per caller.
+  private readonly inflight = new Map<string, Promise<T>>();
+
+  constructor(options: KeyedSwrCacheOptions) {
+    if (options.ttlMs <= 0 || !Number.isFinite(options.ttlMs)) {
+      throw new Error('KeyedSwrCache ttlMs must be a positive finite number.');
+    }
+    this.ttlMs = options.ttlMs;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Resolve `key`, loading via `load` only when necessary:
+   *   - fresh entry (within TTL)  → return it, no load
+   *   - stale entry               → return it immediately, revalidate in background
+   *   - cold (no entry) or force  → await a fresh load
+   *
+   * `load` failures are never cached: a cold failure rejects to the caller; a
+   * background-revalidation failure is swallowed so the last good value keeps
+   * being served (the route surfaces upstream errors on the cold path).
+   */
+  async get(key: string, load: () => Promise<T>, options: { force?: boolean } = {}): Promise<T> {
+    const entry = this.entries.get(key);
+
+    if (!options.force && entry !== undefined) {
+      const fresh = this.now() - entry.fetchedAtMs < this.ttlMs;
+      if (fresh) return entry.value;
+      // Stale: serve the prior value now, refresh out of band.
+      void this.revalidate(key, load).catch(() => {
+        // Swallow — the stale entry remains valid to serve and the next
+        // stale read retries. Mirrors SourceCache's background-refresh guard.
+      });
+      return entry.value;
+    }
+
+    return await this.revalidate(key, load);
+  }
+
+  private revalidate(key: string, load: () => Promise<T>): Promise<T> {
+    const existing = this.inflight.get(key);
+    if (existing !== undefined) return existing;
+
+    const promise = (async () => {
+      const value = await load();
+      this.entries.set(key, { value, fetchedAtMs: this.now() });
+      return value;
+    })().finally(() => {
+      if (this.inflight.get(key) === promise) this.inflight.delete(key);
+    });
+
+    this.inflight.set(key, promise);
+    return promise;
+  }
+}

--- a/backend/test/run-detail-cache.test.ts
+++ b/backend/test/run-detail-cache.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { KeyedSwrCache } from '../src/runs/run-detail-cache.js';
+
+// A controllable clock + a loader that counts calls and returns a
+// monotonically increasing value, so tests can assert exactly when the
+// upstream load fires and which entry version a get() served.
+function harness(initialMs = 0) {
+  let nowMs = initialMs;
+  let calls = 0;
+  const load = async (): Promise<string> => {
+    calls += 1;
+    return `v${calls}`;
+  };
+  return {
+    cache: <T>(ttlMs: number) => new KeyedSwrCache<T>({ ttlMs, now: () => nowMs }),
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+    load,
+    callCount: () => calls,
+  };
+}
+
+// Yield to the microtask queue so a fire-and-forget background revalidation
+// (which is intentionally not awaited by get()) has a chance to settle before
+// the test inspects the result of the next get().
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe('KeyedSwrCache', () => {
+  test('cold get awaits the loader and caches the value', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    const value = await cache.get('k', h.load);
+    assert.equal(value, 'v1');
+    assert.equal(h.callCount(), 1);
+  });
+
+  test('fresh get within TTL serves cached value without reloading', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    await cache.get('k', h.load);
+    h.advance(999);
+    const value = await cache.get('k', h.load);
+    assert.equal(value, 'v1');
+    assert.equal(h.callCount(), 1);
+  });
+
+  test('stale get serves stale value immediately and revalidates in the background', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    await cache.get('k', h.load);
+    h.advance(1001);
+    // Stale: the caller is NOT blocked on the upstream scan — it gets the
+    // prior value instantly while a background refresh runs.
+    const stale = await cache.get('k', h.load);
+    assert.equal(stale, 'v1');
+    await flush();
+    assert.equal(h.callCount(), 2, 'background revalidation should have fired');
+    // The refreshed entry is served on the next get without another load.
+    const fresh = await cache.get('k', h.load);
+    assert.equal(fresh, 'v2');
+    assert.equal(h.callCount(), 2);
+  });
+
+  test('force bypasses a fresh entry and reloads synchronously', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    await cache.get('k', h.load);
+    const forced = await cache.get('k', h.load, { force: true });
+    assert.equal(forced, 'v2');
+    assert.equal(h.callCount(), 2);
+  });
+
+  test('concurrent cold gets for one key coalesce into a single load', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    const [a, b] = await Promise.all([cache.get('k', h.load), cache.get('k', h.load)]);
+    assert.equal(a, 'v1');
+    assert.equal(b, 'v1');
+    assert.equal(h.callCount(), 1);
+  });
+
+  test('distinct keys are isolated', async () => {
+    const h = harness();
+    const cache = h.cache<string>(1000);
+    const a = await cache.get('a', h.load);
+    const b = await cache.get('b', h.load);
+    assert.equal(a, 'v1');
+    assert.equal(b, 'v2');
+    assert.equal(h.callCount(), 2);
+  });
+
+  test('a failed cold load rejects and is not cached', async () => {
+    const nowMs = 0;
+    let calls = 0;
+    const cache = new KeyedSwrCache<string>({ ttlMs: 1000, now: () => nowMs });
+    const failing = async (): Promise<string> => {
+      calls += 1;
+      throw new Error('boom');
+    };
+    await assert.rejects(() => cache.get('k', failing), /boom/);
+    // No entry was cached, so the next get retries the loader.
+    const ok = async (): Promise<string> => `recovered-${calls}`;
+    const value = await cache.get('k', ok);
+    assert.equal(value, 'recovered-1');
+  });
+
+  test('a failed background revalidation keeps serving the last good value', async () => {
+    let nowMs = 0;
+    const cache = new KeyedSwrCache<string>({ ttlMs: 1000, now: () => nowMs });
+    await cache.get('k', async () => 'good');
+    nowMs += 1001;
+    // Stale → serves 'good', kicks a background refresh that throws.
+    const stale = await cache.get('k', async () => {
+      throw new Error('upstream down');
+    });
+    assert.equal(stale, 'good');
+    await flush();
+    // The stale entry survives the failed refresh; still served, no throw.
+    nowMs += 1001;
+    const again = await cache.get('k', async () => {
+      throw new Error('still down');
+    });
+    assert.equal(again, 'good');
+  });
+});

--- a/backend/test/runs.test.ts
+++ b/backend/test/runs.test.ts
@@ -934,4 +934,57 @@ describe('runs detail route', () => {
     }
   });
 
+  test('caches the assembled detail so repeat loads hit the supervisor once', async () => {
+    fake.setHandler((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (respondFormulaDetail(req, res)) return;
+      if (req.url === '/v0/city/racoon-city/sessions') {
+        res.end(JSON.stringify({ items: [], total: 0 }));
+        return;
+      }
+      res.end(JSON.stringify(supervisorWireBody(graphV2Snapshot())));
+    });
+    const { url, close } = await startApp(buildApp(fake.baseUrl));
+    const workflowReqs = () =>
+      fake.requests.filter((u) => u.startsWith('/v0/city/racoon-city/workflow/gc-root')).length;
+    try {
+      const first = await fetch(`${url}/api/runs/gc-root?scope_kind=city&scope_ref=racoon-city`);
+      assert.equal(first.status, 200);
+      assert.equal(workflowReqs(), 1);
+      const second = await fetch(`${url}/api/runs/gc-root?scope_kind=city&scope_ref=racoon-city`);
+      assert.equal(second.status, 200);
+      assert.equal((await second.json()).runId, 'gc-root');
+      // Within TTL the second load is served from cache — no extra scan.
+      assert.equal(workflowReqs(), 1, `unexpected upstream requests: ${fake.requests.join(', ')}`);
+    } finally {
+      await close();
+    }
+  });
+
+  test('?refresh=1 bypasses the cache and re-fetches from the supervisor', async () => {
+    fake.setHandler((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (respondFormulaDetail(req, res)) return;
+      if (req.url === '/v0/city/racoon-city/sessions') {
+        res.end(JSON.stringify({ items: [], total: 0 }));
+        return;
+      }
+      res.end(JSON.stringify(supervisorWireBody(graphV2Snapshot())));
+    });
+    const { url, close } = await startApp(buildApp(fake.baseUrl));
+    const workflowReqs = () =>
+      fake.requests.filter((u) => u.startsWith('/v0/city/racoon-city/workflow/gc-root')).length;
+    try {
+      await fetch(`${url}/api/runs/gc-root?scope_kind=city&scope_ref=racoon-city`);
+      assert.equal(workflowReqs(), 1);
+      const forced = await fetch(
+        `${url}/api/runs/gc-root?scope_kind=city&scope_ref=racoon-city&refresh=1`,
+      );
+      assert.equal(forced.status, 200);
+      assert.equal(workflowReqs(), 2);
+    } finally {
+      await close();
+    }
+  });
+
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -480,7 +480,7 @@ export const api = {
   },
   formulaRun(
     runId: string,
-    params?: { scopeKind?: RunScopeKind; scopeRef?: string },
+    params?: { scopeKind?: RunScopeKind; scopeRef?: string; refresh?: boolean },
   ): Promise<FormulaRunDetail> {
     const qs = runQuery(params);
     return request('GET', cityPath(`/runs/${encodeURIComponent(runId)}${qs}`), decodeFormulaRun);
@@ -525,12 +525,20 @@ export const api = {
   },
 };
 
-function runQuery(params?: { scopeKind?: RunScopeKind; scopeRef?: string }): string {
+function runQuery(params?: {
+  scopeKind?: RunScopeKind;
+  scopeRef?: string;
+  refresh?: boolean;
+}): string {
   const search = new URLSearchParams();
   if (params?.scopeKind && params.scopeRef) {
     search.set('scope_kind', params.scopeKind);
     search.set('scope_ref', params.scopeRef);
   }
+  // `refresh=1` forces the backend run-detail cache to re-fetch from the
+  // supervisor (gascity-dashboard-wqsk) — used by the detail page's explicit
+  // Refresh + SSE-driven refresh so a deliberate refresh never serves stale.
+  if (params?.refresh) search.set('refresh', '1');
   const qs = search.toString();
   return qs.length > 0 ? `?${qs}` : '';
 }

--- a/frontend/src/hooks/useFormulaRunDetail.ts
+++ b/frontend/src/hooks/useFormulaRunDetail.ts
@@ -44,6 +44,10 @@ export function useFormulaRunDetail(
     key,
     () => loadFormulaRunDetail(runId, scopeKind, scopeRef),
     {
+      // Explicit refresh (manual button + SSE bead events) forces the backend
+      // run-detail cache to re-fetch from the supervisor rather than serving a
+      // cached assemble (gascity-dashboard-wqsk).
+      refreshFetcher: () => loadFormulaRunDetail(runId, scopeKind, scopeRef, true),
       onError: (err) => {
         if (runId !== undefined) reportRunDetailError('load detail', runId, err);
       },
@@ -67,11 +71,13 @@ async function loadFormulaRunDetail(
   runId: string | undefined,
   scopeKind?: RunScopeKind,
   scopeRef?: string,
+  refresh?: boolean,
 ): Promise<FormulaRunDetailPayload> {
   if (!runId) return { kind: 'unrequested' };
-  const params: { scopeKind?: RunScopeKind; scopeRef?: string } = {};
+  const params: { scopeKind?: RunScopeKind; scopeRef?: string; refresh?: boolean } = {};
   if (scopeKind !== undefined) params.scopeKind = scopeKind;
   if (scopeRef !== undefined) params.scopeRef = scopeRef;
+  if (refresh) params.refresh = true;
   const detail = await api.formulaRun(runId, params);
   return { kind: 'loaded', detail };
 }


### PR DESCRIPTION
## Problem

Opening a run in the dashboard hangs for **2–8s, repeatedly**. Confirmed by raw `curl` bypassing the dashboard: the gc supervisor's single-run endpoint `GET /v0/city/{name}/workflow/{id}` **scans every store in the city** (its own `stores_scanned[]` listed all 16 — `city:` + 15 `rig:*`) to assemble one run — 2.3–4.4s for a tiny 8-bead/4.4 KB run, 8–9s under load. The run-detail route re-paid that on every navigation, and the client waits up to `GC_CLIENT_TIMEOUT_MS=15000`.

## Fix (dashboard-side mitigation)

Add a per-`(runId, scope)` **TTL + single-flight + stale-while-revalidate** cache (`KeyedSwrCache`) around the assembled run-detail response:

- **Repeat loads** serve from memory — measured **~0.5 ms vs 5.5 s cold** live against `ds-research`.
- **Stale** entries serve instantly while revalidating in the background (mirrors the snapshot's `SourceCache` SWR semantics; 30 s TTL).
- **`?refresh=1`** — wired to the detail page's manual Refresh button and its SSE-driven refresh — bypasses the cache so a deliberate refresh always re-fetches fresh.

Why bespoke and not `SourceCache`: that one is single-entry and bound to the fixed `SourceName`/`SourceState` shapes; run detail is keyed by an unbounded `(runId, scope)` space.

## Root cause (separate, upstream)

The supervisor scanning all 16 stores per run is the real bug; tracked for an upstream `gastownhall/gascity` fix. This PR is the immediate relief in the repo we control.

## Tests

- `KeyedSwrCache` unit tests: cold-await, fresh-hit, stale-SWR (serves stale + background revalidate), force, concurrent single-flight, per-key isolation, errors-not-cached.
- Route tests: repeat `GET /runs/:id` hits the supervisor **once**; `?refresh=1` forces a re-fetch.

Backend 988 · frontend 511 · shared 29 · typecheck (src + test) · build — all green. Lint clean on touched files.

bd: gascity-dashboard-wqsk

🤖 Generated with [Claude Code](https://claude.com/claude-code)