### PR TITLE
fix(snapshot): surface in_progress work via city-level work source

### DIFF
--- a/backend/src/snapshot/collectors/work.ts
+++ b/backend/src/snapshot/collectors/work.ts
@@ -1,0 +1,97 @@
+import type { GcStatus, WorkSummary } from 'gas-city-dashboard-shared';
+
+import { type GcClient } from '../../gc-client.js';
+import { SourceCache } from '../cache.js';
+
+// Work-item census collector — gascity-dashboard-aw75. Surfaces the
+// supervisor's city-wide `status.work` block (GET /v0/city/{name}/status,
+// already fetched via GcClient.getStatus) so in_progress work items reach the
+// dashboard. The run-lane census counts formula-run lanes only; an arbitrary
+// claimed task bead's in_progress state was previously dropped before the UI.
+//
+// The wire's snake_case `in_progress` is translated to the dashboard DTO's
+// camelCase `inProgress` here, at the edge — raw wire shapes never flow inward.
+//
+// `status.work` is optional on the wire: a degraded supervisor may omit it.
+// We THROW in that case rather than fabricate a zero (Don't Swallow Errors).
+// The SourceCache settle wrapper turns the throw into a status='error' source
+// state, which degrades the headline `workInProgress` metric to 'unavailable'
+// instead of reporting a misleading 0.
+
+/**
+ * 45s TTL — matches CITY_STATUS_CACHE_TTL_MS. The headline renders
+ * `workInProgress` next to the city-sourced `activeAgents`/`activeSessions`,
+ * so both must read from the same ~45s clock or the two counts could be a
+ * cache generation apart.
+ */
+export const WORK_CACHE_TTL_MS = 45 * 1000;
+
+export interface CollectWorkOptions {
+  /** Live upstream loader for the supervisor city status. */
+  getStatus: () => Promise<GcStatus>;
+}
+
+export interface CreateWorkSourceCacheOptions {
+  /**
+   * Either/or contract: supply a shared `gc` (production) OR a `getStatus`
+   * seam (tests), not necessarily both. resolveGetStatus throws at
+   * construction if neither is present — a clear runtime guard the type
+   * system cannot express as "at least one of two". buildDefaultCaches
+   * always supplies `gc`; the unit tests always supply `getStatus`.
+   */
+  gc?: GcClient | undefined;
+  now?: (() => Date) | undefined;
+  loadFixture?: (() => Promise<WorkSummary> | WorkSummary) | undefined;
+  useFixture?: boolean | undefined;
+  /** Test seam: override the getStatus binding to avoid a real GcClient. */
+  getStatus?: (() => Promise<GcStatus>) | undefined;
+}
+
+export function createWorkSourceCache(
+  options: CreateWorkSourceCacheOptions,
+): SourceCache<WorkSummary> {
+  const getStatus = resolveGetStatus(options);
+
+  return new SourceCache<WorkSummary>({
+    source: 'work',
+    ttlMs: WORK_CACHE_TTL_MS,
+    now: options.now,
+    load: () => collectWork({ getStatus }),
+    loadFixture: options.loadFixture,
+    useFixture: options.useFixture,
+    // gascity-dashboard-4r5 posture, mirroring the city collector: GcClient
+    // already throws operator-safe messages (`gc supervisor returned ${status}`,
+    // connection refused, etc.) with no OS paths, so the operator benefits from
+    // seeing the actual upstream failure reason on the wire.
+    sanitizeErrorMessage: null,
+  });
+}
+
+export async function collectWork(options: CollectWorkOptions): Promise<WorkSummary> {
+  const status = await options.getStatus();
+  const work = status.work;
+  if (work === undefined) {
+    throw new Error(
+      'supervisor status response omitted work counts (status.work absent)',
+    );
+  }
+
+  return {
+    open: work.open,
+    ready: work.ready,
+    inProgress: work.in_progress,
+  };
+}
+
+function resolveGetStatus(
+  options: CreateWorkSourceCacheOptions,
+): () => Promise<GcStatus> {
+  if (options.getStatus) return options.getStatus;
+  const { gc } = options;
+  if (!gc) {
+    throw new Error(
+      'createWorkSourceCache requires either { gc } or a { getStatus } test seam',
+    );
+  }
+  return () => gc.getStatus();
+}

