### PR TITLE
fix(dashboard): drop invalid 'docs' bead type that 503s the rig-filtered board

### DIFF
--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -130,9 +130,9 @@ describe('BeadsPage', () => {
 
     await screen.findByText('Sample bead');
 
-    expect(beadQueries.length).toBe(4);
+    expect(beadQueries.length).toBe(3);
     expect(new Set(beadQueries.map((query) => query.get('type')))).toEqual(
-      new Set(['feature', 'bug', 'task', 'docs']),
+      new Set(['feature', 'bug', 'task']),
     );
     for (const query of beadQueries) {
       expect(query.get('limit')).toBe('2000');
@@ -149,10 +149,10 @@ describe('BeadsPage', () => {
       target: { value: 'east' },
     });
 
-    await waitFor(() => expect(beadQueries.length).toBe(8));
-    const latestQueries = beadQueries.slice(-4);
+    await waitFor(() => expect(beadQueries.length).toBe(6));
+    const latestQueries = beadQueries.slice(-3);
     expect(new Set(latestQueries.map((query) => query.get('type')))).toEqual(
-      new Set(['feature', 'bug', 'task', 'docs']),
+      new Set(['feature', 'bug', 'task']),
     );
     for (const query of latestQueries) {
       expect(query.get('rig')).toBe('east');

--- a/frontend/src/supervisor/beadReads.ts
+++ b/frontend/src/supervisor/beadReads.ts
@@ -25,11 +25,22 @@ export interface ListSupervisorBeadsOptions {
 
 const BEADS_FETCH_LIMIT = 2000;
 const DETAIL_FALLBACK_FETCH_LIMIT = 2000;
+// The "real work" bead types the board fans out (one typed query each),
+// then keeps via defaultBeadFilter — the bookkeeping types
+// (message/session/molecule/…) are dropped. Every entry MUST be a type the
+// live gc/bd backend accepts as a `type=` filter: a rig-scoped include-closed
+// (`all=true`) query for a type the backend rejects fails closed (HTTP 503
+// "invalid issue type") and that one rejected leg blanks the whole board.
+// 'docs' was removed here because the live bd store's queryable set is
+// bug/feature/task/epic/chore/decision/… and does NOT include it (the
+// city-aggregate read had tolerated the bad filter, hiding the break). Note
+// the shared wire type still lists 'docs' (shared/src/gc-beads.ts
+// BeadIssueType, shared/src/runs/summary.ts ENGINEERING_TYPES) — that
+// shared-type-vs-queryable-backend divergence is a separate cleanup.
 const ENGINEERING_BEAD_TYPES: ReadonlySet<string> = new Set([
   'feature',
   'bug',
   'task',
-  'docs',
 ]);
 
 export async function listSupervisorBeads(


### PR DESCRIPTION
## Summary
Follow-up to #55. The Beads board fans out one supervisor query per bead type (`feature/bug/task/docs`) and keeps those types via `defaultBeadFilter`. **`docs` is not a type the gc/bd backend accepts as a `type=` filter** (valid: bug/feature/task/epic/chore/decision/…). The city-aggregate read tolerated the bad filter and returned empty, but when the board is filtered to a rig whose bd backend validates strictly, the rig-scoped **include-closed** query (the Beads page always sets `all=true`) returns **HTTP 503 "invalid issue type docs"** — and because the fan-out is `Promise.all`, that one rejection blanks the whole board ("No beads on \<rig\>").

Fix: drop `docs` from `ENGINEERING_BEAD_TYPES`. The board now fetches `feature/bug/task`; the rig-scoped include-closed queries all return 200 and the board populates. Verified live against a rig whose backend was 503ing.

## Note on the shared layer
`shared/src/gc-beads.ts` `BeadIssueType` and `shared/src/runs/summary.ts` `ENGINEERING_TYPES` still list `'docs'` as a valid wire value (and a backend test asserts `runBeadFilter` admits it). That `runBeadFilter` path is client-side (no query), so `'docs'` there is inert — but the shared-type-vs-queryable-backend divergence is a real maintenance trap. The code comment documents it precisely; reconciling the shared layer is left as a separate follow-up rather than widening this fix.

## Tests
Updated the two `Beads.test.tsx` fan-out assertions (4→3 queries, type set drops `docs`). Green: frontend typecheck + Beads suite; lint clean.

## Review
Reviewed by code + typescript reviewers — code-reviewer approve; typescript-reviewer's catch (the comment over-claimed vs the shared SSOT) addressed by rewriting the comment to distinguish "live backend rejects the filter" from "shared wire type still lists it."
