### PR TITLE
fix: Beads board reads filtered feed so ready count reflects real work, not bookkeeping beads (#33)

### DIFF
--- a/backend/src/routes/beads-filter.test.ts
+++ b/backend/src/routes/beads-filter.test.ts
@@ -1,0 +1,77 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { GcBead } from 'gas-city-dashboard-shared';
+import { defaultBeadFilter } from './beads.js';
+
+// #33: defaultBeadFilter is the dashboard's "real work"
+// predicate. The Beads board reads the filtered feed so its ready count/list
+// mirrors the supervisor's `gc bd stats → "Ready to Work"` (~78) instead of
+// counting bookkeeping beads (~979). These tests pin the exclusion contract
+// against the bead shapes the supervisor actually emits for each synthetic
+// namespace, so a regression that re-admits them fails here.
+
+function bead(overrides: Partial<GcBead>): GcBead {
+  return {
+    id: 'gascity-0001',
+    title: 'sample',
+    status: 'open',
+    priority: 0,
+    issue_type: 'task',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('defaultBeadFilter', () => {
+  test('keeps engineering work beads', () => {
+    for (const issue_type of ['feature', 'bug', 'task', 'docs']) {
+      assert.equal(
+        defaultBeadFilter(bead({ issue_type })),
+        true,
+        `expected ${issue_type} to be kept`,
+      );
+    }
+  });
+
+  test('keeps a real task bead with no gc: label (e.g. a workflow root)', () => {
+    // mol-focus-review / "Author fix ..." beads: issue_type 'task', no labels.
+    assert.equal(defaultBeadFilter(bead({ title: 'mol-focus-review', labels: undefined })), true);
+    assert.equal(defaultBeadFilter(bead({ labels: [] })), true);
+    assert.equal(defaultBeadFilter(bead({ labels: ['kind/bug'] })), true);
+  });
+
+  test('excludes mail-as-beads (issue_type message)', () => {
+    assert.equal(defaultBeadFilter(bead({ issue_type: 'message', title: 'polecat closed: gc-x' })), false);
+  });
+
+  test('excludes session / identity beads (issue_type session)', () => {
+    assert.equal(defaultBeadFilter(bead({ issue_type: 'session', title: 'gascity/oversight-rig.project-lead' })), false);
+  });
+
+  test('excludes convoy trackers (issue_type convoy)', () => {
+    assert.equal(defaultBeadFilter(bead({ issue_type: 'convoy' })), false);
+  });
+
+  test('excludes nudge state beads (issue_type chore, gc:nudge label)', () => {
+    assert.equal(
+      defaultBeadFilter(bead({ issue_type: 'chore', title: 'nudge:nudge-abc', labels: ['gc:nudge', 'nudge:nudge-abc'] })),
+      false,
+    );
+  });
+
+  test('excludes slack/extmsg beads (task type, gc:extmsg-* label)', () => {
+    // Transcript/binding/delivery beads are issue_type 'task' but carry a
+    // gc:extmsg-* label — the gc: rule, not the type rule, drops them.
+    for (const label of ['gc:extmsg-transcript', 'gc:extmsg-binding', 'gc:extmsg-delivery']) {
+      assert.equal(
+        defaultBeadFilter(bead({ title: 'slack/T123/C456#7', labels: [label] })),
+        false,
+        `expected ${label} to be excluded`,
+      );
+    }
+  });
+
+  test('excludes any bead with a gc:-prefixed label regardless of type', () => {
+    assert.equal(defaultBeadFilter(bead({ issue_type: 'task', labels: ['gc:anything'] })), false);
+  });
+});

--- a/backend/src/routes/beads.ts
+++ b/backend/src/routes/beads.ts
@@ -32,7 +32,13 @@ import { BEAD_ID_RE } from '../lib/beadId.js';
 //   - NOT issue_type 'convoy'                   : auto-convoy trackers
 //
 // ?showAll=1 disables the filter for diagnostic cases.
-function defaultBeadFilter(bead: GcBead): boolean {
+//
+// This is the dashboard's canonical "real work" predicate — it mirrors the
+// supervisor's `gc bd stats → "Ready to Work"` by dropping bookkeeping beads
+// (slack/extmsg + nudge carry `gc:` labels; mail is issue_type 'message';
+// sessions 'session'; convoy 'convoy'; nudge 'chore'). Exported so the
+// exclusion contract is unit-testable (#33).
+export function defaultBeadFilter(bead: GcBead): boolean {
   const allowedTypes = new Set(['feature', 'bug', 'task', 'docs']);
   if (!allowedTypes.has(bead.issue_type)) return false;
   if (Array.isArray(bead.labels) && bead.labels.some((l) => l.startsWith('gc:'))) {

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -13,9 +13,13 @@ import type { GcBead } from 'gas-city-dashboard-shared';
 
 const PROJECT = 'gascity';
 
+let beadsRequestUrls: string[] = [];
+
 beforeEach(() => {
-  // The board implies "show all", so the page only ever reads the
-  // showAll=1 cache key plus the sessions feed.
+  // #33: the board reads the real-work-filtered beads feed
+  // (no showAll), so the count/list mirrors the supervisor's "Ready to Work"
+  // and excludes bookkeeping beads (slack/nudge/mail/session/convoy).
+  beadsRequestUrls = [];
   invalidate('beads:all');
   invalidate('sessions');
   vi.stubGlobal(
@@ -23,6 +27,7 @@ beforeEach(() => {
     vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/city/test-city/beads')) {
+        beadsRequestUrls.push(url);
         return jsonResponse(beadListPayload([sampleBead()]));
       }
       if (url === '/api/city/test-city/sessions') {
@@ -59,6 +64,21 @@ describe('BeadsPage', () => {
     expect(screen.queryByRole('radiogroup', { name: /view/i })).toBeNull();
     expect(screen.queryByRole('radio', { name: /list/i })).toBeNull();
     expect(screen.queryByRole('radio', { name: /board/i })).toBeNull();
+  });
+
+  it('requests the real-work-filtered beads feed, not showAll', async () => {
+    // #33: showAll=1 disables the backend spam filter and
+    // floods the board (and its ready count) with bookkeeping beads
+    // (slack/nudge/mail/session/convoy), inflating ~78 real ready-to-work
+    // to ~979. The board must consume the filtered feed so its count/list
+    // mirrors `gc bd stats → Ready to Work`.
+    renderPage();
+
+    await screen.findByRole('heading', { name: /^beads$/i });
+    expect(beadsRequestUrls.length).toBeGreaterThan(0);
+    for (const url of beadsRequestUrls) {
+      expect(url).not.toContain('showAll');
+    }
   });
 });
 

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -33,11 +33,15 @@ const BEAD_SEARCH_FIELDS = (b: GcBead): ReadonlyArray<string | undefined> => [
 
 export function BeadsPage() {
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
-  // The board is a kanban: its in-progress / blocked / done columns need
-  // the full status set, so it always fetches every bead.
+  // #33: read the real-work-filtered feed (no showAll). The
+  // default endpoint keeps every status (it filters by type/label, not
+  // status), so the kanban's in-progress / blocked / done columns stay
+  // populated, while bookkeeping beads (slack/nudge/mail/session/convoy) are
+  // excluded. This keeps the ready column/count mirroring the supervisor's
+  // "Ready to Work" instead of inflating it with synthetic beads.
   const { data, loading, error, refresh } = useCachedData(
     'beads:all',
-    () => api.listBeads(true),
+    () => api.listBeads(),
   );
   const rows = useMemo(() => data?.items ?? [], [data]);
   const totalShown = data?.total ?? 0;


### PR DESCRIPTION
## Problem

The Beads board fetched `/api/beads?showAll=1`, which **disables** the backend spam filter (`defaultBeadFilter`). That floods the board — and its ready column/count — with the gc store's bookkeeping beads (Slack/extmsg thread-tracking, nudge state, mail-as-beads, session/identity, convoy), inflating the real ~78 ready-to-work to ~979.

Fixes #33.

## Fix

The board now reads the **default filtered** feed (`api.listBeads()` instead of `listBeads(true)`). `defaultBeadFilter` filters by type/label, not status, so the kanban in-progress / blocked / done columns stay populated while the synthetic namespaces drop out — mirroring `gc bd stats → "Ready to Work"`.

Verified each synthetic bead shape is excluded (slack = task + `gc:extmsg-*` label, nudge = chore + `gc:nudge`, mail = `message`, session = `session`, convoy = `convoy`) and real task beads (no `gc:` label) are kept.

`backend/src/routes/beads.ts` (export `defaultBeadFilter`) · `backend/src/routes/beads-filter.test.ts` (new, pins the exclusion contract) · `frontend/src/routes/Beads.tsx` (filtered feed) · `frontend/src/routes/Beads.test.tsx`. +113/-6.

## Test plan

- [x] `typecheck`, `build`, backend (996) + frontend (512) suites green; OpenAPI no-drift; no dist drift.
- [x] New `beads-filter.test.ts` asserts each synthetic namespace is excluded and real task beads kept.

## Out of scope

`AgentDetail.tsx` also uses `listBeads(true)` but filters to a single assignee (no inflation) — left as-is per the issue.
