### PR TITLE
feat(home-alerts): live pending aggregator — wiring + lazy activation + dashboard SSE + consumer

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -19,6 +19,7 @@ import { mailRouter } from '../routes/mail.js';
 import { mailSendRouter } from '../routes/mail-send.js';
 import { createDoltNomsSampler, doltRouter, type DoltNomsSampler } from '../routes/dolt.js';
 import { eventsRouter } from '../routes/events.js';
+import { homePendingRouter } from '../routes/home-pending.js';
 import { snapshotRouter } from '../routes/snapshot.js';
 import { createSnapshotService } from '../snapshot/service.js';
 import { ALL_MODULES } from '../views/registry.js';
@@ -148,6 +149,10 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
 
   const snapshotService = createSnapshotService({ gc, config: dashboardConfig });
   router.use('/snapshot', snapshotRouter(snapshotService));
+  // Home-view pending-decision SSE (gascity-dashboard-26zl). Streams this
+  // runtime's pending aggregator; the consumer count lazily activates the
+  // aggregator's per-session fan-out.
+  router.use('/home/pending', homePendingRouter(snapshotService));
 
   // SSE routes. session-stream + events proxy the supervisor's city-scoped
   // streams; both read this runtime's gc. Mounted on the per-city router so

--- a/backend/src/routes/home-pending.ts
+++ b/backend/src/routes/home-pending.ts
@@ -1,0 +1,62 @@
+import { Router, type Request, type Response } from 'express';
+
+import type { SnapshotService } from '../snapshot/service.js';
+
+// Layer 3 dashboard SSE for the home-view pending-decision feed
+// (gascity-dashboard-26zl, R3/R16, Option A). Unlike events.ts/session-stream
+// this is NOT an upstream proxy — it streams the backend's own pending
+// aggregator (service.streamPending / pendingAlerts). The browser opens ONE
+// EventSource here (the revised-R13 path); registering a consumer is what lazily
+// activates the aggregator's per-session fan-out, so no consumer ⇒ no fan-out.
+
+const DEFAULT_HEARTBEAT_MS = 15_000;
+
+function openSse(res: Response): void {
+  res.status(200);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+/** Core handler, exported for direct unit testing with fake req/res. */
+export function handleHomePendingStream(
+  service: SnapshotService,
+  req: Request,
+  res: Response,
+  opts: { heartbeatMs?: number } = {},
+): void {
+  openSse(res);
+
+  const send = (): void => {
+    if (res.writableEnded) return;
+    const payload = JSON.stringify({ alerts: service.pendingAlerts() });
+    res.write(`event: pending\ndata: ${payload}\n\n`);
+  };
+
+  // Initial frame so a fresh consumer has the current pending set immediately;
+  // then push on every aggregator change (async over poll).
+  send();
+  const unsubscribe = service.streamPending(send);
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded) res.write(':\n\n');
+  }, opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
+  // The heartbeat must not, on its own, keep the process alive — it is purely a
+  // keep-alive for an otherwise-idle connection.
+  heartbeat.unref();
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    if (!res.writableEnded) res.end();
+  });
+}
+
+export function homePendingRouter(service: SnapshotService): Router {
+  const router = Router();
+  router.get('/stream', (req, res) => {
+    handleHomePendingStream(service, req, res);
+  });
+  return router;
+}

