### PR TITLE
fix(dashboard): default beads board to open work, fetch closed lazily

### DIFF
--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -20,7 +20,7 @@ const fetchCalls: FetchCall[] = [];
 beforeEach(() => {
   setActiveCity('test-city');
   fetchCalls.length = 0;
-  invalidate('beads:board');
+  invalidate('beads:board:');
   invalidate('sessions');
   invalidate('agents');
   stubFetch();
@@ -32,14 +32,16 @@ afterEach(() => {
 });
 
 describe('BeadsPage supervisor reads', () => {
-  it('shows only real work while requesting all closed/open supervisor statuses', async () => {
+  it('shows only real work while requesting open supervisor statuses by default', async () => {
     renderPage();
 
     await screen.findByText('direct supervisor bead');
 
     expect(screen.queryByText('supervisor noise bead')).toBeNull();
     expect(fetchCalls.some((call) => call.path === '/api/city/test-city/beads')).toBe(false);
-    expect(beadFetches().every((call) => call.query.get('all') === 'true')).toBe(true);
+    // Default board scope is open-only: no all=true unless the operator
+    // activates the closed status control.
+    expect(beadFetches().every((call) => !call.query.has('all'))).toBe(true);
   });
 
   it('resolves a bead query param even when the bead is outside the list window', async () => {

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
   setActiveCity('test-city');
   beadQueries.length = 0;
   supervisorWrites.length = 0;
-  invalidate('beads:board');
+  invalidate('beads:board:');
   invalidate('sessions');
   invalidate('agents');
   vi.stubGlobal(
@@ -125,7 +125,7 @@ describe('BeadsPage', () => {
     expect(screen.getByRole('button', { name: /new bead/i })).toBeTruthy();
   });
 
-  it('requests direct supervisor engineering beads with closed statuses included', async () => {
+  it('requests direct supervisor engineering beads, open-only by default (no all=true)', async () => {
     renderPage();
 
     await screen.findByText('Sample bead');
@@ -134,10 +134,45 @@ describe('BeadsPage', () => {
     expect(new Set(beadQueries.map((query) => query.get('type')))).toEqual(
       new Set(['feature', 'bug', 'task']),
     );
+    // Default board scope is non-closed work: the supervisor returns
+    // open/in_progress/blocked when `all` is absent. Closed beads (~199.7K
+    // on this city) are fetched lazily, only when the operator opts in.
     for (const query of beadQueries) {
       expect(query.get('limit')).toBe('2000');
-      expect(query.get('all')).toBe('true');
+      expect(query.has('all')).toBe(false);
       expect(query.has('showAll')).toBe(false);
+    }
+  });
+
+  it('refetches with all=true when the operator activates the closed status control', async () => {
+    renderPage();
+
+    await screen.findByText('Sample bead');
+    expect(beadQueries.length).toBe(3);
+    for (const query of beadQueries) {
+      expect(query.has('all')).toBe(false);
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: /^closed$/i }));
+
+    // Activating `closed` flips the data scope, forcing exactly one fresh
+    // fan-out that now carries all=true (closed beads included).
+    await waitFor(() => expect(beadQueries.length).toBe(6));
+    const closedQueries = beadQueries.slice(-3);
+    expect(new Set(closedQueries.map((query) => query.get('type')))).toEqual(
+      new Set(['feature', 'bug', 'task']),
+    );
+    for (const query of closedQueries) {
+      expect(query.get('all')).toBe('true');
+    }
+
+    // Deactivating `closed` must revert to an open-only fetch — otherwise the
+    // chip would read inactive while the board silently keeps scanning closed
+    // history (the showClosed/chip desync this dual-state wiring must avoid).
+    fireEvent.click(screen.getByRole('button', { name: /^closed$/i }));
+    await waitFor(() => expect(beadQueries.length).toBe(9));
+    for (const query of beadQueries.slice(-3)) {
+      expect(query.has('all')).toBe(false);
     }
   });
 
@@ -156,7 +191,9 @@ describe('BeadsPage', () => {
     );
     for (const query of latestQueries) {
       expect(query.get('rig')).toBe('east');
-      expect(query.get('all')).toBe('true');
+      // Rig filtering inherits the default open-only scope: no all=true
+      // unless the operator separately opts into closed beads.
+      expect(query.has('all')).toBe(false);
     }
   });
 

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -32,6 +32,7 @@ import { listSupervisorSessions } from '../supervisor/sessionReads';
 
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 const RIG_FILTER_ALL = '';
+const CLOSED_CHIP_ID = 'closed';
 
 type BeadAction = 'claim' | 'close' | 'nudge';
 
@@ -62,6 +63,20 @@ export function BeadsPage() {
   const [searchParams] = useSearchParams();
   const selectedBeadParam = normalizeSelectedBeadParam(searchParams.get('bead'));
   const [rigFilter, setRigFilter] = useState<string>(RIG_FILTER_ALL);
+  // Closed beads dwarf the open queue (~199.7K closed vs ~1K open on this
+  // city), so scanning them on every load makes the `task` query spike and
+  // trips the fetch-window truncation warning. Default the board to the
+  // non-closed set (open/in_progress/blocked) and fetch closed beads lazily,
+  // only once the operator activates the `closed` status control. showClosed
+  // drives BOTH the fetch (includeClosed) and the cache key so flipping it
+  // forces exactly one fresh fan-out. It lives here — outside useListFilters,
+  // which is declared below and owns the client-side chip filters — because
+  // the fetch must be parameterized before the filters hook exists (the
+  // hook needs `rows` from this fetch). The `closed` chip's toggle is wired
+  // to flip showClosed in addition to the normal client filter, keeping the
+  // four status controls reading as one group while `closed` alone widens
+  // the data scope.
+  const [showClosed, setShowClosed] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(selectedBeadParam);
   const [closing, setClosing] = useState<SupervisorBead | null>(null);
   const [closeReason, setCloseReason] = useState('');
@@ -79,9 +94,9 @@ export function BeadsPage() {
   const [newAgent, setNewAgent] = useState('');
 
   const { data, loading, error, refresh } = useCachedData(
-    `beads:board:${rigFilter}`,
+    `beads:board:${rigFilter}:${showClosed ? 'all' : 'open'}`,
     () => listSupervisorBeads({
-      includeClosed: true,
+      includeClosed: showClosed,
       ...(rigFilter === RIG_FILTER_ALL ? {} : { rigFilter }),
     }),
   );
@@ -143,6 +158,20 @@ export function BeadsPage() {
     searchOf: BEAD_SEARCH_FIELDS,
     chips: BEAD_CHIPS,
   });
+
+  // The `closed` chip is special: besides being a client-side filter (like
+  // open/in_progress/blocked), toggling it flips showClosed, which widens the
+  // fetch to include closed beads. Keeping it inside BEAD_CHIPS means all four
+  // controls render and read as one "Status" group; only this wrapper gives
+  // `closed` its extra data-scope effect.
+  // Destructure the stable toggleChip so the wrapper can depend on it directly
+  // (the `filters` object is a fresh ref each render); keeps toggleStatusChip
+  // stable without depending on the whole object.
+  const { toggleChip } = filters;
+  const toggleStatusChip = useCallback((id: string) => {
+    if (id === CLOSED_CHIP_ID) setShowClosed((prev) => !prev);
+    toggleChip(id);
+  }, [toggleChip]);
 
   useGcEventRefresh([GC_EVENT_PREFIX.bead], () => void refresh());
 
@@ -339,7 +368,7 @@ export function BeadsPage() {
               </span>
             )}
             <span className="text-label uppercase tracking-wider text-fg-faint">
-              All statuses
+              {showClosed ? 'All statuses' : 'Open work'}
             </span>
             <Button
               type="button"
@@ -400,7 +429,7 @@ export function BeadsPage() {
           <FilterChips
             chips={BEAD_CHIPS}
             activeIds={filters.activeChipIds}
-            onToggle={filters.toggleChip}
+            onToggle={toggleStatusChip}
             legend="Status"
           />
           {dispatchRigOptions.length > 1 && (


### PR DESCRIPTION
## Summary
The Beads board hardcoded `includeClosed: true`, so every load fanned out typed queries with `all=true` and scanned the full closed history. On this city that's ~200,685 task beads — **199,698 of them closed** — versus an open queue of ~1,031. That scan is the cause of the 14–21s `task`-query latency spikes (and the earlier empty-board incident), and it trips the "Fetch window covered 1,592 of 201,277 store beads" truncation warning.

**Fix:** default the board to open work (`includeClosed: false` → supervisor returns open/in_progress/blocked). A dedicated `showClosed` state drives both `includeClosed` and the `useCachedData` cache key (`beads:board:${rigFilter}:${showClosed ? 'all' : 'open'}`); the `closed` status chip's toggle is wrapped to flip `showClosed`, so closed beads load **lazily, only when requested**. open/in_progress/blocked remain pure client-side filters. The meta label reads "Open work" by default, "All statuses" once closed is active.

Result: default task fetch drops from ~200,685 → ~987 rows. Truncation warning quiet by default; fires accurately only when the operator opts into closed and hits the 2,000/type cap.

## Tests
- Default board asserts **no `all=true`** on the open-only fan-out.
- New test: activating `closed` triggers one fresh fan-out carrying `all=true`, **and** deactivating it reverts to open-only (guards the showClosed↔chip invariant against desync).
- Rig-filter test inherits the open-only default.
Full suite green (629+), typecheck (src + test), lint clean.

## Review
Reviewed by code + security + typescript reviewers — **approve**, 0 blockers / 0 majors. The one real risk (showClosed vs chip-active desync) was confirmed unreachable (`viewKey` is the constant `'beads'`, so `useListFilters`' reset effect never fires). Applied the two minor improvements flagged: a stable callback identity (depend on destructured `toggleChip`) and the toggle-off regression test.
