### PR TITLE
fix(home-alerts): close the R16 pending missed-alarm hole — liveness provenance end-to-end

### DIFF
--- a/backend/src/snapshot/pending-subscriptions.ts
+++ b/backend/src/snapshot/pending-subscriptions.ts
@@ -87,6 +87,20 @@ export class PendingSubscriptionManager {
   }
 
   /**
+   * True while at least one subscribed session's stream is dark — closed and
+   * awaiting reconnect (gascity-dashboard-26zl, R16). The aggregator's view is
+   * not live for that session, so the dashboard layer degrades provenance to
+   * stale rather than emit a false all-clear. Recovery is observed when the
+   * reconnected stream delivers its next frame (handlePending resets attempt).
+   */
+  get hasDarkSubscription(): boolean {
+    for (const sub of this.subs.values()) {
+      if (sub.cancelReconnect !== undefined) return true;
+    }
+    return false;
+  }
+
+  /**
    * Reconcile subscriptions to `activeSessionIds`: open new ones, tear down
    * sessions no longer active, and drop their pending from the store.
    */
@@ -139,6 +153,10 @@ export class PendingSubscriptionManager {
       if (this.subs.get(sessionId) === sub) this.open(sessionId, attempt + 1);
     }, attempt);
     sub.cancelReconnect = cancel;
+    // Push the dark transition so the dashboard stream restamps the last-known
+    // pending as stale instead of going heartbeat-silent (R16 fail-safe). The
+    // store content is unchanged — only the read-time provenance degrades.
+    this.onChange();
   }
 
   private teardown(sessionId: string): void {

--- a/backend/src/snapshot/service.ts
+++ b/backend/src/snapshot/service.ts
@@ -312,10 +312,16 @@ export function createSnapshotService(
       lastRefreshDurationMs,
       sources: sourceStatuses(caches),
     }),