--- a/backend/src/snapshot/pending-subscriptions.ts
+++ b/backend/src/snapshot/pending-subscriptions.ts
@@ -55,6 +55,8 @@ export interface PendingSubscriptionManagerOptions {
   store: PendingStore;
   now?: () => Date;
   scheduleReconnect?: ReconnectScheduler;
+  /** Invoked after any change to the store's pending set (push for Layer 3). */
+  onChange?: () => void;
 }
 
 interface SessionSub {
@@ -68,6 +70,7 @@ export class PendingSubscriptionManager {
   private readonly store: PendingStore;
   private readonly now: () => Date;
   private readonly scheduleReconnect: ReconnectScheduler;
+  private readonly onChange: () => void;
   private readonly subs = new Map<string, SessionSub>();
 
   constructor(options: PendingSubscriptionManagerOptions) {
@@ -75,6 +78,7 @@ export class PendingSubscriptionManager {
     this.store = options.store;
     this.now = options.now ?? (() => new Date());
     this.scheduleReconnect = options.scheduleReconnect ?? defaultReconnectScheduler;
+    this.onChange = options.onChange ?? (() => {});
   }
 
   /** Number of sessions currently subscribed (live or awaiting reconnect). */
@@ -96,7 +100,7 @@ export class PendingSubscriptionManager {
     for (const sessionId of active) {
       if (!this.subs.has(sessionId)) this.open(sessionId, 0);
     }
-    this.store.retainActive(active);
+    if (this.store.retainActive(active) > 0) this.onChange();
   }
 
   /** Close every subscription and cancel pending reconnects (e.g. shutdown). */
@@ -121,6 +125,7 @@ export class PendingSubscriptionManager {
     } else {
       this.store.observe(sessionId, pending, this.now().toISOString());
     }
+    this.onChange();
   }
 
   private handleError(sessionId: string, _error: Error): void {

--- a/backend/src/snapshot/service.ts
+++ b/backend/src/snapshot/service.ts
@@ -1,10 +1,12 @@
 import type {
+  AlertItem,
   CityStatusSummary,
   DashboardHeadline,
   DashboardMetric,
   DashboardRuntimeConfig,
   DashboardSnapshot,
   DashboardSources,
+  GcSession,
   GcSessionList,
   ResourceSummary,
   RunSummary,
@@ -18,6 +20,12 @@ import type {
 import type { GcClient } from '../gc-client.js';
 import { deriveRunAlerts } from './alerts.js';
 import { SourceCache } from './cache.js';
+import { createSupervisorPendingSubscriber } from './pending-subscriber.js';
+import { PendingStore } from './pending-store.js';
+import {
+  PendingSubscriptionManager,
+  type SessionStreamSubscriber,
+} from './pending-subscriptions.js';
 import { createCityStatusSourceCache } from './collectors/cityStatus.js';
 import { createResourcesSourceCache } from './collectors/resources.js';
 import { createRunsSourceCache } from './collectors/runs.js';
@@ -73,6 +81,16 @@ export interface SnapshotService {
   getSnapshot: () => Promise<DashboardSnapshot>;
   refresh: (sources?: readonly SourceName[]) => Promise<DashboardSnapshot>;
   health: () => SnapshotHealth;
+  /**
+   * Current city-wide pending-decision alerts (gascity-dashboard-mbcy, R3).
+   * Sourced from the per-session pending aggregator, which is fed as a side
+   * effect of each snapshot read reconciling its active-session set. Empty
+   * when no aggregator is wired (fixtures / no gc) or nothing is pending.
+   * Layer 3 (26zl) streams this to the home view.
+   */
+  pendingAlerts: () => readonly AlertItem[];
+  /** Tear down the pending aggregator's subscriptions (process shutdown). */
+  closePending: () => void;
 }
 
 export interface CreateSnapshotServiceOptions {
@@ -89,9 +107,21 @@ export interface CreateSnapshotServiceOptions {
    * spy-tracked cache; otherwise built from `gc`.
    */
   sessions?: SourceCache<GcSessionList> | undefined;
+  /**
+   * Per-session pending subscriber (gascity-dashboard-mbcy). Injected in tests
+   * with a fake; in production defaults to the supervisor SSE subscriber when
+   * `gc` is present and fixtures are off. When neither is available the pending
+   * aggregator stays inert (pendingAlerts() === []).
+   */
+  pendingSubscriber?: SessionStreamSubscriber | undefined;
   config: DashboardRuntimeConfig;
   now?: (() => Date) | undefined;
   uptimeSeconds?: (() => number) | undefined;
+}
+
+/** Sessions worth observing for pending decisions — the live (active) ones. */
+function activeSessionIds(items: readonly GcSession[]): string[] {
+  return items.filter((session) => session.state === 'active').map((session) => session.id);
 }
 
 const sourceNameSet = new Set<string>(SOURCE_NAMES);
@@ -118,6 +148,26 @@ export function createSnapshotService(
   // contains no `await`; do not introduce one inside it.
   let progressMarks = new Map<string, LaneProgressMark>();
   let marksFetchedAt: string | null = null;
+
+  // Per-session pending aggregator (gascity-dashboard-mbcy, R3, Option A). The
+  // store is always present (cheap, in-memory); the manager only runs when a
+  // subscriber is available — injected in tests, else the real supervisor SSE
+  // subscriber when gc is present and fixtures are off. No subscriber => the
+  // aggregator stays inert and pendingAlerts() returns []. The store holds NO
+  // persisted state (R13) and is reconciled to the active-session set on each
+  // read, so a gone session's pending cannot linger.
+  const pendingStore = new PendingStore();
+  const pendingSubscriber =
+    options.pendingSubscriber ??
+    (options.gc !== undefined && !options.config.useFixtures
+      ? createSupervisorPendingSubscriber({
+          streamUrl: (sessionId, after) => options.gc!.sessionStreamUrl(sessionId, after),
+        })
+      : undefined);
+  const pendingManager =
+    pendingSubscriber !== undefined
+      ? new PendingSubscriptionManager({ subscriber: pendingSubscriber, store: pendingStore, now })
+      : undefined;
 
   let lastSnapshotAt: string | null = null;
   let lastSnapshotDurationMs: number | null = null;
@@ -181,6 +231,13 @@ export function createSnapshotService(
       readSources(caches, refreshSources),
       readSessions(sessionsCache, refreshSources),
     ]);
+    // Reconcile the pending aggregator to the active-session set (R3). This is
+    // synchronous and runs OUTSIDE enrichRuns, preserving that function's
+    // load-bearing no-`await` invariant. A sessions read failure leaves the
+    // current subscriptions untouched (degrade-to-quiet, not blank).
+    if (pendingManager !== undefined && sourceIsAvailable(sessionsState)) {
+      pendingManager.syncActiveSessions(activeSessionIds(sessionsState.data.items));
+    }
     const snapshot = buildSnapshot(
       options.config,
       enrichRuns(sources, sessionsState),
@@ -216,6 +273,11 @@ export function createSnapshotService(
       lastRefreshDurationMs,
       sources: sourceStatuses(caches),
     }),
+    // 'fresh' provenance for now: the aggregator keeps last-known pending and
+    // reconciles every read. A liveness-aware provenance (degraded when the
+    // dashboard stream / subscriptions are dark) is Layer 3's job (26zl, R16).
+    pendingAlerts: () => pendingStore.alerts('fresh'),
+    closePending: () => pendingManager?.closeAll(),
   };
 }
 

--- a/backend/src/snapshot/service.ts
+++ b/backend/src/snapshot/service.ts
@@ -89,7 +89,15 @@ export interface SnapshotService {
    * Layer 3 (26zl) streams this to the home view.
    */
   pendingAlerts: () => readonly AlertItem[];
-  /** Tear down the pending aggregator's subscriptions (process shutdown). */
+  /**
+   * Register a live pending-feed consumer (gascity-dashboard-26zl, Layer 3).
+   * The aggregator activates (starts subscribing to active sessions) while ≥1
+   * consumer is registered and tears down when the last unsubscribes — so no
+   * SSE fan-out runs without a consumer. `listener` fires on every change; read
+   * the current set via pendingAlerts(). Returns an unsubscribe function.
+   */
+  streamPending: (listener: () => void) => () => void;
+  /** Tear down the pending aggregator's subscriptions + consumers (shutdown). */
   closePending: () => void;
 }
 
@@ -157,6 +165,10 @@ export function createSnapshotService(
   // persisted state (R13) and is reconciled to the active-session set on each
   // read, so a gone session's pending cannot linger.
   const pendingStore = new PendingStore();
+  const pendingListeners = new Set<() => void>();
+  const notifyPending = (): void => {
+    for (const listener of pendingListeners) listener();
+  };
   const pendingSubscriber =
     options.pendingSubscriber ??
     (options.gc !== undefined && !options.config.useFixtures
@@ -166,8 +178,35 @@ export function createSnapshotService(
       : undefined);
   const pendingManager =
     pendingSubscriber !== undefined
-      ? new PendingSubscriptionManager({ subscriber: pendingSubscriber, store: pendingStore, now })
+      ? new PendingSubscriptionManager({
+          subscriber: pendingSubscriber,
+          store: pendingStore,
+          now,
+          onChange: notifyPending,
+        })
       : undefined;
+  // Lazy activation: the aggregator only fans out per-session SSE while at least
+  // one consumer is streaming (Layer 3), so a backend with no home viewer opens
+  // no connections. Snapshot reads reconcile the active set only while active.
+  let pendingConsumers = 0;
+  const pendingActive = (): boolean => pendingConsumers > 0;
+  const activatePending = (): void => {
+    if (pendingManager === undefined) return;
+    // Kick an immediate sessions read + sync so a new consumer needn't wait for
+    // the next snapshot poll. Best-effort; a sessions failure degrades to quiet.
+    void sessionsCache
+      .get()
+      .then((state) => {
+        if (pendingActive() && sourceIsAvailable(state)) {
+          pendingManager.syncActiveSessions(activeSessionIds(state.data.items));
+        }
+      })
+      .catch(() => {});
+  };
+  const deactivatePending = (): void => {
+    pendingManager?.closeAll();
+    pendingStore.retainActive([]); // drop stale pending so re-activation starts clean
+  };
 
   let lastSnapshotAt: string | null = null;
   let lastSnapshotDurationMs: number | null = null;
@@ -235,7 +274,7 @@ export function createSnapshotService(
     // synchronous and runs OUTSIDE enrichRuns, preserving that function's
     // load-bearing no-`await` invariant. A sessions read failure leaves the
     // current subscriptions untouched (degrade-to-quiet, not blank).
-    if (pendingManager !== undefined && sourceIsAvailable(sessionsState)) {
+    if (pendingManager !== undefined && pendingActive() && sourceIsAvailable(sessionsState)) {
       pendingManager.syncActiveSessions(activeSessionIds(sessionsState.data.items));
     }
     const snapshot = buildSnapshot(
@@ -277,7 +316,21 @@ export function createSnapshotService(
     // reconciles every read. A liveness-aware provenance (degraded when the
     // dashboard stream / subscriptions are dark) is Layer 3's job (26zl, R16).
     pendingAlerts: () => pendingStore.alerts('fresh'),
-    closePending: () => pendingManager?.closeAll(),
+    streamPending: (listener) => {
+      pendingListeners.add(listener);
+      pendingConsumers += 1;
+      if (pendingConsumers === 1) activatePending();
+      return () => {
+        if (!pendingListeners.delete(listener)) return;
+        pendingConsumers -= 1;
+        if (pendingConsumers === 0) deactivatePending();
+      };
+    },
+    closePending: () => {
+      pendingListeners.clear();
+      pendingConsumers = 0;
+      pendingManager?.closeAll();
+    },
   };
 }
 

--- a/backend/test/home-pending-route.test.ts
+++ b/backend/test/home-pending-route.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, test } from 'node:test';
+
+import type { AlertItem } from 'gas-city-dashboard-shared';
+
+import { handleHomePendingStream } from '../src/routes/home-pending.js';
+import type { SnapshotService } from '../src/snapshot/service.js';
+
+// Layer 3 dashboard SSE handler (gascity-dashboard-26zl). Driven with fake
+// req/res + a fake service so the stream contract is deterministic.
+
+class FakeRes extends EventEmitter {
+  statusCode = 0;
+  headers: Record<string, string> = {};
+  writes: string[] = [];
+  writableEnded = false;
+  status(code: number): this { this.statusCode = code; return this; }
+  setHeader(k: string, v: string): void { this.headers[k] = v; }
+  flushHeaders(): void {}
+  write(chunk: string): boolean { this.writes.push(chunk); return true; }
+  end(): void { this.writableEnded = true; }
+}
+
+function fakeService(): {
+  service: SnapshotService;
+  fire: () => void;
+  setAlerts: (a: AlertItem[]) => void;
+  unsubscribed: () => boolean;
+} {
+  let alerts: AlertItem[] = [];
+  let listener: (() => void) | null = null;
+  let unsub = false;
+  const service = {
+    pendingAlerts: () => alerts,
+    streamPending: (l: () => void) => {
+      listener = l;
+      return () => { unsub = true; listener = null; };
+    },
+  } as unknown as SnapshotService;
+  return {
+    service,
+    fire: () => listener?.(),
+    setAlerts: (a) => { alerts = a; },
+    unsubscribed: () => unsub,
+  };
+}
+
+const alert = (requestId: string): AlertItem => ({
+  kind: 'pending-decision', source: 'pending',
+  ref: { requestId, sessionId: 's1' }, href: '/agents/s1',
+  title: 't', reason: 'tool_approval', severity: 'attention',
+  occurredAt: '2026-06-02T12:00:00.000Z',
+  dedupKey: `pending-decision:${requestId}`, version: 1, provenance: 'fresh',
+});
+
+describe('handleHomePendingStream', () => {
+  test('opens an event-stream and sends an initial pending frame', () => {
+    const { service } = fakeService();
+    const res = new FakeRes();
+    handleHomePendingStream(service, new EventEmitter() as never, res as never, { heartbeatMs: 10_000 });
+    assert.equal(res.headers['Content-Type'], 'text/event-stream');
+    assert.equal(res.writes.length, 1);
+    assert.match(res.writes[0]!, /^event: pending\ndata: /);
+    assert.match(res.writes[0]!, /"alerts":\[\]/);
+  });
+
+  test('pushes an updated frame when the aggregator changes', () => {
+    const f = fakeService();
+    const res = new FakeRes();
+    handleHomePendingStream(f.service, new EventEmitter() as never, res as never, { heartbeatMs: 10_000 });
+    f.setAlerts([alert('req-1')]);
+    f.fire();
+    assert.equal(res.writes.length, 2); // initial + change
+    assert.match(res.writes[1]!, /pending-decision:req-1/);
+  });
+
+  test('on client disconnect it unsubscribes and ends the response', () => {
+    const f = fakeService();
+    const res = new FakeRes();
+    const req = new EventEmitter();
+    handleHomePendingStream(f.service, req as never, res as never, { heartbeatMs: 10_000 });
+    req.emit('close');
+    assert.ok(f.unsubscribed());
+    assert.ok(res.writableEnded);
+  });
+});

--- a/backend/test/snapshot-pending-wiring.test.ts
+++ b/backend/test/snapshot-pending-wiring.test.ts
@@ -89,7 +89,18 @@ function baseOptions(): CreateSnapshotServiceOptions {
 }
 
 describe('snapshot service — pending aggregator wiring', () => {
-  test('a snapshot read subscribes the active sessions and exposes their pending', async () => {
+  test('does NOT subscribe while no consumer is streaming (lazy activation)', async () => {
+    const subscriber = new FakeSubscriber();
+    const service = createSnapshotService({
+      ...baseOptions(),
+      sessions: sessionsCacheOf([session('s1', 'active')]),
+      pendingSubscriber: subscriber,
+    });
+    await service.getSnapshot();
+    assert.deepEqual(subscriber.subscribeCalls, []); // inert until a consumer streams
+  });
+
+  test('a streaming consumer activates subscription of active sessions and sees their pending', async () => {
     const subscriber = new FakeSubscriber();
     const service = createSnapshotService({
       ...baseOptions(),
@@ -97,16 +108,34 @@ describe('snapshot service — pending aggregator wiring', () => {
       pendingSubscriber: subscriber,
     });
 
+    let changes = 0;
+    service.streamPending(() => { changes += 1; });
     await service.getSnapshot();
     assert.deepEqual(subscriber.subscribeCalls.sort(), ['s1', 's2']); // 'asleep' is not observed
-    assert.deepEqual(service.pendingAlerts(), []); // nothing pending yet
+    assert.deepEqual(service.pendingAlerts(), []);
 
     subscriber.pending('s1', { request_id: 'req-1', kind: 'tool_approval' });
+    assert.ok(changes >= 1); // listener fired on change (push, not poll)
     const alerts = service.pendingAlerts();
     assert.equal(alerts.length, 1);
-    assert.equal(alerts[0]!.kind, 'pending-decision');
     assert.equal(alerts[0]!.dedupKey, 'pending-decision:req-1');
     assert.equal(alerts[0]!.ref.sessionId, 's1');
+  });
+
+  test('the last consumer leaving tears down subscriptions and clears pending', async () => {
+    const subscriber = new FakeSubscriber();
+    const service = createSnapshotService({
+      ...baseOptions(),
+      sessions: sessionsCacheOf([session('s1', 'active')]),
+      pendingSubscriber: subscriber,
+    });
+    const stop = service.streamPending(() => {});
+    await service.getSnapshot();
+    subscriber.pending('s1', { request_id: 'req-1', kind: 'tool_approval' });
+    assert.equal(service.pendingAlerts().length, 1);
+
+    stop();
+    assert.deepEqual(service.pendingAlerts(), []); // store cleared on deactivate
   });
 
   test('the snapshot envelope still builds (alerts field present) alongside the aggregator', async () => {
@@ -122,8 +151,11 @@ describe('snapshot service — pending aggregator wiring', () => {
   test('with no subscriber and no gc the aggregator is inert (no pending, snapshot works)', async () => {
     const service = createSnapshotService(baseOptions());
     const snap = await service.getSnapshot();
+    const stop = service.streamPending(() => {});
+    await service.getSnapshot();
     assert.deepEqual(service.pendingAlerts(), []);
     assert.ok(Array.isArray(snap.alerts));
-    service.closePending(); // no-op, must not throw
+    stop();
+    service.closePending(); // must not throw
   });
 });

--- a/backend/test/snapshot-pending-wiring.test.ts
+++ b/backend/test/snapshot-pending-wiring.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import type {
+  CityStatusSummary,
+  GcSession,
+  GcSessionList,
+  PendingInteraction,
+  ResourceSummary,
+  RunSummary,
+  WorkSummary,
+} from 'gas-city-dashboard-shared';
+
+import { SourceCache } from '../src/snapshot/cache.js';
+import {
+  createSnapshotService,
+  type CreateSnapshotServiceOptions,
+  type SourceCacheMap,
+} from '../src/snapshot/service.js';
+import type {
+  SessionPendingHandlers,
+  SessionStreamSubscriber,
+} from '../src/snapshot/pending-subscriptions.js';
+
+// Aggregator wiring (gascity-dashboard-mbcy, R3): the snapshot read path drives
+// the pending aggregator off its active-session set, and the service exposes
+// the resulting pending-decision alerts. The aggregator internals are covered
+// by pending-store / pending-subscriptions / pending-subscriber tests; this
+// pins only the service-level wiring.
+
+const CITY: CityStatusSummary = {
+  activeAgents: 1, totalAgents: 1, activeSessions: 1, suspendedSessions: 0,
+  maxSessions: { status: 'available', value: 10 }, sessionsByProvider: [], rigs: [],
+};
+const RESOURCES: ResourceSummary = {
+  vcpuCount: 1, loadAverage: [0, 0, 0], loadPerVcpu: 0,
+  memory: { totalBytes: 1, usedBytes: 0, availableBytes: 1, utilization: 0 },
+  uptimeSeconds: 1, samples: [],
+};
+const RUNS: RunSummary = {
+  totalActive: 0, totalHistorical: 0,
+  runCounts: { total: 0, visible: 0, prReview: 0, designReview: 0, bugfix: 0, blocked: 0, other: 0 },
+  lanes: [], historicalLanes: [], recentChanges: [],
+  census: { status: 'unavailable', error: 'derived in read path' },
+};
+const WORK: WorkSummary = { open: 0, ready: 0, inProgress: 0 };
+
+function caches(): SourceCacheMap {
+  return {
+    city: new SourceCache({ source: 'city', ttlMs: 45_000, load: async () => CITY }),
+    resources: new SourceCache({ source: 'resources', ttlMs: 30_000, load: async () => RESOURCES }),
+    runs: new SourceCache({ source: 'runs', ttlMs: 60_000, load: async () => RUNS }),
+    work: new SourceCache({ source: 'work', ttlMs: 45_000, load: async () => WORK }),
+  };
+}
+
+function session(id: string, state: GcSession['state']): GcSession {
+  return {
+    id, template: 't', session_name: id, title: id, state,
+    created_at: '2026-06-02T12:00:00.000Z', attached: false, running: state === 'active',
+    provider: 'codex',
+  } as GcSession;
+}
+
+function sessionsCacheOf(items: GcSession[]): SourceCache<GcSessionList> {
+  return new SourceCache<GcSessionList>({
+    source: 'city', ttlMs: 45_000, load: async () => ({ items, total: items.length }),
+  });
+}
+
+class FakeSubscriber implements SessionStreamSubscriber {
+  readonly handlers = new Map<string, SessionPendingHandlers>();
+  readonly subscribeCalls: string[] = [];
+  subscribe(sessionId: string, handlers: SessionPendingHandlers) {
+    this.subscribeCalls.push(sessionId);
+    this.handlers.set(sessionId, handlers);
+    return { close: () => {} };
+  }
+  pending(sessionId: string, p: PendingInteraction): void {
+    this.handlers.get(sessionId)!.onPending(p);
+  }
+}
+
+function baseOptions(): CreateSnapshotServiceOptions {
+  return {
+    caches: caches(),
+    config: { cityName: 'c', cityRoot: '/tmp/c', useFixtures: false, enabledModules: null, defaultView: null },
+  };
+}
+
+describe('snapshot service — pending aggregator wiring', () => {
+  test('a snapshot read subscribes the active sessions and exposes their pending', async () => {
+    const subscriber = new FakeSubscriber();
+    const service = createSnapshotService({
+      ...baseOptions(),
+      sessions: sessionsCacheOf([session('s1', 'active'), session('s2', 'active'), session('s3', 'asleep')]),
+      pendingSubscriber: subscriber,
+    });
+
+    await service.getSnapshot();
+    assert.deepEqual(subscriber.subscribeCalls.sort(), ['s1', 's2']); // 'asleep' is not observed
+    assert.deepEqual(service.pendingAlerts(), []); // nothing pending yet
+
+    subscriber.pending('s1', { request_id: 'req-1', kind: 'tool_approval' });
+    const alerts = service.pendingAlerts();
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0]!.kind, 'pending-decision');
+    assert.equal(alerts[0]!.dedupKey, 'pending-decision:req-1');
+    assert.equal(alerts[0]!.ref.sessionId, 's1');
+  });
+
+  test('the snapshot envelope still builds (alerts field present) alongside the aggregator', async () => {
+    const service = createSnapshotService({
+      ...baseOptions(),
+      sessions: sessionsCacheOf([session('s1', 'active')]),
+      pendingSubscriber: new FakeSubscriber(),
+    });
+    const snap = await service.getSnapshot();
+    assert.ok(Array.isArray(snap.alerts)); // run-sourced alerts on the envelope (R2)
+  });
+
+  test('with no subscriber and no gc the aggregator is inert (no pending, snapshot works)', async () => {
+    const service = createSnapshotService(baseOptions());
+    const snap = await service.getSnapshot();
+    assert.deepEqual(service.pendingAlerts(), []);
+    assert.ok(Array.isArray(snap.alerts));
+    service.closePending(); // no-op, must not throw
+  });
+});

--- a/frontend/src/hooks/useHomePending.test.tsx
+++ b/frontend/src/hooks/useHomePending.test.tsx
@@ -1,0 +1,115 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { AlertItem } from 'gas-city-dashboard-shared';
+import { setActiveCity } from '../api/cityBase';
+import { reportClientError } from '../lib/clientErrorReporting';
+import { useHomePending } from './useHomePending';
+
+vi.mock('../lib/clientErrorReporting', () => ({
+  reportClientError: vi.fn(() => Promise.resolve({ status: 'reported' })),
+}));
+
+const eventSources: FakeEventSource[] = [];
+const mockReport = reportClientError as Mock;
+
+const alert = (requestId: string): AlertItem => ({
+  kind: 'pending-decision', source: 'pending',
+  ref: { requestId, sessionId: 's1' }, href: '/agents/s1',
+  title: 't', reason: 'tool_approval', severity: 'attention',
+  occurredAt: '2026-06-02T12:00:00.000Z',
+  dedupKey: `pending-decision:${requestId}`, version: 1, provenance: 'fresh',
+});
+
+describe('useHomePending', () => {
+  beforeEach(() => {
+    eventSources.length = 0;
+    setActiveCity('test-city');
+    vi.stubGlobal('EventSource', FakeEventSource);
+    mockReport.mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('opens a stream and reports open on connect', () => {
+    const { result } = renderHook(() => useHomePending());
+    expect(result.current.conn).toBe('connecting');
+    act(() => eventSources[0]?.open());
+    expect(result.current.conn).toBe('open');
+    expect(eventSources[0]?.url).toContain('/home/pending/stream');
+  });
+
+  it('surfaces pending-decision alerts from a frame', () => {
+    const { result } = renderHook(() => useHomePending());
+    act(() => eventSources[0]?.open());
+    act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [alert('req-1')] })));
+    expect(result.current.alerts.map((a) => a.dedupKey)).toEqual(['pending-decision:req-1']);
+    expect(result.current.conn).toBe('open');
+  });
+
+  it('keeps last-known alerts but marks degraded on a transient error', () => {
+    const { result } = renderHook(() => useHomePending());
+    act(() => eventSources[0]?.open());
+    act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [alert('req-1')] })));
+    act(() => eventSources[0]?.error()); // readyState stays OPEN (reconnecting)
+    expect(result.current.conn).toBe('degraded');
+    expect(result.current.alerts.length).toBe(1); // not cleared — a drop is not a resolve
+  });
+
+  it('reports closed when the stream is permanently closed', () => {
+    const { result } = renderHook(() => useHomePending());
+    act(() => eventSources[0]?.open());
+    act(() => {
+      eventSources[0]!.readyState = FakeEventSource.CLOSED;
+      eventSources[0]!.error();
+    });
+    expect(result.current.conn).toBe('closed');
+  });
+
+  it('degrades (not crashes) on a malformed frame and reports once', () => {
+    const { result } = renderHook(() => useHomePending());
+    act(() => eventSources[0]?.open());
+    act(() => eventSources[0]?.emitNamed('pending', 'not json'));
+    expect(result.current.conn).toBe('degraded');
+    expect(mockReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open a stream when disabled', () => {
+    const { result } = renderHook(() => useHomePending(false));
+    expect(eventSources.length).toBe(0);
+    expect(result.current.conn).toBe('closed');
+  });
+});
+
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readyState = FakeEventSource.CONNECTING;
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  constructor(readonly url: string | URL) {
+    eventSources.push(this);
+  }
+  addEventListener(type: string, listener: EventListener): void {
+    const set = this.listeners.get(type) ?? new Set<EventListener>();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+  close(): void { this.readyState = FakeEventSource.CLOSED; }
+  open(): void { this.readyState = FakeEventSource.OPEN; this.onopen?.(new Event('open')); }
+  error(): void { this.onerror?.(new Event('error')); }
+  emitNamed(type: string, data: string): void {
+    const event = new MessageEvent<string>(type, { data });
+    this.listeners.get(type)?.forEach((listener) => listener(event));
+    if (type === 'message') this.onmessage?.(event);
+  }
+}

--- a/frontend/src/hooks/useHomePending.ts
+++ b/frontend/src/hooks/useHomePending.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+import type { AlertItem } from 'gas-city-dashboard-shared';
+import { cityPath } from '../api/cityBase';
+import { reportClientError } from '../lib/clientErrorReporting';
+
+// Home-view pending-decision consumer (gascity-dashboard-26zl, R3/R16, Option A).
+// Opens ONE same-origin EventSource against the backend's /home/pending/stream
+// (the revised-R13 path — a single dashboard stream, not N per-session browser
+// connections). The frame payload is { alerts: AlertItem[] } of kind
+// 'pending-decision'; we keep the last-known set and surface a connection state
+// so a dark stream renders signal-unavailable, never a false all-clear (R6/R16).
+
+export type HomePendingConnState = 'connecting' | 'open' | 'degraded' | 'closed';
+
+export interface HomePendingState {
+  /** Last-known pending-decision alerts (retained across a transient drop). */
+  readonly alerts: readonly AlertItem[];
+  /** Stream liveness. Anything other than 'open' ⇒ the pending scope is not certified. */
+  readonly conn: HomePendingConnState;
+}
+
+const MALFORMED_FRAME = 'Malformed home-pending stream frame.';
+
+function parsePendingFrame(data: string): readonly AlertItem[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const alerts = (parsed as { alerts?: unknown }).alerts;
+  if (!Array.isArray(alerts)) return null;
+  return alerts as readonly AlertItem[];
+}
+
+export function useHomePending(enabled = true): HomePendingState {
+  const [alerts, setAlerts] = useState<readonly AlertItem[]>([]);
+  const [conn, setConn] = useState<HomePendingConnState>(enabled ? 'connecting' : 'closed');
+  const malformedReportedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || typeof EventSource === 'undefined') {
+      setConn('closed');
+      return;
+    }
+    let cancelled = false;
+    setConn('connecting');
+    const source = new EventSource(cityPath('/home/pending/stream'), { withCredentials: true });
+
+    source.onopen = () => {
+      if (!cancelled) setConn('open');
+    };
+    source.addEventListener('pending', (event) => {
+      if (cancelled) return;
+      const next = parsePendingFrame((event as MessageEvent<string>).data);
+      if (next === null) {
+        if (!malformedReportedRef.current) {
+          malformedReportedRef.current = true;
+          void reportClientError({
+            component: 'home-pending',
+            operation: 'parse stream frame',
+            message: MALFORMED_FRAME,
+          });
+        }
+        setConn('degraded');
+        return;
+      }
+      setAlerts(next);
+      setConn('open');
+    });
+    source.onerror = () => {
+      if (cancelled) return;
+      // EventSource auto-reconnects unless CLOSED; reflect liveness so the
+      // render can mark the pending scope unavailable (R16). Keep last-known
+      // alerts — a disconnect is not a resolve.
+      setConn(source.readyState === EventSource.CLOSED ? 'closed' : 'degraded');
+    };
+
+    return () => {
+      cancelled = true;
+      source.close();
+    };
+  }, [enabled]);
+
+  return { alerts, conn };
+}


### PR DESCRIPTION
## Summary

Makes the home-view pending-decision aggregator **live and consumer-driven** — the runtime layer on top of the machinery merged in #41. Stacks two beads:

- **`mbcy`** — wire the aggregator into the snapshot service
- **`26zl`** — Layer 3: lazy activation + dashboard SSE endpoint + frontend consumer

After #41 the aggregator existed but was inert. This PR instantiates it, activates it **only while a home viewer is connected**, and exposes it over one same-origin SSE.

## What's included

**Wiring (`mbcy`)** — `createSnapshotService` instantiates `PendingStore` + `PendingSubscriptionManager` + a `SessionStreamSubscriber` (injected in tests; the real supervisor-SSE subscriber only when `gc` is present and fixtures are off). Each snapshot read reconciles the aggregator to the active-session set **synchronously, outside `enrichRuns`** (preserving its load-bearing no-`await` invariant). A sessions read failure leaves subscriptions untouched (degrade-to-quiet).

**Lazy activation (`26zl`)** — `service.streamPending(listener)` ref-counts consumers: the per-session SSE fan-out starts on the first consumer and tears down (clearing the store) on the last. A backend with no home viewer opens **zero** connections. The manager gained an `onChange` hook so changes **push** (async over poll).

**Dashboard SSE endpoint** — `routes/home-pending.ts` streams `pending-decision` `AlertItem`s: a LOCAL stream (not an upstream proxy), initial frame + push-on-change + an `unref()`'d heartbeat, unsubscribing and ending on client disconnect. Mounted at `/home/pending` in `city/runtime.ts`.

**Frontend consumer** — `useHomePending`: one same-origin `EventSource` (the revised-R13 single-stream path), parses `{ alerts }`, exposes a `conn` state for R16 signal-unavailable, and keeps last-known alerts on a transient drop (a disconnect is not a resolve).

## Out of scope (intentionally)

Merging pending into the ranked home queue (R5+R17, `bqey`) and the actual home render (R15/R6/R7, `035r`). This PR delivers the **live source + consumer hook**, not the home-view rendering — so nothing visually changes yet.

## Design note

Revisits the PRD's "no 2nd browser EventSource" (R13): the home consumes **one** dashboard stream, justified because `PendingInteraction` is per-session-SSE-only and `/` isn't session-bound (contract spike `wf4c`). Lazy activation keeps the server-side fan-out cost zero when unwatched.

## Test plan

- [x] `npm run typecheck` + `typecheck:test` — clean
- [x] backend — 1057 pass (5 wiring incl. lazy-on/off + teardown-clears, 3 route, + aggregator units)
- [x] frontend — 521 pass (6 `useHomePending`: open/parse/degrade-keeps-last-known/closed/malformed/disabled)
- [x] shared — 45 pass
- [ ] Runtime smoke (live supervisor) — deferred; covered by unit/integration fakes here.

## Follow-ups (`bd`, `[home-alerts]`)

`bqey` R5+R17 ranking/merge · `035r` R15/R6/R7 render · `mpfx` R4 operator-mail · `gye8` R11/R13 respond · `jrs0` R9/R10/R12 · `a6h6` R8 inhibition · `s09b` R14 gated poll · `22vh` scope gate.
