### PR TITLE
fix(runs): normalize pool-qualified session ids (fixes Session tab "invalid session id")

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/index.test.ts src/session-resolve.test.ts src/alert.test.ts src/pending.test.ts"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/shared/src/runs/session-link.test.ts
+++ b/shared/src/runs/session-link.test.ts
@@ -1,0 +1,46 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runSessionLinkFor } from './session-link.js';
+
+// Regression coverage for the rig-store / polecat run "invalid session id"
+// bug. A polecat run records its session as the pool-qualified NAME
+// (`polecat-gc-333573`), whose real supervisor session id is the gc-suffix
+// (`gc-333573`). When the session has completed it is absent from the live
+// session index, so it can't be resolved by name — the link must normalize
+// the recorded value to the supervisor id itself, or the Session tab feeds a
+// name where an id is expected and the route rejects it as "invalid session id".
+describe('runSessionLinkFor — session id normalization', () => {
+  test('normalizes a pool-qualified session name in metadata to the supervisor id', () => {
+    const bead = {
+      assignee: 'polecat-gc-333573',
+      metadata: { session_id: 'polecat-gc-333573' },
+    } as never;
+    const link = runSessionLinkFor(bead, 'done');
+    assert.equal(link?.sessionId, 'gc-333573');
+  });
+
+  test('leaves a clean gc-prefixed session id unchanged', () => {
+    const bead = { metadata: { session_id: 'gc-333573' } } as never;
+    const link = runSessionLinkFor(bead, 'done');
+    assert.equal(link?.sessionId, 'gc-333573');
+  });
+
+  test('derives the id from a pool-qualified assignee when no metadata id is present', () => {
+    const bead = { assignee: 'polecat-gc-333573' } as never;
+    const link = runSessionLinkFor(bead, 'done');
+    assert.equal(link?.sessionId, 'gc-333573');
+  });
+
+  test('falls back to the raw value when it carries no extractable supervisor id', () => {
+    const bead = { metadata: { session_id: 'mystery-handle' } } as never;
+    const link = runSessionLinkFor(bead, 'done');
+    assert.equal(link?.sessionId, 'mystery-handle');
+  });
+
+  test('returns undefined for pending/ready nodes (no session yet)', () => {
+    const bead = { assignee: 'polecat-gc-333573' } as never;
+    assert.equal(runSessionLinkFor(bead, 'pending'), undefined);
+    assert.equal(runSessionLinkFor(bead, 'ready'), undefined);
+  });
+});

--- a/shared/src/runs/session-link.ts
+++ b/shared/src/runs/session-link.ts
@@ -46,12 +46,19 @@ export function runSessionLinkFor(
 ): RunSessionLink | undefined {
   if (status === 'pending' || status === 'ready') return undefined;
   const assignee = nonEmpty(bead.assignee);
-  const sessionId =
+  // The bead's recorded session id can be a pool-qualified session NAME
+  // (e.g. a polecat run records `polecat-gc-333573`, whose real supervisor
+  // session id is `gc-333573`). Normalize every candidate through
+  // supervisorSessionIdFrom so the link carries the id the session routes
+  // expect — otherwise a completed session (absent from the live index, so
+  // unresolvable by name) leaks its name into the id slot and the Session
+  // tab rejects it as "invalid session id".
+  const rawSessionId =
     meta(bead, 'session_id') ??
     meta(bead, 'gc.session_id') ??
     meta(bead, 'gc.sessionId') ??
-    supervisorSessionIdFrom(assignee) ??
     assignee;
+  const sessionId = supervisorSessionIdFrom(rawSessionId) ?? rawSessionId;
   const sessionName =
     meta(bead, 'session_name') ??
     meta(bead, 'gc.session_name') ??


### PR DESCRIPTION
## Symptom

Opening a run's **Session** tab showed **"invalid session id"** for polecat / rig-store runs (e.g. *mol-focus-review*, `gc-r97inq`).

## Root cause

A polecat run records its session as the **pool-qualified session NAME** — `polecat-gc-333573` — whose real supervisor session **id** is the gc-suffix `gc-333573` (the supervisor lists id `gc-333570` with name `polecat-gc-333570`, etc.).

`runSessionLinkFor` normalized only the `assignee` through `supervisorSessionIdFrom`; a `session_id` recorded in bead **metadata** was used verbatim. Once the session completes it drops out of the live session index, so it can't be resolved by name either — and the unnormalized name (`polecat-gc-333573`) leaked into the link's `sessionId`. The Session tab then fed a name where a session id was expected, and the session route rejected it against `SESSION_ID_RE` as "invalid session id".

## Fix

Normalize **every** recorded candidate (metadata `session_id` / `gc.session_id` / `gc.sessionId`, then `assignee`) through `supervisorSessionIdFrom`, falling back to the raw value when no supervisor id can be extracted:
- clean `gc-…` id → unchanged
- pool-qualified name `polecat-gc-333573` → `gc-333573`

The session-id validator (`SESSION_ID_RE`) is left untouched — it was correct; the linker was producing a name-shaped id.

## Tests

- New `shared/src/runs/session-link.test.ts` covering the normalization (metadata name, clean id, assignee derivation, non-id fallback, pending/ready).
- Switched the shared `test` script to a recursive `src/**/*.test.ts` glob — the previous hardcoded list silently skipped subdir tests like this one. Shared suite: 51 pass.
- Typecheck (src+test) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)