-    // 'fresh' provenance for now: the aggregator keeps last-known pending and
-    // reconciles every read. A liveness-aware provenance (degraded when the
-    // dashboard stream / subscriptions are dark) is Layer 3's job (26zl, R16).
-    pendingAlerts: () => pendingStore.alerts('fresh'),
+    // Liveness-aware provenance (gascity-dashboard-26zl, R16): the aggregator
+    // keeps last-known pending across a per-session reconnect, so a dark
+    // subscription would otherwise emit a 'fresh' all-clear over stale data —
+    // the premortem's #1 missed-alarm risk. Stamp 'stale' whenever any active
+    // subscription is in reconnect backoff so the home renders signal-
+    // unavailable; the dark transition is pushed (handleError fires onChange).
+    pendingAlerts: () =>
+      pendingStore.alerts(
+        pendingManager?.hasDarkSubscription === true ? 'stale' : 'fresh',
+      ),
     streamPending: (listener) => {
       pendingListeners.add(listener);
       pendingConsumers += 1;

--- a/backend/test/snapshot-pending-wiring.test.ts
+++ b/backend/test/snapshot-pending-wiring.test.ts
@@ -79,6 +79,9 @@ class FakeSubscriber implements SessionStreamSubscriber {
   pending(sessionId: string, p: PendingInteraction): void {
     this.handlers.get(sessionId)!.onPending(p);
   }
+  error(sessionId: string, e: Error): void {
+    this.handlers.get(sessionId)!.onError(e);
+  }
 }
 
 function baseOptions(): CreateSnapshotServiceOptions {
@@ -136,6 +139,36 @@ describe('snapshot service — pending aggregator wiring', () => {
 
     stop();
     assert.deepEqual(service.pendingAlerts(), []); // store cleared on deactivate
+  });
+
+  test('a dark session stream degrades provenance to stale and pushes a frame (R16 fail-safe)', async () => {
+    // Premortem risk #1: a per-session subscription dropping into reconnect
+    // backoff must NOT silently keep emitting a 'fresh' all-clear. The dark
+    // transition has to (a) push a frame so the dashboard stream is not
+    // heartbeat-silent, and (b) restamp the last-known pending as stale so the
+    // home renders signal-unavailable, never a false all-clear.
+    const subscriber = new FakeSubscriber();
+    const service = createSnapshotService({
+      ...baseOptions(),
+      sessions: sessionsCacheOf([session('s1', 'active')]),
+      pendingSubscriber: subscriber,
+    });
+    let changes = 0;
+    const stop = service.streamPending(() => { changes += 1; });
+    await service.getSnapshot();
+    subscriber.pending('s1', { request_id: 'req-1', kind: 'tool_approval' });
+    assert.equal(service.pendingAlerts()[0]!.provenance, 'fresh'); // live
+
+    const before = changes;
+    subscriber.error('s1', new Error('stream dropped'));
+    assert.ok(changes > before); // pushed on the dark transition, not heartbeat-silent
+
+    const alerts = service.pendingAlerts();
+    assert.equal(alerts.length, 1); // a disconnect is not a resolve — kept
+    assert.equal(alerts[0]!.provenance, 'stale'); // never a false all-clear while dark
+
+    stop(); // cancels the pending reconnect timer
+    service.closePending();
   });
 
   test('the snapshot envelope still builds (alerts field present) alongside the aggregator', async () => {

--- a/frontend/src/hooks/useHomePending.test.tsx
+++ b/frontend/src/hooks/useHomePending.test.tsx
@@ -80,6 +80,60 @@ describe('useHomePending', () => {
     expect(eventSources.length).toBe(0);
     expect(result.current.conn).toBe('closed');
   });
+
+  // gascity-dashboard-gztl (R6/R15/R16): the pending-scope provenance is the
+  // fail-safe the home renders signal-unavailable off. It must gate on the
+  // in-band item provenance, NOT just connection liveness — an open stream over
+  // a dark aggregator is the premortem's #1 missed-alarm risk.
+  describe('provenance (R15 fail-safe)', () => {
+    const staleAlert = (requestId: string): AlertItem => ({ ...alert(requestId), provenance: 'stale' });
+
+    it('is unavailable before any frame, even once the connection is open', () => {
+      const { result } = renderHook(() => useHomePending());
+      expect(result.current.provenance).toBe('unavailable');
+      act(() => eventSources[0]?.open());
+      expect(result.current.provenance).toBe('unavailable'); // open is not yet certified
+    });
+
+    it('certifies fresh once a frame of all-fresh items arrives', () => {
+      const { result } = renderHook(() => useHomePending());
+      act(() => eventSources[0]?.open());
+      act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [alert('req-1')] })));
+      expect(result.current.provenance).toBe('fresh');
+    });
+
+    it('treats an empty fresh frame as a certified quiet state (fresh, not unknown)', () => {
+      const { result } = renderHook(() => useHomePending());
+      act(() => eventSources[0]?.open());
+      act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [] })));
+      expect(result.current.alerts).toEqual([]);
+      expect(result.current.provenance).toBe('fresh');
+    });
+
+    it('stays unavailable on an OPEN stream whose frame carries a stale item (dark aggregator)', () => {
+      const { result } = renderHook(() => useHomePending());
+      act(() => eventSources[0]?.open());
+      act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [alert('req-1')] })));
+      expect(result.current.provenance).toBe('fresh');
+
+      // The backend restamps the last-known pending 'stale' when its per-session
+      // subscription goes dark. Connection is still open — provenance must NOT
+      // read fresh, or the home shows a false all-clear over stale data.
+      act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [staleAlert('req-1')] })));
+      expect(result.current.conn).toBe('open');
+      expect(result.current.provenance).toBe('unavailable');
+      expect(result.current.alerts.length).toBe(1); // row kept, marked unavailable — a dark source is not a resolve
+    });
+
+    it('drops back to unavailable when the stream errors', () => {
+      const { result } = renderHook(() => useHomePending());
+      act(() => eventSources[0]?.open());
+      act(() => eventSources[0]?.emitNamed('pending', JSON.stringify({ alerts: [alert('req-1')] })));
+      expect(result.current.provenance).toBe('fresh');
+      act(() => eventSources[0]?.error());
+      expect(result.current.provenance).toBe('unavailable');
+    });
+  });
 });
 
 class FakeEventSource {

--- a/frontend/src/hooks/useHomePending.ts
+++ b/frontend/src/hooks/useHomePending.ts
@@ -12,11 +12,25 @@ import { reportClientError } from '../lib/clientErrorReporting';
 
 export type HomePendingConnState = 'connecting' | 'open' | 'degraded' | 'closed';
 
+/** Fail-safe freshness of the pending scope, collapsed for the render layer. */
+export type HomePendingProvenance = 'fresh' | 'unavailable';
+
 export interface HomePendingState {
   /** Last-known pending-decision alerts (retained across a transient drop). */
   readonly alerts: readonly AlertItem[];
   /** Stream liveness. Anything other than 'open' ⇒ the pending scope is not certified. */
   readonly conn: HomePendingConnState;
+  /**
+   * Fail-safe freshness of the pending SCOPE (gascity-dashboard-gztl, R6/R15/R16).
+   * 'fresh' is asserted ONLY when the stream is open AND the latest frame's items
+   * are every one fresh. Anything else — connecting, degraded, closed, no frame
+   * received yet, or a frame carrying a stale/error/fixture item (which the
+   * backend stamps when a per-session subscription is dark) — is 'unavailable',
+   * so the home renders signal-unavailable, never a false all-clear. This gates
+   * on the in-band item provenance, which `conn` alone does NOT capture: an open
+   * connection over a dark aggregator is the premortem's #1 missed-alarm risk.
+   */
+  readonly provenance: HomePendingProvenance;
 }
 
 const MALFORMED_FRAME = 'Malformed home-pending stream frame.';
@@ -37,18 +51,26 @@ function parsePendingFrame(data: string): readonly AlertItem[] | null {
 export function useHomePending(enabled = true): HomePendingState {
   const [alerts, setAlerts] = useState<readonly AlertItem[]>([]);
   const [conn, setConn] = useState<HomePendingConnState>(enabled ? 'connecting' : 'closed');
+  // Whether the LATEST frame certified every item fresh. Frame-gated, so an
+  // open connection that has not yet delivered a frame is not asserted fresh,
+  // and a frame carrying a dark-source (stale) item flips it false even while
+  // the connection stays open.
+  const [framedFresh, setFramedFresh] = useState(false);
   const malformedReportedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled || typeof EventSource === 'undefined') {
       setConn('closed');
+      setFramedFresh(false);
       return;
     }
     let cancelled = false;
     setConn('connecting');
+    setFramedFresh(false);
     const source = new EventSource(cityPath('/home/pending/stream'), { withCredentials: true });
 
     source.onopen = () => {
+      // Open is necessary but NOT sufficient to certify fresh — wait for a frame.
       if (!cancelled) setConn('open');
     };
     source.addEventListener('pending', (event) => {
@@ -64,10 +86,15 @@ export function useHomePending(enabled = true): HomePendingState {
           });
         }
         setConn('degraded');
+        setFramedFresh(false);
         return;
       }
       setAlerts(next);
       setConn('open');
+      // R15 fail-safe: certify the scope fresh only when EVERY item is fresh.
+      // The backend stamps 'stale' on a dark per-session subscription, so an
+      // open stream over a dark aggregator does not read as a false all-clear.
+      setFramedFresh(next.every((alert) => alert.provenance === 'fresh'));
     });
     source.onerror = () => {
       if (cancelled) return;
@@ -75,6 +102,7 @@ export function useHomePending(enabled = true): HomePendingState {
       // render can mark the pending scope unavailable (R16). Keep last-known
       // alerts — a disconnect is not a resolve.
       setConn(source.readyState === EventSource.CLOSED ? 'closed' : 'degraded');
+      setFramedFresh(false);
     };
 
     return () => {
@@ -83,5 +111,7 @@ export function useHomePending(enabled = true): HomePendingState {
     };
   }, [enabled]);
 
