### PR TITLE
feat(home-alerts): AlertItem DTO + run alerts + per-session pending aggregator (foundation)

### DIFF
--- a/backend/src/snapshot/alerts.ts
+++ b/backend/src/snapshot/alerts.ts
@@ -1,0 +1,125 @@
+// Run-sourced alert derivation for the home-view attention queue
+// (gascity-dashboard-i4ui, PRD R2/R5). Maps the health-enriched runs source
+// into AlertItems.
+//
+// Scope: this module owns the RUN signals (run-needs-operator, run-thrashing)
+// — they need only `sources.runs`, which the snapshot read path has already
+// enriched with health facts. The `operator-mail` signal (R4) is derived
+// elsewhere: it needs a mail fetch the snapshot read path does not perform
+// today, and the role filter needs the private session list. The
+// `pending-decision` tier (R3) is layered client-side from the live SSE.
+//
+// ZFC: every clause is a named pure predicate over structural lane-health
+// facts (needsOperator, thrashingDetected, phaseConfidence) — no scoring, no
+// keyword matching. phaseConfidence gates the failing tier: an 'inferred' lane
+// must never drive a 'failing' alert (the maroon One Mark), per the engine's
+// own R2 footgun warning and the premortem's degrade-to-quiet rule.
+
+import {
+  ALERT_SEVERITY_RANK,
+  makeAlertDedupKey,
+  type AlertItem,
+  type RunLane,
+  type RunSummary,
+  type SourceState,
+} from 'gas-city-dashboard-shared';
+
+/** Deep link into the authoritative run-detail surface, pre-selecting the stuck node when known. */
+function runLaneHref(lane: RunLane): string {
+  const base = `/runs/${encodeURIComponent(lane.id)}`;
+  const stuck = lane.health.status === 'available' ? lane.health.data.stuckNode : undefined;
+  if (stuck !== undefined && stuck.status === 'available') {
+    return `${base}?node=${encodeURIComponent(stuck.id)}`;
+  }
+  return base;
+}
+
+/** When the lane last changed, falling back to the source generation when unknown. */
+function laneOccurredAt(lane: RunLane, fallbackIso: string): string {
+  return lane.updatedAt.status === 'available' ? lane.updatedAt.at : fallbackIso;
+}
+
+/**
+ * A lane parked at a human-approval gate or blocked (needsOperator). Severity
+ * 'attention' — it needs a decision but is not itself a failure.
+ */
+function needsOperatorAlert(
+  lane: RunLane,
+  version: number,
+  provenance: AlertItem['provenance'],
+  fallbackIso: string,
+): AlertItem | null {
+  if (lane.health.status !== 'available' || !lane.health.data.needsOperator) return null;
+  return {
+    kind: 'run-needs-operator',
+    source: 'runs',
+    ref: { runId: lane.id },
+    href: runLaneHref(lane),
+    title: lane.title,
+    reason: lane.phase === 'blocked' ? 'blocked' : 'awaiting your decision',
+    severity: 'attention',
+    occurredAt: laneOccurredAt(lane, fallbackIso),
+    dedupKey: makeAlertDedupKey('run-needs-operator', { runId: lane.id }),
+    version,
+    provenance,
+  };
+}
+
+/**
+ * A lane whose progress-monotonicity tripped (thrashingDetected). Severity
+ * 'failing'. Gated on phaseConfidence === 'known': an 'inferred' lane's raw
+ * thrashing fact must never drive the maroon (it is suppressed, not promoted).
+ */
+function thrashingAlert(
+  lane: RunLane,
+  version: number,
+  provenance: AlertItem['provenance'],
+  fallbackIso: string,
+): AlertItem | null {
+  if (lane.health.status !== 'available') return null;
+  const { thrashingDetected, phaseConfidence } = lane.health.data;
+  if (!thrashingDetected || phaseConfidence !== 'known') return null;
+  return {
+    kind: 'run-thrashing',
+    source: 'runs',
+    ref: { runId: lane.id },
+    href: runLaneHref(lane),
+    title: lane.title,
+    reason: 'no progress across cycles',
+    severity: 'failing',
+    occurredAt: laneOccurredAt(lane, fallbackIso),
+    dedupKey: makeAlertDedupKey('run-thrashing', { runId: lane.id }),
+    version,
+    provenance,
+  };
+}
+
+/** Stable, deterministic order (R5): severity desc, then oldest first, then dedupKey. */
+function compareAlerts(a: AlertItem, b: AlertItem): number {
+  const sev = ALERT_SEVERITY_RANK[b.severity] - ALERT_SEVERITY_RANK[a.severity];
+  if (sev !== 0) return sev;
+  if (a.occurredAt !== b.occurredAt) return a.occurredAt < b.occurredAt ? -1 : 1;
+  return a.dedupKey < b.dedupKey ? -1 : a.dedupKey > b.dedupKey ? 1 : 0;
+}
+
+/**
+ * Derive the run-sourced AlertItems from the health-enriched runs source.
+ * Returns [] when the source is unavailable — the source's own SourceState
+ * carries the error for the signal-unavailable render (R6/R15); this array is
+ * never the place a failure is signalled. `version` is the source generation
+ * (fetchedAt epoch) so a newer snapshot supersedes an older one under R17.
+ */
+export function deriveRunAlerts(runsState: SourceState<RunSummary>): readonly AlertItem[] {
+  if (runsState.status === 'error') return [];
+  const provenance = runsState.status;
+  const version = Date.parse(runsState.fetchedAt);
+  const fallbackIso = runsState.fetchedAt;
+  const out: AlertItem[] = [];
+  for (const lane of runsState.data.lanes) {
+    const needs = needsOperatorAlert(lane, version, provenance, fallbackIso);
+    if (needs !== null) out.push(needs);
+    const thrash = thrashingAlert(lane, version, provenance, fallbackIso);
+    if (thrash !== null) out.push(thrash);
+  }
+  return out.sort(compareAlerts);
+}

