### PR TITLE
fix(home): concern/status deep-links keep the /city basename (Link, not <a>)

### DIFF
--- a/frontend/src/components/ambient/ConcernRegion.tsx
+++ b/frontend/src/components/ambient/ConcernRegion.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import type { RunLane } from 'gas-city-dashboard-shared';
 
 // gascity-dashboard-kb3 PRD §4 — "Concern region". Items needing a
@@ -94,13 +95,13 @@ export function ConcernRegion({ rows }: ConcernRegionProps) {
       >
         {rows.map(({ lane, reason }) => (
           <li key={lane.id} className="text-body text-fg flex items-baseline gap-3">
-            <a
-              href={rowHref(lane)}
+            <Link
+              to={rowHref(lane)}
               className="font-medium hover:text-fg focus-mark"
               data-testid={`concern-row-${lane.id}`}
             >
               {laneToken(lane)}
-            </a>
+            </Link>
             <span className="text-label uppercase tracking-wider text-fg-muted">
               {reasonLabel(reason)}
             </span>

--- a/frontend/src/components/ambient/StatusSentence.tsx
+++ b/frontend/src/components/ambient/StatusSentence.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import type { RunLane } from 'gas-city-dashboard-shared';
 
 // gascity-dashboard-kb3 PRD §4 line 2 — "the lean-in read".
@@ -95,13 +96,13 @@ export function StatusSentence({ topConcern }: StatusSentenceProps) {
         // as plain text — no maroon class (R2 floor), no deep link.
         <span data-testid="status-sentence-token">{token}</span>
       ) : (
-        <a
-          href={href}
+        <Link
+          to={href}
           className="text-accent font-semibold focus-mark"
           data-testid="status-sentence-token"
         >
           {token}
-        </a>
+        </Link>
       )}{' '}
       {phrase} {ageLabel}.
     </p>


### PR DESCRIPTION
## Symptom

On Home, clicking a "needs you" concern row (e.g. *mol-focus-review*) took the operator **back to Home** instead of opening the run.

## Root cause

The app mounts its router under a **`/city/<cityName>` basename** (`main.tsx`). The Home concern rows (`ConcernRegion`) and the top-concern token (`StatusSentence`) linked to runs with a **plain `<a href="/runs/<id>?...">`**. A raw anchor ignores the router basename, so the browser navigated to a bare `/runs/<id>` (outside the city scope), matched no city-scoped route, and the app redirected back to the city home.

Reproduced headless — nav trail before the fix:
```
/city/ds-research/  →  (click)  /runs/gc-r97inq?...  →  /city/ds-research/   ← bounced home
```

## Fix

Use React Router `<Link to=...>` instead of `<a href=...>` in both components. `<Link>` resolves the target against the basename (`/city/<cityName>/runs/<id>?...`) and does client-side navigation instead of a full reload.

After the fix, the same click lands on `/city/ds-research/runs/gc-r97inq?...` (the run detail page).

## Scope / notes

- Only `ConcernRegion` + `StatusSentence` had this — every other internal deep-link already uses `<Link>`/`<NavLink>` (Header, AttentionSummaryPanel, RelatedEntities). External links (`html_url`, `lane.external.url`) are unaffected.
- 619 frontend tests pass; typecheck + build + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)