### PR TITLE
fix(dashboard): revert Agents to simple view + rig dropdown; lighter rows; clean mail/rig labels; surface stuck agents

### DIFF
--- a/frontend/src/attention/routeHighlight.ts
+++ b/frontend/src/attention/routeHighlight.ts
@@ -49,6 +49,17 @@ export function attentionRowProps(
   };
 }
 
+// Row props that expose the attention severity for tooling (home-alerts
+// panel, keyboard nav) WITHOUT painting a background tint. Used where a
+// domain is not an alert by default — e.g. mail (gascity-dashboard-s464):
+// unread mail is normal, so its rows render in the neutral foreground.
+export function attentionDataProps(
+  severity: AttentionSeverity | null,
+): AttentionAttributes<HTMLTableRowElement> {
+  if (severity === null) return {};
+  return { 'data-attention-severity': severity };
+}
+
 export function attentionListItemProps(
   severity: AttentionSeverity | null,
 ): AttentionAttributes<HTMLLIElement> {

--- a/frontend/src/components/LiveSessionPeek.test.tsx
+++ b/frontend/src/components/LiveSessionPeek.test.tsx
@@ -117,7 +117,7 @@ describe('isSessionStreamable', () => {
   it('is true when the gc state is active', () => {
     expect(isSessionStreamable(session({ state: 'active', running: false }))).toBe(true);
   });
-  it("is true when the gc state is 'running' (aligns with AGENT_CHIPS)", () => {
+  it("is true when the gc state is 'running' (aligns with isRunningAgent)", () => {
     expect(isSessionStreamable(session({ state: 'running', running: false }))).toBe(true);
   });
   it('is false for a non-running, non-active session', () => {

--- a/frontend/src/components/LiveSessionPeek.tsx
+++ b/frontend/src/components/LiveSessionPeek.tsx
@@ -104,7 +104,7 @@ export function streamBadge(
  * Whether a session is worth opening a live stream for. A streamed dead
  * session would hold a connection that never emits a turn and show a
  * perpetual "connecting" badge, so gate on the running signal. Mirrors the
- * "running" filter chip predicate in routes/Agents.tsx (AGENT_CHIPS) so a
+ * "running" predicate (isRunningAgent) in routes/Agents.tsx so a
  * session the rest of the UI shows as running also streams: process
  * `running`, gc state `active`, OR gc state `running`.
  */
@@ -123,7 +123,7 @@ export function isSessionStreamable(session: GcSession | null): boolean {
  * signal is present (process `running` === true, gc state `active`, or gc
  * state `running`). The session check is a hard prerequisite — `running`
  * on an orphan agent does NOT make it streamable because there's nothing
- * to stream from. Mirrors the AGENT_CHIPS `running` predicate on the
+ * to stream from. Mirrors the isRunningAgent `running` predicate on the
  * agent shape so the peek-modal gate stays consistent with what the rest
  * of the Agents view labels as running.
  */

--- a/frontend/src/components/mail/ThreadMessage.tsx
+++ b/frontend/src/components/mail/ThreadMessage.tsx
@@ -1,5 +1,6 @@
 import { StatusBadge } from '../StatusBadge';
 import { PROMPT_INJECTION_NOTICE } from '../../lib/constants';
+import { formatMailSender } from '../../lib/mailSender';
 import type { AttentionSeverity } from '../../attention/compose';
 import type { SupervisorMailItem } from '../../supervisor/mailReads';
 
@@ -13,13 +14,13 @@ export function ThreadMessage({
   return (
     <article
       {...attentionAttrs(attentionSeverity)}
-      className={`space-y-3 pb-4 border-b border-rule last:border-0 ${attentionClass(attentionSeverity)}`}
+      className="space-y-3 pb-4 border-b border-rule last:border-0"
     >
       <header className="flex items-baseline justify-between gap-3">
         <div className="text-label uppercase tracking-wider text-fg-muted truncate">
-          <span className="text-fg font-medium">{message.from}</span>
+          <span className="text-fg font-medium">{formatMailSender(message.from)}</span>
           <span className="mx-1.5 text-fg-faint">→</span>
-          <span>{message.to}</span>
+          <span>{formatMailSender(message.to)}</span>
         </div>
         <span className="text-label uppercase tracking-wider text-fg-faint tnum">
           {formatAbsolute(message.created_at)}
@@ -38,12 +39,6 @@ function attentionAttrs(
   severity: AttentionSeverity | null,
 ): { 'data-attention-severity'?: AttentionSeverity } {
   return severity === null ? {} : { 'data-attention-severity': severity };
-}
-
-function attentionClass(severity: AttentionSeverity | null): string {
-  if (severity === 'attention') return 'bg-accent/10';
-  if (severity === 'watch') return 'bg-warn/10';
-  return '';
 }
 
 function formatAbsolute(iso: string): string {

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -211,3 +211,13 @@ describe('isAgentOutsideRig', () => {
     expect(isAgentOutsideRig({ name: 'a1', pool: 'research' } as never)).toBe(false);
   });
 });
+
+describe('agentProject -main canonicalization', () => {
+  it('strips a -main worktree/build suffix to the base rig', () => {
+    expect(agentProject({ name: 'x', rig: '/home/ds/gascity-main' } as never).label).toBe('gascity');
+    expect(agentProject({ name: 'y', rig: '/home/ds/gascity-packs-main' } as never).label).toBe('gascity-packs');
+  });
+  it('leaves a normal rig path unchanged', () => {
+    expect(agentProject({ name: 'z', rig: '/home/ds/gascity-packs' } as never).label).toBe('gascity-packs');
+  });
+});

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -137,8 +137,18 @@ export function agentProject(agent: AgentResponse): ProjectBucket {
     return { key: NO_RIG_PROJECT, label: NO_RIG_PROJECT };
   }
   const parts = candidate.split(/[\\/]/).filter(Boolean);
-  const basename = parts[parts.length - 1] ?? candidate;
+  const basename = canonicalRigLabel(parts[parts.length - 1] ?? candidate);
   return { key: normalizeRigKey(basename), label: basename };
+}
+
+/**
+ * A pool/worker template path often points at a "-main" build tree or worktree
+ * (e.g. `gascity-main` is the gc build tree, `gascity-packs-main` a packs
+ * worktree) rather than the registered rig. The agent's real rig is the base
+ * name — strip the suffix so the UI shows `gascity`, not `gascity-main`.
+ */
+export function canonicalRigLabel(name: string): string {
+  return name.endsWith('-main') ? name.slice(0, -'-main'.length) : name;
 }
 
 /**

--- a/frontend/src/lib/mailSender.test.ts
+++ b/frontend/src/lib/mailSender.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatMailSender } from './mailSender';
+
+describe('formatMailSender', () => {
+  it('passes clean aliases through', () => {
+    expect(formatMailSender('mayor')).toBe('mayor');
+    expect(formatMailSender('gascity-packs.project-lead')).toBe('gascity-packs.project-lead');
+  });
+  it('formats a worktree path as rig · agent, stripping the redundant rig prefix', () => {
+    expect(formatMailSender('/home/ds/gascity-packs/gascity-packs-polecat-1'))
+      .toBe('gascity-packs · polecat-1');
+  });
+  it('canonicalizes a -main worktree rig to its base rig', () => {
+    expect(formatMailSender('/home/ds/gascity-main/gascity-maintenance-pl'))
+      .toBe('gascity · gascity-maintenance-pl');
+    expect(formatMailSender('/home/ds/gascity-packs-main/gascity-packs-pl'))
+      .toBe('gascity-packs · gascity-packs-pl');
+  });
+  it('handles a plain rig/agent path', () => {
+    expect(formatMailSender('gascity/polecat-2')).toBe('gascity · polecat-2');
+  });
+  it('returns the basename when there is no parent segment', () => {
+    expect(formatMailSender('/polecat-9')).toBe('polecat-9');
+  });
+});

--- a/frontend/src/lib/mailSender.ts
+++ b/frontend/src/lib/mailSender.ts
@@ -1,0 +1,26 @@
+// Mail senders are usually clean aliases ("mayor"), but a worker in a
+// worktree can report its sender as a filesystem path, e.g.
+// "/home/ds/gascity-packs/gascity-packs-polecat-1". Format that for display
+// as "rig · agent" (e.g. "gascity-packs · polecat-1"); pass clean aliases
+// through unchanged.
+import { canonicalRigLabel } from '../hooks/projectOf';
+
+export function formatMailSender(from: string): string {
+  const raw = from.trim();
+  if (raw.length === 0) return raw;
+  if (!raw.includes('/') && !raw.includes('\\')) return raw;
+
+  const parts = raw.split(/[\\/]/).filter((p) => p.length > 0);
+  const agentSeg = parts[parts.length - 1];
+  if (agentSeg === undefined) return raw;
+  const rawRig = parts[parts.length - 2];
+  if (rawRig === undefined) return agentSeg;
+
+  // Drop a redundant "<rig>-" prefix the worktree dir often carries
+  // ("gascity-packs-polecat-1" under ".../gascity-packs" → "polecat-1"),
+  // then canonicalize the rig ("gascity-main" → "gascity").
+  const agent = agentSeg.startsWith(`${rawRig}-`)
+    ? agentSeg.slice(rawRig.length + 1)
+    : agentSeg;
+  return `${canonicalRigLabel(rawRig)} · ${agent}`;
+}

--- a/frontend/src/routes/Agents.chips.test.ts
+++ b/frontend/src/routes/Agents.chips.test.ts
@@ -1,25 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentResponse } from '../generated/gc-supervisor-client/types.gen';
-import { AGENT_CHIPS, AGENT_DEFAULT_CHIPS, buildAgentSynopsis, stateTone } from './Agents';
+import {
+  agentRowLabel,
+  buildAgentSynopsis,
+  isRunningAgent,
+  stateTone,
+} from './Agents';
 
-// gascity-dashboard-ay6: the Agents view consumes the supervisor's
-// first-class agent roster (AgentResponse), not the session list. These tests
-// pin the chip-coverage invariant on the agent shape: every state the
-// supervisor reports must match at least one chip, otherwise agents in
-// that state vanish silently when any chip is active (parallels the bug
-// from gascity-dashboard-9yb on the session side).
-
-// AgentResponse.state is a free `string` in the OpenAPI; this is the set
-// observed in this deployment + the named states the supervisor commits
-// to today. Same conservative posture as the previous NAMED_STATES list.
-const NAMED_STATES = [
-  'creating',
-  'active',
-  'asleep',
-  'detached',
-  'failed',
-  'closed',
-] as const;
+// gascity-dashboard-fgzf: the Agents view was reverted from the flat
+// sortable/filterable table (chips + sort + rig dropdown) to the older,
+// simpler view — a single 'running' toggle over a plain list with the
+// 'rig · agent' label restored. These tests pin the toggle predicate and
+// the label format that drive that simpler view.
 
 function mkAgent(state: string, overrides: Partial<AgentResponse> = {}): AgentResponse {
   return {
@@ -32,72 +24,51 @@ function mkAgent(state: string, overrides: Partial<AgentResponse> = {}): AgentRe
   };
 }
 
-describe('AGENT_CHIPS', () => {
-  it('every named agent state matches at least one chip', () => {
-    for (const state of NAMED_STATES) {
-      const agent = mkAgent(state);
-      const matched = AGENT_CHIPS.some((chip) => chip.match(agent));
-      expect(
-        matched,
-        `state "${state}" must match at least one chip, otherwise it disappears when any chip is active`,
-      ).toBe(true);
-    }
+describe('isRunningAgent', () => {
+  it('treats active/running agents as running', () => {
+    expect(isRunningAgent(mkAgent('active'))).toBe(true);
+    expect(isRunningAgent(mkAgent('running'))).toBe(true);
   });
 
-  it('exposes a "detached" chip so detached agents stay visible under chip filters', () => {
-    const detached = mkAgent('detached');
-    const detachedChip = AGENT_CHIPS.find((chip) => chip.id === 'detached');
-    expect(detachedChip, 'detached chip should exist').toBeDefined();
-    expect(detachedChip?.match(detached)).toBe(true);
+  it('treats idle/asleep/detached agents as not running by default', () => {
+    expect(isRunningAgent(mkAgent('asleep'))).toBe(false);
+    expect(isRunningAgent(mkAgent('idle'))).toBe(false);
+    expect(isRunningAgent(mkAgent('detached'))).toBe(false);
   });
 
-  it('detached agents match only the detached chip when not running', () => {
-    const detached = mkAgent('detached');
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(detached)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toEqual(['detached']);
-  });
-
-  it('a detached agent whose process is still running matches BOTH the running and detached chips', () => {
+  it('counts a detached-but-live process (running flag set) as running', () => {
     // gc can report state='detached' (tmux disconnected) while the
-    // underlying process is still running. The running chip keys on
-    // a.running===true; the detached chip keys on a.state==='detached'.
-    // Detached-but-running must surface under both filters so an
-    // operator scanning for 'what is alive right now' doesn't lose it
-    // just because the tmux attachment is gone. Mirrors the session-side
-    // invariant from gascity-dashboard-bi9.
-    const detachedAndRunning = mkAgent('detached', { running: true });
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(detachedAndRunning)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toContain('running');
-    expect(matchingIds).toContain('detached');
-    // Bound the match set: only those two chips, no spurious third match.
-    expect(matchingIds).toHaveLength(2);
+    // underlying process is still alive. The 'running' toggle keys on the
+    // running flag too, so the operator scanning for "what is alive right
+    // now" does not lose a detached-but-running agent.
+    expect(isRunningAgent(mkAgent('detached', { running: true }))).toBe(true);
   });
 
-  it('defaults the Agents view to the actively-running chip', () => {
-    // The Agents view boots into "what's running right now" (restores
-    // commit 00cad8f, lost in the useListFilters migration). The default
-    // set must name the 'running' chip and only ids that AGENT_CHIPS
-    // actually defines, otherwise the seed silently filters to nothing.
-    expect(AGENT_DEFAULT_CHIPS).toEqual(['running']);
-    const chipIds = new Set(AGENT_CHIPS.map((chip) => chip.id));
-    for (const id of AGENT_DEFAULT_CHIPS) {
-      expect(chipIds.has(id), `default chip "${id}" must exist in AGENT_CHIPS`).toBe(true);
-    }
+  it('never counts a suspended agent as running, even if its state reads alive', () => {
+    expect(isRunningAgent(mkAgent('active', { suspended: true }))).toBe(false);
+    expect(isRunningAgent(mkAgent('detached', { running: true, suspended: true }))).toBe(false);
+  });
+});
+
+describe('agentRowLabel', () => {
+  it("formats in-rig agents as 'rig · agent'", () => {
+    const agent = mkAgent('active', { name: 'polecat-1', rig: 'gascity-packs' });
+    expect(agentRowLabel(agent)).toBe('gascity-packs · polecat-1');
   });
 
-  it('suspended agents match the suspended chip regardless of state', () => {
-    // Suspended is a roster-side signal the session list never carried
-    // (a suspended agent has no session). The dedicated chip lets the
-    // operator slice the new agent surface by it.
-    const suspended = mkAgent('asleep', { suspended: true });
-    const matchingIds = AGENT_CHIPS.filter((chip) => chip.match(suspended)).map(
-      (chip) => chip.id,
-    );
-    expect(matchingIds).toContain('suspended');
+  it('folds the rig path to its basename in the label', () => {
+    const agent = mkAgent('active', { name: 'worker', rig: '/home/ds/projects/geo' });
+    expect(agentRowLabel(agent)).toBe('geo · worker');
+  });
+
+  it('shows just the alias for cross-rig orchestration agents (no rig prefix)', () => {
+    const mayor = mkAgent('active', { name: 'mayor', rig: '' });
+    expect(agentRowLabel(mayor)).toBe('mayor');
+  });
+
+  it('shows just the alias for agents with no rig association', () => {
+    const orphan = mkAgent('asleep', { name: 'control-dispatcher', rig: '' });
+    expect(agentRowLabel(orphan)).toBe('control-dispatcher');
   });
 });
 

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -201,7 +201,8 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    // Alias is the primary label — must be rendered as a Link.
+    // mayor has no rig (cross-rig orchestration) → the label is just the
+    // alias, rendered as a Link.
     const mayorLink = await screen.findByRole('link', { name: /mayor/i });
     expect(mayorLink).toBeDefined();
     expect(mayorLink.textContent).toBe('mayor');
@@ -209,6 +210,71 @@ describe('AgentsPage (post-ay6 regressions)', () => {
     expect(fetchUrls()).not.toContain('/api/city/test-city/agents');
     // display_name appears as secondary muted text — present but not the link.
     expect(screen.getByText('Claude (Account 5)')).toBeDefined();
+  });
+
+  it('boots with the running checkbox checked and renders in-rig agents as "rig · agent"', async () => {
+    // gascity-dashboard-fgzf: the reverted simple view defaults to the
+    // actively-running agents (running checkbox ON) and restores the
+    // 'rig · agent' label format lost in the table refactor.
+    vi.unstubAllGlobals();
+    stubFetch({
+      agentsPayload: {
+        items: [
+          {
+            name: 'polecat-1',
+            available: true,
+            running: true,
+            suspended: false,
+            state: 'active',
+            rig: 'gascity-packs',
+            display_name: 'Claude (Account 5)',
+            provider: 'claude-5',
+            session: {
+              name: 'polecat-1',
+              attached: false,
+              last_activity: '2026-05-30T00:56:31Z',
+            },
+          },
+          // asleep, in-rig — hidden while the running checkbox is checked.
+          {
+            name: 'polecat-2',
+            available: true,
+            running: false,
+            suspended: false,
+            state: 'asleep',
+            rig: 'gascity-packs',
+            provider: 'claude-5',
+          },
+        ],
+        total: 2,
+      },
+    });
+
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <NowProvider intervalMs={1_000_000}>
+          <AgentsPage />
+        </NowProvider>
+      </MemoryRouter>,
+    );
+
+    // The running checkbox is the only filter control, and it boots checked.
+    const runningCheckbox = await screen.findByRole<HTMLInputElement>('checkbox', {
+      name: /running/i,
+    });
+    expect(runningCheckbox.checked).toBe(true);
+
+    // The running agent is shown with the restored 'rig · agent' label.
+    const runningLink = await screen.findByRole('link', { name: /polecat-1/i });
+    expect(runningLink.textContent).toBe('gascity-packs · polecat-1');
+
+    // The asleep agent is hidden by the default-on running filter.
+    expect(screen.queryByRole('link', { name: /polecat-2/i })).toBeNull();
+
+    // Unchecking the box reveals the full roster (asleep agent appears).
+    fireEvent.click(runningCheckbox);
+    const sleepingLink = await screen.findByRole('link', { name: /polecat-2/i });
+    expect(sleepingLink.textContent).toBe('gascity-packs · polecat-2');
   });
 
   it('renders generated supervisor validation failures as operator-safe copy', async () => {
@@ -390,12 +456,12 @@ describe('AgentsPage (post-ay6 regressions)', () => {
   });
 });
 
-// The Agents view boots with the 'running' chip active. Tests that assert
-// on non-running agents (orphans/asleep) toggle it off to reveal the full
-// roster, mirroring the operator clicking the chip.
+// The Agents view boots with the 'running' checkbox checked. Tests that
+// assert on non-running agents (orphans/asleep) uncheck it to reveal the
+// full roster, mirroring the operator toggling the checkbox.
 async function showAllAgents(): Promise<void> {
-  const runningChip = await screen.findByRole('button', { name: /^running$/i });
-  fireEvent.click(runningChip);
+  const runningCheckbox = await screen.findByRole('checkbox', { name: /running/i });
+  fireEvent.click(runningCheckbox);
 }
 
 function contributor(

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -7,23 +7,20 @@ import {
 import { Button } from '../components/Button';
 import { useAttentionModel } from '../attention/context';
 import {
-  attentionRowProps,
+  attentionDataProps,
   resourceAttentionSeverity,
 } from '../attention/routeHighlight';
-import { FilterChips } from '../components/FilterChips';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { PartialDataNotice } from '../components/PartialDataNotice';
 import { LiveSessionPeek, isAgentStreamable } from '../components/LiveSessionPeek';
-import { SortToggle } from '../components/SortToggle';
 import { SseIndicator } from '../components/SseIndicator';
 import { StatusBadge, type StatusTone } from '../components/StatusBadge';
 import { Table, type TableColumn } from '../components/Table';
 import { useNow } from '../contexts/NowContext';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
-import { useListFilters, type FilterChip, type SortMode } from '../hooks/useListFilters';
 import { formatRelative } from '../hooks/time';
 import {
   attachCommand,
@@ -49,111 +46,34 @@ import { agentSlug } from '../hooks/sessionSlug';
 // any agent that wasn't currently running a session
 // (orphan / configured-but-asleep agents simply didn't appear).
 //
-// The cityStatus snapshot collector continues to aggregate over sessions
-// for now — sessionsByProvider migration is sd4's territory.
+// gascity-dashboard-fgzf: reverted from the flat sortable/filterable
+// table (chips + sort + rig dropdown + useListFilters) to the older,
+// simpler view — a single 'running' toggle (default on) over a plain
+// list, with the 'rig · agent' label restored. No sort control, no
+// persisted chip state.
 
-// Flat table: agents are not grouped by rig (the Rig column + sort carry that).
-// useListFilters still drives search/chips/sort, so we collapse every row into
-// one bucket and render the result as a single flat, sortable table.
-const FLAT_GROUP = () => '';
-
-// Sentinel for the rig dropdown's "all rigs" option. Empty string can't
-// collide with a real rig key because agentProject() never returns one.
-const RIG_FILTER_ALL = '';
-
-// Display label + stable key for a row's rig, reusing agentProject so the Rig
-// column, dropdown, and sort all agree (folds case/separator drift and lifts
-// cross-rig agents into the Orchestration bucket).
-function agentRigLabel(a: SupervisorAgent): string {
-  return agentProject(a).label;
+// An agent is "actively running" when it is not suspended and the
+// supervisor reports it as alive (state active/running, or running flag
+// set on a detached-but-live process). The default view shows only these.
+export function isRunningAgent(a: SupervisorAgent): boolean {
+  return (
+    !a.suspended &&
+    (a.state === 'active' || a.state === 'running' || a.running === true)
+  );
 }
 
-function agentRigKey(a: SupervisorAgent): string {
-  return agentProject(a).key;
+// Display label for the row: 'rig · agent' (e.g. 'gascity-packs · polecat-1').
+// Agents outside a rig (cross-rig orchestration or the residual no-rig
+// bucket) carry no rig prefix — just the alias.
+export function agentRowLabel(a: SupervisorAgent): string {
+  if (isAgentOutsideRig(a)) return a.name;
+  return `${agentProject(a).label} · ${a.name}`;
 }
 
-// Activity ordering uses the agent's bound session's last_activity. Agents
-// with no session (orphans) return undefined so the list-filter sink sends
-// them to the bottom under activity-sort rather than ranking them at the
-// epoch.
-function agentActivity(a: SupervisorAgent): number | undefined {
-  const raw = a.session?.last_activity;
-  if (!raw) return undefined;
-  const t = Date.parse(raw);
-  return Number.isFinite(t) ? t : undefined;
-}
-
-const SORT_OPTIONS: ReadonlyArray<{ id: SortMode; label: string }> = [
-  { id: 'activity', label: 'activity' },
-  { id: 'alpha', label: 'alphabetical' },
-];
-
-// Agent state chips collapse the gc supervisor's many states into buckets
-// the operator actually filters by. Every state an agent can carry must
-// match at least one chip — otherwise agents in that state vanish silently
-// when any chip is active (parallels gascity-dashboard-9yb's invariant for
-// sessions). Exported so tests can assert full state coverage.
-// Non-suspended chips all gate on `!a.suspended` so the chip filter
-// matches `stateBucket`'s priority order — `stateBucket` returns
-// 'suspended' before checking state, so a suspended-asleep agent is
-// counted in the suspended bucket only. Without the guard, the idle
-// chip would also surface suspended-asleep agents and the operator's
-// "what's idle?" filter would be over-broad. Same reasoning applies
-// to running/detached/stopped (a suspended agent that also reads as
-// running/detached/stopped via raw state should still only count as
-// suspended).
-export const AGENT_CHIPS: ReadonlyArray<FilterChip<SupervisorAgent>> = [
-  {
-    id: 'running',
-    label: 'running',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'active' || a.state === 'running' || a.running === true),
-  },
-  {
-    id: 'idle',
-    label: 'idle',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'asleep' || a.state === 'idle' || a.state === 'creating'),
-  },
-  {
-    id: 'detached',
-    label: 'detached',
-    match: (a) => !a.suspended && a.state === 'detached',
-  },
-  {
-    id: 'stopped',
-    label: 'stopped',
-    match: (a) =>
-      !a.suspended &&
-      (a.state === 'failed' ||
-        a.state === 'closed' ||
-        a.state === 'errored' ||
-        a.state === 'stuck'),
-  },
-  {
-    id: 'suspended',
-    label: 'suspended',
-    // The agent roster surfaces suspended agents that the session list
-    // never did — a distinct chip lets the operator slice by them
-    // without conflating with stopped/idle.
-    match: (a) => a.suspended === true,
-  },
-];
-
-// Chips the Agents view boots into: actively-running only. Exported so the
-// chips test can assert the default-active set stays in sync with AGENT_CHIPS.
-export const AGENT_DEFAULT_CHIPS: ReadonlyArray<string> = ['running'];
-
-const AGENT_SEARCH_FIELDS = (a: SupervisorAgent): ReadonlyArray<string | undefined> => [
-  a.name,
-  a.display_name,
-  a.pool,
-  a.rig,
-  a.provider,
-  a.model,
-];
+const AGENT_SEARCH_FIELDS = (a: SupervisorAgent): ReadonlyArray<string> =>
+  [a.name, a.display_name, a.pool, a.rig, a.provider, a.model].filter(
+    (field): field is string => typeof field === 'string' && field.length > 0,
+  );
 
 export function AgentsPage() {
   const attention = useAttentionModel();
@@ -195,6 +115,12 @@ export function AgentsPage() {
     return map;
   }, [pendingCache.data]);
   const now = useNow();
+
+  // Default to the actively-running view (restores the older simple view).
+  // Ephemeral: not persisted, resets between visits.
+  const [runningOnly, setRunningOnly] = useState(true);
+  const [search, setSearch] = useState('');
+  const [rigFilter, setRigFilter] = useState('');
 
   // Peek key is the agent alias (`name`); modal resolves the live session
   // by mapping agent.session.name -> session.id via the sessions cache.
@@ -239,92 +165,68 @@ export function AgentsPage() {
     }
   }, [pendingCache]);
 
-  const filters = useListFilters<SupervisorAgent>({
-    viewKey: 'agents',
-    rows,
-    projectOf: FLAT_GROUP,
-    searchOf: AGENT_SEARCH_FIELDS,
-    chips: AGENT_CHIPS,
-    // Default to the actively-running view (restores commit 00cad8f, lost
-    // in the useListFilters migration). Operator can toggle 'running' off
-    // to see all agents.
-    initialActiveChipIds: AGENT_DEFAULT_CHIPS,
-    defaultCollapsed: false,
-    activityOf: agentActivity,
-    defaultSortMode: 'activity',
-  });
-
-  // Rig dropdown (flat table): every rig present in the roster, by stable key
-  // with its display label, sorted alphabetically by label.
-  const [rigFilter, setRigFilter] = useState<string>(RIG_FILTER_ALL);
-  const rigOptions = useMemo(() => {
-    const byKey = new Map<string, string>();
-    for (const a of rows) byKey.set(agentRigKey(a), agentRigLabel(a));
-    return Array.from(byKey, ([key, label]) => ({ key, label })).sort((a, b) =>
-      a.label.localeCompare(b.label),
-    );
-  }, [rows]);
-  // If the selected rig leaves the roster (its agents all stopped and were
-  // pruned on an SSE/manual refresh), reset to "all rigs" so the controlled
-  // <select> doesn't strand the table empty with no visible cause.
+  // Rig dropdown options: the normalized rig labels (basenames, not raw
+  // paths) present in the current roster, sorted. Empty value = all rigs.
+  const rigOptions = useMemo(
+    () => Array.from(new Set(rows.map((a) => agentProject(a).label)))
+      .sort((x, y) => x.localeCompare(y)),
+    [rows],
+  );
+  // If the selected rig leaves the roster, fall back to all rigs.
   useEffect(() => {
-    if (rigFilter !== RIG_FILTER_ALL && !rigOptions.some((o) => o.key === rigFilter)) {
-      setRigFilter(RIG_FILTER_ALL);
-    }
+    if (rigFilter !== '' && !rigOptions.includes(rigFilter)) setRigFilter('');
   }, [rigOptions, rigFilter]);
 
-  // Flatten useListFilters' (now single) group into one sorted, search/chip
-  // filtered list, then apply the rig dropdown.
+  // Simple client-side filtering: rig dropdown, the 'running' toggle, then a
+  // free-text search. No sort mode, no chip group, no persisted state.
   const visibleRows = useMemo(() => {
-    const flat = filters.groups.flatMap((g) => g.rows);
-    if (rigFilter === RIG_FILTER_ALL) return flat;
-    return flat.filter((a) => agentRigKey(a) === rigFilter);
-  }, [filters.groups, rigFilter]);
+    const q = search.trim().toLowerCase();
+    return rows.filter((a) => {
+      if (rigFilter !== '' && agentProject(a).label !== rigFilter) return false;
+      // Always surface agents that need attention (e.g. blocked on a pending
+      // interaction) — they must never be hidden by the 'running' default,
+      // since a stuck agent is usually NOT running.
+      const needsAttention =
+        resourceAttentionSeverity(attention, 'agents', a.name) !== null;
+      if (runningOnly && !isRunningAgent(a) && !needsAttention) return false;
+      if (q.length === 0) return true;
+      return AGENT_SEARCH_FIELDS(a).some((field) => field.toLowerCase().includes(q));
+    });
+  }, [rows, rigFilter, runningOnly, search, attention]);
 
   const rowProps = useMemo(
     () => (agent: SupervisorAgent) =>
-      attentionRowProps(resourceAttentionSeverity(attention, 'agents', agent.name)),
+      attentionDataProps(resourceAttentionSeverity(attention, 'agents', agent.name)),
     [attention],
   );
   const rosterUnavailable = error !== null && rows.length === 0;
   const emptyMessage = rosterUnavailable
     ? 'Agent roster unavailable.'
-    : filters.search.length > 0 || filters.activeChipIds.size > 0
-      ? 'No agents match the current search or filter.'
-      : 'No agents configured.';
+    : rows.length === 0
+      ? 'No agents configured.'
+      : 'No agents match the current search or filter.';
 
   const columns = useMemo<ReadonlyArray<TableColumn<SupervisorAgent>>>(() => [
     {
       key: 'name',
       label: 'Agent',
       sortable: true,
-      // Sort by alias (the identity), not the display_name. Two agents
-      // with the same provider label ("Claude (Account 5)") would
-      // otherwise collide; alias is unique.
-      sortValue: (r) => r.name,
+      // Sort by the visible 'rig · agent' label so the column order matches.
+      sortValue: (r) => agentRowLabel(r),
       render: (r) => {
-        // Per-rig dispatchers (alias '<rig>/control-dispatcher') live
-        // inside their rig group but perform an orchestration role.
-        // Italicize the alias so the operator can spot them at a glance
-        // without lifting them out of their rig (cross-rig
-        // orchestration is handled separately by the Orchestration
-        // pinned group).
+        // Per-rig dispatchers (alias '<rig>/control-dispatcher') perform an
+        // orchestration role; italicize the label so the operator can spot
+        // them at a glance.
         const dispatcher = isPerRigDispatcherAgent(r);
-        // Primary label is the alias (`name`) — that's the identity the
-        // operator dispatches with (`gc sling <alias> ...`) and the only
-        // field guaranteed unique. display_name is the provider's
-        // human-readable label (e.g. "Claude (Account 5)") and is
-        // useful as secondary context but not as a primary identifier.
+        // Primary label is 'rig · agent' (e.g. 'gascity-packs · polecat-1').
+        // display_name is the provider's human-readable label
+        // (e.g. "Claude (Account 5)") and reads as muted secondary context.
         const secondary = r.display_name && r.display_name !== r.name
           ? r.display_name
           : (r.provider ?? r.model ?? '');
-        // ay6.2: orphan agents (no bound session) still render a link
-        // to /agents/<slug>, but AgentDetail will resolve nothing and
-        // show "no session matches" — a confusing dead-end if the
-        // operator clicks expecting a drilldown. A distinct title
-        // tooltip and a muted color pre-empt the surprise without
-        // disabling the link (the configured-but-not-running detail
-        // page is sd4's scope). Dispatchers keep their italic cue.
+        // ay6.2: orphan agents (no bound session) still render a link, but
+        // AgentDetail resolves nothing — a distinct title tooltip and muted
+        // color pre-empt the dead-end without disabling the link.
         const orphan = !r.session;
         const linkTitle = orphan
           ? `${r.name} — configured but not running; detail will show no live session`
@@ -339,7 +241,7 @@ export function AgentsPage() {
               }`}
               title={linkTitle}
             >
-              {r.name}
+              {agentRowLabel(r)}
             </Link>
             {secondary && (
               <div className="text-label uppercase tracking-wider text-fg-faint mt-1 truncate">
@@ -349,29 +251,6 @@ export function AgentsPage() {
           </div>
         );
       },
-    },
-    {
-      key: 'rig',
-      label: 'Rig',
-      sortable: true,
-      // Sort by the display label so the column's visual order matches the
-      // sort order (the key is lowercased/normalized and would diverge).
-      sortValue: (r) => agentRigLabel(r),
-      // Agents outside a rig (Orchestration roles + the residual no-rig bucket)
-      // are not in a real rig, so the column shows a neutral dot rather than a
-      // pseudo-rig label. The dot carries a title/aria-label so the state stays
-      // readable in greyscale and to assistive tech (DESIGN.md: states have words).
-      render: (r) =>
-        isAgentOutsideRig(r) ? (
-          <span
-            className="inline-block h-1.5 w-1.5 rounded-full bg-fg-faint align-middle"
-            title="Not associated with a rig"
-            aria-label="Not associated with a rig"
-          />
-        ) : (
-          <span className="text-fg-muted">{agentRigLabel(r)}</span>
-        ),
-      className: 'w-40',
     },
     {
       key: 'state',
@@ -471,9 +350,7 @@ export function AgentsPage() {
       label: '',
       render: (r) => {
         // Orphan agents (no bound session) have nothing to peek into.
-        // Hide the button so the operator doesn't get a 404 from the
-        // transcript fetch. Use visibility:hidden equivalent (render the
-        // empty cell) rather than collapsing the column width.
+        // Render an empty cell rather than collapsing the column width.
         if (!r.session) return null;
         const pending = pendingByAgent.get(r.name);
         return (
@@ -541,42 +418,43 @@ export function AgentsPage() {
 
       <div className="mb-6 space-y-3">
         <ListSearchBar
-          value={filters.search}
-          onChange={filters.setSearch}
+          value={search}
+          onChange={setSearch}
           placeholder="Search agents by alias, rig, pool, provider"
-          matchCount={filters.totalMatches}
+          matchCount={visibleRows.length}
           totalCount={rows.length}
           ariaLabel="Search agents"
         />
-        <div className="flex flex-wrap items-baseline gap-x-8 gap-y-3">
-          <FilterChips
-            chips={AGENT_CHIPS}
-            activeIds={filters.activeChipIds}
-            onToggle={filters.toggleChip}
-            legend="State"
-          />
-          <label className="flex items-baseline gap-2 text-label">
-            <span className="uppercase tracking-wider text-fg-muted">Rig</span>
-            <select
-              value={rigFilter}
-              onChange={(e) => setRigFilter(e.target.value)}
-              aria-label="Filter by rig"
-              className="text-label uppercase tracking-wider text-fg-muted bg-transparent border-0 focus-mark cursor-pointer hover:text-fg transition-colors duration-150 ease-out-quart"
-            >
-              <option value={RIG_FILTER_ALL}>all rigs</option>
-              {rigOptions.map((opt) => (
-                <option key={opt.key} value={opt.key}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+        <div className="flex items-baseline gap-6">
+          <label className="inline-flex items-baseline gap-2 text-label uppercase tracking-wider text-fg-muted cursor-pointer hover:text-fg transition-colors duration-150 ease-out-quart">
+            <input
+              type="checkbox"
+              checked={runningOnly}
+              onChange={(e) => setRunningOnly(e.target.checked)}
+              // Neutral accent, not maroon: the adjacent "running" word already
+              // names the state (greyscale-safe), and a maroon check would be a
+              // second mark per DESIGN.md One Mark Rule.
+              style={{ accentColor: 'oklch(var(--fg-muted))' }}
+              className="translate-y-[2px]"
+            />
+            <span>running</span>
           </label>
-          <SortToggle<SortMode>
-            value={filters.sortMode}
-            options={SORT_OPTIONS}
-            onChange={filters.setSortMode}
-            legend="Sort"
-          />
+          {rigOptions.length > 1 && (
+            <label className="inline-flex items-baseline gap-2 text-label uppercase tracking-wider text-fg-muted">
+              <span>rig</span>
+              <select
+                value={rigFilter}
+                onChange={(e) => setRigFilter(e.target.value)}
+                aria-label="Rig filter"
+                className="text-label uppercase tracking-wider text-fg-muted bg-transparent border-0 focus-mark cursor-pointer hover:text-fg transition-colors duration-150 ease-out-quart"
+              >
+                <option value="">all rigs</option>
+                {rigOptions.map((rig) => (
+                  <option key={rig} value={rig}>{rig}</option>
+                ))}
+              </select>
+            </label>
+          )}
         </div>
       </div>
       {responseMessage && (

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { formatApiError } from '../api/client';
+import { formatMailSender } from '../lib/mailSender';
 import { useCachedData } from '../hooks/useCachedData';
 import { useAttentionModel } from '../attention/context';
 import {
-  attentionRowProps,
+  attentionDataProps,
   resourceAttentionSeverity,
 } from '../attention/routeHighlight';
 import { Button } from '../components/Button';
@@ -182,8 +183,8 @@ export function MailPage() {
       key: 'from',
       label: 'From',
       sortable: true,
-      sortValue: (r) => r.from,
-      render: (r) => <span className="text-fg-muted">{r.from}</span>,
+      sortValue: (r) => formatMailSender(r.from),
+      render: (r) => <span className="text-fg-muted">{formatMailSender(r.from)}</span>,
       className: 'w-48',
     },
     {
@@ -237,9 +238,14 @@ export function MailPage() {
     searchOf: MAIL_SEARCH_FIELDS,
     chips: MAIL_CHIPS,
   });
+  // gascity-dashboard-s464: mail is not an alert by default. We keep the
+  // data-attention-severity attribute (so the home-alerts panel and
+  // keyboard nav still see flagged rows), but DO NOT paint the warn/accent
+  // background tint that made unread mail read as "slightly red". Mail rows
+  // render in the neutral foreground; severity is exposed for tooling only.
   const rowProps = useMemo(
     () => (mail: SupervisorMailItem) =>
-      attentionRowProps(resourceAttentionSeverity(attention, 'mail', mail.id)),
+      attentionDataProps(resourceAttentionSeverity(attention, 'mail', mail.id)),
     [attention],
   );
   const mailSeverity = useCallback(


### PR DESCRIPTION
## Summary
Operator (Stephanie) feedback pass on the Agents + Mail views, plus making stuck agents visible.

**Agents view — reverted to the simpler design + restored the rig dropdown:**
- Single **`running` checkbox** (default on, neutral accent), **no sort control**, **no sticky/persisted chip state** — replaces the flat sortable/filterable table (chips + sort + `useListFilters`).
- Restored the **`rig · agent` label** (e.g. `gascity-packs · polecat-1`).
- Restored the **rig dropdown** (clean rig names, not filesystem paths).
- **Lighter surface** — agent rows no longer carry the attention background tint (data-attribute only, like mail).
- **Attention agents stay visible by default** — an agent blocked on a pending interaction is *not* hidden by the running-only filter (a stuck agent is usually not "running").

**Mail:**
- Removed the reddish tint on mail rows + message body (kept the genuine prompt-injection warn badge).
- Sender (`from`/`to`) now renders as **`rig · agent`** instead of the raw worktree path (`formatMailSender`).

**Rig-name cleanup:**
- `canonicalRigLabel` strips a `-main` worktree/build suffix (`gascity-main` → `gascity`, `gascity-packs-main` → `gascity-packs`) so build trees/worktrees stop showing up as rigs in labels + the dropdown + mail senders.

## Tests
New: `formatMailSender` (incl. `-main` canonicalization), `agentProject` `-main` cases, `isRunningAgent`/`agentRowLabel`, running-checkbox-default + `rig · agent` label render, attention-agent-stays-visible. Full suite green (637), typecheck (src + test), lint, build.

## Review
Reviewed by code + typescript reviewers — **approve**, 0 blockers / 0 majors. Applied the noted improvements (neutral checkbox accent per DESIGN.md One Mark Rule, `canonicalRigLabel` unit coverage, empty-roster message correctness). No circular import (`mailSender`→`projectOf` only); DESIGN.md One Mark / Greyscale / status=glyph+word all satisfied; unread mail still distinguishable by weight.

Net diff is negative on `Agents.tsx` (the revert removes the table/chips/sort scaffolding).