--- a/backend/src/snapshot/fixtures/snapshot.ts
+++ b/backend/src/snapshot/fixtures/snapshot.ts
@@ -51,6 +51,7 @@ export const fixtureSessions: GcSessionList = {
 
 export const fixtureSnapshot = {
   generatedAt: '2026-05-22T22:00:00.000Z',
+  alerts: [],
   config: {
     cityName: 'example-city',
     cityRoot: '/tmp/example-city',

--- a/backend/src/snapshot/pending-store.ts
+++ b/backend/src/snapshot/pending-store.ts
@@ -1,0 +1,97 @@
+// In-memory store of current per-session PendingInteractions, the core of the
+// city-wide pending aggregator (gascity-dashboard-3rm7, PRD R3/R16, Option A).
+//
+// The home view is not bound to a session, but PendingInteraction is emitted
+// only per-session (spike wf4c). A backend aggregator server-side-observes the
+// active sessions' streams and records pending here; the dashboard SSE endpoint
+// reads alerts() to push pending-decision items to the home (one dashboard
+// stream, not N browser EventSources).
+//
+// Ephemeral by design (PRD R13): no persistence, resets on restart — a process
+// restart re-observes live state, it never resurrects a stale decision.
+//
+// Premortem Theme A (the top tier must never lie):
+//  - observe() supersedes the prior entry for a session with a monotonic
+//    version, so a re-observation after a resolve cannot be re-ordered behind
+//    the stale one (R17 last-write-wins).
+//  - retainActive() drops any session no longer active: an agent in a gone
+//    session cannot still be blocked on the operator, so its pending must not
+//    linger and cry wolf.
+//  - clear() removes a resolved pending immediately.
+
+import {
+  pendingInteractionToAlert,
+  type AlertItem,
+  type IsoTimestamp,
+  type PendingInteraction,
+  type SourceStatus,
+} from 'gas-city-dashboard-shared';
+
+interface PendingEntry {
+  readonly pending: PendingInteraction;
+  readonly observedAt: IsoTimestamp;
+  readonly version: number;
+}
+
+export class PendingStore {
+  private readonly entries = new Map<string, PendingEntry>();
+  private seq = 0;
+
+  /** Record (or supersede) the pending interaction observed for a session. */
+  observe(sessionId: string, pending: PendingInteraction, observedAt: IsoTimestamp): void {
+    this.seq += 1;
+    this.entries.set(sessionId, { pending, observedAt, version: this.seq });
+  }
+
+  /** Clear a session's pending (resolved, or an empty 'pending' frame). */
+  clear(sessionId: string): void {
+    this.entries.delete(sessionId);
+  }
+
+  /**
+   * Drop entries for sessions not in the active set — a pending on a session
+   * that is no longer active can never still need the operator. Returns the
+   * number of stale entries dropped (0 when nothing changed).
+   */
+  retainActive(activeSessionIds: Iterable<string>): number {
+    const active = activeSessionIds instanceof Set ? activeSessionIds : new Set(activeSessionIds);
+    let dropped = 0;
+    for (const sessionId of [...this.entries.keys()]) {
+      if (!active.has(sessionId)) {
+        this.entries.delete(sessionId);
+        dropped += 1;
+      }
+    }
+    return dropped;
+  }
+
+  /** Number of sessions currently holding a pending decision. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Current pending-decision AlertItems, ordered deterministically (oldest
+   * observation first, then dedupKey). `provenance` is the freshness of the
+   * aggregator's view ('fresh' while the subscription is live; the caller
+   * passes a degraded status when the stream is dark, so consumers render
+   * signal-unavailable rather than a false all-clear — R6/R16).
+   */
+  alerts(provenance: SourceStatus): readonly AlertItem[] {
+    const out: AlertItem[] = [];
+    for (const [sessionId, entry] of this.entries) {
+      out.push(
+        pendingInteractionToAlert(entry.pending, {
+          sessionId,
+          occurredAt: entry.observedAt,
+          version: entry.version,
+          provenance,
+        }),
+      );
+    }
+    return out.sort((a, b) => {
+      if (a.occurredAt !== b.occurredAt) return a.occurredAt < b.occurredAt ? -1 : 1;
+      return a.dedupKey < b.dedupKey ? -1 : a.dedupKey > b.dedupKey ? 1 : 0;
+    });
+  }
+}

--- a/backend/src/snapshot/pending-subscriber.ts
+++ b/backend/src/snapshot/pending-subscriber.ts
@@ -1,0 +1,106 @@
+// Real SessionStreamSubscriber (gascity-dashboard-3rm7, Layer 2b): opens the
+// supervisor's per-session text/event-stream, parses frames, and surfaces
+// `pending` events as PendingInteractions to the PendingSubscriptionManager.
+//
+// fetch is injected so the read loop is unit-tested with a scripted
+// ReadableStream. Resume is supported via a per-session last-event-id passed
+// back into the stream URL on the manager's reconnect.
+
+import { parsePendingInteraction } from 'gas-city-dashboard-shared';
+
+import { SseFrameParser } from './sse-frame-parser.js';
+import type {
+  SessionPendingHandlers,
+  SessionStreamSubscriber,
+  SessionStreamSubscription,
+} from './pending-subscriptions.js';
+
+export interface SupervisorPendingSubscriberDeps {
+  /** Build the per-session stream URL, optionally resuming from a last-event-id. */
+  streamUrl: (sessionId: string, after?: string) => URL;
+  /** Injected for tests; defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+function safeJsonParse(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+}
+
+export function createSupervisorPendingSubscriber(
+  deps: SupervisorPendingSubscriberDeps,
+): SessionStreamSubscriber {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const lastEventId = new Map<string, string>();
+
+  return {
+    subscribe(sessionId: string, handlers: SessionPendingHandlers): SessionStreamSubscription {
+      const ctrl = new AbortController();
+      let closed = false;
+
+      const fail = (err: unknown): void => {
+        if (closed || ctrl.signal.aborted) return; // close() is not a failure
+        handlers.onError(err instanceof Error ? err : new Error(String(err)));
+      };
+
+      void (async () => {
+        let res: Response;
+        try {
+          res = await fetchFn(deps.streamUrl(sessionId, lastEventId.get(sessionId)).toString(), {
+            signal: ctrl.signal,
+            headers: { accept: 'text/event-stream' },
+          });
+        } catch (err) {
+          fail(err);
+          return;
+        }
+
+        if (!res.ok || res.body === null) {
+          fail(new Error(`session stream responded ${res.status}`));
+          return;
+        }
+
+        const parser = new SseFrameParser();
+        const decoder = new TextDecoder();
+        const reader = res.body.getReader();
+        try {
+          for (;;) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            for (const ev of parser.push(decoder.decode(value, { stream: true }))) {
+              if (ev.id !== undefined) lastEventId.set(sessionId, ev.id);
+              if (ev.event !== 'pending') continue;
+              const pending = parsePendingInteraction(safeJsonParse(ev.data));
+              // Surface only a valid interaction. A malformed `pending` frame is
+              // ignored (NOT treated as a clear), so a parse hiccup cannot wipe a
+              // real pending. Explicit-clear semantics are unconfirmed upstream;
+              // the manager also clears via retainActive on session inactivity.
+              if (pending !== null) handlers.onPending(pending);
+            }
+          }
+          // The supervisor holds the stream open; a normal end means the
+          // connection dropped — surface it so the manager reconnects.
+          fail(new Error('session stream closed'));
+        } catch (err) {
+          fail(err);
+        } finally {
+          try {
+            reader.releaseLock();
+          } catch {
+            // reader already released on abort; nothing to do.
+          }
+        }
+      })();
+
+      return {
+        close(): void {
+          closed = true;
+          ctrl.abort();
+        },
+      };
+    },
+  };
+}

--- a/backend/src/snapshot/pending-subscriptions.ts
+++ b/backend/src/snapshot/pending-subscriptions.ts
@@ -1,0 +1,146 @@
+// PendingSubscriptionManager — Layer 2 of the city-wide pending aggregator
+// (gascity-dashboard-3rm7, PRD R3/R16, Option A). It reconciles a live set of
+// per-session SSE subscriptions to the active-session set, feeds observed
+// PendingInteractions into the PendingStore, and reconnects with backoff on
+// stream failure.
+//
+// The transport is injected as a SessionStreamSubscriber so this orchestration
+// is unit-tested deterministically with a fake; the real fetch/text-event-stream
+// subscriber (Layer 2b) implements the same interface. The reconnect scheduler
+// is injected for the same reason (tests drive it synchronously).
+//
+// Premortem Theme A (the top tier must never lie):
+//  - syncActiveSessions() closes subscriptions for sessions no longer active and
+//    calls store.retainActive(), so a gone session's pending cannot linger.
+//  - a successful pending frame resets the backoff attempt counter.
+//  - a transient stream error KEEPS the last-known pending (no flapping) and
+//    reconnects; it does not clear, because a disconnect is not a resolve. The
+//    bounded staleness window across a reconnect is the documented tradeoff;
+//    the dashboard layer (R16) surfaces a degraded provenance when the
+//    aggregator's view is not live.
+
+import type { PendingInteraction } from 'gas-city-dashboard-shared';
+
+import type { PendingStore } from './pending-store.js';
+
+export interface SessionStreamSubscription {
+  close(): void;
+}
+
+export interface SessionPendingHandlers {
+  /** A parsed `pending` frame: an interaction, or null when pending was cleared. */
+  onPending(pending: PendingInteraction | null): void;
+  /** The stream failed; the manager will reconnect with backoff. */
+  onError(error: Error): void;
+}
+
+export interface SessionStreamSubscriber {
+  subscribe(sessionId: string, handlers: SessionPendingHandlers): SessionStreamSubscription;
+}
+
+/** Schedule a reconnect for `run`, returning a cancel handle. `attempt` starts at 0. */
+export type ReconnectScheduler = (run: () => void, attempt: number) => () => void;
+
+const MAX_BACKOFF_MS = 30_000;
+const BASE_BACKOFF_MS = 500;
+
+export const defaultReconnectScheduler: ReconnectScheduler = (run, attempt) => {
+  const ms = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** Math.min(attempt, 6));
+  const timer = setTimeout(run, ms);
+  return () => clearTimeout(timer);
+};
+
+export interface PendingSubscriptionManagerOptions {
+  subscriber: SessionStreamSubscriber;
+  store: PendingStore;
+  now?: () => Date;
+  scheduleReconnect?: ReconnectScheduler;
+}
+
+interface SessionSub {
+  subscription: SessionStreamSubscription;
+  attempt: number;
+  cancelReconnect?: () => void;
+}
+
+export class PendingSubscriptionManager {
+  private readonly subscriber: SessionStreamSubscriber;
+  private readonly store: PendingStore;
+  private readonly now: () => Date;
+  private readonly scheduleReconnect: ReconnectScheduler;
+  private readonly subs = new Map<string, SessionSub>();
+
+  constructor(options: PendingSubscriptionManagerOptions) {
+    this.subscriber = options.subscriber;
+    this.store = options.store;
+    this.now = options.now ?? (() => new Date());
+    this.scheduleReconnect = options.scheduleReconnect ?? defaultReconnectScheduler;
+  }
+
+  /** Number of sessions currently subscribed (live or awaiting reconnect). */
+  get subscribedCount(): number {
+    return this.subs.size;
+  }
+
+  /**
+   * Reconcile subscriptions to `activeSessionIds`: open new ones, tear down
+   * sessions no longer active, and drop their pending from the store.
+   */
+  syncActiveSessions(activeSessionIds: Iterable<string>): void {
+    const active = activeSessionIds instanceof Set
+      ? activeSessionIds
+      : new Set(activeSessionIds);
+    for (const sessionId of [...this.subs.keys()]) {
+      if (!active.has(sessionId)) this.teardown(sessionId);
+    }
+    for (const sessionId of active) {
+      if (!this.subs.has(sessionId)) this.open(sessionId, 0);
+    }
+    this.store.retainActive(active);
+  }
+
+  /** Close every subscription and cancel pending reconnects (e.g. shutdown). */
+  closeAll(): void {
+    for (const sessionId of [...this.subs.keys()]) this.teardown(sessionId);
+  }
+
+  private open(sessionId: string, attempt: number): void {
+    const subscription = this.subscriber.subscribe(sessionId, {
+      onPending: (pending) => this.handlePending(sessionId, pending),
+      onError: (error) => this.handleError(sessionId, error),
+    });
+    this.subs.set(sessionId, { subscription, attempt });
+  }
+
+  private handlePending(sessionId: string, pending: PendingInteraction | null): void {
+    const sub = this.subs.get(sessionId);
+    if (sub === undefined) return; // torn down mid-flight
+    sub.attempt = 0; // a live frame resets backoff
+    if (pending === null) {
+      this.store.clear(sessionId);
+    } else {
+      this.store.observe(sessionId, pending, this.now().toISOString());
+    }
+  }
+
+  private handleError(sessionId: string, _error: Error): void {
+    const sub = this.subs.get(sessionId);
+    if (sub === undefined) return;
+    sub.subscription.close();
+    const attempt = sub.attempt;
+    // Keep last-known pending across the reconnect (a disconnect is not a
+    // resolve); reconnect with backoff.
+    const cancel = this.scheduleReconnect(() => {
+      if (this.subs.get(sessionId) === sub) this.open(sessionId, attempt + 1);
+    }, attempt);
+    sub.cancelReconnect = cancel;
+  }
+
+  private teardown(sessionId: string): void {
+    const sub = this.subs.get(sessionId);
+    if (sub === undefined) return;
+    sub.cancelReconnect?.();
+    sub.subscription.close();
+    this.subs.delete(sessionId);
+  }
+}

--- a/backend/src/snapshot/service.ts
+++ b/backend/src/snapshot/service.ts
@@ -15,6 +15,7 @@ import type {
 } from 'gas-city-dashboard-shared';
 
 import type { GcClient } from '../gc-client.js';
+import { deriveRunAlerts } from './alerts.js';
 import { SourceCache } from './cache.js';
 import { createCityStatusSourceCache } from './collectors/cityStatus.js';
 import { createResourcesSourceCache } from './collectors/resources.js';
@@ -228,6 +229,7 @@ export function buildSnapshot(
     config,
     headline: buildHeadline(sources),
     sources,
+    alerts: deriveRunAlerts(sources.runs),
   };
 }
 

--- a/backend/src/snapshot/sse-frame-parser.ts
+++ b/backend/src/snapshot/sse-frame-parser.ts
@@ -1,0 +1,80 @@
+// Incremental text/event-stream frame parser (gascity-dashboard-3rm7, Layer 2b).
+// The repo's sse-proxy only PIPES raw SSE bytes; consuming a stream server-side
+// (to observe `pending` events) needs an actual frame parser. This one is pure
+// and incremental: feed it decoded string chunks (which may split mid-line or
+// mid-event across reads) and it returns the complete events parsed so far.
+//
+// Implements the dispatch subset of the WHATWG event-stream spec we rely on:
+// `event:`, `data:` (multiple lines joined by \n), `id:` (persists as the
+// last-event-id across events), blank line = dispatch, leading `:` = comment
+// (heartbeat). `retry:` and unknown fields are ignored. A single optional
+// leading space after the field colon is stripped.
+
+export interface SseEvent {
+  /** The event type; 'message' when no `event:` field was present. */
+  readonly event: string;
+  /** The concatenated `data:` payload (lines joined by \n). */
+  readonly data: string;
+  /** The most recent `id:` value, if any (persists across events per spec). */
+  readonly id?: string;
+}
+
+export class SseFrameParser {
+  private buffer = '';
+  private eventType = '';
+  private dataLines: string[] = [];
+  private lastId: string | undefined;
+  private dirty = false;
+
+  /** Feed a decoded chunk; returns any events completed by it. */
+  push(chunk: string): SseEvent[] {
+    this.buffer += chunk;
+    const out: SseEvent[] = [];
+    let newlineIdx: number;
+    while ((newlineIdx = this.buffer.indexOf('\n')) >= 0) {
+      let line = this.buffer.slice(0, newlineIdx);
+      this.buffer = this.buffer.slice(newlineIdx + 1);
+      if (line.endsWith('\r')) line = line.slice(0, -1);
+
+      if (line === '') {
+        const event = this.dispatch();
+        if (event !== null) out.push(event);
+        continue;
+      }
+      if (line.startsWith(':')) continue; // comment / heartbeat
+
+      const colon = line.indexOf(':');
+      const field = colon === -1 ? line : line.slice(0, colon);
+      let value = colon === -1 ? '' : line.slice(colon + 1);
+      if (value.startsWith(' ')) value = value.slice(1);
+
+      if (field === 'event') {
+        this.eventType = value;
+        this.dirty = true;
+      } else if (field === 'data') {
+        this.dataLines.push(value);
+        this.dirty = true;
+      } else if (field === 'id') {
+        this.lastId = value;
+        this.dirty = true;
+      }
+      // retry / unknown fields ignored
+    }
+    return out;
+  }
+
+  private dispatch(): SseEvent | null {
+    if (!this.dirty) return null; // blank line with nothing buffered
+    const event: SseEvent = {
+      event: this.eventType === '' ? 'message' : this.eventType,
+      data: this.dataLines.join('\n'),
+    };
+    if (this.lastId !== undefined) {
+      (event as { id?: string }).id = this.lastId; // lastId persists; field-set resets
+    }
+    this.eventType = '';
+    this.dataLines = [];
+    this.dirty = false;
+    return event;
+  }
+}

--- a/backend/test/pending-store.test.ts
+++ b/backend/test/pending-store.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import type { PendingInteraction } from 'gas-city-dashboard-shared';
+
+import { PendingStore } from '../src/snapshot/pending-store.js';
+
+// City-wide pending aggregator core (gascity-dashboard-3rm7, PRD R3/R16).
+// These pin the premortem Theme-A invariants: supersede-on-reobserve, drop
+// pending for gone sessions, and never silently misorder the top tier.
+
+const pi = (request_id: string, kind = 'tool_approval'): PendingInteraction => ({ request_id, kind });
+const T1 = '2026-06-02T12:00:00.000Z';
+const T2 = '2026-06-02T12:00:05.000Z';
+
+describe('PendingStore', () => {
+  test('observe surfaces a pending-decision alert keyed by request_id', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    const alerts = store.alerts('fresh');
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.kind, 'pending-decision');
+    assert.equal(alerts[0]!.dedupKey, 'pending-decision:req-1');
+    assert.equal(alerts[0]!.ref.sessionId, 's1');
+    assert.equal(alerts[0]!.provenance, 'fresh');
+  });
+
+  test('re-observing a session supersedes with a higher version (R17 last-write-wins)', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    const v1 = store.alerts('fresh')[0]!.version;
+    store.observe('s1', pi('req-2'), T2);
+    const after = store.alerts('fresh');
+    assert.equal(after.length, 1); // one session, one pending
+    assert.equal(after[0]!.dedupKey, 'pending-decision:req-2');
+    assert.ok(after[0]!.version > v1);
+  });
+
+  test('clear removes a resolved pending', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    store.clear('s1');
+    assert.deepEqual(store.alerts('fresh'), []);
+    assert.equal(store.size, 0);
+  });
+
+  test('retainActive drops pending for sessions no longer active (cannot still need the operator)', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    store.observe('s2', pi('req-2'), T2);
+    const dropped = store.retainActive(['s2']);
+    assert.equal(dropped, 1);
+    const alerts = store.alerts('fresh');
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.ref.sessionId, 's2');
+  });
+
+  test('retainActive is a no-op when all entries are still active', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    assert.equal(store.retainActive(new Set(['s1'])), 0);
+    assert.equal(store.size, 1);
+  });
+
+  test('alerts are ordered oldest-first, then by dedupKey (deterministic, stable)', () => {
+    const store = new PendingStore();
+    store.observe('s2', pi('req-2'), T2);
+    store.observe('s1', pi('req-1'), T1);
+    const a = store.alerts('fresh').map((x) => x.dedupKey);
+    const b = store.alerts('fresh').map((x) => x.dedupKey);
+    assert.deepEqual(a, ['pending-decision:req-1', 'pending-decision:req-2']); // T1 before T2
+    assert.deepEqual(a, b);
+  });
+
+  test('provenance threads through so a dark aggregator can render signal-unavailable', () => {
+    const store = new PendingStore();
+    store.observe('s1', pi('req-1'), T1);
+    assert.equal(store.alerts('stale')[0]!.provenance, 'stale');
+  });
+
+  test('an empty store yields no alerts', () => {
+    assert.deepEqual(new PendingStore().alerts('fresh'), []);
+  });
+});

