### PR TITLE
fix(dashboard): graceful 404 for stale decision deep-links + calm missing-work_dir run-diff state

### DIFF
--- a/frontend/src/components/BeadDetailModal.test.tsx
+++ b/frontend/src/components/BeadDetailModal.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { useBeadDetail, type BeadDetailState } from '../hooks/useBeadDetail';
+import { useEntityLinks } from '../hooks/useEntityLinks';
+import { BeadDetailModal } from './BeadDetailModal';
+
+vi.mock('../hooks/useBeadDetail', () => ({
+  useBeadDetail: vi.fn(),
+}));
+
+vi.mock('../hooks/useEntityLinks', () => ({
+  useEntityLinks: vi.fn(() => ({
+    view: null,
+    loading: false,
+    error: null,
+  })),
+}));
+
+const mockUseBeadDetail = useBeadDetail as unknown as Mock;
+const mockUseEntityLinks = useEntityLinks as unknown as Mock;
+
+function detailState(overrides: Partial<BeadDetailState>): BeadDetailState {
+  return {
+    bead: null,
+    loading: false,
+    error: null,
+    notFound: false,
+    now: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mockUseEntityLinks.mockReturnValue({ view: null, loading: false, error: null });
+});
+
+describe('BeadDetailModal', () => {
+  it('renders a calm resolved-or-removed state for a stale deep-link (404)', () => {
+    mockUseBeadDetail.mockReturnValue(detailState({ notFound: true }));
+
+    render(
+      <BeadDetailModal open onClose={() => {}} beadId="gc-316879" />,
+    );
+
+    expect(screen.getByText(/resolved or removed/i)).toBeTruthy();
+    // Never the hard "Bead not found in the supervisor." error, and never the
+    // maroon accent for what is an expected absence.
+    expect(screen.queryByText(/not found in the supervisor/i)).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('still surfaces genuine errors via the alert role', () => {
+    mockUseBeadDetail.mockReturnValue(
+      detailState({ error: '500 supervisor down' }),
+    );
+
+    render(<BeadDetailModal open onClose={() => {}} beadId="gc-1" />);
+
+    expect(screen.getByRole('alert').textContent).toContain('supervisor down');
+  });
+});

--- a/frontend/src/components/BeadDetailModal.tsx
+++ b/frontend/src/components/BeadDetailModal.tsx
@@ -51,7 +51,11 @@ export function BeadDetailModal({
   sessions,
   renderActions,
 }: BeadDetailModalProps) {
-  const { bead, loading, error, now } = useBeadDetail(open, beadId, initialBead);
+  const { bead, loading, error, notFound, now } = useBeadDetail(
+    open,
+    beadId,
+    initialBead,
+  );
   const links = useEntityLinks(open ? beadId : null);
   const [runOpen, setRunOpen] = useState(false);
 
@@ -94,7 +98,15 @@ export function BeadDetailModal({
         widthClass="max-w-3xl"
         footer={footer}
       >
-        {error ? (
+        {notFound ? (
+          <div className="space-y-2">
+            <p className="text-fg-muted">This decision was resolved or removed.</p>
+            <p className="text-fg-faint text-sm">
+              The bead it pointed to is no longer in the supervisor — it was
+              likely closed or pruned since this link was surfaced.
+            </p>
+          </div>
+        ) : error ? (
           <p className="text-accent" role="alert">
             {error}
           </p>

--- a/frontend/src/components/run/RunDiffPanel.test.tsx
+++ b/frontend/src/components/run/RunDiffPanel.test.tsx
@@ -7,9 +7,13 @@ afterEach(() => cleanup());
 
 describe('RunDiffPanel', () => {
   it('shows quiet skipped states when the execution folder is unknown or not git', () => {
-    const { rerender } = render(<RunDiffPanel diff={diffFor('path_unknown')} />);
+    const { container, rerender } = render(<RunDiffPanel diff={diffFor('path_unknown')} />);
 
-    expect(screen.getByText(/execution folder is unknown/i)).toBeTruthy();
+    // A missing work_dir is a calm absence, not a failure: explain why there
+    // is no diff and never raise the maroon accent for it.
+    expect(screen.getByText(/no diff available for this run/i)).toBeTruthy();
+    expect(screen.getByText(/did not record a work_dir/i)).toBeTruthy();
+    expect(container.querySelectorAll('.text-accent').length).toBe(0);
 
     rerender(<RunDiffPanel diff={diffFor('not_git')} />);
     expect(screen.getByText(/not a git work tree/i)).toBeTruthy();

--- a/frontend/src/components/run/RunDiffPanel.tsx
+++ b/frontend/src/components/run/RunDiffPanel.tsx
@@ -16,7 +16,18 @@ interface RunDiffPanelProps {
 export function RunDiffPanel({ diff }: RunDiffPanelProps) {
   switch (diff.kind) {
     case 'path_unknown':
-      return <p className="text-body text-fg-muted italic">Execution folder is unknown for this run.</p>;
+      // The run bead carries no work_dir / cwd / rig_root, so there is no
+      // folder to diff against. This is expected for rig-store run beads the
+      // supervisor doesn't yet stamp with `gc.work_dir` (gascity-dashboard-j7np,
+      // upstream-gated) — present it as a calm absence, not a failure.
+      return (
+        <div className="space-y-1">
+          <p className="text-body text-fg-muted italic">No diff available for this run.</p>
+          <p className="text-label text-fg-faint">
+            The run did not record a work_dir, so there is no work tree to compare.
+          </p>
+        </div>
+      );
     case 'not_git':
       return <p className="text-body text-fg-muted italic">Execution folder is not a git work tree.</p>;
     case 'error':

--- a/frontend/src/hooks/useBeadDetail.test.tsx
+++ b/frontend/src/hooks/useBeadDetail.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { fetchSupervisorBead } from '../supervisor/beadReads';
+import { SupervisorApiError } from '../supervisor/client';
+import { useBeadDetail } from './useBeadDetail';
+
+vi.mock('../contexts/NowContext', () => ({
+  useNow: () => 1_700_000_000_000,
+}));
+
+vi.mock('../supervisor/beadReads', () => ({
+  fetchSupervisorBead: vi.fn(),
+}));
+
+const mockFetch = fetchSupervisorBead as unknown as Mock;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('useBeadDetail', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('flags notFound (not error) when the deep-linked bead 404s', async () => {
+    mockFetch.mockRejectedValue(
+      new SupervisorApiError(404, 'bead missing', undefined),
+    );
+
+    const { result } = renderHook(() => useBeadDetail(true, 'gc-316879'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // A pruned / since-closed deep-link is a calm absence, not a hard error:
+    // notFound true, error stays null so the modal can render the resolved
+    // state instead of "Bead not found in the supervisor." (gascity-dashboard-sg9o).
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.bead).toBeNull();
+  });
+
+  it('surfaces non-404 failures as a hard error, never as notFound', async () => {
+    mockFetch.mockRejectedValue(
+      new SupervisorApiError(500, 'supervisor down', undefined),
+    );
+
+    const { result } = renderHook(() => useBeadDetail(true, 'gc-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.notFound).toBe(false);
+    expect(result.current.error).toContain('supervisor down');
+  });
+
+  it('loads the bead and leaves notFound clear on success', async () => {
+    mockFetch.mockResolvedValue({
+      id: 'gc-1',
+      title: 'live bead',
+      issue_type: 'task',
+      status: 'open',
+      description: 'body',
+    });
+
+    const { result } = renderHook(() => useBeadDetail(true, 'gc-1'));
+
+    await waitFor(() => expect(result.current.bead?.id).toBe('gc-1'));
+
+    expect(result.current.notFound).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not fetch when inactive', async () => {
+    renderHook(() => useBeadDetail(false, 'gc-1'));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useBeadDetail.ts
+++ b/frontend/src/hooks/useBeadDetail.ts
@@ -13,6 +13,14 @@ export interface BeadDetailState {
   bead: SupervisorBead | null;
   loading: boolean;
   error: string | null;
+  /**
+   * The bead id resolved to a 404 — it no longer exists in the supervisor.
+   * Distinct from `error` so callers can render a calm "resolved or removed"
+   * state for a stale deep-link (gascity-dashboard-sg9o / -jrs0) rather than a
+   * hard failure. A pruned or since-closed-and-swept bead is an expected,
+   * non-alarming outcome when an attention deep-link outlives its target.
+   */
+  notFound: boolean;
   /** Live clock (ms) for RelatedEntities staleness / "as of". */
   now: number;
 }
@@ -31,6 +39,7 @@ export function useBeadDetail(
   const [bead, setBead] = useState<SupervisorBead | null>(initialBead);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
   const now = useNow();
 
   useEffect(() => {
@@ -42,11 +51,13 @@ export function useBeadDetail(
     ) {
       setBead(initialBead);
       setError(null);
+      setNotFound(false);
       return;
     }
     setBead(initialBead?.id === beadId ? initialBead : null);
     setLoading(true);
     setError(null);
+    setNotFound(false);
     let cancelled = false;
     void (async () => {
       try {
@@ -54,11 +65,14 @@ export function useBeadDetail(
         if (!cancelled) setBead(result);
       } catch (err) {
         if (cancelled) return;
-        setError(
-          err instanceof SupervisorApiError && err.status === 404
-            ? 'Bead not found in the supervisor.'
-            : formatSupervisorError(err),
-        );
+        if (err instanceof SupervisorApiError && err.status === 404) {
+          // The deep-linked bead is gone (pruned, or closed-and-swept since
+          // the attention queue cached it). Surface as a calm absence, not an
+          // error banner.
+          setNotFound(true);
+        } else {
+          setError(formatSupervisorError(err));
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -68,7 +82,7 @@ export function useBeadDetail(
     };
   }, [active, beadId, initialBead]);
 
-  return { bead, loading, error, now };
+  return { bead, loading, error, notFound, now };
 }
 
 function formatSupervisorError(err: unknown): string {

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -239,7 +239,7 @@ async function runTheme(browser, theme) {
       timeout: 5_000,
     });
     await page.getByRole('tab', { name: /diff/i }).click();
-    await page.getByText(/execution folder is unknown/i).waitFor({ timeout: 5_000 });
+    await page.getByText(/no diff available for this run/i).waitFor({ timeout: 5_000 });
 
     await page.goto(`${CITY_BASE}/runs/gc-clean-worktree`, {
       waitUntil: 'domcontentloaded',


### PR DESCRIPTION
## Summary
Two resilience fixes — both are graceful-degradation of alarming states into calm ones (no behavior regressions).

**`gascity-dashboard-sg9o` — stale "needs you" decision deep-link 404s.** Clicking a home decision alert whose bead was pruned/closed after the queue cached its link showed a hard "Bead not found in the supervisor." alert. The decision queue filtering was already correct (`needs/stephanie` + `status: open`) — the dangling ref is inherent to any cached deep-link outliving its target. Fix: `useBeadDetail` now sets a `notFound` flag on a **404 specifically** (non-404 errors still surface), and `BeadDetailModal` renders a calm **"This decision was resolved or removed."** state instead of an error alert.

**`gascity-dashboard-3ozw` — run diffs "broke again."** Reproduced live: it's **not** a frontend regression — the #44 supervisor-client migration preserves `metadata`/`work_dir` end-to-end. ~half of recent runs simply lack `gc.work_dir` (the supervisor doesn't stamp rig-store run beads — upstream **`gascity-dashboard-j7np`**), so the panel showed an alarming "Execution folder is unknown for this run." Fix: the `path_unknown` branch now renders a calm **"No diff available for this run."** + explanation. Real fix stays upstream (j7np). Snap check updated (`r1fg`).

## Tests
New: `useBeadDetail.test.tsx` (404→notFound, 500→error, success), `BeadDetailModal.test.tsx` (calm resolved/removed render; genuine errors still alert), extended `RunDiffPanel.test.tsx` (new copy + greyscale/no-accent). Full suite green (645), typecheck (src+test), lint, build.

## Review
Reviewed by code + typescript reviewers — **approve**, 0 blockers/majors. Applied the noted simplification (`notFound` guard). DESIGN.md: both calm states are neutral (no `role="alert"`, no accent), greyscale-safe. Isolated from the open-PR files (`Beads.tsx`/`Agents.tsx`/`Mail.tsx`).
