### PR TITLE
feat(tui): city board — rig × in-flight phase count matrix view

### DIFF
--- a/specs/architecture/tui-tmux-dashboard-gap-analysis.md
+++ b/specs/architecture/tui-tmux-dashboard-gap-analysis.md
@@ -1,0 +1,149 @@
+# TUI gap analysis vs the gc tmux operator console
+
+Source of inspiration: the custom tmux dashboard from "My Gas City Setup: Adversarial
+Agents, TDD, and a Custom tmux Dashboard" (`/home/ds/gas-city/pngs/dashboard_tmux_example.png`,
+video `https://www.youtube.com/watch?v=bYPkQisCag8`). That console is the `gc`
+supervisor's own operator surface — the exact thing `tui/` exists to replace with a
+calmer, honest, read-only glance surface (`tui/README.md` "What it is and is not").
+
+This is an audit, not a plan. It maps every pane in the screenshot to current TUI
+coverage, judges portability against the binding register (`DESIGN.md`), records what the
+`shared` DTOs actually back, and ends in a prioritized candidate list. It does **not**
+authorize any UI to merge — each candidate still owes its own bead, test, and (for
+anything rendered) a `DESIGN.md` review via `gascity-dashboard-review-pr`.
+
+## The register that bounds any port
+
+`DESIGN.md` is written for the web client but the TUI inherits the same absolutes (its
+README cites the Greyscale Test and the no-color-as-signal rule). Every borrow below is
+judged against:
+
+- **The Greyscale Test / One Mark Rule.** Strip color: every state must still read. Maroon
+  (here: the single red mark) appears at most once per viewport. The screenshot's
+  red/amber/green status-dot grid violates this directly and cannot be ported as-is.
+- **Status is a sentence / paired with a word or glyph.** Counts and states are typeset,
+  not encoded in hue.
+- **Read-only + 127.0.0.1 posture.** No pane-attach (`capture-pane` bypasses the
+  server-side ANSI/OSC sanitisation that is the load-bearing XSS defence); no writes
+  (claim/close/sling/respond/compose need the CSRF double-submit the web client has).
+- **Honest signal.** Never fabricate a value the wire doesn't back (the TUI already does
+  this for cost: Health says *not measured*, `tui/src/panes.tsx:418`).
+- **No em dashes in UI copy** (commas/colons/periods/parentheses).
+
+## Pane-by-pane inventory
+
+| # | Screenshot pane | What it is | Current TUI coverage | Portable in register? | Data backing |
+|---|---|---|---|---|---|
+| 1 | Live agent pane (webcam + Claude scrollback) | Attached tmux client of a working agent | **None, by design** | **No** — pane-attach is explicitly rejected (XSS/sanitisation, 127.0.0.1) | n/a |
+| 2 | Agent task list ("4 tasks: 1 done, 1 in progress, 2 for agents") | The agent's own todo breakdown | None | Maybe — only if read-only and backed | Not exposed by `/api/*` today (no per-session task list DTO) |
+| 3 | "User declined to answer questions" Q&A | Awaiting-human-decision gate | None | Yes, but it's a **write** affordance | Backed (`PendingInteraction`), already scoped by the tmai/amux PRD as dashboard-local write work |
+| 4 | Footer: version current/latest, `97998 tokens` | Build version + token/cost counter | Health shows *not measured* | Counter: only if data flows | Cost fields exist on `WorkerOperationEventPayload` but are "currently always absent" (`cost-token-feasibility.md`) |
+| 5 | **rig × lifecycle-state count matrix** (rigs × review/ok'd/ready/active/stalled/PR/block/**done**/others, with per-row totals) | Whole-city-at-a-glance board | **None** — Beads groups by status (one axis); Health is a vertical list | **Partly** — in-flight phases port as a greyscale count grid + one red mark; the `done`/total/`others` columns do **not** (see caveat) | **In-flight phases backed today** (`RunLane.health.data.phase: RunPhase` + `byPhase: Record<RunPhase, number>`, `shared/src/snapshot/types.ts:254,348`; per-rig grouping via `groupRuns`/`laneRig`, `tui/src/derive.ts:316,253`). **`done`/total NOT backed**: historical `complete` lanes are capped in the snapshot DTO (`shared/src/snapshot/types.ts:213`), so the big cumulative counts (371/609/total) are not in the data the TUI fetches |
+| 6 | Workers panel (`coherence/workers.worker-opus`, ids + ages) | Pool/worker roster per rig | **Agents** view (`AgentRow`, grouped by rig) | Already shipped | `GcSession` |
+| 7 | control-dispatcher panel + "awaiting gc prime initialization" + "(+3 more sessions)" | Orchestration agent + activity + fold | **Agents** (orch `△`) + `activityPhrase` + `+ N more` | Already shipped | `GcSession.activity`/`reason` |
+| 8 | NEEDS REVIEW panel | Items flagged for the operator | **Ledger** + Health "runs needing operator" | Already shipped | `RunLane.health.needsOperator` |
+| 9 | Per-session age / last-active (`28d; 1h ago`) | Recency | `relativeTime` everywhere | Already shipped | `GcSession.last_active` |
+| 10 | outbox / compose (`Ctrl+F11 send`, autosaved draft) | Compose & send mail | **None, by design** | **No** — write affordance, read-only guard | Backend mail is read-only in TUI |
+
+## Findings
+
+**Already covered (no work):** panes 6, 7, 8, 9. The TUI's Agents/Ledger/Health views
+already render the worker roster, orchestration activity, the needs-review queue, and
+recency, in-register. The screenshot's versions are denser and louder; ours are the calmer
+translation that was the point.
+
+**Out of scope by standing constraint (do not build):** panes 1 and 10 (pane-attach,
+compose/send) violate the read-only + 127.0.0.1 + sanitisation guards. These are not
+"not yet" — they are deliberate rejections recorded in the README.
+
+**Already owned by the tmai/amux PRD (do not re-litigate here):** panes 3 (awaiting
+decision) and 4 (token/cost). Both are scoped, with feasibility findings committed
+(`awaiting-decision-signal-feasibility.md`, `cost-token-feasibility.md`). The decision gate
+is buildable dashboard-local write work gated on a `DESIGN.md` review; cost rendering is
+gated on the supervisor populating the always-absent fields. The TUI is read-only, so the
+decision gate would land in the **web** client first; the TUI could later show a read-only
+"awaiting decision" *sentence* (no affordance) once the signal is plumbed.
+
+**Genuinely new and liftable:** pane 5, the rig × phase matrix. It is the one idea with no
+current TUI equivalent, it is backed by DTOs we already fetch, and it translates cleanly
+into the register as a greyscale count grid.
+
+## Prioritized candidate improvements
+
+### P1 — City board: rig × phase count matrix (new TUI view)
+
+The standout borrow. A compact grid: rigs as rows, run phases as columns, tabular counts in
+cells, a single red mark on the column/cell that means a human is needed.
+
+- **Data:** pure derivation over `RunLane[]` the TUI already has. Group by `laneRig`
+  (`tui/src/derive.ts:253`), count by `RunLane.health.data.phase` per group. The phase
+  vocabulary is **ours**, not the screenshot's: `intake / implementation / review /
+  approval / finalization / blocked / complete / active` (`shared/src/snapshot/types.ts:462`).
+  Map to readable column heads (e.g. `intake→ready`, `implementation→active`,
+  `approval→ok'd`, `finalization→PR`, `blocked→block`). Do **not** invent a column the
+  phase enum can't back.
+- **Caveat 1 — "stalled" is not a phase.** In our model it's a time-derived signal the
+  frontend computes from `RunLane.updatedAt` + resolved session activity on a 1s clock
+  (`shared/src/snapshot/types.ts:301`, `phaseConfidence === 'known'` gate). The TUI today
+  only reads `needsOperator`, not a computed stalled tier. So a faithful `stalled` column
+  is one piece needing new derivation; ship the matrix with `needsOperator` as the red-mark
+  source first, add a computed stalled column only if it earns its place.
+- **Caveat 2 — `done`/total/`others` are not backed (honest-signal blocker).** The
+  screenshot's large `done` counts (371, 609) and per-row totals are cumulative history.
+  The dashboard's live `RunLane[]` snapshot carries *active* lanes; historical `complete`
+  lanes are **capped** in the DTO (`shared/src/snapshot/types.ts:213`), so those totals are
+  not in the data the TUI fetches. Mapping `RunPhase = 'complete'` to a `done` column would
+  show a confident, wrong number. **Omit `done`/total/`others`** from the first build; a
+  faithful historical column needs a separate aggregate source that `/api/*` does not expose
+  today (a spike, not a build, same path as cost/decision). `others` has no clean phase
+  mapping and is dropped, not invented.
+- **Scope to in-flight phases only:** build over `intake/implementation/review/approval/
+  finalization/blocked/active` (the live `byPhase`), not `complete`.
+- **Register:** greyscale counts (tabular figures, aligned). One red mark total — on the
+  `block`/needs-operator column when nonzero. Column heads are tracked labels, not tinted.
+  No grid borders if whitespace alignment carries it; Ink box widths already do this in
+  `panes.tsx`.
+- **Risk:** low. Read-only, no new dep, no backend change. Erosion risk is column sprawl —
+  keep to phases the enum backs.
+- **Owes:** a bead, `derive.ts` unit tests for the per-rig×phase counter (TDD, the
+  `derive.test.ts` pattern), a `DESIGN.md` review for the rendered grid.
+
+### P2 — Read-only "awaiting decision" sentence in the TUI
+
+Once the web client's decision gate (tmai/amux PRD) plumbs `PendingInteraction` through the
+backend, surface it in the TUI's Ledger as a **read-only sentence** ("agent X is awaiting a
+decision on Y"), no accept/decline affordance (that stays in the CSRF-protected web client).
+
+- **Data:** backed (`PendingInteraction`), but **blocked on** the web-side plumbing landing
+  first. Not startable standalone.
+- **Register:** status-is-a-sentence; folds into the existing Ledger "waiting on you"
+  section; red mark only if it crosses the existing needs-operator threshold.
+- **Risk:** low once unblocked. Owes: bead dependency on the PRD's decision work.
+
+### P3 — Per-session task breakdown (investigate only)
+
+Pane 2 (the agent's todo list) is appealing but **unbacked**: no `/api/*` DTO carries a
+per-session task list today. This is a feasibility spike, not a build: confirm whether the
+supervisor exposes a session task/todo structure over `GcClient` HTTP. If absent, it routes
+to the same upstream-filing path as cost/decision, with a committed `specs/` finding — not a
+fabricated list. **Do not** synthesize tasks from transcript scraping (honest-signal rule;
+same reasoning as the deliberately-deferred session summary, `tui/README.md` Sessions).
+
+## Non-goals (carried from constraints, recorded so they are not re-proposed)
+
+- No tmux pane-attach / `capture-pane` rendering (pane 1).
+- No compose/send or any write affordance in the TUI (pane 10); writes belong to the web
+  client with CSRF.
+- No faked token/cost counter (pane 4) until the supervisor populates the fields.
+- No status-by-color: the screenshot's dot grid is re-expressed as greyscale counts + at
+  most one red mark.
+- No synthesized per-session task list (pane 2) absent a real DTO.
+- No `done`/total/`others` columns in the city board until a historical aggregate source is
+  confirmed over `/api/*` (the live snapshot caps historical lanes); first build is
+  in-flight phases only.
+
+## Recommended next step
+
+Build **P1** behind a bead, TDD-first (`derive.ts` counter + tests before the pane), with a
+`DESIGN.md` review on the rendered grid. P2 waits on the web decision work; P3 is a spike,
+not a build.

--- a/tui/README.md
+++ b/tui/README.md
@@ -58,6 +58,15 @@ reused tmux split (see Peek).
   context-pressure agents (≥75%), and a never-active-by-rig reallocation rollup.
   Costs are shown as *not measured* (the supervisor exposes none yet — see
   `specs/architecture/cost-token-feasibility.md`); never faked.
+- **City board** (`m`): a compact whole-city matrix — rigs as rows, in-flight run
+  phases as columns (`ready · impl · review · ok'd · PR · block · active`), tabular
+  greyscale counts in cells, with a `needs` column carrying the single red mark when a
+  rig has lanes flagged needs-operator. Rows order attention-first (needs-operator rigs,
+  then busiest). Inspired by the gc tmux console's per-repo status grid, translated into
+  the TUI register (greyscale counts, one red mark, no color-as-signal). **History is not
+  shown:** completed lanes are capped in the snapshot DTO, so a `done`/total column would
+  read a confident wrong number — the board is in-flight only, never faked (see
+  `specs/architecture/tui-tmux-dashboard-gap-analysis.md`).
 - **Detail** (`p`, agents only): in-TUI detail for the selected agent — ids, the
   peek commands, that rig's beads and active run lanes. `c` toggles a **config**
   tab showing the agent's fetchable session config (template, pool, kind, model,
@@ -78,8 +87,8 @@ it. Quitting (`q`) tears the peek pane down. All drill-ins READ (logs/show/diff)
 
 `↑`/`↓` or `j`/`k` move the selection · **mouse wheel** scrolls · `PageUp`/`PageDown`
 · `g`/`G` top/bottom · `enter` drill into split · `x` close split · `a` cycle agent
-status filter · `b` beads · `f` runs · `s` sessions · `l` ledger · `h` health · `p`
-agent detail · `c` toggle config tab (in detail) · `q` (or `esc`) quit.
+status filter · `b` beads · `f` runs · `s` sessions · `l` ledger · `h` health · `m` city
+board · `p` agent detail · `c` toggle config tab (in detail) · `q` (or `esc`) quit.
 
 ## Run
 

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -5,6 +5,7 @@ import { useMouseWheel } from './useMouseWheel.ts';
 import {
   AgentRow,
   BeadRow,
+  CityBoardPane,
   DetailPane,
   HealthPane,
   LedgerPane,
@@ -23,6 +24,7 @@ import {
 import {
   beadsForRig,
   categorize,
+  cityBoard,
   contextPressure,
   groupBeads,
   groupByRig,
@@ -48,7 +50,7 @@ interface AppProps {
   readonly city: string;
 }
 
-type ViewMode = 'list' | 'beads' | 'runs' | 'detail' | 'health' | 'sessions' | 'ledger';
+type ViewMode = 'list' | 'beads' | 'runs' | 'detail' | 'health' | 'sessions' | 'ledger' | 'board';
 
 type Entry =
   | { readonly kind: 'agent'; readonly id: string; readonly agent: AgentView }
@@ -179,11 +181,12 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
   const now = Date.now();
 
   const health = useMemo(() => systemHealth(snapshot), [snapshot]);
+  const board = useMemo(() => cityBoard(health.lanes), [health.lanes]);
   // detail navigates the same agent list as 'list' underneath.
   const navView: ViewMode = view === 'detail' ? 'list' : view;
   const { entries, renderRows } = useMemo(
     () =>
-      navView === 'health' || navView === 'ledger'
+      navView === 'health' || navView === 'ledger' || navView === 'board'
         ? EMPTY_NAV
         : buildNav(navView, sessions, beads, health.lanes, statusFilter),
     [navView, sessions, beads, health.lanes, statusFilter],
@@ -295,6 +298,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
       if (input === 'q') return quit();
       if (key.escape) return view === 'list' ? quit() : (setView('list'), setScrollTop(0));
       if (input === 'h') return toggle('health');
+      if (input === 'm') return toggle('board');
       if (input === 'b') return toggle('beads');
       if (input === 'f') return toggle('runs');
       if (input === 's') return toggle('sessions');
@@ -342,7 +346,14 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
   const mailFolded = foldedMailCount(mail, ledgerMail);
 
   const summary =
-    view === 'beads' ? (
+    view === 'board' ? (
+      // No red here: the board's own `needs` column carries the one mark, so a
+      // second red region in the same viewport would break the One Mark Rule.
+      <Text dimColor>
+        board · {board.length} {board.length === 1 ? 'rig' : 'rigs'} active
+        {needsOpRuns > 0 ? ` · ${needsOpRuns} need operator` : ''}
+      </Text>
+    ) : view === 'beads' ? (
       <Text dimColor>
         beads · {openBeads} open · {beads.length} total
       </Text>
@@ -391,7 +402,11 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
         </Box>
       ) : null}
 
-      {view === 'health' ? (
+      {view === 'board' ? (
+        <Box marginTop={1}>
+          <CityBoardPane board={board} />
+        </Box>
+      ) : view === 'health' ? (
         <Box marginTop={1}>
           <HealthPane
             health={health}
@@ -472,7 +487,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
                 {below > 0 ? `↓ ${below}` : ''}
               </Text>
             )}
-            <Text dimColor>↑↓ · enter drill · a filter · s/b/f/l/h views · p detail · x close · q quit</Text>
+            <Text dimColor>↑↓ · enter drill · a filter · s/b/f/l/h/m views · p detail · x close · q quit</Text>
           </Box>
         </>
       )}
@@ -481,6 +496,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
 }
 
 function emptyLabel(view: ViewMode): string {
+  if (view === 'board') return 'no active runs';
   if (view === 'beads') return 'no beads';
   if (view === 'runs') return 'no active runs';
   if (view === 'sessions') return 'no live sessions';

--- a/tui/src/derive.test.ts
+++ b/tui/src/derive.test.ts
@@ -4,11 +4,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { GcMailItem, GcSession } from 'gas-city-dashboard-shared';
+import type { GcMailItem, GcSession, RunLane, RunPhase } from 'gas-city-dashboard-shared';
 import {
   AGENT_KINDS,
   activityPhrase,
   agentKind,
+  cityBoard,
+  CITY_BOARD_PHASES,
+  CITY_BOARD_PHASE_LABEL,
   foldedMailCount,
   kindGlyph,
   kindLabel,
@@ -16,6 +19,7 @@ import {
   matchesStatusFilter,
   nextStatusFilter,
   operatorMail,
+  ORCHESTRATION,
   runningSessions,
   type StatusFilter,
 } from './derive.ts';
@@ -204,4 +208,134 @@ test('mailSnippet collapses whitespace and truncates with an ellipsis', () => {
   const snip = mailSnippet(long, 10);
   assert.equal(snip.length, 10);
   assert.ok(snip.endsWith('…'));
+});
+
+// ── city board (rig × in-flight phase count matrix) ──────────────────────────
+
+function lane(over: {
+  id?: string;
+  /** null → city scope (buckets under orchestration); otherwise the rig name. */
+  rig?: string | null;
+  phase?: RunPhase;
+  needsOperator?: boolean;
+  /** Scope reports unavailable (the other null-rig path → orchestration bucket). */
+  scopeUnavailable?: boolean;
+}): RunLane {
+  const rig = over.rig === undefined ? 'gascity' : over.rig;
+  const scope: RunLane['scope'] = over.scopeUnavailable
+    ? { status: 'unavailable', error: 'scope timeout' }
+    : rig === null
+      ? { status: 'available', kind: 'city', ref: 'city', rootStoreRef: 'city:gastown' }
+      : { status: 'available', kind: 'rig', ref: rig, rootStoreRef: `rig:${rig}` };
+  const phase = over.phase ?? 'implementation';
+  return {
+    id: over.id ?? 'l1',
+    title: over.id ?? 'l1',
+    formula: { status: 'unavailable', error: 'none' },
+    scope,
+    external: { status: 'unavailable', error: 'none' },
+    phase,
+    phaseLabel: phase,
+    statusCounts: {},
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-06-01T00:00:00Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'none' },
+    formulaStageResolved: false,
+    health: {
+      status: 'available',
+      data: {
+        phaseConfidence: 'known',
+        needsOperator: over.needsOperator ?? false,
+        stuckNode: { status: 'unavailable', error: 'none' },
+        thrashingDetected: false,
+        session: { status: 'unresolved', error: 'none' },
+      },
+    },
+  };
+}
+
+test('CITY_BOARD_PHASES excludes complete and every column has a label', () => {
+  assert.ok(!(CITY_BOARD_PHASES as readonly string[]).includes('complete'), 'complete is not a column');
+  for (const p of CITY_BOARD_PHASES) {
+    assert.ok(CITY_BOARD_PHASE_LABEL[p].length > 0, `label for ${p}`);
+  }
+});
+
+test('cityBoard counts lanes per rig × in-flight phase', () => {
+  const board = cityBoard([
+    lane({ id: 'a', rig: 'stealth-retainers', phase: 'review' }),
+    lane({ id: 'b', rig: 'stealth-retainers', phase: 'review' }),
+    lane({ id: 'c', rig: 'stealth-retainers', phase: 'approval' }),
+    lane({ id: 'd', rig: 'gc2', phase: 'implementation' }),
+  ]);
+  const sr = board.find((r) => r.rig === 'stealth-retainers');
+  const gc2 = board.find((r) => r.rig === 'gc2');
+  assert.ok(sr && gc2);
+  assert.equal(sr.counts.review, 2);
+  assert.equal(sr.counts.approval, 1);
+  assert.equal(sr.total, 3);
+  assert.equal(gc2.counts.implementation, 1);
+  assert.equal(gc2.total, 1);
+});
+
+test('cityBoard excludes complete lanes entirely (honest-signal: history is capped)', () => {
+  const board = cityBoard([
+    lane({ id: 'a', rig: 'gc2', phase: 'implementation' }),
+    lane({ id: 'done1', rig: 'gc2', phase: 'complete' }),
+    lane({ id: 'done2', rig: 'gc2', phase: 'complete' }),
+  ]);
+  const gc2 = board.find((r) => r.rig === 'gc2');
+  assert.ok(gc2);
+  assert.equal(gc2.total, 1, 'complete lanes are not counted in the total');
+  // No 'complete' key on the counts record.
+  assert.deepEqual(Object.keys(gc2.counts).sort(), [...CITY_BOARD_PHASES].sort());
+});
+
+test('cityBoard counts needsOperator separately as the red-mark source', () => {
+  const board = cityBoard([
+    lane({ id: 'a', rig: 'gc2', phase: 'blocked', needsOperator: true }),
+    lane({ id: 'b', rig: 'gc2', phase: 'review', needsOperator: false }),
+  ]);
+  const gc2 = board.find((r) => r.rig === 'gc2');
+  assert.ok(gc2);
+  assert.equal(gc2.needsOperator, 1);
+  assert.equal(gc2.total, 2);
+});
+
+test('cityBoard buckets city-scoped lanes under orchestration', () => {
+  const board = cityBoard([lane({ id: 'city', rig: null, phase: 'intake' })]);
+  assert.equal(board.length, 1);
+  assert.equal(board[0]?.rig, ORCHESTRATION);
+  assert.equal(board[0]?.counts.intake, 1);
+});
+
+test('cityBoard buckets unavailable-scope lanes under orchestration too', () => {
+  // laneRig returns null both for city scope and for an unavailable scope; the
+  // latter must not vanish — it falls into the orchestration bucket.
+  const board = cityBoard([lane({ id: 'u', scopeUnavailable: true, phase: 'review' })]);
+  assert.equal(board.length, 1);
+  assert.equal(board[0]?.rig, ORCHESTRATION);
+  assert.equal(board[0]?.counts.review, 1);
+});
+
+test('cityBoard omits a rig whose only lanes are complete (no empty row)', () => {
+  const board = cityBoard([
+    lane({ id: 'd1', rig: 'done-rig', phase: 'complete' }),
+    lane({ id: 'd2', rig: 'done-rig', phase: 'complete' }),
+  ]);
+  assert.equal(board.find((r) => r.rig === 'done-rig'), undefined);
+  assert.equal(board.length, 0);
+});
+
+test('cityBoard orders attention rigs (needsOperator) first, then busiest', () => {
+  const board = cityBoard([
+    // calm-but-busy rig
+    lane({ id: 'b1', rig: 'busy', phase: 'implementation' }),
+    lane({ id: 'b2', rig: 'busy', phase: 'review' }),
+    lane({ id: 'b3', rig: 'busy', phase: 'review' }),
+    // attention rig, fewer lanes
+    lane({ id: 'a1', rig: 'attention', phase: 'blocked', needsOperator: true }),
+  ]);
+  assert.deepEqual(board.map((r) => r.rig), ['attention', 'busy']);
 });

--- a/tui/src/derive.ts
+++ b/tui/src/derive.ts
@@ -334,6 +334,97 @@ export function groupRuns(lanes: readonly RunLane[]): RunGroup[] {
     .sort((a, b) => a.rig.localeCompare(b.rig));
 }
 
+// ── city board (rig × in-flight phase count matrix) ──────────────────────────
+
+/**
+ * In-flight run phases shown as columns on the city board, in display order.
+ * `complete` is deliberately excluded: historical complete lanes are capped in
+ * the snapshot DTO (shared `RunsAggregate`), so a `done`/total column would show
+ * a confident wrong number from data the TUI doesn't fetch. Every other RunPhase
+ * is in-flight and maps to exactly one column, so a row's total is the sum of
+ * its columns. See specs/architecture/tui-tmux-dashboard-gap-analysis.md (P1).
+ */
+export const CITY_BOARD_PHASES = [
+  'intake',
+  'implementation',
+  'review',
+  'approval',
+  'finalization',
+  'blocked',
+  'active',
+] as const;
+
+export type CityBoardPhase = (typeof CITY_BOARD_PHASES)[number];
+
+/**
+ * Short, greyscale-readable column head per phase — the signal is the word, not
+ * a hue (DESIGN.md Greyscale Test). Mirrors the operator's gc-console vocabulary
+ * where it reads cleanly (intake→ready, approval→ok'd, finalization→PR).
+ */
+export const CITY_BOARD_PHASE_LABEL: Record<CityBoardPhase, string> = {
+  intake: 'ready',
+  implementation: 'impl',
+  review: 'review',
+  approval: "ok'd",
+  finalization: 'PR',
+  blocked: 'block',
+  active: 'active',
+};
+
+export interface RigPhaseCounts {
+  readonly rig: string;
+  readonly counts: Record<CityBoardPhase, number>;
+  /**
+   * In-flight lanes in this rig flagged needs-operator — the board's single
+   * red-mark source. It stands in for the gc console's "stalled" attention
+   * column until a client-computed stalled tier (from `updatedAt` + session
+   * activity) is added; `needsOperator` is the honest signal the TUI reads today.
+   */
+  readonly needsOperator: number;
+  /** Total in-flight lanes counted for this rig (sum of the phase columns). */
+  readonly total: number;
+}
+
+function emptyPhaseCounts(): Record<CityBoardPhase, number> {
+  return Object.fromEntries(CITY_BOARD_PHASES.map((phase) => [phase, 0])) as Record<
+    CityBoardPhase,
+    number
+  >;
+}
+
+/**
+ * The city board: per-rig counts of in-flight run lanes by phase, plus a
+ * separate needs-operator tally. Complete (historical) lanes are excluded.
+ * City-scoped lanes bucket under {@link ORCHESTRATION}. Rows are ordered so the
+ * operator's eye lands first on rigs needing attention: needs-operator rigs
+ * lead, then by busiest (total desc), then name.
+ */
+export function cityBoard(lanes: readonly RunLane[]): RigPhaseCounts[] {
+  const byRig = new Map<
+    string,
+    { counts: Record<CityBoardPhase, number>; needsOperator: number; total: number }
+  >();
+  for (const lane of lanes) {
+    if (lane.phase === 'complete') continue;
+    const phase: CityBoardPhase = lane.phase;
+    const rig = laneRig(lane) ?? ORCHESTRATION;
+    const entry = byRig.get(rig) ?? { counts: emptyPhaseCounts(), needsOperator: 0, total: 0 };
+    entry.counts[phase] += 1;
+    entry.total += 1;
+    if (laneNeedsOperator(lane)) entry.needsOperator += 1;
+    byRig.set(rig, entry);
+  }
+  return [...byRig.entries()]
+    .map(([rig, v]) => ({ rig, counts: { ...v.counts }, needsOperator: v.needsOperator, total: v.total }))
+    .sort((a, b) => {
+      const aAttn = a.needsOperator > 0 ? 0 : 1;
+      const bAttn = b.needsOperator > 0 ? 0 : 1;
+      if (aAttn !== bAttn) return aAttn - bAttn;
+      if (b.total !== a.total) return b.total - a.total;
+      return a.rig.localeCompare(b.rig);
+    });
+}
+
 // ── snapshot accessors (collapse the Avail/SourceState unions) ───────────────
 
 export interface SystemHealth {

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -5,6 +5,8 @@ import type { GcBead, GcMailItem } from './api.ts';
 import {
   activityPhrase,
   basename,
+  CITY_BOARD_PHASE_LABEL,
+  CITY_BOARD_PHASES,
   ctxPct,
   kindGlyph,
   kindLabel,
@@ -17,6 +19,7 @@ import {
   type AgentView,
   type ContextPressureEntry,
   type IdleRollup,
+  type RigPhaseCounts,
   type SystemHealth,
 } from './derive.ts';
 
@@ -425,6 +428,73 @@ export function HealthPane({ health, idle, pressure }: HealthPaneProps): React.J
 
       <Box marginTop={1}>
         <Text dimColor>h close · q quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── city board pane (rig × in-flight phase count matrix) ─────────────────────
+
+interface CityBoardPaneProps {
+  readonly board: readonly RigPhaseCounts[];
+}
+
+const BOARD_RIG_W = 22;
+const BOARD_COL_W = 7;
+
+/** One right-aligned count cell. Zero reads as a calm hairline dot so the eye
+ *  lands on the populated columns; the needs-operator cell is the board's single
+ *  red mark (DESIGN.md One Mark / Greyscale: the count, not a hue, is the data). */
+function BoardCell({ n, alert = false }: { readonly n: number; readonly alert?: boolean }): React.JSX.Element {
+  return (
+    <Box width={BOARD_COL_W} justifyContent="flex-end">
+      {n === 0 ? <Text dimColor>·</Text> : alert ? <Text color="red">{n}</Text> : <Text>{n}</Text>}
+    </Box>
+  );
+}
+
+export function CityBoardPane({ board }: CityBoardPaneProps): React.JSX.Element {
+  return (
+    <Box flexDirection="column">
+      <Text bold>city board</Text>
+      <Text dimColor>(in-flight run lanes by rig, phase columns; complete history not shown)</Text>
+
+      <Box marginTop={1}>
+        <Box width={BOARD_RIG_W}>
+          <Text dimColor>rig</Text>
+        </Box>
+        {CITY_BOARD_PHASES.map((p) => (
+          <Box key={p} width={BOARD_COL_W} justifyContent="flex-end">
+            <Text dimColor>{CITY_BOARD_PHASE_LABEL[p]}</Text>
+          </Box>
+        ))}
+        <Box width={BOARD_COL_W} justifyContent="flex-end">
+          <Text dimColor>needs</Text>
+        </Box>
+      </Box>
+
+      {board.length === 0 ? (
+        <Text dimColor>no active runs</Text>
+      ) : (
+        board.map((r) => (
+          <Box key={r.rig}>
+            <Box width={BOARD_RIG_W}>
+              {/* Weight (not hue) leads the eye to an attention rig; the red mark
+                  is reserved for the needs cell. */}
+              <Text wrap="truncate-end" bold={r.needsOperator > 0}>
+                {r.rig}
+              </Text>
+            </Box>
+            {CITY_BOARD_PHASES.map((p) => (
+              <BoardCell key={p} n={r.counts[p]} />
+            ))}
+            <BoardCell n={r.needsOperator} alert={r.needsOperator > 0} />
+          </Box>
+        ))
+      )}
+
+      <Box marginTop={1}>
+        <Text dimColor>m close · q quit</Text>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## What

Adds a **city board** to the dashboard TUI — a compact whole-city glance surface inspired by the gc tmux operator console's per-repo status grid. Rigs as rows, in-flight run phases as columns (`ready · impl · review · ok'd · PR · block · active`), tabular greyscale counts, with a single red mark confined to a `needs` column for needs-operator lanes. Bound on the `m` key; closes on `m`/`esc`.

Full rationale and the pane-by-pane mapping against the inspiration screenshot: `specs/architecture/tui-tmux-dashboard-gap-analysis.md`. Tracks bead `gascity-dashboard-iuzo`.

## Why

The rig × lifecycle-state matrix was the one genuinely new, in-register, data-backed idea from the gc console. The TUI's other views already cover the console's worker roster / needs-review / activity regions, and its dense, colored, write-capable panes are deliberately rejected (read-only, 127.0.0.1, no pane-attach).

## Translated into the register, not ported

Per `DESIGN.md` (inherited by the TUI):
- **Greyscale Test** — the counts carry the data; zeros are a calm `·`. Strip color and the grid still reads.
- **One Mark Rule** — red is confined to the `needs` column; the header summary on this view renders no red, so the board's column is the single mark.
- Weight (bold rig name), not hue, flags an attention rig.

## Honest-signal guardrails

- **No `done`/total/`others` columns.** The console shows large cumulative history; the dashboard's live `RunLane[]` snapshot caps historical (`complete`) lanes, so a `done`/total column would render a confident wrong number from data the TUI doesn't fetch. The board is **in-flight only** — `complete` lanes are excluded entirely (no empty rows).
- **`stalled` deferred.** The console's stalled column is a time-derived signal; the TUI reads only `needsOperator` today, which stands in as the red-mark source until a client-computed stalled tier earns its place.

## Scope

TUI-only. **No `shared/`, `backend/`, or `frontend/` changes; no new dependency.** `cityBoard` is a pure derivation over the `RunLane[]` the TUI already fetches, following the established `groupRuns`/`laneRig` pattern.

## Test plan

- [x] `npm --workspace tui run typecheck` — clean (re-verified after rebasing onto current `main`)
- [x] `npm --workspace tui test` — 28/28 (6 derive cases: per-rig×phase counting, `complete` exclusion, `needsOperator` tally, city + unavailable-scope → orchestration bucketing, attention-first ordering, no-empty-row for complete-only rigs)
- [x] Live smoke against a real snapshot (city `ds-research`): the one in-flight lane (`codeprobe`, `approval` phase, needs-operator) rendered as `ok'd=1`, `needs=1`, total 1, others calm — no fabricated data, no crash.
- [x] Multi-reviewer review (`/gascity-dashboard-review-pr`: code + security + typescript). The One Mark finding (header red coexisting with the board's red column) was fixed; remaining items were polish + a pre-existing backend security nit, now tracked as `gascity-dashboard-5e5v`.

> Note: the `tui/` workspace is not yet in root CI `typecheck` (per `tui/README.md` "Status"); its gates are the two TUI commands above.

## Follow-ups (not in this PR)

- `gascity-dashboard-5e5v` — backend: strip ANSI/OSC from supervisor rig names at the snapshot edge (pre-existing; affects all consumers, not just the board).