--- a/backend/test/pending-subscriber.test.ts
+++ b/backend/test/pending-subscriber.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import type { PendingInteraction } from 'gas-city-dashboard-shared';
+
+import { createSupervisorPendingSubscriber } from '../src/snapshot/pending-subscriber.js';
+import type { SessionPendingHandlers } from '../src/snapshot/pending-subscriptions.js';
+
+// Real fetch->SSE-parse subscriber (gascity-dashboard-3rm7, Layer 2b), driven
+// by a scripted ReadableStream so the read loop + resume are deterministic.
+
+function streamOf(chunks: string[], opts: { error?: Error } = {}): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      if (opts.error) controller.error(opts.error);
+      else controller.close();
+    },
+  });
+}
+
+function collector(): {
+  handlers: SessionPendingHandlers;
+  pendings: (PendingInteraction | null)[];
+  errors: Error[];
+} {
+  const pendings: (PendingInteraction | null)[] = [];
+  const errors: Error[] = [];
+  return {
+    pendings,
+    errors,
+    handlers: { onPending: (p) => pendings.push(p), onError: (e) => errors.push(e) },
+  };
+}
+
+async function settle(predicate: () => boolean, tries = 100): Promise<void> {
+  for (let i = 0; i < tries && !predicate(); i += 1) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+const streamUrl = (sessionId: string, after?: string): URL =>
+  new URL(`http://gc.local/session/${sessionId}/stream${after ? `?after=${after}` : ''}`);
+
+describe('createSupervisorPendingSubscriber', () => {
+  test('surfaces a valid pending frame as a PendingInteraction', async () => {
+    const c = collector();
+    const fetchFn = (async () =>
+      new Response(streamOf(['event: pending\ndata: {"request_id":"r1","kind":"tool_approval"}\n\n']), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    const sub = createSupervisorPendingSubscriber({ streamUrl, fetchFn });
+    sub.subscribe('s1', c.handlers);
+    await settle(() => c.pendings.length > 0);
+    assert.equal(c.pendings.length, 1);
+    assert.equal(c.pendings[0]!.request_id, 'r1');
+  });
+
+  test('ignores a malformed pending frame (does not clear)', async () => {
+    const c = collector();
+    const fetchFn = (async () =>
+      new Response(streamOf(['event: pending\ndata: {not json}\n\n']), { status: 200 })) as unknown as typeof fetch;
+
+    createSupervisorPendingSubscriber({ streamUrl, fetchFn }).subscribe('s1', c.handlers);
+    await settle(() => c.errors.length > 0); // stream then closes -> onError
+    assert.equal(c.pendings.length, 0); // never surfaced, never cleared
+  });
+
+  test('a stream close surfaces onError so the manager reconnects', async () => {
+    const c = collector();
+    const fetchFn = (async () => new Response(streamOf([]), { status: 200 })) as unknown as typeof fetch;
+    createSupervisorPendingSubscriber({ streamUrl, fetchFn }).subscribe('s1', c.handlers);
+    await settle(() => c.errors.length > 0);
+    assert.match(c.errors[0]!.message, /closed/);
+  });
+
+  test('a non-ok response surfaces onError', async () => {
+    const c = collector();
+    const fetchFn = (async () => new Response('nope', { status: 502 })) as unknown as typeof fetch;
+    createSupervisorPendingSubscriber({ streamUrl, fetchFn }).subscribe('s1', c.handlers);
+    await settle(() => c.errors.length > 0);
+    assert.match(c.errors[0]!.message, /502/);
+  });
+
+  test('resumes from the last-event-id on the next subscribe', async () => {
+    const c = collector();
+    const afters: (string | undefined)[] = [];
+    const trackingUrl = (sessionId: string, after?: string): URL => {
+      afters.push(after);
+      return streamUrl(sessionId, after);
+    };
+    const fetchFn = (async () =>
+      new Response(streamOf(['id: 42\nevent: pending\ndata: {"request_id":"r1","kind":"k"}\n\n']), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    const subscriber = createSupervisorPendingSubscriber({ streamUrl: trackingUrl, fetchFn });
+    subscriber.subscribe('s1', c.handlers);
+    await settle(() => c.errors.length > 0); // first connection ends
+    subscriber.subscribe('s1', collector().handlers); // manager reconnect
+    await settle(() => afters.length >= 2);
+    assert.equal(afters[0], undefined); // first connect: no resume
+    assert.equal(afters[1], '42'); // reconnect resumes from last id
+  });
+
+  test('close() before completion suppresses onError', async () => {
+    const c = collector();
+    // A never-ending stream: stays open until aborted.
+    const fetchFn = (async (_url: string, init?: { signal?: AbortSignal }) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener('abort', () => {
+            try { controller.error(new Error('aborted')); } catch { /* already closed */ }
+          });
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const handle = createSupervisorPendingSubscriber({ streamUrl, fetchFn }).subscribe('s1', c.handlers);
+    await new Promise((r) => setTimeout(r, 2));
+    handle.close();
+    await new Promise((r) => setTimeout(r, 5));
+    assert.equal(c.errors.length, 0); // close is not a failure
+  });
+});

--- a/backend/test/pending-subscriptions.test.ts
+++ b/backend/test/pending-subscriptions.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, test } from 'node:test';
+
+import type { PendingInteraction } from 'gas-city-dashboard-shared';
+
+import { PendingStore } from '../src/snapshot/pending-store.js';
+import {
+  PendingSubscriptionManager,
+  type ReconnectScheduler,
+  type SessionPendingHandlers,
+  type SessionStreamSubscriber,
+} from '../src/snapshot/pending-subscriptions.js';
+
+// Layer 2 orchestration (gascity-dashboard-3rm7). Deterministic via a fake
+// subscriber + a captured reconnect scheduler.
+
+const pi = (request_id: string): PendingInteraction => ({ request_id, kind: 'tool_approval' });
+const NOW = () => new Date('2026-06-02T12:00:00.000Z');
+
+class FakeSubscriber implements SessionStreamSubscriber {
+  readonly handlers = new Map<string, SessionPendingHandlers>();
+  readonly subscribeCalls: string[] = [];
+  readonly closed: string[] = [];
+
+  subscribe(sessionId: string, handlers: SessionPendingHandlers) {
+    this.subscribeCalls.push(sessionId);
+    this.handlers.set(sessionId, handlers);
+    return { close: () => { this.closed.push(sessionId); } };
+  }
+
+  pending(sessionId: string, p: PendingInteraction | null): void {
+    this.handlers.get(sessionId)!.onPending(p);
+  }
+
+  fail(sessionId: string): void {
+    this.handlers.get(sessionId)!.onError(new Error('stream lost'));
+  }
+}
+
+interface Scheduled { run: () => void; attempt: number; cancelled: boolean }
+
+function makeScheduler(): { scheduler: ReconnectScheduler; scheduled: Scheduled[] } {
+  const scheduled: Scheduled[] = [];
+  const scheduler: ReconnectScheduler = (run, attempt) => {
+    const entry: Scheduled = { run, attempt, cancelled: false };
+    scheduled.push(entry);
+    return () => { entry.cancelled = true; };
+  };
+  return { scheduler, scheduled };
+}
+
+describe('PendingSubscriptionManager', () => {
+  let subscriber: FakeSubscriber;
+  let store: PendingStore;
+  let scheduled: Scheduled[];
+  let manager: PendingSubscriptionManager;
+
+  beforeEach(() => {
+    subscriber = new FakeSubscriber();
+    store = new PendingStore();
+    const s = makeScheduler();
+    scheduled = s.scheduled;
+    manager = new PendingSubscriptionManager({ subscriber, store, now: NOW, scheduleReconnect: s.scheduler });
+  });
+
+  test('syncActiveSessions opens a subscription per active session', () => {
+    manager.syncActiveSessions(['s1', 's2']);
+    assert.deepEqual(subscriber.subscribeCalls.sort(), ['s1', 's2']);
+    assert.equal(manager.subscribedCount, 2);
+  });
+
+  test('a pending frame lands in the store as a pending-decision alert', () => {
+    manager.syncActiveSessions(['s1']);
+    subscriber.pending('s1', pi('req-1'));
+    const alerts = store.alerts('fresh');
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.dedupKey, 'pending-decision:req-1');
+    assert.equal(alerts[0]!.ref.sessionId, 's1');
+  });
+
+  test('a null pending frame clears the session', () => {
+    manager.syncActiveSessions(['s1']);
+    subscriber.pending('s1', pi('req-1'));
+    subscriber.pending('s1', null);
+    assert.deepEqual(store.alerts('fresh'), []);
+  });
+
+  test('removing a session tears down its subscription and drops its pending', () => {
+    manager.syncActiveSessions(['s1', 's2']);
+    subscriber.pending('s1', pi('a'));
+    subscriber.pending('s2', pi('b'));
+    manager.syncActiveSessions(['s1']);
+    assert.ok(subscriber.closed.includes('s2'));
+    const alerts = store.alerts('fresh');
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.ref.sessionId, 's1');
+  });
+
+  test('a stream error schedules a reconnect that re-subscribes', () => {
+    manager.syncActiveSessions(['s1']);
+    subscriber.fail('s1');
+    assert.ok(subscriber.closed.includes('s1'));
+    assert.equal(scheduled.length, 1);
+    assert.equal(scheduled[0]!.attempt, 0);
+    scheduled[0]!.run();
+    assert.equal(subscriber.subscribeCalls.filter((id) => id === 's1').length, 2);
+  });
+
+  test('backoff attempt increments across consecutive failures and resets on a live frame', () => {
+    manager.syncActiveSessions(['s1']);
+    subscriber.fail('s1');
+    scheduled[0]!.run();           // reconnect #1 (attempt was 0 -> opens with attempt 1)
+    subscriber.fail('s1');
+    assert.equal(scheduled[1]!.attempt, 1);
+    scheduled[1]!.run();           // reconnect #2 (attempt 2)
+    subscriber.pending('s1', pi('x')); // live frame resets attempt
+    subscriber.fail('s1');
+    assert.equal(scheduled[2]!.attempt, 0);
+  });
+
+  test('tearing down a session mid-reconnect cancels the scheduled reconnect', () => {
+    manager.syncActiveSessions(['s1']);
+    subscriber.fail('s1');
+    manager.syncActiveSessions([]); // s1 no longer active
+    assert.ok(scheduled[0]!.cancelled);
+    const before = subscriber.subscribeCalls.length;
+    scheduled[0]!.run(); // stale reconnect must be a no-op
+    assert.equal(subscriber.subscribeCalls.length, before);
+  });
+
+  test('closeAll closes every subscription', () => {
+    manager.syncActiveSessions(['s1', 's2']);
+    manager.closeAll();
+    assert.deepEqual(subscriber.closed.sort(), ['s1', 's2']);
+    assert.equal(manager.subscribedCount, 0);
+  });
+});

--- a/backend/test/snapshot-alerts.test.ts
+++ b/backend/test/snapshot-alerts.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import type {
+  RunLane,
+  RunLaneHealth,
+  RunSummary,
+  SourceState,
+} from 'gas-city-dashboard-shared';
+
+import { deriveRunAlerts } from '../src/snapshot/alerts.js';
+
+// Run-sourced alert derivation (gascity-dashboard-i4ui, PRD R2/R5).
+// These pin the structural predicates and the premortem's degrade-to-quiet
+// gate: an 'inferred' lane's thrashing fact must never become a failing alert.
+
+const FETCHED_AT = '2026-06-02T12:00:00.000Z';
+
+function health(partial: Partial<RunLaneHealth> = {}): RunLane['health'] {
+  return {
+    status: 'available',
+    data: {
+      phaseConfidence: 'known',
+      needsOperator: false,
+      stuckNode: { status: 'unavailable', error: 'no stuck node in test' },
+      thrashingDetected: false,
+      session: { status: 'unresolved', error: 'session unresolved in test' },
+      ...partial,
+    },
+  };
+}
+
+function lane(partial: Partial<RunLane> & { id: string }): RunLane {
+  return {
+    title: `run ${partial.id}`,
+    formula: { status: 'unavailable', error: 'formula unavailable in test' },
+    scope: { status: 'unavailable', error: 'not scoped in test' },
+    external: { status: 'unavailable', error: 'external unavailable in test' },
+    phase: 'implementation',
+    phaseLabel: 'implementation',
+    statusCounts: {},
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-06-02T11:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'progress unavailable in test' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'health not derived in test' },
+    ...partial,
+  };
+}
+
+function availableRuns(
+  lanes: RunLane[],
+  status: 'fresh' | 'stale' | 'fixture' = 'fresh',
+): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status,
+    fetchedAt: FETCHED_AT,
+    staleAt: '2026-06-02T12:01:00.000Z',
+    error: { kind: 'none' },
+    data: {
+      totalActive: lanes.length,
+      totalHistorical: 0,
+      runCounts: { total: lanes.length, visible: lanes.length, prReview: 0, designReview: 0, bugfix: 0, blocked: 0, other: 0 },
+      lanes,
+      historicalLanes: [],
+      recentChanges: [],
+      census: { status: 'unavailable', error: 'census not derived in test' },
+    },
+  };
+}
+
+describe('deriveRunAlerts', () => {
+  test('emits a run-needs-operator (attention) for a needsOperator lane', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', phase: 'approval', health: health({ needsOperator: true }) }),
+    ]));
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.kind, 'run-needs-operator');
+    assert.equal(alerts[0]!.severity, 'attention');
+    assert.equal(alerts[0]!.dedupKey, 'run-needs-operator:r1');
+    assert.equal(alerts[0]!.reason, 'awaiting your decision');
+    assert.equal(alerts[0]!.ref.runId, 'r1');
+    assert.equal(alerts[0]!.href, '/runs/r1');
+  });
+
+  test('blocked phase reasons as "blocked"', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', phase: 'blocked', health: health({ needsOperator: true }) }),
+    ]));
+    assert.equal(alerts[0]!.reason, 'blocked');
+  });
+
+  test('emits run-thrashing (failing) for a known-confidence thrashing lane', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', health: health({ thrashingDetected: true, phaseConfidence: 'known' }) }),
+    ]));
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.kind, 'run-thrashing');
+    assert.equal(alerts[0]!.severity, 'failing');
+  });
+
+  test('SUPPRESSES thrashing on an inferred-confidence lane (premortem: inferred never drives the maroon)', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', health: health({ thrashingDetected: true, phaseConfidence: 'inferred' }) }),
+    ]));
+    assert.deepEqual(alerts, []);
+  });
+
+  test('a healthy lane produces no alerts (withholding: a calm run is absent)', () => {
+    const alerts = deriveRunAlerts(availableRuns([lane({ id: 'r1', health: health() })]));
+    assert.deepEqual(alerts, []);
+  });
+
+  test('a lane both needing-operator and thrashing yields two alerts, failing ranked first', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', phase: 'approval', health: health({ needsOperator: true, thrashingDetected: true, phaseConfidence: 'known' }) }),
+    ]));
+    assert.equal(alerts.length, 2);
+    assert.equal(alerts[0]!.kind, 'run-thrashing'); // failing sorts above attention
+    assert.equal(alerts[1]!.kind, 'run-needs-operator');
+  });
+
+  test('href deep-links to the stuck node when known', () => {
+    const alerts = deriveRunAlerts(availableRuns([
+      lane({ id: 'r1', health: health({ needsOperator: true, stuckNode: { status: 'available', id: 'node-7' } }) }),
+    ]));
+    assert.equal(alerts[0]!.href, '/runs/r1?node=node-7');
+  });
+
+  test('provenance inherits the source status; version is the generation epoch', () => {
+    const alerts = deriveRunAlerts(availableRuns(
+      [lane({ id: 'r1', health: health({ needsOperator: true }) })],
+      'stale',
+    ));
+    assert.equal(alerts[0]!.provenance, 'stale');
+    assert.equal(alerts[0]!.version, Date.parse(FETCHED_AT));
+  });
+
+  test('returns [] for an unavailable source (the SourceState carries the error, not this array)', () => {
+    const errored: SourceState<RunSummary> = { source: 'runs', status: 'error', error: 'supervisor unreachable' };
+    assert.deepEqual(deriveRunAlerts(errored), []);
+  });
+
+  test('ordering is stable across two derivations (R5)', () => {
+    const runs = availableRuns([
+      lane({ id: 'r2', health: health({ thrashingDetected: true, phaseConfidence: 'known' }) }),
+      lane({ id: 'r1', phase: 'approval', health: health({ needsOperator: true }) }),
+    ]);
+    const a = deriveRunAlerts(runs).map((x) => x.dedupKey);
+    const b = deriveRunAlerts(runs).map((x) => x.dedupKey);
+    assert.deepEqual(a, b);
+  });
+});

