### PR TITLE
feat(home-alerts): surface mayor-decision queue from needs/stephanie beads

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -109,16 +109,23 @@ describe('useLiveAttentionContributors', () => {
         request_id: 'req-1',
       },
     });
-    mockSupervisorApi.listBeads.mockResolvedValue({
-      total: 1,
-      items: [{
-        created_at: '2026-05-29T20:00:00.000Z',
-        id: 'B-1',
-        issue_type: 'task',
-        priority: null,
-        status: 'blocked',
-        title: 'Blocked bead',
-      }],
+    mockSupervisorApi.listBeads.mockImplementation((_city, query) => {
+      // The label-filtered call is the dedicated mayor-decision queue; the
+      // unfiltered call is the general bead list.
+      if (query?.label !== undefined) {
+        return Promise.resolve({ total: 0, items: [] });
+      }
+      return Promise.resolve({
+        total: 1,
+        items: [{
+          created_at: '2026-05-29T20:00:00.000Z',
+          id: 'B-1',
+          issue_type: 'task',
+          priority: null,
+          status: 'blocked',
+          title: 'Blocked bead',
+        }],
+      });
     });
     mockSupervisorApi.listMail.mockResolvedValue({
       total: 2,
@@ -266,6 +273,10 @@ describe('useLiveAttentionContributors', () => {
     expect(mockSupervisorApi.listSessions).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApi.sessionPending).toHaveBeenCalledWith('test-city', 'gc-2568');
     expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', { limit: 1000 });
+    expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', {
+      label: 'needs/stephanie',
+      status: 'open',
+    });
     expect(mockSupervisorApi.listEvents).toHaveBeenCalledWith('test-city', { limit: 100, since: '24h' });
     expect(mockSupervisorApi.listMail).toHaveBeenCalledWith('test-city', { limit: 100 });
     expect(mockSupervisorApi.cityHealth).toHaveBeenCalledWith('test-city');

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -15,6 +15,7 @@ import {
 import type { AttentionContributor } from './compose';
 import {
   createAttentionContributors,
+  NEEDS_STEPHANIE_LABEL,
   type ActivityAttentionFacts,
   type AgentsAttentionFacts,
   type AttentionContributorFacts,
@@ -134,16 +135,33 @@ async function fetchBeadsAttention(
   cityName: string | null,
 ): Promise<BeadsAttentionFacts> {
   if (cityName === null) return {};
-  try {
-    const list = await supervisorApi().listBeads(cityName, { limit: ATTENTION_LIST_LIMIT });
-    return {
-      items: list.items ?? [],
-      nowMs: Date.now(),
-      partial: list.partial === true,
-    };
-  } catch (err) {
-    return { error: formatApiError(err, 'bead list unavailable') };
+  // Two independent reads: the general bead list (capped) and the dedicated
+  // mayor-decision queue (label+status filtered, always complete). Settled
+  // separately so one failing does not blank the other — the decision queue
+  // and generic bead alerts are distinct signals.
+  const [list, decisions] = await Promise.allSettled([
+    supervisorApi().listBeads(cityName, { limit: ATTENTION_LIST_LIMIT }),
+    supervisorApi().listBeads(cityName, {
+      label: NEEDS_STEPHANIE_LABEL,
+      status: 'open',
+    }),
+  ]);
+  const facts: BeadsAttentionFacts = { nowMs: Date.now() };
+  if (list.status === 'fulfilled') {
+    facts.items = list.value.items ?? [];
+    facts.partial = list.value.partial === true;
+  } else {
+    facts.error = formatApiError(list.reason, 'bead list unavailable');
   }
+  if (decisions.status === 'fulfilled') {
+    facts.decisions = decisions.value.items ?? [];
+  } else {
+    facts.decisionsError = formatApiError(
+      decisions.reason,
+      'decision queue unavailable',
+    );
+  }
+  return facts;
 }
 
 async function fetchMailAttention(

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -17,7 +17,11 @@ import type {
   TypedEventStreamEnvelope,
 } from '../generated/gc-supervisor-client/types.gen';
 import { ATTENTION_DOMAINS, composeAttention } from './compose';
-import { createAttentionContributors, type AgentsAttentionFacts } from './registry';
+import {
+  createAttentionContributors,
+  NEEDS_STEPHANIE_LABEL,
+  type AgentsAttentionFacts,
+} from './registry';
 
 describe('createAttentionContributors', () => {
   it('registers an explicit contributor for every first-class attention domain', () => {
@@ -302,6 +306,81 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.mail.items.map((item) => item.href)).toContain(
       '/mail?message=M-stale-unread',
     );
+  });
+
+  it('surfaces each open mayor-decision bead as an attention item linked to the bead view', () => {
+    const model = composeAttention(createAttentionContributors({
+      beads: {
+        decisions: [
+          bead({
+            id: 'dec-nqy',
+            title: 'Decide: stale-CHANGES_REQUESTED merge-queue protocol',
+            assignee: 'stephanie',
+            labels: [NEEDS_STEPHANIE_LABEL],
+            updated_at: '2026-06-03T14:18:47.000Z',
+            metadata: { 'decision.decide': 'Auto-close or escalate stale CR PRs?' },
+          }),
+        ],
+      },
+    }));
+
+    expect(model.byDomain.beads.items).toEqual([
+      expect.objectContaining({
+        id: 'beads:dec-nqy:mayor-decision',
+        domain: 'beads',
+        severity: 'attention',
+        title: 'Decide: stale-CHANGES_REQUESTED merge-queue protocol',
+        summary: 'Auto-close or escalate stale CR PRs?',
+        href: '/beads?bead=dec-nqy',
+        updatedAt: '2026-06-03T14:18:47.000Z',
+      }),
+    ]);
+  });
+
+  it('renders a mayor-decision with no decision.decide metadata using the title alone', () => {
+    const model = composeAttention(createAttentionContributors({
+      beads: {
+        decisions: [
+          bead({ id: 'dec-rwr', title: 'Decide: P0 baseline-honesty-gate halt', labels: [NEEDS_STEPHANIE_LABEL] }),
+        ],
+      },
+    }));
+
+    const item = model.byDomain.beads.items[0];
+    expect(item?.id).toBe('beads:dec-rwr:mayor-decision');
+    expect(item?.summary).toBeUndefined();
+  });
+
+  it('does not double-surface a marker bead present in the general list', () => {
+    const model = composeAttention(createAttentionContributors({
+      beads: {
+        // Same bead in both the dedicated queue and the capped general list:
+        // priority 1 would otherwise also trip the generic high-priority branch.
+        decisions: [
+          bead({ id: 'dec-nqy', title: 'Decide: X', labels: [NEEDS_STEPHANIE_LABEL], priority: 1 }),
+        ],
+        items: [
+          bead({ id: 'dec-nqy', title: 'Decide: X', labels: [NEEDS_STEPHANIE_LABEL], priority: 1 }),
+        ],
+      },
+    }));
+
+    expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
+      'beads:dec-nqy:mayor-decision',
+    ]);
+  });
+
+  it('surfaces a decision-queue fetch failure without blanking generic bead alerts', () => {
+    const model = composeAttention(createAttentionContributors({
+      beads: {
+        decisionsError: 'decision queue unavailable: ECONNREFUSED',
+        items: [bead({ id: 'B-1', title: 'Fix broken formula', status: 'blocked' })],
+      },
+    }));
+
+    const ids = model.byDomain.beads.items.map((item) => item.id);
+    expect(ids).toContain('beads:decisions-unavailable');
+    expect(ids).toContain('beads:B-1:blocked');
   });
 
   it('derives maintainer attention from needs-you, awaiting-triage, and blocked slung facts', () => {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -55,9 +55,20 @@ export interface AgentsAttentionFacts {
 
 export interface BeadsAttentionFacts {
   items?: readonly Bead[];
+  /**
+   * The mayor-decision queue: open beads carrying the `needs/stephanie`
+   * marker, fetched with the dedicated label+status filter
+   * (specs/architecture/mayor-decision-ledger.md §6). Kept separate from the
+   * general `items` list because that list is capped and can paginate the
+   * decision beads out; the filtered query is always complete. Rendered as
+   * their own attention identity, never re-triaged (ZFC).
+   */
+  decisions?: readonly Bead[];
   nowMs?: number;
   partial?: boolean;
   error?: string;
+  /** Failure of the dedicated decision-queue fetch, independent of `error`. */
+  decisionsError?: string;
 }
 
 export interface MailAttentionFacts {
@@ -98,6 +109,22 @@ const AGENT_IDLE_WATCH_MS = 4 * 60 * 60 * 1000;
 const BEAD_UNCLAIMED_WATCH_MS = 24 * 60 * 60 * 1000;
 const BEAD_STALE_ATTENTION_MS = 72 * 60 * 60 * 1000;
 const MAIL_UNREAD_STALE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The mayor-decision marker label (specs/architecture/mayor-decision-ledger.md
+ * §2). An open bead carrying it is a curated decision awaiting Stephanie's
+ * direction. Exported so the dedicated fetch filter (liveContributors) and the
+ * generic-loop skip below resolve the same marker — a rename touches one line.
+ */
+export const NEEDS_STEPHANIE_LABEL = 'needs/stephanie';
+
+/**
+ * Flat metadata key for the mayor's one-sentence decision question (the spec's
+ * `metadata.decision.decide`). Optional: absent on a minimally-authored
+ * decision bead, present once the mayor writes the full payload (spec §7). When
+ * present it becomes the row summary; when absent the title carries the ask.
+ */
+const DECISION_DECIDE_META_KEY = 'decision.decide';
 
 export function createAttentionContributors(
   facts: AttentionContributorFacts = {},
@@ -435,8 +462,23 @@ function deriveBeadsAttention(
       href: '/beads',
     }));
   }
+  if (facts.decisionsError !== undefined && facts.decisionsError.length > 0) {
+    items.push(domainAttention('beads', {
+      id: 'beads:decisions-unavailable',
+      title: 'Decision queue unavailable',
+      summary: facts.decisionsError,
+      href: '/beads',
+    }));
+  }
+  for (const decision of facts.decisions ?? []) {
+    items.push(mayorDecisionAttention(decision));
+  }
   const nowMs = facts.nowMs ?? Date.now();
   for (const bead of facts.items ?? []) {
+    // Marker beads surface via the dedicated decision queue above; skip them
+    // here so a priority-1 decision bead is not also surfaced as a generic
+    // high-priority/stale bead alert (double-surfacing).
+    if (isMayorDecision(bead)) continue;
     if (bead.status === 'blocked') {
       items.push(domainAttention('beads', {
         id: `beads:${bead.id}:blocked`,
@@ -500,6 +542,37 @@ function beadHref(beadId: string): string {
   const search = new URLSearchParams();
   search.set('bead', beadId);
   return `/beads?${search.toString()}`;
+}
+
+/**
+ * A bead carries the mayor-decision marker. Used to keep a marker bead that
+ * also appears in the general list from double-surfacing as a generic bead
+ * alert (the decision-queue fetch already restricts to open).
+ */
+function isMayorDecision(bead: Bead): boolean {
+  return (bead.labels ?? []).includes(NEEDS_STEPHANIE_LABEL);
+}
+
+/**
+ * Project one mayor-decision bead into its home-view attention identity
+ * (spec §6). Mechanical: title + bead-linked-view href, with the decision
+ * question as the summary when the mayor has written it. severity=attention
+ * via domainAttention — a curated human-authored ask, never a failure. The
+ * `:mayor-decision` id namespace keeps its identity distinct from generic
+ * bead alerts and self-clears when the bead closes (the queue stops returning
+ * it).
+ */
+function mayorDecisionAttention(bead: Bead): AttentionItem {
+  const decide = bead.metadata?.[DECISION_DECIDE_META_KEY];
+  return domainAttention('beads', {
+    id: `beads:${bead.id}:mayor-decision`,
+    title: bead.title,
+    href: beadHref(bead.id),
+    updatedAt: bead.updated_at ?? bead.created_at,
+    ...(decide !== undefined && decide.trim().length > 0
+      ? { summary: decide }
+      : {}),
+  });
 }
 
 function deriveMailAttention(


### PR DESCRIPTION
## What

Surfaces a **mayor-decision** queue in the home-alerts attention tier, consuming the supervisor beads API filtered by label `needs/stephanie` (response key `.items`), on the post-PR-44 attention-registry architecture. Resolves the mayor-decision alert tier (gascity-dashboard-k0cr).

## Review

Reviewed via the dashboard multi-reviewer pipeline (code + security + typescript). **Decision: approve.**
- CI parity all green: typecheck (src) + typecheck:test (backend+frontend) + lint + frontend build + 623 frontend tests + 908 backend tests.
- Wire-shape contract clean (uses generated `Bead` type; `BeadsAttentionFacts` is frontend-local, no `shared/` drift); null-safety, `Promise.allSettled` fetch isolation, and double-surfacing dedup all correct; security trust boundaries clean (React text-node escaping, no `dangerouslySetInnerHTML`, no origin/bind weakening, no secret leak).

## Non-blocking follow-ups (tracked separately)
- `decisionsError` uses `domainAttention`; secondary-fetch failures elsewhere use `domainWatch`.
- A `needs/stephanie` bead with non-`open` status is silently dropped (status filter + dedup skip).
- Add `.max()` to bead title/metadata in the frontend zod schema (defense-in-depth; not rendered today).
- Greyscale: severity distinction is color-only in `AttentionSummaryPanel` (pre-existing) — add a severity glyph.
- Add an integration test exercising non-empty `decisions` through `useLiveAttentionContributors`.

## Test plan
- [x] typecheck + typecheck:test + lint + build + both suites green
- [ ] verify mayor-decision rows render against live `needs/stephanie` beads (dec-rwr/nqy/cox/h16)