--- a/backend/src/snapshot/fixtures/snapshot.ts
+++ b/backend/src/snapshot/fixtures/snapshot.ts
@@ -67,6 +67,7 @@ export const fixtureSnapshot = {
     maxAgents: { status: 'available', value: 100 },
     activeSessions: { status: 'available', value: 28 },
     activeRuns: { status: 'available', value: 6 },
+    workInProgress: { status: 'available', value: 3 },
   },
   sources: {
     city: {
@@ -211,6 +212,18 @@ export const fixtureSnapshot = {
           status: 'unavailable',
           error: 'run health has not been derived',
         },
+      },
+    },
+    work: {
+      source: 'work',
+      status: 'fixture',
+      fetchedAt: '2026-05-22T22:00:00.000Z',
+      staleAt: '2026-05-22T22:00:45.000Z',
+      error: { kind: 'none' },
+      data: {
+        open: 24,
+        ready: 9,
+        inProgress: 3,
       },
     },
   },

--- a/backend/src/snapshot/service.ts
+++ b/backend/src/snapshot/service.ts
@@ -12,6 +12,7 @@ import type {
   SourceName,
   SourceState,
   SourceStatus,
+  WorkSummary,
 } from 'gas-city-dashboard-shared';
 
 import type { GcClient } from '../gc-client.js';
@@ -19,6 +20,7 @@ import { SourceCache } from './cache.js';
 import { createCityStatusSourceCache } from './collectors/cityStatus.js';
 import { createResourcesSourceCache } from './collectors/resources.js';
 import { createRunsSourceCache } from './collectors/runs.js';
+import { createWorkSourceCache } from './collectors/work.js';
 import { fixtureSourceLoader } from './fixtures/loader.js';
 import { fixtureSessions } from './fixtures/snapshot.js';
 import {
@@ -46,12 +48,14 @@ export const SOURCE_NAMES = [
   'city',
   'resources',
   'runs',
+  'work',
 ] as const satisfies readonly SourceName[];
 
 export interface SourceCacheMap {
   city: SourceCache<CityStatusSummary>;
   resources: SourceCache<ResourceSummary>;
   runs: SourceCache<RunSummary>;
+  work: SourceCache<WorkSummary>;
 }
 
 export interface SnapshotHealth {
@@ -310,6 +314,12 @@ function buildDefaultCaches(
       useFixture,
       loadFixture: useFixture ? fixtureSourceLoader('runs') : undefined,
     }),
+    work: createWorkSourceCache({
+      gc,
+      now,
+      useFixture,
+      loadFixture: useFixture ? fixtureSourceLoader('work') : undefined,
+    }),
   };
 }
 
@@ -355,13 +365,14 @@ async function readSources(
     }
   };
 