--- a/backend/test/sse-frame-parser.test.ts
+++ b/backend/test/sse-frame-parser.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { SseFrameParser } from '../src/snapshot/sse-frame-parser.js';
+
+// text/event-stream frame parser (gascity-dashboard-3rm7, Layer 2b).
+
+describe('SseFrameParser', () => {
+  test('parses a complete named event with data', () => {
+    const p = new SseFrameParser();
+    const events = p.push('event: pending\ndata: {"request_id":"r1"}\n\n');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.event, 'pending');
+    assert.equal(events[0]!.data, '{"request_id":"r1"}');
+  });
+
+  test('strips a single leading space after the field colon', () => {
+    const p = new SseFrameParser();
+    const [ev] = p.push('event:pending\ndata:x\n\n'); // no space
+    assert.equal(ev!.event, 'pending');
+    assert.equal(ev!.data, 'x');
+  });
+
+  test('joins multiple data lines with newline', () => {
+    const p = new SseFrameParser();
+    const [ev] = p.push('data: a\ndata: b\n\n');
+    assert.equal(ev!.data, 'a\nb');
+    assert.equal(ev!.event, 'message'); // default type
+  });
+
+  test('reassembles an event split across chunks (mid-line and mid-event)', () => {
+    const p = new SseFrameParser();
+    assert.deepEqual(p.push('event: pen'), []);
+    assert.deepEqual(p.push('ding\ndata: {"request_id":'), []);
+    const events = p.push('"r9"}\n\n');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.event, 'pending');
+    assert.equal(events[0]!.data, '{"request_id":"r9"}');
+  });
+
+  test('ignores comment/heartbeat lines', () => {
+    const p = new SseFrameParser();
+    assert.deepEqual(p.push(':\n'), []);
+    assert.deepEqual(p.push(': keep-alive\n'), []);
+    const [ev] = p.push('event: pending\ndata: x\n\n');
+    assert.equal(ev!.event, 'pending');
+  });
+
+  test('carries id and persists it as last-event-id across events', () => {
+    const p = new SseFrameParser();
+    const [a] = p.push('id: 7\nevent: pending\ndata: x\n\n');
+    assert.equal(a!.id, '7');
+    const [b] = p.push('event: pending\ndata: y\n\n'); // no new id
+    assert.equal(b!.id, '7'); // persists
+  });
+
+  test('handles CRLF line endings', () => {
+    const p = new SseFrameParser();
+    const [ev] = p.push('event: pending\r\ndata: x\r\n\r\n');
+    assert.equal(ev!.event, 'pending');
+    assert.equal(ev!.data, 'x');
+  });
+
+  test('a blank line with nothing buffered does not emit a phantom event', () => {
+    const p = new SseFrameParser();
+    assert.deepEqual(p.push('\n\n'), []);
+  });
+
+  test('emits multiple events from one chunk', () => {
+    const p = new SseFrameParser();
+    const events = p.push('event: pending\ndata: 1\n\nevent: pending\ndata: 2\n\n');
+    assert.equal(events.length, 2);
+    assert.deepEqual(events.map((e) => e.data), ['1', '2']);
+  });
+});