-  return { alerts, conn };
+  const provenance: HomePendingProvenance =
+    conn === 'open' && framedFresh ? 'fresh' : 'unavailable';
+  return { alerts, conn, provenance };
 }


### PR DESCRIPTION
## What & why

Follow-up to **#42** (live pending aggregator: wiring + lazy activation + dashboard SSE + consumer). #42 shipped the Layer 3 pipeline but left the **R16 fail-safe incomplete**, which re-opens the premortem's **#1 catastrophic risk (R15): a missed alarm**.

The aggregator deliberately keeps the last-known pending across a per-session SSE reconnect (a disconnect is not a resolve). But on `main` today:

- **Backend** (`service.ts`) stamps every frame `provenance: 'fresh'` — `pendingAlerts: () => pendingStore.alerts('fresh')`. A per-session subscription dropping into reconnect-backoff keeps its stale pending labelled fresh.
- **Frontend** (`useHomePending`) gates only on connection state (`conn === 'open'`) and never inspects the in-band `AlertItem.provenance`.

Net: an **open** dashboard stream over a **dark** per-session source renders a **false all-clear**. If the pending resolved during the dark window, the operator sees "all calm" over stale data.

## The fix (end-to-end)

**Backend — liveness-aware provenance**
- `PendingSubscriptionManager.hasDarkSubscription`: true while any subscribed session is in reconnect backoff (its stream is dark).
- `handleError` now fires `onChange()` on the dark transition, so the dashboard SSE **pushes a degraded frame** instead of going heartbeat-silent.
- `service.pendingAlerts()` stamps `'stale'` when any subscription is dark; recovery to `'fresh'` is observed on the next live frame.

**Frontend — in-band provenance gate**
- `useHomePending` now exposes a fail-safe `provenance: 'fresh' | 'unavailable'`, derived from **both** the connection state **and** the latest frame's in-band item provenance. `'fresh'` is asserted only when the stream is open **and** every item is fresh; no-frame-yet, a dropped stream, or any `stale`/`error`/`fixture` item ⇒ `'unavailable'`. `conn` is retained as the transport-detail signal.

## Tests
- Backend wiring test drives a session into reconnect backoff and asserts a **pushed `'stale'`-provenance frame** (not heartbeat silence).
- Frontend tests: an **open** stream delivering a `'stale'`-stamped frame renders `unavailable` (the missed-alarm case `conn`-only gating misses), plus frame-gated (`unavailable` before first frame) and empty-certified-quiet (`fresh`) cases.

## Verification (local)
- `npm run typecheck` (source + `typecheck:test`) — clean
- backend `test/` — 727/727
- frontend `useHomePending` — 11/11
- `npm run lint` — clean

Refs: gascity-dashboard-gztl, gascity-dashboard-26zl

🤖 Generated with [Claude Code](https://claude.com/claude-code)