### PR TITLE
fix(beads): server-side type-filtered fetch + per-rig dropdown

### DIFF
--- a/backend/src/routes/beads.ts
+++ b/backend/src/routes/beads.ts
@@ -25,9 +25,17 @@ import {
 
 import { BEAD_ID_RE } from '../lib/beadId.js';
 
+// The dashboard's "real work" issue types — engineering work only. Used both
+// to scope the server-side fetch (one supervisor query per type, since its
+// `type` filter is single-valued) and by defaultBeadFilter's type gate.
+// Exported so the route's fan-out and the filter share one source of truth.
+export const ENG_BEAD_TYPES = ['feature', 'bug', 'task', 'docs'] as const;
+
+const ENG_TYPE_SET: ReadonlySet<string> = new Set(ENG_BEAD_TYPES);
+
 // v0 hardcoded spam filter. Comments here are the load-bearing
 // documentation — "why isn't bead X showing" has a file/line answer.
-//   - issue_type in {feature, bug, task, docs}  : engineering work only
+//   - issue_type in ENG_BEAD_TYPES              : engineering work only
 //   - NOT label starting 'gc:'                  : session/message noise
 //   - NOT issue_type 'convoy'                   : auto-convoy trackers
 //
@@ -38,21 +46,27 @@ import { BEAD_ID_RE } from '../lib/beadId.js';
 // (slack/extmsg + nudge carry `gc:` labels; mail is issue_type 'message';
 // sessions 'session'; convoy 'convoy'; nudge 'chore'). Exported so the
 // exclusion contract is unit-testable (#33).
+//
+// The list route now fetches by type server-side, so the type gate is
+// usually redundant by the time a bead reaches here — but gc:-labelled
+// noise (e.g. gc:extmsg-* beads are issue_type 'task') is type-matched and
+// can only be excluded client-side, since the supervisor's `label` param is
+// a positive match and can't express exclusion. Keep the full predicate.
 export function defaultBeadFilter(bead: GcBead): boolean {
-  const allowedTypes = new Set(['feature', 'bug', 'task', 'docs']);
-  if (!allowedTypes.has(bead.issue_type)) return false;
+  if (!ENG_TYPE_SET.has(bead.issue_type)) return false;
   if (Array.isArray(bead.labels) && bead.labels.some((l) => l.startsWith('gc:'))) {
     return false;
   }
   return true;
 }
 
-// td-7t24i6 fix: gc default /beads limit is 50, far below the city's working
-// set (~2139 total, ~183 eng-only). Pull a wide window so the spam filter
-// operates on the full set, not a 50-item slice. 1000 is well over the
-// current ~183-item eng-only count and leaves headroom; safety cap in case
-// the supervisor returns more.
-const BEADS_FETCH_LIMIT = 1000;
+// Per-type fetch ceiling. The route queries each ENG_BEAD_TYPES value
+// independently, so this caps a single type, not the whole store. The
+// 'task' type is the largest (it carries gc:extmsg-* noise the spam filter
+// then drops); 2000 leaves comfortable headroom over its current ~935 count.
+// A limit is a ceiling, not a fetch size — the supervisor returns min(total,
+// limit) — so generous headroom costs nothing when actual counts are lower.
+const BEADS_FETCH_LIMIT = 2000;
 
 interface BeadsRouterOptions {
   /**
@@ -90,18 +104,46 @@ export function beadsRouter(
 
   router.get('/', async (req, res) => {
     try {
-      const { items, total } = await gc.listBeads(undefined, { limit: BEADS_FETCH_LIMIT });
       const showAll = req.query.showAll === '1';
-      const filtered = showAll ? items : items.filter(defaultBeadFilter);
+      if (showAll) {
+        // Diagnostic path: pull the wide unfiltered window (bookkeeping beads
+        // included) in a single call. Truncation against the whole-store
+        // total is expected and reported via the coverage counters below.
+        const { items, total } = await gc.listBeads(undefined, { limit: BEADS_FETCH_LIMIT });
+        res.json({
+          items,
+          total: items.length,
+          upstream_total: typeof total === 'number' ? total : undefined,
+          upstream_fetched: items.length,
+          fetch_limit: BEADS_FETCH_LIMIT,
+        });
+        return;
+      }
+
+      // Real-work path: fetch only engineering types server-side — one query
+      // per type, since the supervisor's `type` filter is single-valued —
+      // then drop gc:-labelled noise client-side. This scopes the fetch to
+      // the ~969-bead eng working set instead of the ~1604-bead store, so the
+      // coverage warning only fires on genuine engineering-work truncation.
+      const perType = await Promise.all(
+        ENG_BEAD_TYPES.map((type) =>
+          gc.listBeads(undefined, { limit: BEADS_FETCH_LIMIT, type }),
+        ),
+      );
+      const merged = perType.flatMap((r) => r.items);
+      const filtered = merged.filter(defaultBeadFilter);
+      // upstream_total: the engineering working set's size (sum of per-type
+      // totals). Diff vs upstream_fetched tells the UI when a single type
+      // overflowed BEADS_FETCH_LIMIT and engineering work sits past the window.
+      const upstreamTotal = perType.reduce(
+        (sum, r) => sum + (typeof r.total === 'number' ? r.total : r.items.length),
+        0,
+      );
       res.json({
         items: filtered,
         total: filtered.length,
-        // upstream_total: the store's total bead count (per gc's `total`
-        // field). Diff between upstream_total and items.length tells the UI
-        // how much was truncated by our fetch limit so the operator can see
-        // when the window isn't covering everything.
-        upstream_total: typeof total === 'number' ? total : undefined,
-        upstream_fetched: items.length,
+        upstream_total: upstreamTotal,
+        upstream_fetched: merged.length,
         fetch_limit: BEADS_FETCH_LIMIT,
       });
     } catch (err) {

--- a/backend/test/beads-list.test.ts
+++ b/backend/test/beads-list.test.ts
@@ -1,0 +1,155 @@
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import type { GcBead, GcBeadList } from 'gas-city-dashboard-shared';
+import { beadsRouter, ENG_BEAD_TYPES } from '../src/routes/beads.js';
+import { GcClient } from '../src/gc-client.js';
+
+// gascity-dashboard-oh19: GET /api/beads fetches the engineering working set
+// server-side (one supervisor query per eng type — the `type` param is
+// single-valued), merges the results, and drops gc:-labelled noise
+// client-side. These tests pin that the route issues per-type queries (not a
+// single unfiltered firehose), that the gc: label exclusion still applies to
+// type-matched beads (e.g. gc:extmsg-* task beads), and that the upstream
+// coverage counters are summed from the eng-type totals so the truncation
+// warning only fires on genuine engineering-work truncation.
+
+function bead(overrides: Partial<GcBead>): GcBead {
+  return {
+    id: 'gascity-0001',
+    title: 'sample',
+    status: 'open',
+    priority: 0,
+    issue_type: 'task',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+interface ListCall {
+  type: string | undefined;
+  limit: number | undefined;
+}
+
+interface AppHandle {
+  url: string;
+  close: () => Promise<void>;
+  calls: ListCall[];
+}
+
+// Per-type fixtures keyed by the `type` query param the route passes. The
+// stub records every call so a test can assert the route fans out by type.
+async function buildApp(
+  byType: Record<string, GcBeadList>,
+): Promise<AppHandle> {
+  const gc = new GcClient({ baseUrl: 'http://127.0.0.1:1', cityName: 'test' });
+  const calls: ListCall[] = [];
+  // Override the upstream list call with a recording stub. The route only
+  // depends on the public listBeads contract, so this isolates the route's
+  // fan-out/merge logic from the HTTP client.
+  gc.listBeads = async (_signal, params) => {
+    calls.push({ type: params?.type, limit: params?.limit });
+    const key = params?.type ?? '__all__';
+    return byType[key] ?? { items: [], total: 0 };
+  };
+
+  const app = express();
+  app.use('/api/beads', beadsRouter(gc, '/home/test/gas-city'));
+  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    calls,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe('GET /api/beads (server-side type-filtered fetch)', () => {
+  let handle: AppHandle | undefined;
+  afterEach(async () => {
+    await handle?.close();
+    handle = undefined;
+  });
+
+  test('fans out one query per engineering type, never an unfiltered fetch', async () => {
+    handle = await buildApp({
+      feature: { items: [bead({ id: 'app-1', issue_type: 'feature' })], total: 1 },
+      bug: { items: [bead({ id: 'app-2', issue_type: 'bug' })], total: 1 },
+      task: { items: [bead({ id: 'app-3', issue_type: 'task' })], total: 1 },
+      docs: { items: [], total: 0 },
+    });
+    const res = await fetch(`${handle.url}/api/beads`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    const typesQueried = handle.calls.map((c) => c.type).sort();
+    assert.deepEqual(typesQueried, [...ENG_BEAD_TYPES].sort());
+    // No call may omit the type param (that would be the old firehose).
+    assert.ok(handle.calls.every((c) => typeof c.type === 'string'));
+    assert.equal(body.items.length, 3);
+    assert.deepEqual(
+      body.items.map((b: GcBead) => b.id).sort(),
+      ['app-1', 'app-2', 'app-3'],
+    );
+  });
+
+  test('drops gc:-labelled noise returned by a type query (gc:extmsg-* tasks)', async () => {
+    handle = await buildApp({
+      feature: { items: [], total: 0 },
+      bug: { items: [], total: 0 },
+      task: {
+        items: [
+          bead({ id: 'real-1', issue_type: 'task' }),
+          bead({ id: 'noise-1', issue_type: 'task', labels: ['gc:extmsg-transcript'] }),
+        ],
+        total: 2,
+      },
+      docs: { items: [], total: 0 },
+    });
+    const res = await fetch(`${handle.url}/api/beads`);
+    const body = await res.json();
+    assert.deepEqual(body.items.map((b: GcBead) => b.id), ['real-1']);
+    assert.equal(body.total, 1);
+  });
+
+  test('upstream counters sum eng-type totals; warning does not fire when each type is covered', async () => {
+    handle = await buildApp({
+      feature: { items: [bead({ id: 'f1', issue_type: 'feature' })], total: 20 },
+      bug: { items: [bead({ id: 'b1', issue_type: 'bug' })], total: 14 },
+      task: { items: [bead({ id: 't1', issue_type: 'task' })], total: 935 },
+      docs: { items: [], total: 0 },
+    });
+    const res = await fetch(`${handle.url}/api/beads`);
+    const body = await res.json();
+    // Sum of per-type totals = the engineering working set, NOT the whole
+    // store (~1604). fetched is the merged item count (3 here).
+    assert.equal(body.upstream_total, 969);
+    assert.equal(body.upstream_fetched, 3);
+    assert.ok(typeof body.fetch_limit === 'number');
+  });
+
+  test('showAll=1 keeps the wide unfiltered diagnostic fetch (single call, no type)', async () => {
+    handle = await buildApp({
+      __all__: {
+        items: [
+          bead({ id: 'eng-1', issue_type: 'task' }),
+          bead({ id: 'msg-1', issue_type: 'message' }),
+        ],
+        total: 1604,
+      },
+    });
+    const res = await fetch(`${handle.url}/api/beads?showAll=1`);
+    const body = await res.json();
+    assert.equal(handle.calls.length, 1);
+    assert.equal(handle.calls[0]?.type, undefined);
+    // showAll bypasses the real-work filter — bookkeeping beads pass through.
+    assert.equal(body.items.length, 2);
+    assert.equal(body.upstream_total, 1604);
+  });
+});

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GC_EVENT_PREFIX, type GcBead } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { BeadBoardSection } from '../components/beads/BeadBoardSection';
@@ -17,6 +17,11 @@ import { beadProject } from '../hooks/projectOf';
 
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 
+// Sentinel for the rig dropdown's "all rigs" option. Empty string can't
+// collide with a derived rig key (beadProject always returns a non-empty
+// prefix), mirroring the Agents view's RIG_FILTER_ALL.
+const RIG_FILTER_ALL = '';
+
 const BEAD_CHIPS: ReadonlyArray<FilterChip<GcBead>> = [
   { id: 'open', label: 'open', match: (b) => b.status === 'open' },
   { id: 'in_progress', label: 'in progress', match: (b) => b.status === 'in_progress' },
@@ -33,6 +38,7 @@ const BEAD_SEARCH_FIELDS = (b: GcBead): ReadonlyArray<string | undefined> => [
 
 export function BeadsPage() {
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
+  const [rigFilter, setRigFilter] = useState<string>(RIG_FILTER_ALL);
   // #33: read the real-work-filtered feed (no showAll). The
   // default endpoint keeps every status (it filters by type/label, not
   // status), so the kanban's in-progress / blocked / done columns stay
@@ -62,10 +68,35 @@ export function BeadsPage() {
     [sessions.data],
   );
 
+  // Rig options for the dropdown: every rig present in the fetched beads,
+  // keyed by the same beadProject derivation the board groups on, sorted
+  // alphabetically. Keeping the key identical to the group key means the
+  // selection maps 1:1 onto a rendered section.
+  const rigOptions = useMemo(
+    () => Array.from(new Set(rows.map(beadProject))).sort((a, b) => a.localeCompare(b)),
+    [rows],
+  );
+
+  // If the selected rig leaves the feed (e.g. its last bead closed and was
+  // dropped on a refresh), the controlled <select> would keep filtering
+  // against a rig with no rows and strand the board empty with no visible
+  // cause. Reset to "all rigs" when the selection is no longer present.
+  useEffect(() => {
+    if (rigFilter !== RIG_FILTER_ALL && !rigOptions.includes(rigFilter)) {
+      setRigFilter(RIG_FILTER_ALL);
+    }
+  }, [rigOptions, rigFilter]);
+
   const filteredRows = useMemo(() => {
-    if (labelFilter === null) return rows;
-    return rows.filter((r) => Array.isArray(r.labels) && r.labels.includes(labelFilter));
-  }, [rows, labelFilter]);
+    let rs = rows;
+    if (rigFilter !== RIG_FILTER_ALL) {
+      rs = rs.filter((r) => beadProject(r) === rigFilter);
+    }
+    if (labelFilter !== null) {
+      rs = rs.filter((r) => Array.isArray(r.labels) && r.labels.includes(labelFilter));
+    }
+    return rs;
+  }, [rows, rigFilter, labelFilter]);
 
   const filters = useListFilters<GcBead>({
     viewKey: 'beads',
@@ -188,12 +219,32 @@ export function BeadsPage() {
           totalCount={filteredRows.length}
           ariaLabel="Search beads"
         />
-        <FilterChips
-          chips={BEAD_CHIPS}
-          activeIds={filters.activeChipIds}
-          onToggle={filters.toggleChip}
-          legend="Status"
-        />
+        <div className="flex flex-wrap items-baseline gap-x-8 gap-y-3">
+          <FilterChips
+            chips={BEAD_CHIPS}
+            activeIds={filters.activeChipIds}
+            onToggle={filters.toggleChip}
+            legend="Status"
+          />
+          {rigOptions.length > 1 && (
+            <label className="flex items-baseline gap-2 text-label">
+              <span className="uppercase tracking-wider text-fg-muted">Rig</span>
+              <select
+                value={rigFilter}
+                onChange={(e) => setRigFilter(e.target.value)}
+                aria-label="Filter by rig"
+                className="text-label uppercase tracking-wider text-fg-muted bg-transparent border-0 focus-mark cursor-pointer hover:text-fg transition-colors duration-150 ease-out-quart"
+              >
+                <option value={RIG_FILTER_ALL}>all rigs</option>
+                {rigOptions.map((rig) => (
+                  <option key={rig} value={rig}>
+                    {rig}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
       </div>
 
       {matched.length === 0 ? (


### PR DESCRIPTION
## Why

The Beads page showed a persistent warning — *"Fetch window covered 1000 of 1619 store beads. Raise the limit…"* — that read as a regression of the earlier bead-count work. It wasn't.

`1604`/`1619` is the supervisor store's **total** bead count (sessions, mail, convoy, nudges, slack/`extmsg` noise), **not** engineering work. #33/#35 fixed *which beads get displayed*; they never touched the **fetch window**. So `/api/beads` pulled a wide unfiltered window (`limit=1000`), filtered client-side, and the coverage warning compared 1000 against the whole noisy store — firing even though only **~970** engineering-typed beads exist and each eng type is individually well under the limit.

| type | count |
|---|---|
| feature | 21 |
| bug | 14 |
| task | 935 |
| docs | 0 |
| **eng total** | **~970** |
| (message 527, chore 55, session 39 = noise) | |

## What

**Backend (`backend/src/routes/beads.ts`)**
- Fetch the engineering working set **server-side**: one supervisor query per `ENG_BEAD_TYPES` value (`feature/bug/task/docs`) — the supervisor's `type` param is single-valued — then merge and drop `gc:`-labelled noise client-side (`gc:extmsg-*` beads are `issue_type: 'task'` and can't be excluded server-side, since the `label` param is positive-match only).
- `upstream_total` is now the **eng working set** (sum of per-type totals), so the truncation warning only fires on *genuine* engineering-work truncation, not store growth.
- Per-type cap `1000 → 2000` (a ceiling, not a fetch size — costs nothing when actual counts are lower) for `task` headroom.
- Extracted `ENG_BEAD_TYPES` as the shared source of truth for the fetch fan-out and `defaultBeadFilter`.
- `?showAll=1` keeps the wide single-call diagnostic fetch.

**Frontend (`frontend/src/routes/Beads.tsx`)**
- Added a rig `<select>` (default *all rigs*) mirroring the existing `Agents.tsx` pattern: options derived from the fetched beads via `beadProject`, filters the board to one rig, and resets to *all rigs* if the selection leaves the feed. Only renders when more than one rig is present.

## Test plan
- [x] `backend/test/beads-list.test.ts` (new): per-type fan-out (never an unfiltered fetch), `gc:` exclusion on type-matched beads, summed coverage counters, `showAll` diagnostic path
- [x] `npm --workspace backend test` → 1001/1001
- [x] `npm --workspace frontend test` → 513/513
- [x] `npm run typecheck` (source + test) clean
- [x] `npm --workspace frontend run build` clean
- [x] Live-verified against the supervisor: eng types sum to ~970, each under the 2000 cap → `fetched == total` → warning clears

Closes gascity-dashboard-oh19