### PR TITLE
feat(tui): mayor-companion dashboard — pin-beside launcher + scrollable peekable overview

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -24,7 +24,15 @@ Each is a full-screen toggle over the same navigable area; the selection
 persists across the live refresh. `enter` drills the selected row into a single
 reused tmux split (see Peek).
 
-- **Agents** (default): grouped by rig (orchestration layer first; within a rig,
+- **Overview** (`o`): the calm mayor-companion summary, four attention-first bands
+  top to bottom: **WAITING ON YOU** (needs-operator runs first, then mayor
+  escalations, the single red region), **ACTIVE** (live agents, orchestration
+  first, capped), **BEADS** (open + in-progress counts with the wip list), **RUNS**
+  (active + needs-operator counts). Each band truncates with a `+ N more`, never a
+  dump. This is the default view when the panel is launched beside another session
+  (`--split` / `--target`, which pass `--compact`); the full views below stay one
+  keypress away. Greyscale, one red region (DESIGN.md Reading Room / One Mark).
+- **Agents** (default standalone): grouped by rig (orchestration layer first; within a rig,
   active before idle), one line each as `glyph · agent · kind · ctx% · activity ·
   model · last-active`. A leading glyph + short word carries the agent kind so it
   reads in greyscale (no color-as-signal, per `DESIGN.md`): `△ orch` (mayor,

--- a/tui/README.md
+++ b/tui/README.md
@@ -137,6 +137,12 @@ in place:
 # or: npm --workspace tui run start:tmux -- --split <city>
 ```
 
+**Mouse vs drag-resize.** The full dashboard grabs the mouse for wheel scrolling.
+Pinned companion panels (`--split` / `--target`) default to `--no-mouse` so tmux
+keeps the mouse and you can **drag the pane border to resize** the panel (scroll
+the lists with the keyboard: `↑↓` / `PgUp` / `PgDn` / `g` / `G`). Force either way
+with `--mouse` / `--no-mouse`.
+
 `--split` needs an existing tmux window to split into; run outside tmux it falls
 back to the dedicated `gc-tui` session (with a note). Without `--split` the
 default is unchanged: take over the current pane when already in tmux, else a

--- a/tui/README.md
+++ b/tui/README.md
@@ -25,8 +25,9 @@ persists across the live refresh. `enter` drills the selected row into a single
 reused tmux split (see Peek).
 
 - **Overview** (`o`): the calm mayor-companion view — one scrollable, peekable list
-  with attention-first sections, **WAITING ON YOU** (needs-operator runs then mayor
-  escalations, the single red heading) → **ACTIVE** (live agents, orchestration
+  with attention-first sections, **LEDGER** (what's waiting on you: needs-operator
+  runs then mayor-escalated mail, worker chatter folded away with the folded count
+  shown, the single red heading) → **ACTIVE** (live agents, orchestration
   first) → **BEADS** (in-progress) → **RUNS** (summary). `↑`/`↓`/wheel scroll the
   whole list; `enter` peeks the selected row whatever it is — a run (`bd show` +
   diff), a **mail** (`gc mail peek`, read-only, doesn't mark read), an agent (live

--- a/tui/README.md
+++ b/tui/README.md
@@ -26,12 +26,17 @@ reused tmux split (see Peek).
 
 - **Overview** (`o`): the calm mayor-companion summary, four attention-first bands
   top to bottom: **WAITING ON YOU** (needs-operator runs first, then mayor
-  escalations, the single red region), **ACTIVE** (live agents, orchestration
-  first, capped), **BEADS** (open + in-progress counts with the wip list), **RUNS**
-  (active + needs-operator counts). Each band truncates with a `+ N more`, never a
-  dump. This is the default view when the panel is launched beside another session
-  (`--split` / `--target`, which pass `--compact`); the full views below stay one
-  keypress away. Greyscale, one red region (DESIGN.md Reading Room / One Mark).
+  escalations, the single red region), **ACTIVE**, **BEADS** (open + in-progress
+  counts with the wip list), **RUNS** (active + needs-operator counts). WAITING /
+  BEADS / RUNS truncate with a `+ N more`, never a dump. The **ACTIVE** band is the
+  navigable region: `↑`/`↓`/wheel scroll through *all* live agents (orchestration
+  first), `enter` peeks the selected agent's live log, `p` opens its detail. Each
+  ACTIVE row shows `on <run>` when the agent is assigned to a run lane
+  (`activeAssignees`), else its activity hint; city-level agents read as the city
+  name, not `orchestration`. This is the default view when the panel is launched
+  beside another session (`--split` / `--target`, which pass `--compact`); the full
+  views below stay one keypress away. Greyscale, one red region (DESIGN.md Reading
+  Room / One Mark).
 - **Agents** (default standalone): grouped by rig (orchestration layer first; within a rig,
   active before idle), one line each as `glyph · agent · kind · ctx% · activity ·
   model · last-active`. A leading glyph + short word carries the agent kind so it

--- a/tui/README.md
+++ b/tui/README.md
@@ -89,9 +89,11 @@ reused tmux split (see Peek).
 
 ## Peek (tmux split)
 
-`enter` on a row opens **one reused** tmux split beside the dashboard and points
+`enter` on a row opens **one reused** tmux split **below** the dashboard and points
 it at the selected row's drill-in (agent → live `session logs -f`; bead →
-`bd show`; run → `bd show` + diff). `enter` retargets that pane to a new
+`bd show`; run → `bd show` + diff; mail → `gc mail peek`). Splitting below (not to
+the right) keeps the dashboard's full width, which matters when it's pinned narrow
+beside the mayor. `enter` retargets that pane to a new
 selection (no pile-up); `enter` on the row it's already showing, or `x`, closes
 it. Quitting (`q`) tears the peek pane down. All drill-ins READ (logs/show/diff)
 — none attaches as a tmux client, so peeking can't resize or disturb an agent.

--- a/tui/README.md
+++ b/tui/README.md
@@ -24,19 +24,19 @@ Each is a full-screen toggle over the same navigable area; the selection
 persists across the live refresh. `enter` drills the selected row into a single
 reused tmux split (see Peek).
 
-- **Overview** (`o`): the calm mayor-companion summary, four attention-first bands
-  top to bottom: **WAITING ON YOU** (needs-operator runs first, then mayor
-  escalations, the single red region), **ACTIVE**, **BEADS** (open + in-progress
-  counts with the wip list), **RUNS** (active + needs-operator counts). WAITING /
-  BEADS / RUNS truncate with a `+ N more`, never a dump. The **ACTIVE** band is the
-  navigable region: `↑`/`↓`/wheel scroll through *all* live agents (orchestration
-  first), `enter` peeks the selected agent's live log, `p` opens its detail. Each
-  ACTIVE row shows `on <run>` when the agent is assigned to a run lane
-  (`activeAssignees`), else its activity hint; city-level agents read as the city
+- **Overview** (`o`): the calm mayor-companion view — one scrollable, peekable list
+  with attention-first sections, **WAITING ON YOU** (needs-operator runs then mayor
+  escalations, the single red heading) → **ACTIVE** (live agents, orchestration
+  first) → **BEADS** (in-progress) → **RUNS** (summary). `↑`/`↓`/wheel scroll the
+  whole list; `enter` peeks the selected row whatever it is — a run (`bd show` +
+  diff), a **mail** (`gc mail peek`, read-only, doesn't mark read), an agent (live
+  log), or a bead; `enter` again or `x` closes the peek; `p` opens an agent's
+  detail. ACTIVE rows show `on <run>` when the agent is in a run lane's
+  `activeAssignees`, else the activity hint; city-level agents read as the city
   name, not `orchestration`. This is the default view when the panel is launched
-  beside another session (`--split` / `--target`, which pass `--compact`); the full
-  views below stay one keypress away. Greyscale, one red region (DESIGN.md Reading
-  Room / One Mark).
+  beside another session (`--split` / `--target`, which pass `--compact`); `o`
+  toggles to the full dashboard and back. Greyscale, one red region (DESIGN.md
+  Reading Room / One Mark).
 - **Agents** (default standalone): grouped by rig (orchestration layer first; within a rig,
   active before idle), one line each as `glyph · agent · kind · ctx% · activity ·
   model · last-active`. A leading glyph + short word carries the agent kind so it

--- a/tui/README.md
+++ b/tui/README.md
@@ -110,6 +110,25 @@ use the launcher, which creates/attaches a dedicated `gc-tui` session:
 npm --workspace tui run start:tmux -- <city>     # or ./tui/start-tmux.sh <city>
 ```
 
+### Pin it beside another session (the mayor)
+
+To leave the dashboard glancing on the *side* of the session you're working in
+(the way an operator keeps it next to the mayor) rather than taking over the
+pane, run the launcher with `--split` **from inside the tmux window you want to
+split**. It adds a right-hand pane running the TUI and leaves your original pane
+in place:
+
+```bash
+./tui/start-tmux.sh --split <city>            # 40% wide by default
+./tui/start-tmux.sh --split --pct 30 <city>   # narrower side panel
+# or: npm --workspace tui run start:tmux -- --split <city>
+```
+
+`--split` needs an existing tmux window to split into; run outside tmux it falls
+back to the dedicated `gc-tui` session (with a note). Without `--split` the
+default is unchanged: take over the current pane when already in tmux, else a
+dedicated `gc-tui` session. Press `m` once it's up for the city board.
+
 Env: `DASHBOARD_URL` (default `http://127.0.0.1:8081`), `GC_CITY_NAME` or
 `--city=<name>` (required — no silent fallback to a default city). Press `q` to
 quit.

--- a/tui/README.md
+++ b/tui/README.md
@@ -129,6 +129,21 @@ back to the dedicated `gc-tui` session (with a note). Without `--split` the
 default is unchanged: take over the current pane when already in tmux, else a
 dedicated `gc-tui` session. Press `m` once it's up for the city board.
 
+**One-shot, from anywhere — `--target`.** You don't have to attach and hand-split.
+gc runs each city's tmux on a socket named after the city, so the launcher can
+split a named session directly:
+
+```bash
+./tui/start-tmux.sh --target mayor <city>            # pin beside the mayor
+./tui/start-tmux.sh --target mayor --pct 30 <city>   # narrower
+```
+
+This splits `tmux -L <city> -t <session>` (override the socket with
+`--socket <name>`), adding the dashboard to the right of that session's window
+and leaving it in place. Then `gc session attach mayor` shows the mayor and the
+dashboard side by side. If the session or socket isn't found, it lists what's on
+the socket and exits non-zero rather than guessing.
+
 Env: `DASHBOARD_URL` (default `http://127.0.0.1:8081`), `GC_CITY_NAME` or
 `--city=<name>` (required — no silent fallback to a default city). Press `q` to
 quit.

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -151,25 +151,29 @@ function buildNav(
   }
 
   if (view === 'overview') {
-    // One scrollable, peekable list with attention-first sections: WAITING (the
-    // needs-operator runs and mayor escalations) leads, then ACTIVE agents, then
+    // One scrollable, peekable list with attention-first sections: the LEDGER
+    // (what's waiting on the operator — needs-operator runs and mayor-escalated
+    // mail, worker chatter folded away) leads, then ACTIVE agents, then
     // in-progress BEADS, then a RUNS summary. Every item peeks via the shared
-    // drill (run/mail/agent/bead). The single red mark is the WAITING heading.
+    // drill (run/mail/agent/bead). The single red mark is the ledger heading.
     const needsOp = lanes.filter(laneNeedsOperator);
     const escalations = operatorMail(mail, sessions);
+    const folded = foldedMailCount(mail, escalations);
     const actives = orchFirstActive(sessions);
     const wip = beads.filter((b) => b.status === 'in_progress');
     const open = beads.filter((b) => b.status === 'open').length;
 
-    const waitingTotal = needsOp.length + escalations.length;
-    const waitGroup: GroupInfo = {
-      label: 'WAITING ON YOU',
-      sub: `${waitingTotal}`,
-      alert: waitingTotal > 0,
+    const ledgerTotal = needsOp.length + escalations.length;
+    const ledgerGroup: GroupInfo = {
+      // The ledger's signature honesty: never silently drop the worker firehose
+      // the mayor digested — report how much was folded.
+      label: 'LEDGER',
+      sub: folded > 0 ? `${ledgerTotal} · ${folded} folded` : `${ledgerTotal}`,
+      alert: ledgerTotal > 0,
     };
-    renderRows.push({ kind: 'heading', group: waitGroup });
-    for (const l of needsOp) push({ kind: 'run', id: l.id, lane: l }, false, waitGroup);
-    for (const m of escalations) push({ kind: 'mail', id: m.id, mail: m }, false, waitGroup);
+    renderRows.push({ kind: 'heading', group: ledgerGroup });
+    for (const l of needsOp) push({ kind: 'run', id: l.id, lane: l }, false, ledgerGroup);
+    for (const m of escalations) push({ kind: 'mail', id: m.id, mail: m }, false, ledgerGroup);
 
     const actGroup: GroupInfo = {
       label: 'ACTIVE',
@@ -426,10 +430,10 @@ export function App({ baseUrl, city, compact = false, mouse = true }: AppProps):
 
   const summary =
     view === 'overview' ? (
-      // No red here: the WAITING band inside the pane carries the one mark.
+      // No red here: the LEDGER heading inside the list carries the one mark.
       <Text dimColor>
         overview
-        {overview.waitingTotal > 0 ? ` · ${overview.waitingTotal} waiting on you` : ' · all clear'}
+        {overview.waitingTotal > 0 ? ` · ${overview.waitingTotal} on the ledger` : ' · ledger clear'}
       </Text>
     ) : view === 'board' ? (
       // No red here: the board's own `needs` column carries the one mark, so a

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -3,13 +3,14 @@ import { Box, Text, useApp, useInput, useStdout } from 'ink';
 import { useCity } from './useCity.ts';
 import { useMouseWheel } from './useMouseWheel.ts';
 import {
+  ActiveAgentRow,
   AgentRow,
   BeadRow,
   CityBoardPane,
   DetailPane,
   HealthPane,
   LedgerPane,
-  OverviewPane,
+  MailRow,
   RunRow,
   SessionRow,
   type DetailTab,
@@ -46,7 +47,7 @@ import {
   type Category,
   type StatusFilter,
 } from './derive.ts';
-import type { GcBead, GcSession, RunLane } from './api.ts';
+import type { GcBead, GcMailItem, GcSession, RunLane } from './api.ts';
 
 interface AppProps {
   readonly baseUrl: string;
@@ -70,7 +71,8 @@ type ViewMode =
 type Entry =
   | { readonly kind: 'agent'; readonly id: string; readonly agent: AgentView }
   | { readonly kind: 'bead'; readonly id: string; readonly bead: GcBead }
-  | { readonly kind: 'run'; readonly id: string; readonly lane: RunLane };
+  | { readonly kind: 'run'; readonly id: string; readonly lane: RunLane }
+  | { readonly kind: 'mail'; readonly id: string; readonly mail: GcMailItem };
 
 interface GroupInfo {
   readonly label: string;
@@ -100,6 +102,7 @@ function buildNav(
   sessions: readonly GcSession[],
   beads: readonly GcBead[],
   lanes: readonly RunLane[],
+  mail: readonly GcMailItem[],
   filter: StatusFilter,
 ): Nav {
   const entries: Entry[] = [];
@@ -144,13 +147,50 @@ function buildNav(
   }
 
   if (view === 'overview') {
-    // The ACTIVE band is a flat, navigable list (orchestration first); the pane
-    // renders the WAITING/BEADS/RUNS bands around this scrollable slice. No
-    // heading — the band head lives in the pane.
-    const blank: GroupInfo = { label: '', sub: '', alert: false };
-    for (const v of orchFirstActive(sessions)) {
-      push({ kind: 'agent', id: v.session.id, agent: v }, false, blank);
-    }
+    // One scrollable, peekable list with attention-first sections: WAITING (the
+    // needs-operator runs and mayor escalations) leads, then ACTIVE agents, then
+    // in-progress BEADS, then a RUNS summary. Every item peeks via the shared
+    // drill (run/mail/agent/bead). The single red mark is the WAITING heading.
+    const needsOp = lanes.filter(laneNeedsOperator);
+    const escalations = operatorMail(mail, sessions);
+    const actives = orchFirstActive(sessions);
+    const wip = beads.filter((b) => b.status === 'in_progress');
+    const open = beads.filter((b) => b.status === 'open').length;
+
+    const waitingTotal = needsOp.length + escalations.length;
+    const waitGroup: GroupInfo = {
+      label: 'WAITING ON YOU',
+      sub: `${waitingTotal}`,
+      alert: waitingTotal > 0,
+    };
+    renderRows.push({ kind: 'heading', group: waitGroup });
+    for (const l of needsOp) push({ kind: 'run', id: l.id, lane: l }, false, waitGroup);
+    for (const m of escalations) push({ kind: 'mail', id: m.id, mail: m }, false, waitGroup);
+
+    const actGroup: GroupInfo = {
+      label: 'ACTIVE',
+      sub: `${actives.length} of ${sessions.length}`,
+      alert: false,
+    };
+    renderRows.push({ kind: 'heading', group: actGroup });
+    for (const v of actives) push({ kind: 'agent', id: v.session.id, agent: v }, false, actGroup);
+
+    const beadGroup: GroupInfo = {
+      label: 'BEADS',
+      sub: `${open} open · ${wip.length} in progress`,
+      alert: false,
+    };
+    renderRows.push({ kind: 'heading', group: beadGroup });
+    for (const b of wip) push({ kind: 'bead', id: b.id, bead: b }, false, beadGroup);
+
+    renderRows.push({
+      kind: 'heading',
+      group: {
+        label: 'RUNS',
+        sub: `${lanes.length} active · ${needsOp.length} needs operator`,
+        alert: false,
+      },
+    });
     return { entries, renderRows };
   }
 
@@ -174,6 +214,7 @@ function buildNav(
 function entryLabel(e: Entry): string {
   if (e.kind === 'agent') return e.agent.agent;
   if (e.kind === 'bead') return e.bead.id;
+  if (e.kind === 'mail') return e.mail.subject;
   return e.lane.title;
 }
 
@@ -218,8 +259,8 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
     () =>
       navView === 'health' || navView === 'ledger' || navView === 'board'
         ? EMPTY_NAV
-        : buildNav(navView, sessions, beads, health.lanes, statusFilter),
-    [navView, sessions, beads, health.lanes, statusFilter],
+        : buildNav(navView, sessions, beads, health.lanes, mail, statusFilter),
+    [navView, sessions, beads, health.lanes, mail, statusFilter],
   );
 
   const cursorIndex = Math.max(0, entries.findIndex((e) => e.id === cursorId));
@@ -293,23 +334,9 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
   };
 
   // Exact one-line-per-row accounting prevents screen overflow. chrome =
-  // header + sticky line + footer (+ error line). The overview reserves more:
-  // its fixed WAITING/BEADS/RUNS bands frame the scrollable ACTIVE list, so the
-  // ACTIVE viewport is what's left after those bands.
-  const overviewReserve = (): number => {
-    const wShown = overview.waiting.length;
-    const wRows = 1 + Math.max(1, wShown) + (overview.waitingTotal > wShown ? 1 : 0);
-    const bShown = overview.wip.length;
-    const bRows = 2 + Math.max(1, bShown) + (overview.beadsInProgress > bShown ? 1 : 0);
-    // header + error + WAITING + active-head + below-indicator + BEADS + RUNS +
-    // footer + one row of safety margin.
-    return 1 + (error ? 1 : 0) + wRows + 1 + 1 + bRows + 2 + 2 + 1;
-  };
+  // header + sticky line + footer (+ error line).
   const chrome = error ? 4 : 3;
-  const viewport =
-    view === 'overview'
-      ? Math.max(3, rows - overviewReserve())
-      : Math.max(3, rows - chrome);
+  const viewport = Math.max(3, rows - chrome);
   const maxTop = Math.max(0, renderRows.length - viewport);
 
   const cursorRowIndex = renderRows.findIndex(
@@ -332,14 +359,6 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
   const stickyGroup: GroupInfo | null =
     firstVisible && firstVisible.kind === 'entry' ? firstVisible.group : null;
 
-  // The visible ACTIVE rows for the overview, with selection (overview entries
-  // are all agents).
-  const overviewActive = visible.flatMap((r) =>
-    r.kind === 'entry' && r.entry.kind === 'agent'
-      ? [{ view: r.entry.agent, selected: r.index === cursorIndex }]
-      : [],
-  );
-
   const toggle = (target: ViewMode): void => {
     setView((v) => (v === target ? 'list' : target));
     setScrollTop(0);
@@ -357,11 +376,10 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
       if (input === 's') return toggle('sessions');
       if (input === 'l') return toggle('ledger');
       if (input === 'p') {
-        // Detail for the selected agent — reachable from the agent list and from
-        // the overview's ACTIVE band (both navigate agent entries).
-        if (navView === 'list' || navView === 'overview') {
-          setView((v) => (v === 'detail' ? 'list' : 'detail'));
-        }
+        // Detail for the selected agent — from the agent list, or from the
+        // overview when an agent row (not a run/mail/bead) is selected.
+        const onAgent = navView === 'list' || (navView === 'overview' && selected?.kind === 'agent');
+        if (onAgent) setView((v) => (v === 'detail' ? 'list' : 'detail'));
         return;
       }
       if (input === 'a') {
@@ -465,19 +483,7 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
         </Box>
       ) : null}
 
-      {view === 'overview' ? (
-        <Box marginTop={1}>
-          <OverviewPane
-            model={overview}
-            city={city}
-            lanes={health.lanes}
-            now={now}
-            activeVisible={overviewActive}
-            activeAbove={above}
-            activeBelow={below}
-          />
-        </Box>
-      ) : view === 'board' ? (
+      {view === 'board' ? (
         <Box marginTop={1}>
           <CityBoardPane board={board} />
         </Box>
@@ -548,6 +554,7 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
                     dim={row.dim}
                     now={now}
                     sessionRow={navView === 'sessions'}
+                    overview={navView === 'overview' ? { city, lanes: health.lanes } : null}
                   />
                 ),
               )
@@ -562,7 +569,10 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
                 {below > 0 ? `↓ ${below}` : ''}
               </Text>
             )}
-            <Text dimColor>↑↓ · enter drill · a filter · o/s/b/f/l/h/m views · p detail · x close · q quit</Text>
+            <Text dimColor>
+              ↑↓ · enter peek · {view === 'overview' ? 'o full' : 'o overview'} · a filter ·
+              s/b/f/l/h/m · p detail · x close · q quit
+            </Text>
           </Box>
         </>
       )}
@@ -586,15 +596,32 @@ interface EntryRowProps {
   /** Render an agent entry as the activity-forward Sessions row instead of the
    *  grouped Agents row. */
   readonly sessionRow: boolean;
+  /** Overview context: render the calm overview rows (agent = city + on-lane,
+   *  mail = sender/subject). Null outside the overview. */
+  readonly overview: { readonly city: string; readonly lanes: readonly RunLane[] } | null;
 }
 
-function EntryRow({ entry, selected, dim, now, sessionRow }: EntryRowProps): React.JSX.Element {
+function EntryRow({ entry, selected, dim, now, sessionRow, overview }: EntryRowProps): React.JSX.Element {
   if (entry.kind === 'agent') {
+    if (overview) {
+      return (
+        <ActiveAgentRow
+          view={entry.agent}
+          selected={selected}
+          city={overview.city}
+          lanes={overview.lanes}
+          now={now}
+        />
+      );
+    }
     return sessionRow ? (
       <SessionRow view={entry.agent} selected={selected} now={now} />
     ) : (
       <AgentRow view={entry.agent} selected={selected} dim={dim} now={now} />
     );
+  }
+  if (entry.kind === 'mail') {
+    return <MailRow mail={entry.mail} selected={selected} />;
   }
   if (entry.kind === 'bead') {
     return <BeadRow bead={entry.bead} selected={selected} dim={dim} />;

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -55,6 +55,10 @@ interface AppProps {
   /** Mayor-companion mode: open on the truncated overview instead of the full
    *  agent list (set by the launcher's --split/--target via --compact). */
   readonly compact?: boolean;
+  /** Whether to grab the mouse for wheel scrolling. False (`--no-mouse`) leaves
+   *  the mouse to tmux so a pinned panel is drag-resizable; keyboard nav still
+   *  works. */
+  readonly mouse?: boolean;
 }
 
 type ViewMode =
@@ -231,7 +235,7 @@ function useTerminalRows(): number {
   return rows;
 }
 
-export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Element {
+export function App({ baseUrl, city, compact = false, mouse = true }: AppProps): React.JSX.Element {
   const { exit } = useApp();
   const { sessions, snapshot, beads, mail, error, conn } = useCity(baseUrl, city);
   const rows = useTerminalRows();
@@ -290,7 +294,7 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
     setCursorId(list[next]?.id ?? null);
   }, []);
 
-  useMouseWheel(useCallback((dir: -1 | 1) => moveCursor(dir * 3), [moveCursor]));
+  useMouseWheel(useCallback((dir: -1 | 1) => moveCursor(dir * 3), [moveCursor]), mouse);
 
   const closeActivePeek = (): void => {
     if (peekPaneId !== null && paneExists(peekPaneId)) closePeek(peekPaneId);

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -37,6 +37,7 @@ import {
   neverActiveByRig,
   nextStatusFilter,
   operatorMail,
+  orchFirstActive,
   overviewModel,
   runningSessions,
   systemHealth,
@@ -142,6 +143,17 @@ function buildNav(
     return { entries, renderRows };
   }
 
+  if (view === 'overview') {
+    // The ACTIVE band is a flat, navigable list (orchestration first); the pane
+    // renders the WAITING/BEADS/RUNS bands around this scrollable slice. No
+    // heading — the band head lives in the pane.
+    const blank: GroupInfo = { label: '', sub: '', alert: false };
+    for (const v of orchFirstActive(sessions)) {
+      push({ kind: 'agent', id: v.session.id, agent: v }, false, blank);
+    }
+    return { entries, renderRows };
+  }
+
   // list (and detail, which navigates the same agent list underneath).
   // Failed agents always pass the filter so a problem is never hidden.
   const filtered = sessions.filter((s) => matchesStatusFilter(categorize(s), filter));
@@ -204,7 +216,7 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
   const navView: ViewMode = view === 'detail' ? 'list' : view;
   const { entries, renderRows } = useMemo(
     () =>
-      navView === 'health' || navView === 'ledger' || navView === 'board' || navView === 'overview'
+      navView === 'health' || navView === 'ledger' || navView === 'board'
         ? EMPTY_NAV
         : buildNav(navView, sessions, beads, health.lanes, statusFilter),
     [navView, sessions, beads, health.lanes, statusFilter],
@@ -281,9 +293,23 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
   };
 
   // Exact one-line-per-row accounting prevents screen overflow. chrome =
-  // header + sticky line + footer (+ error line).
+  // header + sticky line + footer (+ error line). The overview reserves more:
+  // its fixed WAITING/BEADS/RUNS bands frame the scrollable ACTIVE list, so the
+  // ACTIVE viewport is what's left after those bands.
+  const overviewReserve = (): number => {
+    const wShown = overview.waiting.length;
+    const wRows = 1 + Math.max(1, wShown) + (overview.waitingTotal > wShown ? 1 : 0);
+    const bShown = overview.wip.length;
+    const bRows = 2 + Math.max(1, bShown) + (overview.beadsInProgress > bShown ? 1 : 0);
+    // header + error + WAITING + active-head + below-indicator + BEADS + RUNS +
+    // footer + one row of safety margin.
+    return 1 + (error ? 1 : 0) + wRows + 1 + 1 + bRows + 2 + 2 + 1;
+  };
   const chrome = error ? 4 : 3;
-  const viewport = Math.max(3, rows - chrome);
+  const viewport =
+    view === 'overview'
+      ? Math.max(3, rows - overviewReserve())
+      : Math.max(3, rows - chrome);
   const maxTop = Math.max(0, renderRows.length - viewport);
 
   const cursorRowIndex = renderRows.findIndex(
@@ -306,6 +332,14 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
   const stickyGroup: GroupInfo | null =
     firstVisible && firstVisible.kind === 'entry' ? firstVisible.group : null;
 
+  // The visible ACTIVE rows for the overview, with selection (overview entries
+  // are all agents).
+  const overviewActive = visible.flatMap((r) =>
+    r.kind === 'entry' && r.entry.kind === 'agent'
+      ? [{ view: r.entry.agent, selected: r.index === cursorIndex }]
+      : [],
+  );
+
   const toggle = (target: ViewMode): void => {
     setView((v) => (v === target ? 'list' : target));
     setScrollTop(0);
@@ -323,7 +357,11 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
       if (input === 's') return toggle('sessions');
       if (input === 'l') return toggle('ledger');
       if (input === 'p') {
-        if (navView === 'list') setView((v) => (v === 'detail' ? 'list' : 'detail'));
+        // Detail for the selected agent — reachable from the agent list and from
+        // the overview's ACTIVE band (both navigate agent entries).
+        if (navView === 'list' || navView === 'overview') {
+          setView((v) => (v === 'detail' ? 'list' : 'detail'));
+        }
         return;
       }
       if (input === 'a') {
@@ -429,7 +467,15 @@ export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Ele
 
       {view === 'overview' ? (
         <Box marginTop={1}>
-          <OverviewPane model={overview} now={now} />
+          <OverviewPane
+            model={overview}
+            city={city}
+            lanes={health.lanes}
+            now={now}
+            activeVisible={overviewActive}
+            activeAbove={above}
+            activeBelow={below}
+          />
         </Box>
       ) : view === 'board' ? (
         <Box marginTop={1}>

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -9,6 +9,7 @@ import {
   DetailPane,
   HealthPane,
   LedgerPane,
+  OverviewPane,
   RunRow,
   SessionRow,
   type DetailTab,
@@ -36,6 +37,7 @@ import {
   neverActiveByRig,
   nextStatusFilter,
   operatorMail,
+  overviewModel,
   runningSessions,
   systemHealth,
   toAgentView,
@@ -48,9 +50,21 @@ import type { GcBead, GcSession, RunLane } from './api.ts';
 interface AppProps {
   readonly baseUrl: string;
   readonly city: string;
+  /** Mayor-companion mode: open on the truncated overview instead of the full
+   *  agent list (set by the launcher's --split/--target via --compact). */
+  readonly compact?: boolean;
 }
 
-type ViewMode = 'list' | 'beads' | 'runs' | 'detail' | 'health' | 'sessions' | 'ledger' | 'board';
+type ViewMode =
+  | 'list'
+  | 'beads'
+  | 'runs'
+  | 'detail'
+  | 'health'
+  | 'sessions'
+  | 'ledger'
+  | 'board'
+  | 'overview';
 
 type Entry =
   | { readonly kind: 'agent'; readonly id: string; readonly agent: AgentView }
@@ -164,12 +178,12 @@ function useTerminalRows(): number {
   return rows;
 }
 
-export function App({ baseUrl, city }: AppProps): React.JSX.Element {
+export function App({ baseUrl, city, compact = false }: AppProps): React.JSX.Element {
   const { exit } = useApp();
   const { sessions, snapshot, beads, mail, error, conn } = useCity(baseUrl, city);
   const rows = useTerminalRows();
 
-  const [view, setView] = useState<ViewMode>('list');
+  const [view, setView] = useState<ViewMode>(compact ? 'overview' : 'list');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active+idle');
   const [detailTab, setDetailTab] = useState<DetailTab>('overview');
   const [cursorId, setCursorId] = useState<string | null>(null);
@@ -182,11 +196,15 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
 
   const health = useMemo(() => systemHealth(snapshot), [snapshot]);
   const board = useMemo(() => cityBoard(health.lanes), [health.lanes]);
+  const overview = useMemo(
+    () => overviewModel(sessions, beads, mail, health.lanes),
+    [sessions, beads, mail, health.lanes],
+  );
   // detail navigates the same agent list as 'list' underneath.
   const navView: ViewMode = view === 'detail' ? 'list' : view;
   const { entries, renderRows } = useMemo(
     () =>
-      navView === 'health' || navView === 'ledger' || navView === 'board'
+      navView === 'health' || navView === 'ledger' || navView === 'board' || navView === 'overview'
         ? EMPTY_NAV
         : buildNav(navView, sessions, beads, health.lanes, statusFilter),
     [navView, sessions, beads, health.lanes, statusFilter],
@@ -297,6 +315,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
     (input, key) => {
       if (input === 'q') return quit();
       if (key.escape) return view === 'list' ? quit() : (setView('list'), setScrollTop(0));
+      if (input === 'o') return toggle('overview');
       if (input === 'h') return toggle('health');
       if (input === 'm') return toggle('board');
       if (input === 'b') return toggle('beads');
@@ -346,7 +365,13 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
   const mailFolded = foldedMailCount(mail, ledgerMail);
 
   const summary =
-    view === 'board' ? (
+    view === 'overview' ? (
+      // No red here: the WAITING band inside the pane carries the one mark.
+      <Text dimColor>
+        overview
+        {overview.waitingTotal > 0 ? ` · ${overview.waitingTotal} waiting on you` : ' · all clear'}
+      </Text>
+    ) : view === 'board' ? (
       // No red here: the board's own `needs` column carries the one mark, so a
       // second red region in the same viewport would break the One Mark Rule.
       <Text dimColor>
@@ -402,7 +427,11 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
         </Box>
       ) : null}
 
-      {view === 'board' ? (
+      {view === 'overview' ? (
+        <Box marginTop={1}>
+          <OverviewPane model={overview} now={now} />
+        </Box>
+      ) : view === 'board' ? (
         <Box marginTop={1}>
           <CityBoardPane board={board} />
         </Box>
@@ -487,7 +516,7 @@ export function App({ baseUrl, city }: AppProps): React.JSX.Element {
                 {below > 0 ? `↓ ${below}` : ''}
               </Text>
             )}
-            <Text dimColor>↑↓ · enter drill · a filter · s/b/f/l/h/m views · p detail · x close · q quit</Text>
+            <Text dimColor>↑↓ · enter drill · a filter · o/s/b/f/l/h/m views · p detail · x close · q quit</Text>
           </Box>
         </>
       )}

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -12,6 +12,10 @@ export interface TuiConfig {
   /** Mayor-companion mode: open on the truncated overview (set by the launcher's
    *  --split/--target via --compact). */
   readonly compact: boolean;
+  /** Whether the TUI grabs the mouse for wheel scrolling. `--no-mouse` turns it
+   *  off so tmux keeps the mouse (drag-resize a pinned panel); keyboard nav is
+   *  unaffected. */
+  readonly mouse: boolean;
 }
 
 const DEFAULT_BASE_URL = 'http://127.0.0.1:8081';
@@ -40,5 +44,6 @@ export function resolveConfig(
     baseUrl: (env.DASHBOARD_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, ''),
     city: resolveCity(argv, env),
     compact: argv.includes('--compact'),
+    mouse: !argv.includes('--no-mouse'),
   };
 }

--- a/tui/src/config.ts
+++ b/tui/src/config.ts
@@ -9,6 +9,9 @@ export interface TuiConfig {
   readonly baseUrl: string;
   /** Active city; every read/stream rides /api/city/:cityName/*. */
   readonly city: string;
+  /** Mayor-companion mode: open on the truncated overview (set by the launcher's
+   *  --split/--target via --compact). */
+  readonly compact: boolean;
 }
 
 const DEFAULT_BASE_URL = 'http://127.0.0.1:8081';
@@ -36,5 +39,6 @@ export function resolveConfig(
   return {
     baseUrl: (env.DASHBOARD_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, ''),
     city: resolveCity(argv, env),
+    compact: argv.includes('--compact'),
   };
 }

--- a/tui/src/derive.test.ts
+++ b/tui/src/derive.test.ts
@@ -4,7 +4,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { GcMailItem, GcSession, RunLane, RunPhase } from 'gas-city-dashboard-shared';
+import type { GcBead, GcMailItem, GcSession, RunLane, RunPhase } from 'gas-city-dashboard-shared';
 import {
   AGENT_KINDS,
   activityPhrase,
@@ -20,6 +20,9 @@ import {
   nextStatusFilter,
   operatorMail,
   ORCHESTRATION,
+  OVERVIEW_ACTIVE_CAP,
+  OVERVIEW_WAITING_CAP,
+  overviewModel,
   runningSessions,
   type StatusFilter,
 } from './derive.ts';
@@ -338,4 +341,97 @@ test('cityBoard orders attention rigs (needsOperator) first, then busiest', () =
     lane({ id: 'a1', rig: 'attention', phase: 'blocked', needsOperator: true }),
   ]);
   assert.deepEqual(board.map((r) => r.rig), ['attention', 'busy']);
+});
+
+// ── mayor-companion overview ──────────────────────────────────────────────────
+
+function bead(overrides: Partial<GcBead>): GcBead {
+  return {
+    id: 'b1',
+    title: 'a bead',
+    status: 'open',
+    issue_type: 'task',
+    priority: 2,
+    created_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('overviewModel: waiting lists needs-operator runs before mayor mail, full total', () => {
+  const sessions = [session({ id: 'may', title: 'mayor' })];
+  const m = overviewModel(
+    sessions,
+    [],
+    [mail({ id: 'esc', from: 'mayor', subject: 'decide scope' })],
+    [lane({ id: 'r', rig: 'gc2', phase: 'approval', needsOperator: true })],
+  );
+  assert.equal(m.waiting.length, 2);
+  assert.equal(m.waiting[0]?.kind, 'run');
+  assert.equal(m.waiting[1]?.kind, 'mail');
+  assert.equal(m.waitingTotal, 2);
+});
+
+test('overviewModel: waiting caps the list but reports the true total', () => {
+  const lanes = Array.from({ length: OVERVIEW_WAITING_CAP + 2 }, (_, i) =>
+    lane({ id: `r${i}`, rig: 'gc2', phase: 'approval', needsOperator: true }),
+  );
+  const m = overviewModel([], [], [], lanes);
+  assert.equal(m.waiting.length, OVERVIEW_WAITING_CAP);
+  assert.equal(m.waitingTotal, OVERVIEW_WAITING_CAP + 2);
+});
+
+test('overviewModel: active floats orchestration first, counts active vs total', () => {
+  const sessions = [
+    session({ id: 'p', title: 'polecat-2', rig: 'gascity', pool: 'polecat', state: 'active', last_active: '2026-06-01T00:09:00Z' }),
+    session({ id: 'may', title: 'mayor', state: 'active', last_active: '2026-06-01T00:01:00Z' }),
+    session({ id: 'idle', title: 'sleeper', rig: 'gascity', state: 'asleep' }),
+  ];
+  const m = overviewModel(sessions, [], [], []);
+  assert.deepEqual(m.active.map((a) => a.agent), ['mayor', 'polecat-2']);
+  assert.equal(m.activeCount, 2);
+  assert.equal(m.agentTotal, 3);
+});
+
+test('overviewModel: active is capped', () => {
+  const sessions = Array.from({ length: OVERVIEW_ACTIVE_CAP + 3 }, (_, i) =>
+    session({ id: `a${i}`, title: `polecat-${i}`, rig: 'gascity', pool: 'polecat', state: 'active', last_active: `2026-06-01T00:0${i}:00Z` }),
+  );
+  const m = overviewModel(sessions, [], [], []);
+  assert.equal(m.active.length, OVERVIEW_ACTIVE_CAP);
+  assert.equal(m.activeCount, OVERVIEW_ACTIVE_CAP + 3);
+});
+
+test('overviewModel: beads count open and in-progress, wip lists in-progress', () => {
+  const beads = [
+    bead({ id: 'o1', status: 'open' }),
+    bead({ id: 'o2', status: 'open' }),
+    bead({ id: 'w1', status: 'in_progress', title: 'discount pipeline' }),
+    bead({ id: 'c1', status: 'closed' }),
+  ];
+  const m = overviewModel([], beads, [], []);
+  assert.equal(m.beadsOpen, 2);
+  assert.equal(m.beadsInProgress, 1);
+  assert.deepEqual(m.wip.map((b) => b.id), ['w1']);
+});
+
+test('overviewModel: runs count active lanes and needs-operator lanes', () => {
+  const lanes = [
+    lane({ id: 'a', rig: 'gc2', phase: 'implementation', needsOperator: false }),
+    lane({ id: 'b', rig: 'gc2', phase: 'approval', needsOperator: true }),
+  ];
+  const m = overviewModel([], [], [], lanes);
+  assert.equal(m.runsActive, 2);
+  assert.equal(m.runsNeedsOp, 1);
+});
+
+test('overviewModel: all-calm city yields empty bands', () => {
+  const m = overviewModel([], [], [], []);
+  assert.equal(m.waiting.length, 0);
+  assert.equal(m.waitingTotal, 0);
+  assert.equal(m.active.length, 0);
+  assert.equal(m.activeCount, 0);
+  assert.equal(m.beadsOpen, 0);
+  assert.equal(m.beadsInProgress, 0);
+  assert.equal(m.runsActive, 0);
+  assert.equal(m.runsNeedsOp, 0);
 });

--- a/tui/src/derive.test.ts
+++ b/tui/src/derive.test.ts
@@ -19,11 +19,14 @@ import {
   matchesStatusFilter,
   nextStatusFilter,
   operatorMail,
+  agentLane,
+  displayRig,
   ORCHESTRATION,
-  OVERVIEW_ACTIVE_CAP,
+  orchFirstActive,
   OVERVIEW_WAITING_CAP,
   overviewModel,
   runningSessions,
+  toAgentView,
   type StatusFilter,
 } from './derive.ts';
 
@@ -223,6 +226,7 @@ function lane(over: {
   needsOperator?: boolean;
   /** Scope reports unavailable (the other null-rig path → orchestration bucket). */
   scopeUnavailable?: boolean;
+  assignees?: string[];
 }): RunLane {
   const rig = over.rig === undefined ? 'gascity' : over.rig;
   const scope: RunLane['scope'] = over.scopeUnavailable
@@ -240,7 +244,7 @@ function lane(over: {
     phase,
     phaseLabel: phase,
     statusCounts: {},
-    activeAssignees: [],
+    activeAssignees: over.assignees ?? [],
     updatedAt: { status: 'available', at: '2026-06-01T00:00:00Z' },
     stages: [],
     progress: { status: 'unavailable', error: 'none' },
@@ -392,13 +396,35 @@ test('overviewModel: active floats orchestration first, counts active vs total',
   assert.equal(m.agentTotal, 3);
 });
 
-test('overviewModel: active is capped', () => {
-  const sessions = Array.from({ length: OVERVIEW_ACTIVE_CAP + 3 }, (_, i) =>
+test('overviewModel: active is uncapped (the band scrolls)', () => {
+  const sessions = Array.from({ length: 12 }, (_, i) =>
     session({ id: `a${i}`, title: `polecat-${i}`, rig: 'gascity', pool: 'polecat', state: 'active', last_active: `2026-06-01T00:0${i}:00Z` }),
   );
   const m = overviewModel(sessions, [], [], []);
-  assert.equal(m.active.length, OVERVIEW_ACTIVE_CAP);
-  assert.equal(m.activeCount, OVERVIEW_ACTIVE_CAP + 3);
+  assert.equal(m.active.length, 12);
+  assert.equal(m.activeCount, 12);
+});
+
+test('displayRig swaps the orchestration key for the city name, leaves rigs alone', () => {
+  assert.equal(displayRig(ORCHESTRATION, 'ds-research'), 'ds-research');
+  assert.equal(displayRig('gascity', 'ds-research'), 'gascity');
+});
+
+test('orchFirstActive floats orchestration first, drops idle, uncapped', () => {
+  const sessions = [
+    session({ id: 'p', title: 'polecat-2', rig: 'gascity', pool: 'polecat', state: 'active', last_active: '2026-06-01T00:09:00Z' }),
+    session({ id: 'may', title: 'mayor', state: 'active', last_active: '2026-06-01T00:01:00Z' }),
+    session({ id: 'idle', title: 'sleeper', rig: 'gascity', state: 'asleep' }),
+  ];
+  assert.deepEqual(orchFirstActive(sessions).map((a) => a.agent), ['mayor', 'polecat-2']);
+});
+
+test('agentLane matches an agent to its run lane via activeAssignees, else undefined', () => {
+  const view = toAgentView(session({ id: 'cp', title: 'codeprobe.lead', rig: 'codeprobe' }));
+  const onLane = lane({ id: 'l1', rig: 'codeprobe', phase: 'approval', assignees: ['codeprobe.lead'] });
+  const otherLane = lane({ id: 'l2', rig: 'gc2', phase: 'review' });
+  assert.equal(agentLane(view, [onLane, otherLane])?.id, 'l1');
+  assert.equal(agentLane(view, [otherLane]), undefined);
 });
 
 test('overviewModel: beads count open and in-progress, wip lists in-progress', () => {

--- a/tui/src/derive.ts
+++ b/tui/src/derive.ts
@@ -603,10 +603,40 @@ export function mailSnippet(body: string, max = 120): string {
 
 // ── mayor-companion overview (truncated attention-first summary) ──────────────
 
-/** Row caps for the overview bands — a side panel summarises, it never dumps. */
+/** Row caps for the fixed overview bands — a side panel summarises, it never
+ *  dumps. ACTIVE is not capped: it is the scrollable region. */
 export const OVERVIEW_WAITING_CAP = 4;
-export const OVERVIEW_ACTIVE_CAP = 5;
 export const OVERVIEW_WIP_CAP = 4;
+
+/** Display label for a rig: city-level (rig-less) agents read as the city name,
+ *  not the internal `orchestration` grouping key. Display-only — the key that
+ *  drives grouping/mail/board logic is unchanged. */
+export function displayRig(rig: string, city: string): string {
+  return rig === ORCHESTRATION ? city : rig;
+}
+
+/** All currently-active agents, orchestration first (the layer tracked from the
+ *  mayor seat), then the recency order `runningSessions` already produced.
+ *  Uncapped — the overview's ACTIVE band scrolls. */
+export function orchFirstActive(sessions: readonly GcSession[]): AgentView[] {
+  return runningSessions(sessions)
+    .map(toAgentView)
+    .sort((a, b) => (a.kind === 'orch' ? 0 : 1) - (b.kind === 'orch' ? 0 : 1));
+}
+
+/** The run lane an agent is working, matched via `RunLane.activeAssignees`
+ *  (the wire's who-is-on-this-lane list). Best-effort by the agent's display
+ *  name / alias / agent_name (assignees carry no session id). `undefined` when
+ *  the agent isn't assigned to a lane — callers fall back to the activity hint,
+ *  never a fabricated task. */
+export function agentLane(view: AgentView, lanes: readonly RunLane[]): RunLane | undefined {
+  const ids = new Set(
+    [view.agent, view.session.alias, view.session.title]
+      .filter((s): s is string => Boolean(s))
+      .flatMap((s) => [s, basename(s)]),
+  );
+  return lanes.find((l) => l.activeAssignees.some((a) => ids.has(a) || ids.has(basename(a))));
+}
 
 /** One thing the operator is on the hook for: a run parked on them, or a piece
  *  of orchestration mail escalated to them. */
@@ -624,8 +654,8 @@ export interface OverviewModel {
   readonly waiting: readonly WaitingItem[];
   /** Full waiting count before the cap, so a backlog is never silently hidden. */
   readonly waitingTotal: number;
-  /** Live agents, orchestration first (the layer you track from the mayor seat),
-   *  then the recency order. Capped. */
+  /** All live agents, orchestration first (the layer you track from the mayor
+   *  seat), then the recency order. Uncapped — the ACTIVE band scrolls. */
   readonly active: readonly AgentView[];
   readonly activeCount: number;
   readonly agentTotal: number;
@@ -650,20 +680,14 @@ export function overviewModel(
     ...escalations.map((m): WaitingItem => ({ kind: 'mail', mail: m })),
   ];
 
-  // runningSessions is already recency-ordered; a stable sort by orch-first
-  // floats the orchestration layer up while preserving recency within a tier.
-  const activeAll = runningSessions(sessions).map(toAgentView);
-  const active = activeAll
-    .slice()
-    .sort((a, b) => (a.kind === 'orch' ? 0 : 1) - (b.kind === 'orch' ? 0 : 1));
-
+  const active = orchFirstActive(sessions);
   const wipAll = beads.filter((b) => b.status === 'in_progress');
 
   return {
     waiting: waitingAll.slice(0, OVERVIEW_WAITING_CAP),
     waitingTotal: waitingAll.length,
-    active: active.slice(0, OVERVIEW_ACTIVE_CAP),
-    activeCount: activeAll.length,
+    active,
+    activeCount: active.length,
     agentTotal: sessions.length,
     beadsOpen: beads.filter((b) => b.status === 'open').length,
     beadsInProgress: wipAll.length,

--- a/tui/src/derive.ts
+++ b/tui/src/derive.ts
@@ -600,3 +600,75 @@ export function mailSnippet(body: string, max = 120): string {
   const oneLine = body.replace(/\s+/g, ' ').trim();
   return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
 }
+
+// ── mayor-companion overview (truncated attention-first summary) ──────────────
+
+/** Row caps for the overview bands — a side panel summarises, it never dumps. */
+export const OVERVIEW_WAITING_CAP = 4;
+export const OVERVIEW_ACTIVE_CAP = 5;
+export const OVERVIEW_WIP_CAP = 4;
+
+/** One thing the operator is on the hook for: a run parked on them, or a piece
+ *  of orchestration mail escalated to them. */
+export type WaitingItem =
+  | { readonly kind: 'run'; readonly lane: RunLane }
+  | { readonly kind: 'mail'; readonly mail: GcMailItem };
+
+/**
+ * The truncated summary a mayor-seat operator scans: what needs them, what's
+ * live, what's queued. A projection over the same DTOs the full views use, so
+ * it can never disagree with a drill-in.
+ */
+export interface OverviewModel {
+  /** Needs-operator runs first (they block a pipeline), then mayor mail. Capped. */
+  readonly waiting: readonly WaitingItem[];
+  /** Full waiting count before the cap, so a backlog is never silently hidden. */
+  readonly waitingTotal: number;
+  /** Live agents, orchestration first (the layer you track from the mayor seat),
+   *  then the recency order. Capped. */
+  readonly active: readonly AgentView[];
+  readonly activeCount: number;
+  readonly agentTotal: number;
+  readonly beadsOpen: number;
+  readonly beadsInProgress: number;
+  /** In-progress beads (the wip list), capped. */
+  readonly wip: readonly GcBead[];
+  readonly runsActive: number;
+  readonly runsNeedsOp: number;
+}
+
+export function overviewModel(
+  sessions: readonly GcSession[],
+  beads: readonly GcBead[],
+  mail: readonly GcMailItem[],
+  lanes: readonly RunLane[],
+): OverviewModel {
+  const needsOp = lanes.filter(laneNeedsOperator);
+  const escalations = operatorMail(mail, sessions);
+  const waitingAll: WaitingItem[] = [
+    ...needsOp.map((lane): WaitingItem => ({ kind: 'run', lane })),
+    ...escalations.map((m): WaitingItem => ({ kind: 'mail', mail: m })),
+  ];
+
+  // runningSessions is already recency-ordered; a stable sort by orch-first
+  // floats the orchestration layer up while preserving recency within a tier.
+  const activeAll = runningSessions(sessions).map(toAgentView);
+  const active = activeAll
+    .slice()
+    .sort((a, b) => (a.kind === 'orch' ? 0 : 1) - (b.kind === 'orch' ? 0 : 1));
+
+  const wipAll = beads.filter((b) => b.status === 'in_progress');
+
+  return {
+    waiting: waitingAll.slice(0, OVERVIEW_WAITING_CAP),
+    waitingTotal: waitingAll.length,
+    active: active.slice(0, OVERVIEW_ACTIVE_CAP),
+    activeCount: activeAll.length,
+    agentTotal: sessions.length,
+    beadsOpen: beads.filter((b) => b.status === 'open').length,
+    beadsInProgress: wipAll.length,
+    wip: wipAll.slice(0, OVERVIEW_WIP_CAP),
+    runsActive: lanes.length,
+    runsNeedsOp: needsOp.length,
+  };
+}

--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -28,7 +28,7 @@ function main(): void {
     if (useAlt) process.stdout.write(ALT_LEAVE);
   };
 
-  const app = render(<App baseUrl={config.baseUrl} city={config.city} />);
+  const app = render(<App baseUrl={config.baseUrl} city={config.city} compact={config.compact} />);
   app.waitUntilExit().then(restore, restore);
   // Belt-and-suspenders: leave the alt screen even on an abrupt exit so the
   // user's terminal is never left in the alternate buffer.

--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -28,7 +28,9 @@ function main(): void {
     if (useAlt) process.stdout.write(ALT_LEAVE);
   };
 
-  const app = render(<App baseUrl={config.baseUrl} city={config.city} compact={config.compact} />);
+  const app = render(
+    <App baseUrl={config.baseUrl} city={config.city} compact={config.compact} mouse={config.mouse} />,
+  );
   app.waitUntilExit().then(restore, restore);
   // Belt-and-suspenders: leave the alt screen even on an abrupt exit so the
   // user's terminal is never left in the alternate buffer.

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -19,6 +19,7 @@ import {
   type AgentView,
   type ContextPressureEntry,
   type IdleRollup,
+  type OverviewModel,
   type RigPhaseCounts,
   type SystemHealth,
 } from './derive.ts';
@@ -578,6 +579,128 @@ export function LedgerPane({ mail, mailFolded, runs }: LedgerPaneProps): React.J
 
       <Box marginTop={1}>
         <Text dimColor>l close · q quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── mayor-companion overview pane (attention-first bands) ─────────────────────
+
+interface OverviewPaneProps {
+  readonly model: OverviewModel;
+  readonly now: number;
+}
+
+/** Trailing "+ N more" so a capped band never reads as the whole story. */
+function MoreRow({ total, shown }: { readonly total: number; readonly shown: number }): React.JSX.Element | null {
+  if (total <= shown) return null;
+  return <Text dimColor>{'   '}+ {total - shown} more</Text>;
+}
+
+/** Section heading with a trailing count; the count is the one red mark when
+ *  `alert` (reserved for WAITING ON YOU). */
+function BandHead({
+  label,
+  count,
+  alert = false,
+}: {
+  readonly label: string;
+  readonly count: string;
+  readonly alert?: boolean;
+}): React.JSX.Element {
+  return (
+    <Box>
+      <Text bold>{label}</Text>
+      <Text>{'   '}</Text>
+      {alert ? <Text bold color="red">{count}</Text> : <Text dimColor>{count}</Text>}
+    </Box>
+  );
+}
+
+export function OverviewPane({ model, now }: OverviewPaneProps): React.JSX.Element {
+  return (
+    <Box flexDirection="column">
+      {/* WAITING ON YOU — the single red region. */}
+      <BandHead label="WAITING ON YOU" count={`${model.waitingTotal}`} alert={model.waitingTotal > 0} />
+      {model.waiting.length === 0 ? (
+        <Text dimColor> nothing waiting</Text>
+      ) : (
+        model.waiting.map((w) =>
+          w.kind === 'run' ? (
+            <Box key={`run:${w.lane.id}`}>
+              <Text color="red"> ● </Text>
+              <Text wrap="truncate-end">{w.lane.title}</Text>
+              <Text dimColor> needs operator</Text>
+            </Box>
+          ) : (
+            <Box key={`mail:${w.mail.id}`}>
+              <Text dimColor> ✉ </Text>
+              <Box width={14} marginRight={1}>
+                <Text wrap="truncate-end">{basename(w.mail.from) || w.mail.from}</Text>
+              </Box>
+              <Text wrap="truncate-end">{w.mail.subject}</Text>
+            </Box>
+          ),
+        )
+      )}
+      <MoreRow total={model.waitingTotal} shown={model.waiting.length} />
+
+      {/* ACTIVE */}
+      <Box marginTop={1}>
+        <BandHead label="ACTIVE" count={`${model.activeCount} of ${model.agentTotal}`} />
+      </Box>
+      {model.active.length === 0 ? (
+        <Text dimColor> no agents active</Text>
+      ) : (
+        model.active.map((a) => (
+          <Box key={a.session.id}>
+            <Box width={2} marginLeft={1}>
+              <Text bold={a.kind === 'orch'} dimColor={a.kind !== 'orch'}>
+                {kindGlyph(a.kind)}
+              </Text>
+            </Box>
+            <Box width={18} marginRight={1}>
+              <Text wrap="truncate-end">{a.agent}</Text>
+            </Box>
+            <Box flexGrow={1} marginRight={1}>
+              <Text dimColor wrap="truncate-end">{activityPhrase(a.session)}</Text>
+            </Box>
+            <Box width={5} justifyContent="flex-end">
+              <Text dimColor>{relativeTime(a.session.last_active, now)}</Text>
+            </Box>
+          </Box>
+        ))
+      )}
+
+      {/* BEADS */}
+      <Box marginTop={1}>
+        <BandHead
+          label="BEADS"
+          count={`${model.beadsOpen} open · ${model.beadsInProgress} in progress`}
+        />
+      </Box>
+      {model.wip.length === 0 ? (
+        <Text dimColor> none in progress</Text>
+      ) : (
+        model.wip.map((b) => (
+          <Box key={b.id}>
+            <Text dimColor> ◐ </Text>
+            <Text wrap="truncate-end">{b.title}</Text>
+          </Box>
+        ))
+      )}
+      <MoreRow total={model.beadsInProgress} shown={model.wip.length} />
+
+      {/* RUNS — needs-op count stays greyscale; it is already red under WAITING. */}
+      <Box marginTop={1}>
+        <BandHead
+          label="RUNS"
+          count={`${model.runsActive} active · ${model.runsNeedsOp} needs operator`}
+        />
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>o full dashboard · b/f/s/l/h views · q quit</Text>
       </Box>
     </Box>
   );

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -4,10 +4,12 @@ import type { RunLane } from 'gas-city-dashboard-shared';
 import type { GcBead, GcMailItem } from './api.ts';
 import {
   activityPhrase,
+  agentLane,
   basename,
   CITY_BOARD_PHASE_LABEL,
   CITY_BOARD_PHASES,
   ctxPct,
+  displayRig,
   kindGlyph,
   kindLabel,
   laneNeedsOperator,
@@ -586,9 +588,65 @@ export function LedgerPane({ mail, mailFolded, runs }: LedgerPaneProps): React.J
 
 // ── mayor-companion overview pane (attention-first bands) ─────────────────────
 
+interface OverviewActiveRow {
+  readonly view: AgentView;
+  readonly selected: boolean;
+}
+
 interface OverviewPaneProps {
   readonly model: OverviewModel;
+  readonly city: string;
+  readonly lanes: readonly RunLane[];
   readonly now: number;
+  /** The visible slice of the (scrollable) ACTIVE list, with selection. */
+  readonly activeVisible: readonly OverviewActiveRow[];
+  readonly activeAbove: number;
+  readonly activeBelow: number;
+}
+
+/** One scrollable ACTIVE row: kind glyph, agent, city/rig, what it's working on
+ *  (the assigned run lane, else the activity hint), recency. */
+function ActiveAgentRow({
+  view,
+  selected,
+  city,
+  lanes,
+  now,
+}: OverviewActiveRow & {
+  readonly city: string;
+  readonly lanes: readonly RunLane[];
+  readonly now: number;
+}): React.JSX.Element {
+  const lane = agentLane(view, lanes);
+  const work = lane ? `on ${lane.title}` : activityPhrase(view.session);
+  return (
+    <Box>
+      <Box width={2}>{selected ? <Text color="cyan">▸</Text> : <Text> </Text>}</Box>
+      <Box width={2}>
+        <Text bold={view.kind === 'orch'} dimColor={view.kind !== 'orch'}>
+          {kindGlyph(view.kind)}
+        </Text>
+      </Box>
+      <Box width={16} marginRight={1}>
+        <Text wrap="truncate-end" bold={selected} inverse={selected}>
+          {view.agent}
+        </Text>
+      </Box>
+      <Box width={12} marginRight={1}>
+        <Text dimColor wrap="truncate-end">
+          {displayRig(view.rig, city)}
+        </Text>
+      </Box>
+      <Box flexGrow={1} marginRight={1}>
+        <Text dimColor wrap="truncate-end">
+          {work}
+        </Text>
+      </Box>
+      <Box width={5} justifyContent="flex-end">
+        <Text dimColor>{relativeTime(view.session.last_active, now)}</Text>
+      </Box>
+    </Box>
+  );
 }
 
 /** Trailing "+ N more" so a capped band never reads as the whole story. */
@@ -617,7 +675,15 @@ function BandHead({
   );
 }
 
-export function OverviewPane({ model, now }: OverviewPaneProps): React.JSX.Element {
+export function OverviewPane({
+  model,
+  city,
+  lanes,
+  now,
+  activeVisible,
+  activeAbove,
+  activeBelow,
+}: OverviewPaneProps): React.JSX.Element {
   return (
     <Box flexDirection="column">
       {/* WAITING ON YOU — the single red region. */}
@@ -645,32 +711,26 @@ export function OverviewPane({ model, now }: OverviewPaneProps): React.JSX.Eleme
       )}
       <MoreRow total={model.waitingTotal} shown={model.waiting.length} />
 
-      {/* ACTIVE */}
-      <Box marginTop={1}>
+      {/* ACTIVE — the scrollable, peekable region. */}
+      <Box marginTop={1} justifyContent="space-between">
         <BandHead label="ACTIVE" count={`${model.activeCount} of ${model.agentTotal}`} />
+        {activeAbove > 0 ? <Text dimColor>↑ {activeAbove}</Text> : <Text> </Text>}
       </Box>
-      {model.active.length === 0 ? (
+      {activeVisible.length === 0 ? (
         <Text dimColor> no agents active</Text>
       ) : (
-        model.active.map((a) => (
-          <Box key={a.session.id}>
-            <Box width={2} marginLeft={1}>
-              <Text bold={a.kind === 'orch'} dimColor={a.kind !== 'orch'}>
-                {kindGlyph(a.kind)}
-              </Text>
-            </Box>
-            <Box width={18} marginRight={1}>
-              <Text wrap="truncate-end">{a.agent}</Text>
-            </Box>
-            <Box flexGrow={1} marginRight={1}>
-              <Text dimColor wrap="truncate-end">{activityPhrase(a.session)}</Text>
-            </Box>
-            <Box width={5} justifyContent="flex-end">
-              <Text dimColor>{relativeTime(a.session.last_active, now)}</Text>
-            </Box>
-          </Box>
+        activeVisible.map((r) => (
+          <ActiveAgentRow
+            key={r.view.session.id}
+            view={r.view}
+            selected={r.selected}
+            city={city}
+            lanes={lanes}
+            now={now}
+          />
         ))
       )}
+      {activeBelow > 0 ? <Text dimColor>{'  '}↓ {activeBelow}</Text> : null}
 
       {/* BEADS */}
       <Box marginTop={1}>
@@ -700,7 +760,7 @@ export function OverviewPane({ model, now }: OverviewPaneProps): React.JSX.Eleme
       </Box>
 
       <Box marginTop={1}>
-        <Text dimColor>o full dashboard · b/f/s/l/h views · q quit</Text>
+        <Text dimColor>↑↓ scroll · enter peek · x close · o full · q quit</Text>
       </Box>
     </Box>
   );

--- a/tui/src/panes.tsx
+++ b/tui/src/panes.tsx
@@ -21,7 +21,6 @@ import {
   type AgentView,
   type ContextPressureEntry,
   type IdleRollup,
-  type OverviewModel,
   type RigPhaseCounts,
   type SystemHealth,
 } from './derive.ts';
@@ -586,37 +585,19 @@ export function LedgerPane({ mail, mailFolded, runs }: LedgerPaneProps): React.J
   );
 }
 
-// ── mayor-companion overview pane (attention-first bands) ─────────────────────
+// ── overview rows (rendered by the generic grouped list) ─────────────────────
 
-interface OverviewActiveRow {
+interface ActiveAgentRowProps {
   readonly view: AgentView;
   readonly selected: boolean;
-}
-
-interface OverviewPaneProps {
-  readonly model: OverviewModel;
   readonly city: string;
   readonly lanes: readonly RunLane[];
   readonly now: number;
-  /** The visible slice of the (scrollable) ACTIVE list, with selection. */
-  readonly activeVisible: readonly OverviewActiveRow[];
-  readonly activeAbove: number;
-  readonly activeBelow: number;
 }
 
-/** One scrollable ACTIVE row: kind glyph, agent, city/rig, what it's working on
- *  (the assigned run lane, else the activity hint), recency. */
-function ActiveAgentRow({
-  view,
-  selected,
-  city,
-  lanes,
-  now,
-}: OverviewActiveRow & {
-  readonly city: string;
-  readonly lanes: readonly RunLane[];
-  readonly now: number;
-}): React.JSX.Element {
+/** One ACTIVE row in the overview: kind glyph, agent, city/rig, what it's working
+ *  on (the assigned run lane, else the activity hint), recency. */
+export function ActiveAgentRow({ view, selected, city, lanes, now }: ActiveAgentRowProps): React.JSX.Element {
   const lane = agentLane(view, lanes);
   const work = lane ? `on ${lane.title}` : activityPhrase(view.session);
   return (
@@ -649,118 +630,26 @@ function ActiveAgentRow({
   );
 }
 
-/** Trailing "+ N more" so a capped band never reads as the whole story. */
-function MoreRow({ total, shown }: { readonly total: number; readonly shown: number }): React.JSX.Element | null {
-  if (total <= shown) return null;
-  return <Text dimColor>{'   '}+ {total - shown} more</Text>;
+interface MailRowProps {
+  readonly mail: GcMailItem;
+  readonly selected: boolean;
 }
 
-/** Section heading with a trailing count; the count is the one red mark when
- *  `alert` (reserved for WAITING ON YOU). */
-function BandHead({
-  label,
-  count,
-  alert = false,
-}: {
-  readonly label: string;
-  readonly count: string;
-  readonly alert?: boolean;
-}): React.JSX.Element {
+/** One WAITING mail row: a quiet envelope, the sender, the subject. `enter`
+ *  peeks the full message (read-only `gc mail peek`). */
+export function MailRow({ mail, selected }: MailRowProps): React.JSX.Element {
   return (
     <Box>
-      <Text bold>{label}</Text>
-      <Text>{'   '}</Text>
-      {alert ? <Text bold color="red">{count}</Text> : <Text dimColor>{count}</Text>}
-    </Box>
-  );
-}
-
-export function OverviewPane({
-  model,
-  city,
-  lanes,
-  now,
-  activeVisible,
-  activeAbove,
-  activeBelow,
-}: OverviewPaneProps): React.JSX.Element {
-  return (
-    <Box flexDirection="column">
-      {/* WAITING ON YOU — the single red region. */}
-      <BandHead label="WAITING ON YOU" count={`${model.waitingTotal}`} alert={model.waitingTotal > 0} />
-      {model.waiting.length === 0 ? (
-        <Text dimColor> nothing waiting</Text>
-      ) : (
-        model.waiting.map((w) =>
-          w.kind === 'run' ? (
-            <Box key={`run:${w.lane.id}`}>
-              <Text color="red"> ● </Text>
-              <Text wrap="truncate-end">{w.lane.title}</Text>
-              <Text dimColor> needs operator</Text>
-            </Box>
-          ) : (
-            <Box key={`mail:${w.mail.id}`}>
-              <Text dimColor> ✉ </Text>
-              <Box width={14} marginRight={1}>
-                <Text wrap="truncate-end">{basename(w.mail.from) || w.mail.from}</Text>
-              </Box>
-              <Text wrap="truncate-end">{w.mail.subject}</Text>
-            </Box>
-          ),
-        )
-      )}
-      <MoreRow total={model.waitingTotal} shown={model.waiting.length} />
-
-      {/* ACTIVE — the scrollable, peekable region. */}
-      <Box marginTop={1} justifyContent="space-between">
-        <BandHead label="ACTIVE" count={`${model.activeCount} of ${model.agentTotal}`} />
-        {activeAbove > 0 ? <Text dimColor>↑ {activeAbove}</Text> : <Text> </Text>}
+      <Box width={2}>{selected ? <Text color="cyan">▸</Text> : <Text dimColor>✉</Text>}</Box>
+      <Box width={16} marginRight={1}>
+        <Text wrap="truncate-end" bold={selected} inverse={selected}>
+          {basename(mail.from) || mail.from}
+        </Text>
       </Box>
-      {activeVisible.length === 0 ? (
-        <Text dimColor> no agents active</Text>
-      ) : (
-        activeVisible.map((r) => (
-          <ActiveAgentRow
-            key={r.view.session.id}
-            view={r.view}
-            selected={r.selected}
-            city={city}
-            lanes={lanes}
-            now={now}
-          />
-        ))
-      )}
-      {activeBelow > 0 ? <Text dimColor>{'  '}↓ {activeBelow}</Text> : null}
-
-      {/* BEADS */}
-      <Box marginTop={1}>
-        <BandHead
-          label="BEADS"
-          count={`${model.beadsOpen} open · ${model.beadsInProgress} in progress`}
-        />
-      </Box>
-      {model.wip.length === 0 ? (
-        <Text dimColor> none in progress</Text>
-      ) : (
-        model.wip.map((b) => (
-          <Box key={b.id}>
-            <Text dimColor> ◐ </Text>
-            <Text wrap="truncate-end">{b.title}</Text>
-          </Box>
-        ))
-      )}
-      <MoreRow total={model.beadsInProgress} shown={model.wip.length} />
-
-      {/* RUNS — needs-op count stays greyscale; it is already red under WAITING. */}
-      <Box marginTop={1}>
-        <BandHead
-          label="RUNS"
-          count={`${model.runsActive} active · ${model.runsNeedsOp} needs operator`}
-        />
-      </Box>
-
-      <Box marginTop={1}>
-        <Text dimColor>↑↓ scroll · enter peek · x close · o full · q quit</Text>
+      <Box flexGrow={1}>
+        <Text wrap="truncate-end" dimColor>
+          {mail.subject}
+        </Text>
       </Box>
     </Box>
   );

--- a/tui/src/peek.ts
+++ b/tui/src/peek.ts
@@ -14,7 +14,7 @@ export function insideTmux(): boolean {
   return Boolean(process.env.TMUX);
 }
 
-export type PeekKind = 'agent' | 'bead' | 'run';
+export type PeekKind = 'agent' | 'bead' | 'run' | 'mail';
 
 export interface PeekRequest {
   readonly kind: PeekKind;
@@ -53,6 +53,9 @@ export function buildCommand(req: PeekRequest): string | { error: string } {
       return `bash '${AGENT_SCRIPT}' '${root}' '${req.id}'`;
     case 'bead':
       return `gc --city ${root} bd show ${req.id}; exec $SHELL`;
+    case 'mail':
+      // `mail peek` shows the message WITHOUT marking it read (read-only posture).
+      return `gc --city ${root} mail peek ${req.id}; exec $SHELL`;
     case 'run':
       // peek-run.sh prints `bd show <run>` then the code diff; args are
       // single-quoted (all validated/owned, no quotes) for the sh -c tmux runs.

--- a/tui/src/peek.ts
+++ b/tui/src/peek.ts
@@ -76,12 +76,18 @@ export function paneExists(paneId: string): boolean {
   return r.stdout.split('\n').includes(paneId);
 }
 
-/** Opens the peek pane beside the dashboard (focus stays on the dashboard). */
+/**
+ * Opens the peek pane BELOW the dashboard (focus stays on the dashboard). A
+ * vertical split (not a right-hand one) keeps the dashboard's full width — it is
+ * often already narrow when pinned beside the mayor — and gives wide peek output
+ * (logs, `bd show`, diffs) the full width too.
+ */
 export function openPeek(command: string): PeekResult {
-  // -d: don't move focus. -P -F prints the new pane's id so we can retarget it.
+  // -d: don't move focus. -v: split below. -P -F prints the new pane's id so we
+  // can retarget it.
   const r = spawnSync(
     'tmux',
-    ['split-window', '-d', '-h', '-l', '45%', '-P', '-F', '#{pane_id}', command],
+    ['split-window', '-d', '-v', '-l', '50%', '-P', '-F', '#{pane_id}', command],
     { encoding: 'utf8' },
   );
   if (r.error || (typeof r.status === 'number' && r.status !== 0)) {

--- a/tui/src/useCity.ts
+++ b/tui/src/useCity.ts
@@ -118,6 +118,10 @@ export function useCity(baseUrl: string, city: string): CityState {
         if (cancelled) return;
         retryDelayMs = 1_000;
         setState((prev) => ({ ...prev, conn: 'open' }));
+        // Resync on (re)connect: a stream that dropped (e.g. the backend
+        // restarted) may have missed events, so the snapshot/sessions could be
+        // stale. Coalesced, so the initial mount refresh + this don't double up.
+        scheduleRefresh();
       };
       const handle = (msg: MessageEvent<string>): void => {
         if (cancelled) return;

--- a/tui/src/useMouseWheel.ts
+++ b/tui/src/useMouseWheel.ts
@@ -15,13 +15,19 @@ const SGR_MOUSE = /\x1b\[<(\d+);\d+;\d+[Mm]/g;
 /**
  * Calls `onWheel(-1)` on wheel-up and `onWheel(1)` on wheel-down. No-op when
  * the terminal can't do raw mode (piped output) — keyboard nav still works.
+ *
+ * `enabled` gates the mouse grab: when false, the TUI never enables mouse
+ * reporting, so tmux keeps the mouse (drag-resize, click-to-focus, native
+ * scrollback). Used by the pinned-beside-the-mayor launch (`--no-mouse`), where
+ * a drag-resizable panel beats wheel scrolling. Keyboard nav is unaffected
+ * either way (Ink owns raw mode for keypresses).
  */
-export function useMouseWheel(onWheel: (direction: -1 | 1) => void): void {
+export function useMouseWheel(onWheel: (direction: -1 | 1) => void, enabled = true): void {
   const { stdin, setRawMode, isRawModeSupported } = useStdin();
   const { stdout } = useStdout();
 
   useEffect(() => {
-    if (!isRawModeSupported || !stdin) return;
+    if (!enabled || !isRawModeSupported || !stdin) return;
     setRawMode(true);
     stdout.write(ENABLE);
 
@@ -42,5 +48,5 @@ export function useMouseWheel(onWheel: (direction: -1 | 1) => void): void {
       stdout.write(DISABLE);
     };
     // onWheel is captured fresh each render via the dependency.
-  }, [stdin, stdout, setRawMode, isRawModeSupported, onWheel]);
+  }, [stdin, stdout, setRawMode, isRawModeSupported, onWheel, enabled]);
 }

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -19,10 +19,15 @@
 # the city, so this splits `tmux -L <city> -t <session>`. e.g. --target mayor
 # adds the dashboard to the right of the mayor's window; then
 # `gc session attach mayor` shows both. Override the socket with --socket.
+#
+# Mouse: pinned companion panels (--split / --target) default to --no-mouse, so
+# tmux keeps the mouse and you can DRAG the pane border to resize it (scroll the
+# lists with the keyboard). A standalone launch keeps wheel-scroll. Force either
+# with --mouse / --no-mouse.
 set -euo pipefail
 
 usage() {
-  sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 split=0
@@ -30,12 +35,15 @@ pct=40
 city=""
 target=""
 socket=""
+mouse_pref="" # "", "on", or "off" — empty means auto (companion → off)
 while [ $# -gt 0 ]; do
   case "$1" in
     --split) split=1; shift ;;
     -l | --pct) pct="${2:-40}"; shift 2 ;;
     --target) target="${2:-}"; shift 2 ;;
     --socket) socket="${2:-}"; shift 2 ;;
+    --mouse) mouse_pref="on"; shift ;;
+    --no-mouse) mouse_pref="off"; shift ;;
     --city) city="${2:-}"; shift 2 ;;
     --city=*) city="${1#--city=}"; shift ;;
     --help) usage; exit 0 ;;
@@ -51,8 +59,21 @@ pct="${pct%\%}"           # accept "40" or "40%"
 compact=0
 { [ -n "$target" ] || [ "$split" = "1" ]; } && compact=1
 
+# Pinned companion panels default to tmux-owned mouse so the pane is
+# drag-resizable (the TUI releases the wheel; keyboard nav still scrolls). A
+# standalone launch keeps wheel-scroll. --mouse / --no-mouse force either way.
+no_mouse=0
+if [ "$mouse_pref" = "off" ]; then
+  no_mouse=1
+elif [ "$mouse_pref" = "on" ]; then
+  no_mouse=0
+elif [ "$compact" = "1" ]; then
+  no_mouse=1
+fi
+
 app_args=""
 [ -n "$city" ] && app_args="--city=$city"
+[ "$no_mouse" = "1" ] && app_args="$app_args --no-mouse"
 [ "$compact" = "1" ] && app_args="$app_args --compact"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -1,15 +1,41 @@
 #!/usr/bin/env bash
 # Launch the Gas City TUI inside tmux so the live-peek split (enter) works.
 #
-#   ./tui/start-tmux.sh <city>        # or set GC_CITY_NAME
-#   npm --workspace tui run start:tmux -- <city>
+#   ./tui/start-tmux.sh [--split] [--pct N] [<city>]   # or set GC_CITY_NAME
+#   npm --workspace tui run start:tmux -- [--split] [--pct N] [<city>]
 #
-# If you are already inside tmux, it runs directly (peek splits the current
-# window). Otherwise it creates/attaches a dedicated `gc-tui` session so the
-# TUI has a tmux to split into.
+# Default: if you are already inside tmux, the TUI takes over the current pane
+# (enter-peek then splits that window); otherwise it creates a dedicated
+# `gc-tui` session so the TUI has a tmux to split into.
+#
+# --split: pin the dashboard BESIDE the current pane instead of taking it over,
+# so you can leave it glancing on the side of the session you're working in
+# (e.g. the mayor). Run it from inside the tmux window you want split; it adds
+# a right-hand pane running the TUI and leaves your original pane in place.
+# Outside tmux there is no window to split, so --split falls back to the
+# dedicated `gc-tui` session (with a note).
 set -euo pipefail
 
-city="${1:-${GC_CITY_NAME:-}}"
+usage() {
+  sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+split=0
+pct=40
+city=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --split) split=1; shift ;;
+    -l | --pct) pct="${2:-40}"; shift 2 ;;
+    --city) city="${2:-}"; shift 2 ;;
+    --city=*) city="${1#--city=}"; shift ;;
+    --help) usage; exit 0 ;;
+    *) city="$1"; shift ;;
+  esac
+done
+city="${city:-${GC_CITY_NAME:-}}"
+pct="${pct%\%}" # accept "40" or "40%"
+
 city_flag=""
 [ -n "$city" ] && city_flag="-- --city=$city"
 
@@ -17,12 +43,31 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 run="cd '$root' && npm --workspace tui run start $city_flag"
 
+start_dedicated_session() {
+  # Start a CLEAN dedicated session: kill any stale `gc-tui` (orphan peek panes
+  # from a previous run) first, then create fresh.
+  tmux kill-session -t gc-tui 2>/dev/null || true
+  exec tmux new-session -s gc-tui "$run"
+}
+
+if [ "$split" = "1" ]; then
+  if [ -n "${TMUX:-}" ]; then
+    # Pin the dashboard beside the current pane (e.g. the mayor). Non-blocking:
+    # the new right-hand pane runs the TUI; the current pane is preserved.
+    # `-l N%` is tmux >= 3.1; fall back to the older `-p N` form otherwise.
+    tmux split-window -h -l "${pct}%" "$run" 2>/dev/null ||
+      tmux split-window -h -p "$pct" "$run"
+  else
+    echo "start-tmux.sh: --split needs an existing tmux window to split into;" >&2
+    echo "  not inside tmux, so launching the dedicated 'gc-tui' session instead." >&2
+    start_dedicated_session
+  fi
+  exit 0
+fi
+
 if [ -n "${TMUX:-}" ]; then
   # Already in tmux — run directly; enter-peek splits the current window.
   eval "$run"
 else
-  # Not in tmux — start a CLEAN dedicated session: kill any stale `gc-tui`
-  # (orphan peek panes from a previous run) first, then create fresh.
-  tmux kill-session -t gc-tui 2>/dev/null || true
-  exec tmux new-session -s gc-tui "$run"
+  start_dedicated_session
 fi

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -46,12 +46,18 @@ city="${city:-${GC_CITY_NAME:-}}"
 socket="${socket:-$city}" # gc's per-city tmux socket is named after the city
 pct="${pct%\%}"           # accept "40" or "40%"
 
-city_flag=""
-[ -n "$city" ] && city_flag="-- --city=$city"
+# Companion modes (--split / --target) open the truncated overview via --compact;
+# a plain launch keeps the full dashboard default.
+compact=0
+{ [ -n "$target" ] || [ "$split" = "1" ]; } && compact=1
+
+app_args=""
+[ -n "$city" ] && app_args="--city=$city"
+[ "$compact" = "1" ] && app_args="$app_args --compact"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/.." && pwd)"
-run="cd '$root' && npm --workspace tui run start $city_flag"
+run="cd '$root' && npm --workspace tui run start -- $app_args"
 
 # Split horizontally, running $run in the new pane. `-L <socket>` is a server
 # flag (before the subcommand); `-t <target>` is a split-window flag (after it),

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -1,32 +1,41 @@
 #!/usr/bin/env bash
 # Launch the Gas City TUI inside tmux so the live-peek split (enter) works.
 #
-#   ./tui/start-tmux.sh [--split] [--pct N] [<city>]   # or set GC_CITY_NAME
-#   npm --workspace tui run start:tmux -- [--split] [--pct N] [<city>]
+#   ./tui/start-tmux.sh [--split] [--pct N] [<city>]            # or set GC_CITY_NAME
+#   ./tui/start-tmux.sh --target mayor [--pct N] [<city>]       # pin beside a session
+#   npm --workspace tui run start:tmux -- [flags] [<city>]
 #
 # Default: if you are already inside tmux, the TUI takes over the current pane
 # (enter-peek then splits that window); otherwise it creates a dedicated
 # `gc-tui` session so the TUI has a tmux to split into.
 #
-# --split: pin the dashboard BESIDE the current pane instead of taking it over,
-# so you can leave it glancing on the side of the session you're working in
-# (e.g. the mayor). Run it from inside the tmux window you want split; it adds
-# a right-hand pane running the TUI and leaves your original pane in place.
-# Outside tmux there is no window to split, so --split falls back to the
-# dedicated `gc-tui` session (with a note).
+# --split: pin the dashboard BESIDE the current pane instead of taking it over.
+# Run it from inside the tmux window you want split; it adds a right-hand pane
+# running the TUI and leaves your original pane in place. Outside tmux there is
+# no window to split, so --split falls back to the dedicated `gc-tui` session.
+#
+# --target <session>: pin the dashboard beside a NAMED gc session FROM ANYWHERE
+# (no need to attach first). gc runs each city's tmux on a socket named after
+# the city, so this splits `tmux -L <city> -t <session>`. e.g. --target mayor
+# adds the dashboard to the right of the mayor's window; then
+# `gc session attach mayor` shows both. Override the socket with --socket.
 set -euo pipefail
 
 usage() {
-  sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 split=0
 pct=40
 city=""
+target=""
+socket=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --split) split=1; shift ;;
     -l | --pct) pct="${2:-40}"; shift 2 ;;
+    --target) target="${2:-}"; shift 2 ;;
+    --socket) socket="${2:-}"; shift 2 ;;
     --city) city="${2:-}"; shift 2 ;;
     --city=*) city="${1#--city=}"; shift ;;
     --help) usage; exit 0 ;;
@@ -34,7 +43,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 city="${city:-${GC_CITY_NAME:-}}"
-pct="${pct%\%}" # accept "40" or "40%"
+socket="${socket:-$city}" # gc's per-city tmux socket is named after the city
+pct="${pct%\%}"           # accept "40" or "40%"
 
 city_flag=""
 [ -n "$city" ] && city_flag="-- --city=$city"
@@ -43,6 +53,18 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 run="cd '$root' && npm --workspace tui run start $city_flag"
 
+# Split horizontally, running $run in the new pane. `-L <socket>` is a server
+# flag (before the subcommand); `-t <target>` is a split-window flag (after it),
+# so they go in separate argv slots. `-l N%` is tmux >= 3.1; `-p N` is the
+# pre-3.1 fallback.
+split_h() { # split_h <socket-or-empty> <target-or-empty>
+  local srv=() cmd=()
+  [ -n "$1" ] && srv=(-L "$1")
+  [ -n "$2" ] && cmd=(-t "$2")
+  tmux "${srv[@]}" split-window -h "${cmd[@]}" -l "${pct}%" "$run" 2>/dev/null ||
+    tmux "${srv[@]}" split-window -h "${cmd[@]}" -p "$pct" "$run"
+}
+
 start_dedicated_session() {
   # Start a CLEAN dedicated session: kill any stale `gc-tui` (orphan peek panes
   # from a previous run) first, then create fresh.
@@ -50,13 +72,28 @@ start_dedicated_session() {
   exec tmux new-session -s gc-tui "$run"
 }
 
+# --target: split a named session on the city socket, from anywhere.
+if [ -n "$target" ]; then
+  if [ -z "$socket" ]; then
+    echo "start-tmux.sh: --target needs a socket; pass a <city> or --socket <name>." >&2
+    exit 2
+  fi
+  if ! tmux -L "$socket" has-session -t "$target" 2>/dev/null; then
+    echo "start-tmux.sh: no tmux session '$target' on socket '$socket'." >&2
+    echo "  sessions on '$socket':" >&2
+    tmux -L "$socket" list-sessions -F '    #{session_name}' 2>/dev/null >&2 ||
+      echo "    (socket '$socket' not found — is the city running?)" >&2
+    exit 1
+  fi
+  split_h "$socket" "$target"
+  echo "Dashboard pinned beside '$target' (socket '$socket'). Attach with: gc session attach $target"
+  exit 0
+fi
+
+# --split: pin beside the current pane (must already be in a tmux window).
 if [ "$split" = "1" ]; then
   if [ -n "${TMUX:-}" ]; then
-    # Pin the dashboard beside the current pane (e.g. the mayor). Non-blocking:
-    # the new right-hand pane runs the TUI; the current pane is preserved.
-    # `-l N%` is tmux >= 3.1; fall back to the older `-p N` form otherwise.
-    tmux split-window -h -l "${pct}%" "$run" 2>/dev/null ||
-      tmux split-window -h -p "$pct" "$run"
+    split_h "" ""
   else
     echo "start-tmux.sh: --split needs an existing tmux window to split into;" >&2
     echo "  not inside tmux, so launching the dedicated 'gc-tui' session instead." >&2
@@ -65,6 +102,7 @@ if [ "$split" = "1" ]; then
   exit 0
 fi
 
+# default
 if [ -n "${TMUX:-}" ]; then
   # Already in tmux — run directly; enter-peek splits the current window.
   eval "$run"


### PR DESCRIPTION
## What

Turns the dashboard TUI into a **mayor-companion** you pin beside the mayor's tmux session: a launcher that splits it in next to the mayor, and a calm, scrollable, peekable **overview** tuned for what an operator tracks while working in the mayor seat. Stacks on the merged city-board (#39). Beads: `gascity-dashboard-o9vi` (launcher), `gascity-dashboard-3be4` + `gascity-dashboard-zcuc` (overview).

## The launcher (`tui/start-tmux.sh`)

- **`--split`** — pin the dashboard *beside* the current pane instead of taking it over (run from inside the window you want split).
- **`--target <session>`** — pin it beside a **named gc session from anywhere**, no attach needed. gc runs each city's tmux on a socket named after the city, so this splits `tmux -L <city> -t <session>`. e.g. `--target mayor ds-research` drops the dashboard to the right of the mayor's window; `gc session attach mayor` then shows both.
- **`--no-mouse`** (default for `--split`/`--target`) — the TUI releases the mouse so **tmux can drag-resize** the pinned pane; keyboard nav still scrolls. `--mouse` forces wheel-scroll back on.
- Companion modes open the TUI in compact (overview) mode via `--compact`.

## The companion overview (`o`, default when pinned)

One **scrollable, peekable** list with attention-first sections:

- **LEDGER** — what's waiting on you: needs-operator runs + mayor-escalated mail, worker chatter folded away with the **folded count shown** (`8 · 433 folded`). The single red heading.
- **ACTIVE** — all live agents, orchestration first; each row shows the **city name** (not `orchestration`) and what it's working on (`on <run>` via the lane's `activeAssignees`, else the activity hint).
- **BEADS** — in-progress, with open count.
- **RUNS** — active / needs-operator summary.

`enter` **peeks** any row — run (`bd show` + diff), **mail** (`gc mail peek`, read-only), agent (live log), bead — in a split **below** the dashboard (keeps full width; matters when pinned narrow). `enter` again / `x` closes it. `p` opens an agent's detail. `o` toggles to the full dashboard and back.

## Honest-signal / register

- No fabricated "what it's doing" summary — `on <run>` is wire-backed (`activeAssignees`); a model-written summary stays a separate follow-up (`gascity-dashboard-7dae`).
- City-name swap is display-only; the internal `orchestration` grouping key is unchanged.
- Greyscale, one red region (the LEDGER heading), no em dashes (DESIGN.md Reading Room / One Mark).

## Robustness fix

`useCity` now **resyncs on SSE (re)connect**, not just on events — so after a backend restart the dashboard recovers immediately instead of sitting stale (a null snapshot was surfacing as a confusing "city path not loaded" on peek).

## Scope

**TUI-only** — no `backend/`, `frontend/`, or `shared/` changes; no new dependency. The overview is a pure projection (`overviewModel`/`orchFirstActive`/`agentLane`/`displayRig`) over DTOs the TUI already fetches, rendered through the existing nav/peek machinery.

## Test plan

- [x] `npm --workspace tui run typecheck` — clean
- [x] `npm --workspace tui test` — **38/38** (counter, ledger ordering + folded count, orch-first active, agent→lane match, city-name swap, etc.)
- [x] Launcher verified live against tmux: `--split`/`--target` split + preserve the original pane; `--target` resolves the live mayor socket; `--no-mouse`/`--compact` injected for companion modes, `--mouse` opts out.
- [x] Headless render OK; live renders against a real snapshot confirmed the LEDGER (with folded count), city-name (`mayor → ds-research`), and on-lane (`control-dispatcher → on mol-focus-review`).

> Note: the `tui/` workspace is not yet in root CI `typecheck` (per `tui/README.md`); its gates are the two commands above.

## Follow-ups (not here)

- `gascity-dashboard-5e5v` — backend: strip ANSI/OSC from supervisor rig names at the snapshot edge (pre-existing).
- `gascity-dashboard-7dae` — model-written per-session task summaries.
- Mouse-drag resize is still limited by the *neighbouring* Claude Code pane also grabbing the mouse; `--no-mouse` does its part, keyboard/`resize-pane` is the reliable resize.
