### PR TITLE
fix(runs): share detail cache with diff endpoint + optimistic skeleton

### DIFF
--- a/backend/src/routes/runs.ts
+++ b/backend/src/routes/runs.ts
@@ -75,12 +75,20 @@ export function runsRouter(
       return;
     }
     try {
-      const { raw } = await getRunWithRuntimeState(
-        gc,
-        parsed.runId,
-        parsed.scope ?? defaultRunScope(gc.cityName),
+      const scope = parsed.scope ?? defaultRunScope(gc.cityName);
+      // Reuse the cached detail assemble — it already carries executionPath —
+      // so the diff endpoint never re-pays the supervisor's all-store scan that
+      // the detail endpoint just paid. On a run-detail page the two fetches
+      // fire together and share one scan via the cache's single-flight; repeat
+      // loads are served from memory (gascity-dashboard-wqsk). `?refresh=1`
+      // forces a fresh assemble in lockstep with the detail refresh.
+      const force = req.query.refresh === '1';
+      const cacheKey = runDetailCacheKey(parsed.runId, scope);
+      const detail = await detailCache.get(
+        cacheKey,
+        () => assembleRunDetail(gc, parsed.runId, scope, opts),
+        { force },
       );
-      const detail = enrichFormulaRun(raw, baseEnrichOptions(opts));
       const diff = await readRunGitDiff(detail.executionPath, opts.runCwdAllowedRoots ?? []);
       res.json(diff);
     } catch (err) {
@@ -322,12 +330,6 @@ function parseRunRequest(
 
 function defaultRunScope(cityName: string): { scopeKind: RunScopeKind; scopeRef: string } {
   return { scopeKind: 'city', scopeRef: cityName };
-}
-
-function baseEnrichOptions(opts: RunsRouterOptions): { rigRoot?: string } {
-  return {
-    ...(opts.rigRoot !== undefined ? { rigRoot: opts.rigRoot } : {}),
-  };
 }
 
 function enrichOptions(

--- a/backend/test/runs.test.ts
+++ b/backend/test/runs.test.ts
@@ -961,6 +961,33 @@ describe('runs detail route', () => {
     }
   });
 
+  test('the diff endpoint shares the detail cache: detail then diff hits the supervisor once', async () => {
+    fake.setHandler((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (respondFormulaDetail(req, res)) return;
+      if (req.url === '/v0/city/racoon-city/sessions') {
+        res.end(JSON.stringify({ items: [], total: 0 }));
+        return;
+      }
+      res.end(JSON.stringify(supervisorWireBody(graphV2Snapshot())));
+    });
+    const { url, close } = await startApp(buildApp(fake.baseUrl));
+    const workflowReqs = () =>
+      fake.requests.filter((u) => u.startsWith('/v0/city/racoon-city/workflow/gc-root')).length;
+    try {
+      const detail = await fetch(`${url}/api/runs/gc-root?scope_kind=city&scope_ref=racoon-city`);
+      assert.equal(detail.status, 200);
+      assert.equal(workflowReqs(), 1);
+      // The diff endpoint reuses the cached detail (it only needs
+      // executionPath) instead of re-scanning every store.
+      const diff = await fetch(`${url}/api/runs/gc-root/diff?scope_kind=city&scope_ref=racoon-city`);
+      assert.equal(diff.status, 200);
+      assert.equal(workflowReqs(), 1, `unexpected upstream requests: ${fake.requests.join(', ')}`);
+    } finally {
+      await close();
+    }
+  });
+
   test('?refresh=1 bypasses the cache and re-fetches from the supervisor', async () => {
     fake.setHandler((req, res) => {
       res.setHeader('content-type', 'application/json');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -487,7 +487,7 @@ export const api = {
   },
   runDiff(
     runId: string,
-    params?: { scopeKind?: RunScopeKind; scopeRef?: string },
+    params?: { scopeKind?: RunScopeKind; scopeRef?: string; refresh?: boolean },
   ): Promise<RunDiffResponse> {
     const qs = runQuery(params);
     return request('GET', cityPath(`/runs/${encodeURIComponent(runId)}/diff${qs}`), decodeRunDiff);

--- a/frontend/src/hooks/useRunDiff.ts
+++ b/frontend/src/hooks/useRunDiff.ts
@@ -41,6 +41,10 @@ export function useRunDiff(
     key,
     () => loadRunDiff(runId, scopeKind, scopeRef),
     {
+      // Explicit refresh forces the backend to re-assemble (bypassing the
+      // shared run-detail cache the diff now reads from) so a deliberate
+      // refresh re-fetches in lockstep with the detail (gascity-dashboard-wqsk).
+      refreshFetcher: () => loadRunDiff(runId, scopeKind, scopeRef, true),
       onError: (err) => {
         if (runId !== undefined) reportRunDiffError('load diff', runId, err);
       },
@@ -64,11 +68,13 @@ async function loadRunDiff(
   runId: string | undefined,
   scopeKind?: RunScopeKind,
   scopeRef?: string,
+  refresh?: boolean,
 ): Promise<RunDiffPayload> {
   if (!runId) return { kind: 'unrequested' };
-  const params: { scopeKind?: RunScopeKind; scopeRef?: string } = {};
+  const params: { scopeKind?: RunScopeKind; scopeRef?: string; refresh?: boolean } = {};
   if (scopeKind !== undefined) params.scopeKind = scopeKind;
   if (scopeRef !== undefined) params.scopeRef = scopeRef;
+  if (refresh) params.refresh = true;
   const diff = await api.runDiff(runId, params);
   return { kind: 'loaded', diff };
 }

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -12,6 +12,8 @@ import {
   type RunDiffResponse,
   type FormulaRunDetail,
   type RunScopeKind,
+  type DashboardSnapshot,
+  type RunLane,
 } from 'gas-city-dashboard-shared';
 import rawFormulaRunDetailFixture from '../test/fixtures/formula-run-detail.json';
 
@@ -105,6 +107,36 @@ describe('FormulaRunDetailPage', () => {
     const refreshButton = screen.getByRole('button', { name: /^refresh$/i }) as HTMLButtonElement;
     expect(refreshButton.disabled).toBe(true);
     expect(screen.queryByRole('button', { name: /^refreshing$/i })).toBeNull();
+  });
+
+  it('renders an optimistic stage-ladder skeleton from the snapshot lane while detail loads', async () => {
+    // The first load of a run is bounded by the supervisor's all-store scan
+    // (gascity-dashboard-wqsk). When the operator arrives from /runs the
+    // snapshot cache already holds this run's lane, so the page shows its
+    // title + phase stages instantly instead of a blank spinner. Here the
+    // detail (and diff) fetch hangs while the snapshot resolves with a lane.
+    invalidate('snapshot');
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/city/test-city/snapshot')) {
+        return jsonResponse(snapshotWithActiveLane());
+      }
+      // Everything run-specific (detail, diff, links) hangs → stay in loading.
+      return new Promise<Response>(() => {});
+    }));
+
+    renderPage();
+
+    const ladder = await screen.findByRole('list', { name: /pending adoption run stages/i });
+    const stageRows = within(ladder)
+      .getAllByRole('listitem')
+      .map((item) => item.textContent?.replace(/\s+/g, ' ').trim());
+    expect(stageRows).toEqual(['◆ Intake', '⬣ Implementation', '· Review']);
+    expect(screen.getByText(/^Loading run detail\.$/i)).toBeTruthy();
+    // The plain spinner is replaced by the skeleton, and the heavy detail
+    // diagram has not rendered yet.
+    expect(screen.queryByText(/^Loading formula run\.$/i)).toBeNull();
+    expect(screen.queryByRole('heading', { name: /local changes/i })).toBeNull();
   });
 
   it('does not repeat missing formula metadata as formula detail and a partial banner', async () => {
@@ -608,6 +640,85 @@ function RouteControls() {
       Clear node query
     </button>
   );
+}
+
+// A snapshot whose runs source carries one lane matching the route's runId, so
+// the detail page can render an optimistic skeleton while the full detail
+// loads. city/resources are error states — the skeleton only reads runs.lanes.
+function snapshotWithActiveLane(): DashboardSnapshot {
+  const lane: RunLane = {
+    id: 'gc-adopt-pr-active',
+    title: 'Pending adoption run',
+    formula: { status: 'known', name: 'mol-adopt-pr-v2' },
+    scope: { status: 'available', kind: 'city', ref: 'racoon-city', rootStoreRef: 'city:racoon-city' },
+    external: { status: 'unavailable', error: 'external unavailable in test' },
+    phase: 'implementation',
+    phaseLabel: 'Implementation',
+    statusCounts: { in_progress: 1 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-05-27T22:01:00Z' },
+    stages: [
+      { key: 'intake', label: 'Intake', status: 'complete' },
+      { key: 'implementation', label: 'Implementation', status: 'active' },
+      { key: 'review', label: 'Review', status: 'pending' },
+    ],
+    progress: { status: 'unavailable', error: 'active run step unavailable' },
+    formulaStageResolved: false,
+    health: {
+      status: 'available',
+      data: {
+        phaseConfidence: 'known',
+        needsOperator: false,
+        stuckNode: { status: 'unavailable', error: 'run stuck node unavailable' },
+        thrashingDetected: false,
+        session: { status: 'unresolved', error: 'run session unresolved' },
+      },
+    },
+  };
+  return {
+    generatedAt: '2026-05-25T00:00:00.000Z',
+    config: {
+      cityName: 'test-city',
+      cityRoot: '/tmp/example-city',
+      useFixtures: false,
+      enabledModules: null,
+      defaultView: null,
+    },
+    headline: {
+      activeAgents: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
+      maxAgents: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
+      activeSessions: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
+      activeRuns: { status: 'available', value: 1 },
+    },
+    sources: {
+      city: { source: 'city', status: 'error', error: 'city unavailable in test' },
+      resources: { source: 'resources', status: 'error', error: 'resources unavailable in test' },
+      runs: {
+        source: 'runs',
+        status: 'fresh',
+        fetchedAt: '2026-05-25T00:00:00.000Z',
+        staleAt: '2026-05-25T00:01:00.000Z',
+        error: { kind: 'none' },
+        data: {
+          totalActive: 1,
+          totalHistorical: 0,
+          historicalLanes: [],
+          runCounts: {
+            total: 1,
+            visible: 1,
+            prReview: 0,
+            designReview: 0,
+            bugfix: 0,
+            blocked: 0,
+            other: 1,
+          },
+          lanes: [lane],
+          recentChanges: [],
+          census: { status: 'unavailable', error: 'run health has not been derived' },
+        },
+      },
+    },
+  };
 }
 
 function jsonResponse(payload: unknown): Response {

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { GC_EVENT_PREFIX, SCOPE_REF_RE } from 'gas-city-dashboard-shared';
 import type {
@@ -25,6 +25,8 @@ import { useRunNodeSelection } from '../hooks/useRunNodeSelection';
 import { useFormulaRunDetail } from '../hooks/useFormulaRunDetail';
 import { useRunDiff } from '../hooks/useRunDiff';
 import { useEntityLinks } from '../hooks/useEntityLinks';
+import { useCachedData } from '../hooks/useCachedData';
+import { api } from '../api/client';
 import { NEEDS_YOU_VIEW_PARAM } from '../views/modules/maintainer/needsYou';
 
 const RUN_DETAIL_EVENT_PREFIXES = [
@@ -96,6 +98,25 @@ export function FormulaRunDetailPage() {
   const [viewingBeadId, setViewingBeadId] = useState<string | null>(null);
   const now = useNow();
 
+  // Optimistic skeleton (gascity-dashboard-wqsk): the first load of a run is
+  // bounded by the supervisor's all-store scan (seconds). The snapshot cache —
+  // already warm when the operator arrives from /runs — carries this run's lane
+  // (title + phase stages), so render that instantly instead of a blank spinner
+  // while the full detail assembles. Shares the 'snapshot' cache key with the
+  // Runs list, so list→detail navigation pays no extra fetch; a cold deep-link
+  // does one cheap snapshot GET and falls back to the plain spinner if the lane
+  // isn't present.
+  const snapshot = useCachedData('snapshot', () => api.snapshot());
+  const skeletonLane = useMemo(() => {
+    if (!runId) return null;
+    const runs = snapshot.data?.sources.runs;
+    const runsData =
+      runs && (runs.status === 'fresh' || runs.status === 'stale' || runs.status === 'fixture')
+        ? runs.data
+        : null;
+    return runsData?.lanes.find((lane) => lane.id === runId) ?? null;
+  }, [snapshot.data, runId]);
+
   const synopsis = detail
     ? `${detail.progress.visibleNodeCount} nodes. ${summarizeNodeStatuses(detail.progress)}. Local changes are shown for the run execution folder.`
     : initialLoading && !routeError
@@ -153,7 +174,14 @@ export function FormulaRunDetailPage() {
       />
 
       {loading && !routeError && !detail ? (
-        <p className="text-body text-fg-muted italic">Loading formula run.</p>
+        skeletonLane ? (
+          <>
+            <StageLadder stages={skeletonLane.stages} label={skeletonLane.title} />
+            <p className="text-body text-fg-muted italic mt-8">Loading run detail.</p>
+          </>
+        ) : (
+          <p className="text-body text-fg-muted italic">Loading formula run.</p>
+        )
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">{pageError}</p>
       ) : readyRun ? (


### PR DESCRIPTION
## Why a second PR

PR #34 was squash-merged with only its **first** commit (the run-detail SWR cache). Two follow-up commits — the diff-endpoint fix and the optimistic skeleton — were left off `main`. This PR brings them in, rebased onto current `main`.

## Problem still on `main`

The run-detail page fires **both** `GET /runs/:id` and `GET /runs/:id/diff`. PR #34 cached the detail but left the **diff endpoint doing its own uncached all-store scan** on every load — measured **1.8s, then 8.5s** for a rig-stored run (`gpk-up6du`). For an active run whose SSE bead events drive refreshes, that uncached scan re-fired and piled up against the supervisor, so the page kept hanging.

## Changes

**1. Diff endpoint shares the detail cache** (`backend/src/routes/runs.ts`)
The diff handler only needs `executionPath`, which the assembled detail already carries. It now reads through the same `KeyedSwrCache` (single-flight + SWR) instead of re-scanning. On a page load the two fetches share one scan; repeat loads are served from memory. Measured **8.5s → ~2ms** live. `?refresh=1` is wired through `useRunDiff` so explicit refresh re-assembles in lockstep with detail. Removes the now-dead `baseEnrichOptions`.

**2. Optimistic stage-ladder skeleton** (`frontend/src/routes/FormulaRunDetail.tsx`)
The first load of a run is still bounded by the supervisor's all-store scan (upstream gastownhall/gascity#2940). The snapshot cache — already warm when arriving from `/runs` — carries this run's lane (title + phase stages), so the page renders that instantly instead of a blank spinner while the full detail assembles. List→detail navigation pays no extra fetch; a cold deep-link does one cheap snapshot GET and falls back to the plain spinner when the lane isn't present.

## Tests

- Backend: detail-then-diff hits the supervisor **once** (diff shares the cache).
- Frontend: with a snapshot lane cached and detail hanging, the stage ladder renders from the lane (title + stages) and the plain spinner is gone.
- Full gate green: typecheck (src+test), backend 997, frontend 513, build, lint.

bd: gascity-dashboard-wqsk

🤖 Generated with [Claude Code](https://claude.com/claude-code)