### PR TITLE
fix(mail): neutral Compose button (drop accent/maroon tone)

### DIFF
--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -268,7 +268,6 @@ export function MailPage() {
               </span>
             )}
             <Button
-              tone="accent"
               size="sm"
               onClick={() => setComposing(true)}
               disabled={!viewingAs.isOperator}


### PR DESCRIPTION
## What

The Mail **Compose** button carried `tone="accent"`, rendering it in the maroon accent.

## Why

DESIGN.md reserves the maroon accent for the rare loud moment — an anomaly indicator, a focused state, a destructive action, or a count that has crossed a threshold — and the **One Mark Rule** caps maroon at one per viewport. A routine Compose action is none of those, so it shouldn't carry the accent. This drops `tone="accent"` so Compose falls back to the neutral default tone, matching the neighbouring **Refresh** button's hairline.

## Scope

One line. No behaviour change, only the button's tone. Frontend typecheck clean; Mail tests pass (20).

## Note (not in this PR)

The **Reply** button in the thread footer also uses `tone="accent"`. Left as-is since only Compose was flagged — happy to neutralize it too (it would also help the One Mark Rule) if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)