### PR TITLE
docs(tui): launcher prints how to focus the pinned dashboard (Ctrl-b →/←)

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -166,6 +166,13 @@ and leaving it in place. Then `gc session attach mayor` shows the mayor and the
 dashboard side by side. If the session or socket isn't found, it lists what's on
 the socket and exits non-zero rather than guessing.
 
+**Driving it (focus).** Pinning deliberately keeps focus on the session you were
+in (so you keep typing to the mayor), which means the keyboard reaches the
+dashboard only once you focus its pane: **`Ctrl-b →`** steps into the dashboard
+(then `↑↓`/`enter`/`o`/`q` work there), **`Ctrl-b ←`** goes back to the mayor,
+`Ctrl-b o` toggles. One keyboard, two panes — you switch focus between typing and
+driving the dashboard. The launcher prints this hint when it pins.
+
 Env: `DASHBOARD_URL` (default `http://127.0.0.1:8081`), `GC_CITY_NAME` or
 `--city=<name>` (required — no silent fallback to a default city). Press `q` to
 quit.

--- a/tui/start-tmux.sh
+++ b/tui/start-tmux.sh
@@ -101,6 +101,14 @@ start_dedicated_session() {
   exec tmux new-session -s gc-tui "$run"
 }
 
+# Pinned beside another pane, focus deliberately stays where you were (so you
+# keep typing there) — so the keyboard reaches the dashboard only once you focus
+# it. Spell that out; it's the #1 "how do I use this" question.
+focus_hint() { # focus_hint <where-focus-stays>
+  echo "  Keyboard goes to the focused pane. Press Ctrl-b →  to drive the dashboard"
+  echo "  (scroll, enter to peek, q to quit) and Ctrl-b ←  to get back to $1."
+}
+
 # --target: split a named session on the city socket, from anywhere.
 if [ -n "$target" ]; then
   if [ -z "$socket" ]; then
@@ -116,6 +124,7 @@ if [ -n "$target" ]; then
   fi
   split_h "$socket" "$target"
   echo "Dashboard pinned beside '$target' (socket '$socket'). Attach with: gc session attach $target"
+  focus_hint "$target"
   exit 0
 fi
 
@@ -123,6 +132,8 @@ fi
 if [ "$split" = "1" ]; then
   if [ -n "${TMUX:-}" ]; then
     split_h "" ""
+    echo "Dashboard pinned beside this pane."
+    focus_hint "this pane"
   else
     echo "start-tmux.sh: --split needs an existing tmux window to split into;" >&2
     echo "  not inside tmux, so launching the dedicated 'gc-tui' session instead." >&2


### PR DESCRIPTION
After the focus fix (#47), pinning the dashboard keeps focus on the original pane (so you keep typing to the mayor) — which means the keyboard reaches the dashboard only once you focus its pane. That's the first thing every user hits. The launcher now prints a focus hint when it pins (`--split`/`--target`):

```
Dashboard pinned beside 'mayor' (socket 'ds-research'). Attach with: gc session attach mayor
  Keyboard goes to the focused pane. Press Ctrl-b →  to drive the dashboard
  (scroll, enter to peek, q to quit) and Ctrl-b ←  to get back to mayor.
```

README's pin section documents the same (one keyboard, two panes — `Ctrl-b →`/`←`/`o` to switch). No behaviour change; launcher + docs only. Follow-up to #45/#47.