--- a/frontend/src/hooks/useSessionStream.ts
+++ b/frontend/src/hooks/useSessionStream.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
-import type { TranscriptResult, TranscriptTurn } from 'gas-city-dashboard-shared';
-import { errorMessage } from 'gas-city-dashboard-shared';
+import type {
+  PendingInteraction,
+  TranscriptResult,
+  TranscriptTurn,
+} from 'gas-city-dashboard-shared';
+import { errorMessage, parsePendingInteraction } from 'gas-city-dashboard-shared';
 import { api } from '../api/client';
 import { reportClientError } from '../lib/clientErrorReporting';
 
@@ -18,7 +22,19 @@ export type SessionStreamState =
   | { status: 'idle'; stream: { status: 'idle' } }
   | { status: 'loading'; stream: { status: 'idle' } | { status: 'connecting' } }
   | { status: 'failed'; error: string; stream: { status: 'idle' } }
-  | { status: 'ready'; result: TranscriptResult; stream: SessionStreamProgress };
+  | {
+    status: 'ready';
+    result: TranscriptResult;
+    stream: SessionStreamProgress;
+    /**
+     * Latest pending interaction observed on the stream (PRD R3), or null when
+     * none is outstanding. The supervisor emits this ONLY as a per-session SSE
+     * `pending` event — see parsePendingInteraction. The R11 respond write
+     * clears it; until then a present value means an agent is blocked on the
+     * operator. Absent/undefined on a never-streamed ready state.
+     */
+    pending?: PendingInteraction | null;
+  };
 
 export function useSessionStream(
   sessionId: string | null,
@@ -100,6 +116,23 @@ export function useSessionStream(
           };
           source.onmessage = onTurn;
           source.addEventListener('turn', onTurn);
+          const onPending = (event: MessageEvent<string>) => {
+            if (cancelled) return;
+            const pending = parsePendingInteraction(safeJsonParse(event.data));
+            setState((current) => {
+              const base = current.status === 'ready' ? current.result : result;
+              if (pending === null) {
+                reportMalformedSessionEvent(sessionId, malformedEventReportedRef);
+                return {
+                  status: 'ready',
+                  result: base,
+                  stream: { status: 'degraded', error: MALFORMED_SESSION_STREAM_EVENT },
+                };
+              }
+              return { status: 'ready', result: base, stream: { status: 'open' }, pending };
+            });
+          };
+          source.addEventListener('pending', onPending);
           source.onerror = () => {
             if (cancelled) return;
             const streamState =
@@ -160,6 +193,14 @@ type SessionStreamPayload =
   | { kind: 'invalid'; error: string };
 
 const MALFORMED_SESSION_STREAM_EVENT = 'Malformed session stream event.';
+
+function safeJsonParse(data: string): unknown {
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+}
 
 function parseStreamPayload(data: string): SessionStreamPayload {
   let parsed: unknown;

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -152,6 +152,7 @@ function envelope({
 } = {}): DashboardSnapshot {
   return {
     generatedAt,
+    alerts: [],
     config: {
       cityName: 'racoon-city',
       cityRoot: '/tmp/x',

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -677,6 +677,7 @@ function snapshotWithActiveLane(): DashboardSnapshot {
   };
   return {
     generatedAt: '2026-05-25T00:00:00.000Z',
+    alerts: [],
     config: {
       cityName: 'test-city',
       cityRoot: '/tmp/example-city',

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -62,6 +62,7 @@ function buildEnvelope(
 ): DashboardSnapshot {
   return {
     generatedAt: '2026-05-25T00:00:00.000Z',
+    alerts: [],
     config: {
       cityName: 'racoon-city',
       cityRoot: '/tmp/example-city',

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/index.test.ts src/session-resolve.test.ts src/alert.test.ts"
+    "test": "tsx --test src/index.test.ts src/session-resolve.test.ts src/alert.test.ts src/pending.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/index.test.ts src/session-resolve.test.ts"
+    "test": "tsx --test src/index.test.ts src/session-resolve.test.ts src/alert.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/shared/src/alert.test.ts
+++ b/shared/src/alert.test.ts
@@ -1,0 +1,99 @@
+// Run with: npx tsx --test shared/src/alert.test.ts
+//
+// Contract tests for the AlertItem DTO (gascity-dashboard-4s07, PRD R1).
+// The home-view alert system unifies typed actionable signals into one
+// ranked attention queue; this DTO is the single source of truth both
+// backend (snapshot read path) and frontend (SSE pending layer) import,
+// so a contract mismatch is a compile error, not a runtime undefined.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ALERT_KINDS,
+  ALERT_SOURCES,
+  ALERT_SEVERITIES,
+  ALERT_SEVERITY_RANK,
+  makeAlertDedupKey,
+} from './alert.js';
+import type { AlertItem, AlertRef } from './alert.js';
+import {
+  ALERT_KINDS as barrelAlertKinds,
+  makeAlertDedupKey as barrelMakeAlertDedupKey,
+} from './index.js';
+
+test('ALERT_KINDS is the closed union the PRD defines (R1)', () => {
+  assert.deepEqual(
+    [...ALERT_KINDS].sort(),
+    ['operator-mail', 'pending-decision', 'run-needs-operator', 'run-thrashing'],
+  );
+});
+
+test('ALERT_SOURCES groups by data plane', () => {
+  assert.deepEqual([...ALERT_SOURCES].sort(), ['mail', 'pending', 'runs']);
+});
+
+test('ALERT_SEVERITIES + rank order place failing above attention (R5/R7)', () => {
+  assert.deepEqual([...ALERT_SEVERITIES].sort(), ['attention', 'failing']);
+  assert.ok(ALERT_SEVERITY_RANK.failing > ALERT_SEVERITY_RANK.attention);
+});
+
+test('makeAlertDedupKey is deterministic and stable across calls', () => {
+  const ref: AlertRef = { runId: 'r1' };
+  assert.equal(
+    makeAlertDedupKey('run-needs-operator', ref),
+    makeAlertDedupKey('run-needs-operator', ref),
+  );
+  assert.equal(makeAlertDedupKey('run-needs-operator', ref), 'run-needs-operator:r1');
+});
+
+test('makeAlertDedupKey prefers requestId (the pending idempotency key) over other ids', () => {
+  const key = makeAlertDedupKey('pending-decision', { requestId: 'req-9', sessionId: 's1' });
+  assert.equal(key, 'pending-decision:req-9');
+});
+
+test('makeAlertDedupKey throws on a ref with no identifying id (fail fast, no silent empty key)', () => {
+  assert.throws(() => makeAlertDedupKey('operator-mail', {}), /identif/i);
+});
+
+test('barrel (index.js) re-exports the alert module as value exports', () => {
+  assert.equal(barrelMakeAlertDedupKey, makeAlertDedupKey);
+  assert.equal(barrelAlertKinds, ALERT_KINDS);
+});
+
+test('AlertItem carries provenance and the R17 monotonic version for last-write-wins', () => {
+  const item: AlertItem = {
+    kind: 'pending-decision',
+    source: 'pending',
+    ref: { requestId: 'req-1', sessionId: 's1' },
+    href: '/agents/s1',
+    title: 'agent awaiting your decision',
+    reason: 'tool approval',
+    severity: 'failing',
+    occurredAt: '2026-06-02T00:00:00.000Z',
+    dedupKey: makeAlertDedupKey('pending-decision', { requestId: 'req-1' }),
+    version: 3,
+    provenance: 'fresh',
+  };
+  assert.equal(item.provenance, 'fresh');
+  assert.equal(item.version, 3);
+  // foldedCount is optional: absent means this row is not a fold parent (R8).
+  assert.equal(item.foldedCount, undefined);
+});
+
+test('a fold-parent AlertItem carries a visible foldedCount (R8: no silent fold)', () => {
+  const parent: AlertItem = {
+    kind: 'run-thrashing',
+    source: 'runs',
+    ref: { runId: 'rig-a' },
+    href: '/runs/rig-a',
+    title: 'rig-a has a failed agent',
+    reason: 'failed run',
+    severity: 'failing',
+    occurredAt: '2026-06-02T00:00:00.000Z',
+    dedupKey: makeAlertDedupKey('run-thrashing', { runId: 'rig-a' }),
+    version: 1,
+    provenance: 'fresh',
+    foldedCount: 3,
+  };
+  assert.equal(parent.foldedCount, 3);
+});

--- a/shared/src/alert.ts
+++ b/shared/src/alert.ts
@@ -1,0 +1,112 @@
+// Dashboard-owned DTO for the home-view alert system (gascity-dashboard-4s07,
+// PRD R1). This is the single source of truth for one ranked "actionable
+// work" item; both the backend snapshot read path and the frontend SSE
+// pending layer import it, so a shape mismatch is a compile error rather
+// than a runtime undefined.
+//
+// Design constraints carried from the converged PRD + premortem:
+//  - Closed unions (no stringly-typed logic): the `as const` arrays below are
+//    the single source for both the runtime list and the derived type.
+//  - Provenance travels with every item (R6/R15): `provenance` is the source's
+//    SourceStatus, so a stale/error/fixture-derived alert can never be rendered
+//    as live truth and never drives the One Mark.
+//  - Last-write-wins dedup (R17): `dedupKey` + a monotonic upstream `version`
+//    let a newer live (SSE) row supersede a stale (snapshot-envelope) row with
+//    the same key, closing the resolved-while-stale self-contradiction window.
+//  - Ranking, eligibility predicates, and inhibition live in R5/R8, not here —
+//    this module is the contract only.
+
+import type { IsoTimestamp } from './gc-client-types.js';
+import type { SourceStatus } from './snapshot/types.js';
+
+/** The closed set of actionable-signal kinds surfaced on the home view. */
+export const ALERT_KINDS = [
+  'pending-decision',
+  'run-needs-operator',
+  'run-thrashing',
+  'operator-mail',
+] as const;
+export type AlertKind = (typeof ALERT_KINDS)[number];
+
+/** The data plane an alert was derived from. */
+export const ALERT_SOURCES = ['runs', 'mail', 'pending'] as const;
+export type AlertSource = (typeof ALERT_SOURCES)[number];
+
+/**
+ * Severity tier. Deliberately two-valued — it maps to DESIGN.md's One Mark
+ * (a single maroon for the top item), NOT a 0-100 score. `failing` outranks
+ * `attention`; see ALERT_SEVERITY_RANK.
+ */
+export const ALERT_SEVERITIES = ['attention', 'failing'] as const;
+export type AlertSeverity = (typeof ALERT_SEVERITIES)[number];
+
+/**
+ * Centralized severity ordering so R5 ranking never re-encodes magic numbers.
+ * Higher rank = more severe = sorts first.
+ */
+export const ALERT_SEVERITY_RANK: Readonly<Record<AlertSeverity, number>> = {
+  attention: 0,
+  failing: 1,
+};
+
+/**
+ * Deep-link identifiers for an alert. At least one must be present (enforced
+ * by makeAlertDedupKey). `requestId` is the PendingInteraction idempotency key
+ * (R11) and takes precedence as the dedup identity for pending decisions.
+ */
+export interface AlertRef {
+  readonly runId?: string;
+  readonly beadId?: string;
+  readonly mailId?: string;
+  readonly sessionId?: string;
+  readonly requestId?: string;
+}
+
+/** One ranked actionable-work item on the home view. */
+export interface AlertItem {
+  readonly kind: AlertKind;
+  readonly source: AlertSource;
+  /** Identifiers used to build `href` and `dedupKey`. */
+  readonly ref: AlertRef;
+  /** Authoritative-surface deep link the row navigates to. */
+  readonly href: string;
+  readonly title: string;
+  /** Machine-derived "why this is here" (e.g. sender role, phase). Never a semantic score. */
+  readonly reason: string;
+  readonly severity: AlertSeverity;
+  readonly occurredAt: IsoTimestamp;
+  /** Stable identity for dedup; pair with `version` for R17 last-write-wins. */
+  readonly dedupKey: string;
+  /**
+   * Monotonic upstream version/sequence for this dedupKey. A higher value
+   * supersedes a lower one with the same key (R17), so a live SSE row discards
+   * a stale snapshot-envelope row instead of contradicting it.
+   */
+  readonly version: number;
+  /** Freshness of the source this item was derived from (R6/R15). */
+  readonly provenance: SourceStatus;
+  /**
+   * Count of lower-severity signals inhibited (folded) under this item (R8).
+   * Present and > 0 only on a fold parent; absent means this row folds nothing.
+   * A fold must never be silent, so the parent always carries the count.
+   */
+  readonly foldedCount?: number;
+}
+
+/**
+ * Build the stable dedup identity for an alert. Mechanical and deterministic
+ * (no semantic judgment): `<kind>:<id>` where the id is the most specific
+ * available ref. `requestId` wins so a pending decision keeps one identity
+ * across snapshot/SSE layers. Throws if no identifying ref is present — an
+ * unidentifiable alert is a producer bug, not a silent empty key.
+ */
+export function makeAlertDedupKey(kind: AlertKind, ref: AlertRef): string {
+  const id =
+    ref.requestId ?? ref.runId ?? ref.beadId ?? ref.mailId ?? ref.sessionId;
+  if (id === undefined || id.length === 0) {
+    throw new Error(
+      `makeAlertDedupKey: AlertRef for kind "${kind}" has no identifying id`,
+    );
+  }
+  return `${kind}:${id}`;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from './links.js';
 export * from './city.js';
 export * from './operator.js';
 export * from './alert.js';
+export * from './pending.js';
 export * from './context-window.js';
 export type * from './lists.js';
 export type * from './transcript.js';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -13,6 +13,7 @@ export type * from './run-snapshot.js';
 export * from './links.js';
 export * from './city.js';
 export * from './operator.js';
+export * from './alert.js';
 export * from './context-window.js';
 export type * from './lists.js';
 export type * from './transcript.js';

--- a/shared/src/pending.test.ts
+++ b/shared/src/pending.test.ts
@@ -1,0 +1,78 @@
+// Run with: npx tsx --test shared/src/pending.test.ts
+//
+// PendingInteraction boundary parse + AlertItem mapping (gascity-dashboard-8167,
+// PRD R3). The supervisor emits this only on the per-session SSE; the parse is
+// the edge that keeps untyped frames from flowing in as a known shape.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parsePendingInteraction,
+  pendingInteractionToAlert,
+  type PendingAlertContext,
+} from './pending.js';
+import { parsePendingInteraction as barrelParse } from './index.js';
+
+const CTX: PendingAlertContext = {
+  sessionId: 's1',
+  occurredAt: '2026-06-02T12:00:00.000Z',
+  version: 7,
+  provenance: 'fresh',
+};
+
+test('parses a valid pending frame (required request_id + kind)', () => {
+  const pi = parsePendingInteraction({ request_id: 'req-1', kind: 'tool_approval' });
+  assert.notEqual(pi, null);
+  assert.equal(pi!.request_id, 'req-1');
+  assert.equal(pi!.kind, 'tool_approval');
+});
+
+test('carries optional prompt/options/metadata when present and well-typed', () => {
+  const pi = parsePendingInteraction({
+    request_id: 'req-1',
+    kind: 'prompt_for_input',
+    prompt: 'Approve push?',
+    options: ['allow', 'deny'],
+    metadata: { tool: 'git' },
+  });
+  assert.deepEqual(pi!.options, ['allow', 'deny']);
+  assert.equal(pi!.prompt, 'Approve push?');
+  assert.deepEqual(pi!.metadata, { tool: 'git' });
+});
+
+test('rejects frames missing request_id or kind (boundary validation)', () => {
+  assert.equal(parsePendingInteraction({ kind: 'x' }), null);
+  assert.equal(parsePendingInteraction({ request_id: 'r' }), null);
+  assert.equal(parsePendingInteraction({ request_id: '', kind: 'x' }), null);
+  assert.equal(parsePendingInteraction('not an object'), null);
+  assert.equal(parsePendingInteraction(null), null);
+});
+
+test('drops malformed options rather than passing a wrong-typed array through', () => {
+  const pi = parsePendingInteraction({ request_id: 'r', kind: 'k', options: ['ok', 3] });
+  assert.equal(pi!.options, undefined);
+});
+
+test('maps to a pending-decision AlertItem with requestId-keyed dedup', () => {
+  const pi = parsePendingInteraction({ request_id: 'req-9', kind: 'tool_approval', prompt: 'Approve push?\nmore' })!;
+  const alert = pendingInteractionToAlert(pi, CTX);
+  assert.equal(alert.kind, 'pending-decision');
+  assert.equal(alert.source, 'pending');
+  assert.equal(alert.dedupKey, 'pending-decision:req-9');
+  assert.equal(alert.ref.requestId, 'req-9');
+  assert.equal(alert.ref.sessionId, 's1');
+  assert.equal(alert.href, '/agents/s1');
+  assert.equal(alert.title, 'Approve push?'); // first line only
+  assert.equal(alert.reason, 'tool_approval'); // kind carried verbatim
+  assert.equal(alert.version, 7);
+  assert.equal(alert.provenance, 'fresh');
+});
+
+test('falls back to a generic title when the prompt is absent', () => {
+  const pi = parsePendingInteraction({ request_id: 'r', kind: 'k' })!;
+  assert.equal(pendingInteractionToAlert(pi, CTX).title, 'agent awaiting your decision');
+});
+
+test('barrel re-exports the pending module', () => {
+  assert.equal(barrelParse, parsePendingInteraction);
+});

--- a/shared/src/pending.ts
+++ b/shared/src/pending.ts
@@ -1,0 +1,104 @@
+// PendingInteraction — the "an agent is blocked waiting on a human decision"
+// signal (gascity-dashboard-8167, PRD R3). This is the highest-value home-view
+// signal and the supervisor emits it ONLY on the per-session SSE stream
+// (event: "pending"); the city event stream does not carry it (spike wf4c).
+//
+// Dashboard-owned wire shape, translated at the edge: it mirrors the gc
+// supervisor `PendingInteraction` schema exactly (request_id + kind required;
+// prompt/options/metadata optional). `parsePendingInteraction` is the boundary
+// validator so untyped SSE JSON never flows in as a known shape.
+//
+// `kind` is a free-form string upstream (no enum, no "needs-human-judgment"
+// marker — spike wf4c), so it is carried verbatim as the `reason` and never
+// used to classify urgency (ZFC). `options` is the authoritative set of
+// response verbs for R11's accept/decline; do not hardcode allow/deny.
+
+import type { AlertItem } from './alert.js';
+import { makeAlertDedupKey } from './alert.js';
+import type { IsoTimestamp } from './gc-client-types.js';
+import type { SourceStatus } from './snapshot/types.js';
+
+export interface PendingInteraction {
+  readonly request_id: string;
+  readonly kind: string;
+  readonly prompt?: string;
+  /** Accepted response verbs for this interaction (R11). Null/absent upstream when unconstrained. */
+  readonly options?: readonly string[];
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Boundary parse for an SSE `pending` frame. Returns null on any shape that is
+ * not a valid PendingInteraction — the caller surfaces that as a degraded
+ * stream, never as a silently-accepted partial.
+ */
+export function parsePendingInteraction(data: unknown): PendingInteraction | null {
+  if (!isRecord(data)) return null;
+  if (typeof data.request_id !== 'string' || data.request_id.length === 0) return null;
+  if (typeof data.kind !== 'string' || data.kind.length === 0) return null;
+
+  const result: {
+    request_id: string;
+    kind: string;
+    prompt?: string;
+    options?: readonly string[];
+    metadata?: Readonly<Record<string, string>>;
+  } = { request_id: data.request_id, kind: data.kind };
+
+  if (typeof data.prompt === 'string') result.prompt = data.prompt;
+  if (Array.isArray(data.options) && data.options.every((o) => typeof o === 'string')) {
+    result.options = data.options as readonly string[];
+  }
+  if (isRecord(data.metadata)) {
+    const entries = Object.entries(data.metadata).filter(
+      (e): e is [string, string] => typeof e[1] === 'string',
+    );
+    if (entries.length > 0) result.metadata = Object.fromEntries(entries);
+  }
+  return result;
+}
+
+/** First non-empty line of the prompt, trimmed for a one-line title. */
+function promptTitle(prompt: string | undefined): string {
+  if (prompt === undefined) return 'agent awaiting your decision';
+  const firstLine = prompt.split('\n', 1)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : 'agent awaiting your decision';
+}
+
+export interface PendingAlertContext {
+  readonly sessionId: string;
+  readonly occurredAt: IsoTimestamp;
+  /** Monotonic per-dedupKey ordinal for R17 last-write-wins (e.g. an event sequence). */
+  readonly version: number;
+  /** Freshness of the stream this was observed on (R6/R16); 'fresh' for a live SSE frame. */
+  readonly provenance: SourceStatus;
+}
+
+/**
+ * Map a PendingInteraction to a `pending-decision` AlertItem. Pure — the live
+ * SSE layer (or the per-session detail view) supplies the context. Severity is
+ * 'attention' (a request for input, not a system failure); pending-decision's
+ * rank ABOVE run signals is R5's job via kind precedence, not a severity hack.
+ */
+export function pendingInteractionToAlert(
+  pending: PendingInteraction,
+  ctx: PendingAlertContext,
+): AlertItem {
+  return {
+    kind: 'pending-decision',
+    source: 'pending',
+    ref: { requestId: pending.request_id, sessionId: ctx.sessionId },
+    href: `/agents/${encodeURIComponent(ctx.sessionId)}`,
+    title: promptTitle(pending.prompt),
+    reason: pending.kind,
+    severity: 'attention',
+    occurredAt: ctx.occurredAt,
+    dedupKey: makeAlertDedupKey('pending-decision', { requestId: pending.request_id }),
+    version: ctx.version,
+    provenance: ctx.provenance,
+  };
+}

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -6,6 +6,7 @@
 // visible product surface.
 
 import type { Avail } from '../lists.js';
+import type { AlertItem } from '../alert.js';
 
 export type SourceName =
   | 'city'
@@ -42,6 +43,18 @@ export interface DashboardSnapshot {
   config: DashboardRuntimeConfig;
   headline: DashboardHeadline;
   sources: DashboardSources;
+  /**
+   * Ranked home-view attention queue (gascity-dashboard-i4ui, PRD R2).
+   * Run-sourced alerts (run-needs-operator, run-thrashing) are assembled here
+   * in the backend snapshot read path from the health-enriched `sources.runs`,
+   * inheriting that source's provenance. The `pending-decision` tier is layered
+   * client-side from the live per-session SSE (R3) and is NOT carried here —
+   * folding it into this TTL-bound envelope would gate the highest tier behind
+   * the snapshot clock. `operator-mail` (R4) lands here once the read path
+   * fetches mail. Empty array means "no run-sourced alerts"; the per-source
+   * SourceState (not this array) is the signal-unavailable channel (R6/R15).
+   */
+  alerts: readonly AlertItem[];
 }
 
 export interface DashboardRuntimeConfig {


### PR DESCRIPTION
## Summary

Foundation for the home-view alert system — the unified, highest-priority *actionable work* queue on `/`. This PR lands the contract, the run-sourced alerts, and the per-session pending-decision machinery, sourced from a `/research-project` pipeline (diverge → converge → premortem) captured in `prd_home-view-alert-system.md` + `premortem_home-view-alert-system.md` (not in this PR).

Built strictly bottom-up so it lands first per the premortem's "land R1 (the SSOT DTO) before consumers" ordering. **No runtime surface is exposed yet** — the aggregator machinery is complete and unit-tested but not yet instantiated in the running service (tracked: `mbcy` wiring, `26zl` Layer 3).

## What's included

**R1 — `AlertItem` DTO (`shared`)** — single source of truth imported by backend + frontend (mismatch = compile error). Closed unions via `as const` arrays; `provenance` (`SourceStatus`) and a monotonic `version` travel with every item (R6/R15/R17); `makeAlertDedupKey` is mechanical and fails fast on an unidentifiable ref.

**R2 — run-sourced alerts on the snapshot envelope** — `deriveRunAlerts` maps the health-enriched runs source into `run-needs-operator` (attention) + `run-thrashing` (failing). Named pure predicates (ZFC); **`run-thrashing` only fires at `phaseConfidence==='known'`** — an inferred lane is suppressed, never promoted to the maroon (premortem degrade-to-quiet). Added `DashboardSnapshot.alerts`.

**R3 foundation — per-session `PendingInteraction` consumed** — the supervisor emits "an agent is blocked on a human" only as a per-session SSE `pending` event (confirmed by a contract spike); the hook had no listener so it was silently ignored. Adds a dashboard-owned `PendingInteraction` wire type + boundary parse + pure `→ AlertItem` mapper, and surfaces it on the session stream.

**City-wide pending aggregator (Option A) — machinery, fully tested, not yet wired**
- `PendingStore` — ephemeral in-memory (no persistence, R13); supersede-on-reobserve, drop pending for sessions no longer active, provenance threading.
- `PendingSubscriptionManager` — reconciles per-session subscriptions to the active set, reconnect with capped backoff; transport + scheduler injected.
- `SseFrameParser` + `createSupervisorPendingSubscriber` — the repo had no SSE frame parser; this adds a pure incremental one + the real `fetch`/text-event-stream subscriber (resume via last-event-id, malformed frame ignored not false-cleared, `close()` suppresses error).

## Architecture notes

- **Hybrid delivery (R2):** run/mail alerts ride the `/api/snapshot` envelope (inherit `SourceState` provenance, no second session fetch); `pending-decision` stays a live layer off the TTL envelope.
- **Option A** for city-wide pending (operator-chosen): a backend aggregator observes active sessions' SSE and exposes one dashboard stream — revisits the PRD's "no 2nd browser EventSource" (justified: pending is per-session-SSE-only and `/` isn't session-bound).
- A required `DashboardSnapshot.alerts` field meant updating the snapshot fixtures/test builders — done explicitly, no contract weakening.

## Test plan

- [x] `npm run typecheck` + `typecheck:test` (backend + frontend) — clean
- [x] `npm --workspace shared test` — 45 pass
- [x] `npm --workspace backend test` — 1038 pass (~50 new across alerts/pending-store/subscriptions/subscriber/sse-parser)
- [x] `npm --workspace frontend test` — 513 pass
- [ ] Runtime verification deferred to the wiring PR (`mbcy`) — this PR adds no live surface.

## Follow-ups (tracked in `bd`, `[home-alerts]`)

`mbcy` aggregator wiring → `26zl` Layer 3 endpoint+frontend; `mpfx` R4 operator-mail; `bqey` R5+R17 ranking; `035r` R15/R6/R7 render; `gye8` R11/R13 respond; `jrs0` R9/R10/R12; `a6h6` R8 inhibition; `s09b` R14 gated poll; `22vh` scope-validation gate.