-  const [city, resources, runs] = await Promise.all([
+  const [city, resources, runs, work] = await Promise.all([
     settle('city', caches.city),
     settle('resources', caches.resources),
     settle('runs', caches.runs),
+    settle('work', caches.work),
   ]);
 
-  return { city, resources, runs };
+  return { city, resources, runs, work };
 }
 
 /**
@@ -412,6 +423,11 @@ function buildHeadline(sources: DashboardSources): DashboardHeadline {
       sources.runs,
       activeRunCount,
       'active run count',
+    ),
+    workInProgress: sourceMetric(
+      sources.work,
+      (work) => work.inProgress,
+      'in-progress work count',
     ),
   };
 }
@@ -483,5 +499,6 @@ function sourceStatuses(caches: SourceCacheMap): Record<SourceName, SourceStatus
     city: caches.city.snapshot().status,
     resources: caches.resources.snapshot().status,
     runs: caches.runs.snapshot().status,
+    work: caches.work.snapshot().status,
   };
 }

--- a/backend/test/snapshot-failure-isolation.test.ts
+++ b/backend/test/snapshot-failure-isolation.test.ts
@@ -5,6 +5,7 @@ import type {
   CityStatusSummary,
   ResourceSummary,
   RunSummary,
+  WorkSummary,
 } from 'gas-city-dashboard-shared';
 
 import { SourceCache } from '../src/snapshot/cache.js';
@@ -93,6 +94,12 @@ const SAMPLE_RESOURCES: ResourceSummary = {
   samples: [],
 };
 
+const SAMPLE_WORK: WorkSummary = {
+  open: 1,
+  ready: 0,
+  inProgress: 1,
+};
+
 /**
  * Build a healthy cache for a source whose data fits SourceCache<T>.
  * Default loaders return the SAMPLE_* fixtures so siblings stay 'fresh'
@@ -114,6 +121,11 @@ function buildHealthyCaches(): SourceCacheMap {
       source: 'runs',
       ttlMs: 60_000,
       load: async () => SAMPLE_RunS,
+    }),
+    work: new SourceCache({
+      source: 'work',
+      ttlMs: 45_000,
+      load: async () => SAMPLE_WORK,
     }),
   };
 }
@@ -170,12 +182,13 @@ describe('readSources failure isolation (settle wrapper contract)', () => {
     sabotageCache(caches.city as SourceCache<unknown>, 'city down');
     sabotageCache(caches.resources as SourceCache<unknown>, 'resources down');
     sabotageCache(caches.runs as SourceCache<unknown>, 'runs down');
+    sabotageCache(caches.work as SourceCache<unknown>, 'work down');
 
     const service = buildService(caches);
 
     const snapshot = await service.getSnapshot();
 
-    for (const name of ['city', 'resources', 'runs'] as const) {
+    for (const name of ['city', 'resources', 'runs', 'work'] as const) {
       assert.equal(snapshot.sources[name].status, 'error', `${name} should be status=error`);
       assert.equal('data' in snapshot.sources[name], false, `${name} should not expose data`);
       assert.equal(snapshot.sources[name].source, name, `${name} envelope should carry source name`);

--- a/backend/test/snapshot-health-wiring.test.ts
+++ b/backend/test/snapshot-health-wiring.test.ts
@@ -11,6 +11,7 @@ import type {
   RunSummary,
   SourceAvailableState,
   SourceState,
+  WorkSummary,
 } from 'gas-city-dashboard-shared';
 
 import { SourceCache } from '../src/snapshot/cache.js';
@@ -90,7 +91,13 @@ const SAMPLE_RESOURCES: ResourceSummary = {
   samples: [],
 };
 
-function fresh<T>(source: 'city' | 'resources' | 'runs', data: T): SourceCache<T> {
+const SAMPLE_WORK: WorkSummary = {
+  open: 1,
+  ready: 0,
+  inProgress: 1,
+};
+
+function fresh<T>(source: 'city' | 'resources' | 'runs' | 'work', data: T): SourceCache<T> {
   return new SourceCache<T>({ source, ttlMs: 60_000, sanitizeErrorMessage: null, load: () => data });
 }
 
@@ -99,6 +106,7 @@ function buildCaches(runs: RunSummary): SourceCacheMap {
     city: fresh('city', SAMPLE_CITY),
     resources: fresh('resources', SAMPLE_RESOURCES),
     runs: fresh('runs', runs),
+    work: fresh('work', SAMPLE_WORK),
   };
 }
 
@@ -330,7 +338,7 @@ function laneThrashing(snap: { sources: { runs: SourceState<RunSummary> } }): bo
 
 // A clock-injected cache: every source in these tests shares one controlled
 // `now` so each runs generation gets a distinct fetchedAt under test control.
-function clocked<T>(source: 'city' | 'resources' | 'runs', now: () => Date, load: () => T | Promise<T>): SourceCache<T> {
+function clocked<T>(source: 'city' | 'resources' | 'runs' | 'work', now: () => Date, load: () => T | Promise<T>): SourceCache<T> {
   return new SourceCache<T>({ source, ttlMs: 600_000, now, sanitizeErrorMessage: null, load });
 }
 
@@ -358,6 +366,7 @@ describe('progress-mark monotonicity under concurrent reads (gascity-dashboard-7
         }),
         resources: clocked('resources', now, () => SAMPLE_RESOURCES),
         runs: clocked('runs', now, () => currentRuns),
+        work: clocked('work', now, () => SAMPLE_WORK),
       },
       // The shared sessions cache is labeled with the 'city' SourceName (it IS
       // the city's session list) — mirroring buildSessionsCache in service.ts.
@@ -414,6 +423,7 @@ describe('progress-mark monotonicity under concurrent reads (gascity-dashboard-7
         city: clocked('city', now, () => SAMPLE_CITY),
         resources: clocked('resources', now, () => SAMPLE_RESOURCES),
         runs: clocked('runs', now, () => currentRuns),
+        work: clocked('work', now, () => SAMPLE_WORK),
       },
       sessions: clocked<GcSessionList>('city', now, () => ({ items: [], total: 0 })),
       config: CONFIG,

--- a/backend/test/snapshot-route.test.ts
+++ b/backend/test/snapshot-route.test.ts
@@ -9,6 +9,7 @@ import type {
   ResourceSummary,
   RunSummary,
   SourceName,
+  WorkSummary,
 } from 'gas-city-dashboard-shared';
 
 import { snapshotRouter } from '../src/routes/snapshot.js';
@@ -87,6 +88,12 @@ const SAMPLE_RESOURCES: ResourceSummary = {
   samples: [],
 };
 
+const SAMPLE_WORK: WorkSummary = {
+  open: 24,
+  ready: 9,
+  inProgress: 3,
+};
+
 interface SpyLoads {
   city: number;
   runs: number;
@@ -148,6 +155,17 @@ function buildCaches(opts: {
       },
       loadFixture: wireFor.has('runs') ? fixtureSourceLoader('runs') : undefined,
     }),
+    // work is not spy-tracked: no test asserts its refetch count, so it
+    // serves SAMPLE_WORK directly and stays out of SpyLoads to avoid
+    // churning every counts literal in this file.
+    work: new SourceCache({
+      source: 'work',
+      ttlMs: 45_000,
+      useFixture,
+      load: async () => SAMPLE_WORK,
+      loadFixture: wireFor.has('work') ? fixtureSourceLoader('work') : undefined,
+      sanitizeErrorMessage: null,
+    }),
   };
 }
 
@@ -189,7 +207,7 @@ describe('GET /api/snapshot', () => {
       const res = await fetch(`${url}/api/snapshot`);
       assert.equal(res.status, 200);
       const body = (await res.json()) as DashboardSnapshot;
-      assert.deepEqual(Object.keys(body.sources).sort(), ['city', 'resources', 'runs']);
+      assert.deepEqual(Object.keys(body.sources).sort(), ['city', 'resources', 'runs', 'work']);
 
       assert.equal(body.sources.city.status, 'fresh');
       assert.deepEqual(body.sources.city.data, SAMPLE_CITY);
@@ -197,12 +215,15 @@ describe('GET /api/snapshot', () => {
       assert.deepEqual(body.sources.runs.data, SAMPLE_RunS);
       assert.equal(body.sources.resources.status, 'fresh');
       assert.deepEqual(body.sources.resources.data, SAMPLE_RESOURCES);
+      assert.equal(body.sources.work.status, 'fresh');
+      assert.deepEqual(body.sources.work.data, SAMPLE_WORK);
 
-      // headline composed from city + runs without nullable sentinels.
+      // headline composed from city + runs + work without nullable sentinels.
       assert.deepEqual(body.headline.activeAgents, { status: 'available', value: 2 });
       assert.deepEqual(body.headline.maxAgents, { status: 'available', value: 100 });
       assert.deepEqual(body.headline.activeSessions, { status: 'available', value: 2 });
       assert.deepEqual(body.headline.activeRuns, { status: 'available', value: 0 });
+      assert.deepEqual(body.headline.workInProgress, { status: 'available', value: 3 });
 
       // generatedAt present and ISO.
       assert.ok(body.generatedAt.endsWith('Z'));

--- a/backend/test/snapshot-work.test.ts
+++ b/backend/test/snapshot-work.test.ts
@@ -1,0 +1,101 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { GcStatus, WorkSummary } from 'gas-city-dashboard-shared';
+
+import {
+  collectWork,
+  createWorkSourceCache,
+  WORK_CACHE_TTL_MS,
+} from '../src/snapshot/collectors/work.js';
+
+// work collector coverage for gascity-dashboard-aw75.
+//
+// The collector reads the supervisor's `status.work` block from
+// GET /v0/city/{name}/status (already fetched via GcClient.getStatus) and
+// translates the wire's snake_case `in_progress` into the dashboard DTO's
+// camelCase `inProgress` at the edge. `status.work` is optional on the wire;
+// an absent block is an upstream degradation and must surface as a source
+// error (status='error'), never a fabricated zero — per "Don't Swallow Errors".
+
+function status(work: GcStatus['work']): GcStatus {
+  return { version: 'test', ...(work !== undefined ? { work } : {}) };
+}
+
+describe('collectWork', () => {
+  test('maps status.work to WorkSummary, translating in_progress to inProgress', async () => {
+    const summary = await collectWork({
+      getStatus: async () => status({ open: 1091, ready: 0, in_progress: 1 }),
+    });
+
+    const expected: WorkSummary = { open: 1091, ready: 0, inProgress: 1 };
+    assert.deepEqual(summary, expected);
+  });
+
+  test('throws when status.work is absent (degraded supervisor, not a fake zero)', async () => {
+    await assert.rejects(
+      () => collectWork({ getStatus: async () => status(undefined) }),
+      /work counts/i,
+    );
+  });
+
+  test('propagates an upstream getStatus failure', async () => {
+    await assert.rejects(
+      () =>
+        collectWork({
+          getStatus: async () => {
+            throw new Error('gc supervisor returned 503');
+          },
+        }),
+      /503/,
+    );
+  });
+});
+
+describe('createWorkSourceCache', () => {
+  test('serves live status.work via the getStatus seam', async () => {
+    const cache = createWorkSourceCache({
+      getStatus: async () => status({ open: 5, ready: 2, in_progress: 3 }),
+    });
+
+    const state = await cache.get();
+    assert.equal(state.status === 'error', false);
+    if (state.status === 'error') return;
+    assert.equal(state.source, 'work');
+    assert.deepEqual(state.data, { open: 5, ready: 2, inProgress: 3 });
+  });
+
+  test('an absent work block surfaces as a source error, not a thrown route', async () => {
+    const cache = createWorkSourceCache({
+      getStatus: async () => status(undefined),
+    });
+
+    const state = await cache.get();
+    assert.equal(state.status, 'error');
+  });
+
+  test('falls back to committed fixture data when the live load fails', async () => {
+    // SourceCache always attempts load() first and only serves the fixture on
+    // failure (degraded-mode fallback, never a persistent shadow store). A
+    // throwing getStatus simulates an unreachable supervisor under
+    // SNAPSHOT_USE_FIXTURES=1.
+    const fixture: WorkSummary = { open: 7, ready: 1, inProgress: 4 };
+    const cache = createWorkSourceCache({
+      useFixture: true,
+      loadFixture: () => fixture,
+      getStatus: async () => {
+        throw new Error('supervisor unreachable');
+      },
+    });
+
+    const state = await cache.get();
+    assert.equal(state.status === 'error', false);
+    if (state.status === 'error') return;
+    assert.equal(state.status, 'fixture');
+    assert.deepEqual(state.data, fixture);
+  });
+
+  test('uses a 45s TTL to match the city clock the headline reads alongside', () => {
+    assert.equal(WORK_CACHE_TTL_MS, 45 * 1000);
+  });
+});

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import type {
+  DashboardMetric,
   DashboardSnapshot,
   RunCensus,
   RunLane,
@@ -144,11 +145,16 @@ function envelope({
   census = DEFAULT_CENSUS,
   runsStatus = 'fresh' as 'fresh' | 'fixture' | 'stale',
   generatedAt = '2026-05-29T20:00:00.000Z',
+  // Default the work metric to unavailable so the synopsis renders without an
+  // in-progress clause in tests that don't exercise it; the dedicated synopsis
+  // tests pass an explicit available value.
+  workInProgress = { status: 'unavailable', source: 'work', error: 'unused' } as DashboardMetric,
 }: {
   lanes?: RunLane[];
   census?: RunCensus;
   runsStatus?: 'fresh' | 'fixture' | 'stale';
   generatedAt?: string;
+  workInProgress?: DashboardMetric;
 } = {}): DashboardSnapshot {
   return {
     generatedAt,
@@ -164,10 +170,19 @@ function envelope({
       maxAgents: { status: 'unavailable', source: 'city', error: 'unused' },
       activeSessions: { status: 'unavailable', source: 'city', error: 'unused' },
       activeRuns: { status: 'available', value: lanes.length },
+      workInProgress,
     },
     sources: {
       city: { source: 'city', status: 'error', error: 'unused' },
       resources: { source: 'resources', status: 'error', error: 'unused' },
+      work: {
+        source: 'work',
+        status: 'fresh',
+        fetchedAt: '2026-05-29T20:00:00.000Z',
+        staleAt: '2026-05-29T20:00:45.000Z',
+        error: { kind: 'none' },
+        data: { open: 0, ready: 0, inProgress: 0 },
+      },
       runs: {
         source: 'runs',
         status: runsStatus,
@@ -277,6 +292,32 @@ describe('AmbientHomePage', () => {
     // Failing clause reads 'nothing failing'; denominator omitted when unverifiable=0.
     expect(screen.getByTestId('phase-census-failing').textContent).toContain('nothing failing');
     expect(screen.getByTestId('phase-census-failing').textContent).not.toContain('of');
+  });
+
+  it('surfaces the in-progress work count in the synopsis (gascity-dashboard-aw75)', async () => {
+    // The bug: a claimed (in_progress) bead never surfaced because the
+    // run-lane census only counts formula-run lanes. The work headline metric
+    // closes that gap — its value must appear in the Home synopsis.
+    mockSnapshot.mockResolvedValue(
+      envelope({ workInProgress: { status: 'available', value: 3 } }),
+    );
+
+    mount();
+    await waitFor(() => expect(screen.getByTestId('phase-census')).toBeTruthy());
+
+    expect(screen.getByText(/racoon-city, 0 active, 3 in progress/)).toBeTruthy();
+  });
+
+  it('omits the in-progress clause when the work source is unavailable', async () => {
+    mockSnapshot.mockResolvedValue(
+      envelope({ workInProgress: { status: 'unavailable', source: 'work', error: 'down' } }),
+    );
+
+    mount();
+    await waitFor(() => expect(screen.getByTestId('phase-census')).toBeTruthy());
+
+    expect(screen.getByText(/racoon-city, 0 active$/)).toBeTruthy();
+    expect(screen.queryByText(/in progress/)).toBeNull();
   });
 
   it('appends "(of N known)" denominator when unverifiable > 0 (R5)', async () => {

--- a/frontend/src/routes/AmbientHome.tsx
+++ b/frontend/src/routes/AmbientHome.tsx
@@ -131,9 +131,21 @@ function AmbientBody({ fresh, cycleKey }: BodyProps) {
 
   useFaviconSignal({ failing, cycleKey });
 
+  // gascity-dashboard-aw75: surface the city-wide in-progress work count
+  // (claimed beads the run-lane census never covers) alongside the active
+  // run count. Shown whenever the work source RESOLVED — including a value of
+  // 0. Zero is deliberately NOT suppressed: this bug was "in_progress never
+  // surfaces", and hiding the clause at 0 reproduces that exact ambiguity
+  // (the operator could not tell "nothing claimed" from "dimension missing").
+  // A 0 reads as "tracked, currently none", mirroring the adjacent "0 active".
+  // Only a source ERROR omits the clause, to avoid a broken token. Neutral
+  // type — the One Mark maroon stays reserved for the StatusSentence run-id.
+  const workInProgress = snapshot.headline.workInProgress;
+  const inProgressClause =
+    workInProgress.status === 'available' ? `, ${workInProgress.value} in progress` : '';
   const synopsis =
     snapshot.config !== undefined
-      ? `${snapshot.config.cityName}, ${summary.totalActive} active`
+      ? `${snapshot.config.cityName}, ${summary.totalActive} active${inProgressClause}`
       : null;
 
   if (summary.census.status !== 'available') {

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -689,10 +689,12 @@ function snapshotWithActiveLane(): DashboardSnapshot {
       maxAgents: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
       activeSessions: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
       activeRuns: { status: 'available', value: 1 },
+      workInProgress: { status: 'unavailable', source: 'work', error: 'work unavailable in test' },
     },
     sources: {
       city: { source: 'city', status: 'error', error: 'city unavailable in test' },
       resources: { source: 'resources', status: 'error', error: 'resources unavailable in test' },
+      work: { source: 'work', status: 'error', error: 'work unavailable in test' },
       runs: {
         source: 'runs',
         status: 'fresh',

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -74,10 +74,12 @@ function buildEnvelope(
       maxAgents: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
       activeSessions: { status: 'unavailable', source: 'city', error: 'city unavailable in test' },
       activeRuns: { status: 'available', value: 0 },
+      workInProgress: { status: 'unavailable', source: 'work', error: 'work unavailable in test' },
     },
     sources: {
       city: { source: 'city', status: 'error', error: 'city unavailable in test' },
       resources: { source: 'resources', status: 'error', error: 'resources unavailable in test' },
+      work: { source: 'work', status: 'error', error: 'work unavailable in test' },
       runs: {
         source: 'runs',
         status: runsStatus,

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -535,10 +535,12 @@ function snapshotFixture() {
       maxAgents: unavailableMetric('city', 'city unavailable in fixture'),
       activeSessions: unavailableMetric('city', 'city unavailable in fixture'),
       activeRuns: { status: 'available', value: 1 },
+      workInProgress: { status: 'available', value: 1 },
     },
     sources: {
       city: sourceUnavailable('city', 'city unavailable in fixture'),
       resources: sourceUnavailable('resources', 'resources unavailable in fixture'),
+      work: sourceFixture('work', { open: 1, ready: 0, inProgress: 1 }),
       runs: sourceFixture('runs', {
         totalActive: 1,
         // yh5i: shared RunSummary now carries totalHistorical +

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -10,7 +10,8 @@ import type { Avail } from '../lists.js';
 export type SourceName =
   | 'city'
   | 'resources'
-  | 'runs';
+  | 'runs'
+  | 'work';
 
 export type SourceStatus = 'fresh' | 'stale' | 'error' | 'fixture';
 
@@ -94,12 +95,21 @@ export interface DashboardHeadline {
   maxAgents: DashboardMetric;
   activeSessions: DashboardMetric;
   activeRuns: DashboardMetric;
+  /**
+   * In-progress work-item count (gascity-dashboard-aw75). Sourced from the
+   * `work` source's `inProgress` field, which mirrors the supervisor's
+   * `status.work.in_progress`. Closes the observability gap where a claimed
+   * (in_progress) bead never surfaced in the dashboard — the run-lane census
+   * counts formula-run lanes only, not arbitrary claimed beads.
+   */
+  workInProgress: DashboardMetric;
 }
 
 export interface DashboardSources {
   city: SourceState<CityStatusSummary>;
   resources: SourceState<ResourceSummary>;
   runs: SourceState<RunSummary>;
+  work: SourceState<WorkSummary>;
 }
 
 /**
@@ -191,6 +201,29 @@ export interface ResourceSample {
   memoryUsedBytes: number;
   memoryAvailableBytes: number;
   memoryUtilization: number;
+}
+
+// ── work ──────────────────────────────────────────────────────────────
+
+/**
+ * City-wide work-item census (gascity-dashboard-aw75). Mirrors the
+ * supervisor's `status.work` block from `GET /v0/city/{name}/status` —
+ * the wire's snake_case `in_progress` is translated to `inProgress` at the
+ * collector edge so the dashboard DTO stays camelCase.
+ *
+ * These counts cover ALL beads in the city's stores, not just formula-run
+ * lanes (the runs census), so a claimed task bead's `in_progress` state
+ * surfaces here even when it is not part of any formula run.
+ *
+ * NOTE on `ready` vs `open`: the supervisor computes these itself and its
+ * `ready` does NOT match `bd ready` semantics (verified live: ready=0 while
+ * open=1091). The dashboard exposes all three verbatim for completeness but
+ * only headline-surfaces `inProgress`, which is accurate.
+ */
+export interface WorkSummary {
+  open: number;
+  ready: number;
+  inProgress: number;
 }
 
 // ── runs ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The dashboard snapshot had exactly three sources (`city`, `resources`, `runs`)
