### PR TITLE
fix(dashboard): rescue empty beads board + restore agents active-only default

### DIFF
--- a/frontend/src/hooks/useCachedData.test.tsx
+++ b/frontend/src/hooks/useCachedData.test.tsx
@@ -75,6 +75,45 @@ describe("useCachedData", () => {
     expect(getCached<string>(cacheKey)).toBe("fresh result");
   });
 
+  it("seeds data from a superseded run when no result has landed yet", async () => {
+    // A busy SSE stream re-fires refresh() faster than the slow fetch
+    // resolves, so every run is superseded before it completes. Without
+    // first-paint rescue the latest-run guard never sets data and the
+    // panel stays empty forever (the beads-board "Nothing on the queue"
+    // bug). The first completing run for the still-current key must seed
+    // data even though a newer run is already in flight.
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const calls = [first, second];
+    let callIndex = 0;
+    const fetcher = vi.fn(() => calls[callIndex++]!.promise);
+    const cacheKey = "beads:board:";
+
+    const { result } = renderHook(() =>
+      useCachedData(cacheKey, fetcher),
+    );
+
+    // Mount fires run #1 (first). A refresh supersedes it with run #2
+    // (second) before run #1 resolves.
+    act(() => {
+      void result.current.refresh();
+    });
+
+    // Run #1 resolves AFTER being superseded — first-paint rescue seeds it.
+    await act(async () => {
+      first.resolve("first result");
+      await first.promise;
+    });
+    await waitFor(() => expect(result.current.data).toBe("first result"));
+
+    // Once the latest run lands it wins, replacing the rescued value.
+    await act(async () => {
+      second.resolve("second result");
+      await second.promise;
+    });
+    await waitFor(() => expect(result.current.data).toBe("second result"));
+  });
+
   it("reports the latest fetch failure through onError", async () => {
     const onError = vi.fn();
     const failure = new Error("network down");

--- a/frontend/src/hooks/useCachedData.ts
+++ b/frontend/src/hooks/useCachedData.ts
@@ -60,9 +60,21 @@ export function useCachedData<T>(
       try {
         const fresh = await fetch();
         const isLatestRun = runIdRef.current === runId;
-        const isInactiveKey = currentKeyRef.current !== cacheKey;
-        if (isLatestRun || isInactiveKey) setCached(cacheKey, fresh);
-        if (isLatestRun) setData(fresh);
+        const isActiveKey = currentKeyRef.current === cacheKey;
+        if (isLatestRun || !isActiveKey) setCached(cacheKey, fresh);
+        if (isLatestRun) {
+          setData(fresh);
+        } else if (isActiveKey) {
+          // First-paint rescue: a busy SSE stream can re-fire refresh()
+          // faster than a slow fetch (e.g. the beads board's per-type
+          // task query) completes, so every run is superseded before it
+          // lands and the latest-run guard never sets data — the panel
+          // stays empty forever. Seed from this superseded-but-current
+          // run only while data is still undefined; once any result has
+          // landed, latest-run-wins resumes and a stale slow fetch never
+          // clobbers fresher data.
+          setData((prev) => (prev === undefined ? fresh : prev));
+        }
       } catch (err) {
         if (runIdRef.current === runId) {
           setError(err instanceof Error ? err.message : 'failed to load');

--- a/frontend/src/hooks/useListFilters.test.ts
+++ b/frontend/src/hooks/useListFilters.test.ts
@@ -176,6 +176,65 @@ describe('useListFilters', () => {
     expect(gcGroup?.rows.map((r) => r.id)).toEqual(['gc-1', 'gc-2']);
   });
 
+  it('seeds activeChipIds from initialActiveChipIds on mount', () => {
+    // Chip state is ephemeral, so initialActiveChipIds is the only way to
+    // give a view a default filter (Agents booting into "open" only).
+    const { result } = renderHook(() =>
+      useListFilters({
+        viewKey: 'beads',
+        rows,
+        projectOf,
+        searchOf,
+        chips,
+        initialActiveChipIds: ['open'],
+      }),
+    );
+
+    expect(result.current.activeChipIds.has('open')).toBe(true);
+    // 3 open rows across gc + codeprobe + agent-diagnostics.
+    expect(result.current.totalMatches).toBe(3);
+  });
+
+  it('lets the operator toggle a seeded default chip back off', () => {
+    const { result } = renderHook(() =>
+      useListFilters({
+        viewKey: 'beads',
+        rows,
+        projectOf,
+        searchOf,
+        chips,
+        initialActiveChipIds: ['open'],
+      }),
+    );
+
+    act(() => result.current.toggleChip('open'));
+    expect(result.current.activeChipIds.has('open')).toBe(false);
+    expect(result.current.totalMatches).toBe(5);
+  });
+
+  it('re-seeds the default chip set when viewKey changes', () => {
+    let viewKey = 'agents:a';
+    const { result, rerender } = renderHook(() =>
+      useListFilters({
+        viewKey,
+        rows,
+        projectOf,
+        searchOf,
+        chips,
+        initialActiveChipIds: ['open'],
+      }),
+    );
+
+    act(() => result.current.toggleChip('open'));
+    expect(result.current.activeChipIds.has('open')).toBe(false);
+
+    viewKey = 'agents:b';
+    rerender();
+
+    // viewKey reset restores the seed, not an empty set.
+    expect(result.current.activeChipIds.has('open')).toBe(true);
+  });
+
   it('resets ephemeral search and chip state when viewKey changes (Mail inbox <-> sent)', () => {
     let viewKey = 'mail:inbox';
     const { result, rerender } = renderHook(() =>

--- a/frontend/src/hooks/useListFilters.ts
+++ b/frontend/src/hooks/useListFilters.ts
@@ -63,6 +63,13 @@ interface UseListFiltersOptions<T> {
   /** Strings to consider for substring search. */
   searchOf: (row: T) => ReadonlyArray<string | undefined | null>;
   chips: ReadonlyArray<FilterChip<T>>;
+  /**
+   * Chip ids active on first mount and after every viewKey change. Chip
+   * state is ephemeral (never persisted), so this is the only way to give
+   * a view a default filter — e.g. Agents booting into "running" only.
+   * The operator can still toggle the seeded chips off.
+   */
+  initialActiveChipIds?: ReadonlyArray<string>;
   /** When true, groups start collapsed and the persisted Set is "user-expanded". */
   defaultCollapsed?: boolean;
   /** Activity timestamp (epoch ms) for a row. Required for sortMode='activity'. */
@@ -149,6 +156,7 @@ function reportStorageParseFailure(key: string, err: unknown): void {
 
 const EMPTY_PINNED: ReadonlyArray<string> = [];
 const EMPTY_NONCOLLAPSIBLE: ReadonlySet<string> = new Set();
+const EMPTY_INITIAL_CHIPS: ReadonlyArray<string> = [];
 
 export function useListFilters<T>({
   viewKey,
@@ -156,15 +164,19 @@ export function useListFilters<T>({
   projectOf,
   searchOf,
   chips,
+  initialActiveChipIds = EMPTY_INITIAL_CHIPS,
   defaultCollapsed = false,
   activityOf,
   defaultSortMode = 'alpha',
   pinnedProjects = EMPTY_PINNED,
   nonCollapsibleProjects = EMPTY_NONCOLLAPSIBLE,
 }: UseListFiltersOptions<T>): UseListFiltersResult<T> {
+  // Stable key so the viewKey-reset effect re-runs only when the seed set
+  // actually changes, not on every render (the array prop is unstable).
+  const initialChipKey = initialActiveChipIds.join(',');
   const [search, setSearch] = useState('');
   const [activeChipIds, setActiveChipIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
+    () => new Set(initialActiveChipIds),
   );
   // The Set is "user overrides": projects whose current collapse state
   // differs from defaultCollapsed. isCollapsed(p) = defaultCollapsed XOR overrides.has(p).
@@ -183,8 +195,10 @@ export function useListFilters<T>({
     setOverrides(loadOverrides(viewKey, defaultCollapsed));
     setSortModeState(loadSortMode(viewKey, defaultSortMode));
     setSearch('');
-    setActiveChipIds(new Set());
-  }, [viewKey, defaultCollapsed, defaultSortMode]);
+    setActiveChipIds(new Set(initialActiveChipIds));
+    // initialActiveChipIds is keyed by initialChipKey for dep stability.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewKey, defaultCollapsed, defaultSortMode, initialChipKey]);
 
   const toggleChip = useCallback((id: string) => {
     setActiveChipIds((cur) => {

--- a/frontend/src/routes/Agents.chips.test.ts
+++ b/frontend/src/routes/Agents.chips.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentResponse } from '../generated/gc-supervisor-client/types.gen';
-import { AGENT_CHIPS, buildAgentSynopsis, stateTone } from './Agents';
+import { AGENT_CHIPS, AGENT_DEFAULT_CHIPS, buildAgentSynopsis, stateTone } from './Agents';
 
 // gascity-dashboard-ay6: the Agents view consumes the supervisor's
 // first-class agent roster (AgentResponse), not the session list. These tests
@@ -75,6 +75,18 @@ describe('AGENT_CHIPS', () => {
     expect(matchingIds).toContain('detached');
     // Bound the match set: only those two chips, no spurious third match.
     expect(matchingIds).toHaveLength(2);
+  });
+
+  it('defaults the Agents view to the actively-running chip', () => {
+    // The Agents view boots into "what's running right now" (restores
+    // commit 00cad8f, lost in the useListFilters migration). The default
+    // set must name the 'running' chip and only ids that AGENT_CHIPS
+    // actually defines, otherwise the seed silently filters to nothing.
+    expect(AGENT_DEFAULT_CHIPS).toEqual(['running']);
+    const chipIds = new Set(AGENT_CHIPS.map((chip) => chip.id));
+    for (const id of AGENT_DEFAULT_CHIPS) {
+      expect(chipIds.has(id), `default chip "${id}" must exist in AGENT_CHIPS`).toBe(true);
+    }
   });
 
   it('suspended agents match the suspended chip regardless of state', () => {

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -342,11 +342,12 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    // With no state chip active, the current Agents view shows the full
-    // supervisor roster, including configured-but-not-running agents.
-    // Both rows render their alias as a Link, but the title must
-    // differ — session-bound agents promise a real drilldown; orphan
-    // agents warn that the detail page will show no live session.
+    // The Agents view defaults to the 'running' chip, so the asleep
+    // control-dispatcher orphan is hidden until we toggle it off to reveal
+    // the full supervisor roster. Both rows then render their alias as a
+    // Link, but the title must differ — session-bound agents promise a
+    // real drilldown; orphan agents warn the detail page shows no session.
+    await showAllAgents();
     const mayorLink = await screen.findByRole('link', { name: /mayor/i });
     const orphanLink = await screen.findByRole('link', { name: /control-dispatcher/i });
 
@@ -379,6 +380,8 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
+    // Toggle off the default 'running' chip so the asleep orphan shows.
+    await showAllAgents();
     const orphanLink = await screen.findByRole('link', { name: /control-dispatcher/i });
     const mayorLink = await screen.findByRole('link', { name: /mayor/i });
 
@@ -386,6 +389,14 @@ describe('AgentsPage (post-ay6 regressions)', () => {
     expect(mayorLink.closest('tr')?.getAttribute('data-attention-severity')).toBeNull();
   });
 });
+
+// The Agents view boots with the 'running' chip active. Tests that assert
+// on non-running agents (orphans/asleep) toggle it off to reveal the full
+// roster, mirroring the operator clicking the chip.
+async function showAllAgents(): Promise<void> {
+  const runningChip = await screen.findByRole('button', { name: /^running$/i });
+  fireEvent.click(runningChip);
+}
 
 function contributor(
   domain: 'agents',

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -142,6 +142,10 @@ export const AGENT_CHIPS: ReadonlyArray<FilterChip<SupervisorAgent>> = [
   },
 ];
 
+// Chips the Agents view boots into: actively-running only. Exported so the
+// chips test can assert the default-active set stays in sync with AGENT_CHIPS.
+export const AGENT_DEFAULT_CHIPS: ReadonlyArray<string> = ['running'];
+
 const AGENT_SEARCH_FIELDS = (a: SupervisorAgent): ReadonlyArray<string | undefined> => [
   a.name,
   a.display_name,
@@ -241,6 +245,10 @@ export function AgentsPage() {
     projectOf: FLAT_GROUP,
     searchOf: AGENT_SEARCH_FIELDS,
     chips: AGENT_CHIPS,
+    // Default to the actively-running view (restores commit 00cad8f, lost
+    // in the useListFilters migration). Operator can toggle 'running' off
+    // to see all agents.
+    initialActiveChipIds: AGENT_DEFAULT_CHIPS,
     defaultCollapsed: false,
     activityOf: agentActivity,
     defaultSortMode: 'activity',


### PR DESCRIPTION
## Summary
Two user-reported regressions on the live dashboard.

**1. Beads board stuck empty ("Nothing on the queue right now.")** — `useCachedData`'s latest-run-wins guard could starve the panel. On a busy city, `bead.*` SSE events re-fire `refresh()` ~every 3s; the beads board's slowest leg (the per-type `task` query — normally ~4ms, but 14–21s under a transient store load spike) was superseded by a newer run (runId mismatch) before it resolved, so `setData` never ran and `data` stayed `undefined` indefinitely. Fix: a **first-paint rescue** — a superseded-but-still-current run seeds `data` only while it is still `undefined`. Latest-run-wins and the stale-clobber guard are preserved: `setData(prev => prev === undefined ? fresh : prev)`.

**2. Agents view stopped defaulting to actively-running** — the migration to `useListFilters` hard-initialized `activeChipIds` to an empty Set, dropping the "what's running right now" default. Fix: `useListFilters` gains an optional `initialActiveChipIds`; `Agents` seeds `['running']`. The operator can still toggle it off to see the full roster.

## Tests
New coverage: first-paint rescue + latest-run-wins-after-rescue (`useCachedData.test.tsx`); default-seed, toggle-off, viewKey re-seed (`useListFilters.test.ts`); default-active chip kept in sync with `AGENT_CHIPS` (`Agents.chips.test.ts`); render tests toggle the default off before asserting on the full roster (`Agents.render.test.tsx`). Full suite green: frontend 628, backend 919, typecheck (src + test), lint, and the frontend build all clean.

## Review
Reviewed by parallel code + security + typescript reviewers — **approve**, 0 blockers / 0 majors. Security: no new surface (filter state is client-side only; never reaches a fetch URL or DOM sink). Two acknowledged **minor**, non-blocking follow-ups:
- If a rescued run is immediately followed by a *failing* latest run, the `loading` flag (finally-guarded on latest-run) can stay true → the Refresh button lingers on "Refreshing" while displaying the rescued data. Narrow ordering; cosmetic.
- `initialChipKey = ids.join(',')` is a dep-stability proxy that assumes chip ids contain no commas (true for all current chips: `running`/`open`/…).

Separately worth a follow-up (not in this PR): the beads board refetches all four typed lists (~1.3MB) on every `bead.*` SSE event, which is what makes it fragile to store-latency spikes — coalescing harder or doing targeted per-bead updates would be the durable fix.