and no bead/work-status dimension. The run-lane census counts formula-run
**lanes** only, so a claimed (`in_progress`) task bead never reached the UI —
operators saw "none in progress" even when work was active. Verified live: the
supervisor reported `status.work.in_progress: 1` while the dashboard surfaced
nothing.

Fixes gascity-dashboard-aw75.

## Fix

Add a city-level `work` snapshot source backed by the supervisor's **existing**
`GET /v0/city/{name}/status` → `status.work = {open, ready, in_progress}`
(already fetched via `gc.getStatus()`, previously consumed only by the Health
page).

- **shared:** `SourceName 'work'`, `DashboardSources.work`, `WorkSummary`,
  `DashboardHeadline.workInProgress`
- **backend:** `collectors/work.ts` — translates wire `in_progress` →
  `inProgress` at the edge; **throws** if `status.work` is absent rather than
  fabricating a zero (Don't Swallow Errors), surfacing as a source error that
  degrades the headline metric to `unavailable`. `WORK_CACHE_TTL_MS = 45s` to
  match the city clock the headline reads alongside. Wired through every
  `service.ts` registration site.
- **frontend:** `AmbientHome` synopsis appends `", N in progress"` when the
  work source resolved — **including 0**, to distinguish "tracked, none" from
  the prior invisible symptom. Omitted only on a source error.

## Scope

Out of scope (deferred): per-rig/per-agent breakdown, a `blocked` count (the
supervisor's `status.work` omits it), and a dedicated work panel.

## Verification

- Live `/api/snapshot` against the `ds-research` supervisor served
  `sources.work` + `headline.workInProgress`, mirroring `status.work` exactly.
- CI parity locally: `typecheck` (source + test), backend **1008** tests,
  frontend **515**, shared **29**, frontend build, generated-client drift
  check, lint — all green.

## Test plan

- [x] `npm run typecheck`
- [x] `npm --workspace backend test`
- [x] `npm --workspace frontend test`
- [x] `npm --workspace shared test`
- [x] `npm --workspace frontend run build`
- [x] `npm run openapi:gc-supervisor:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)