### PR TITLE
feat(dashboard): 'Workers active' signal (session-driven, peekable) + running-filter/label/transcript fixes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -93,6 +93,16 @@ In the meantime, every component built during initial implementation should sati
 - **One mark per region.** Maroon never appears twice in adjacent regions. If two regions both want emphasis, the page is unclear about what it is emphasising.
 - **States have words.** Hover, focus, selected, disabled, errored. Every state has a textual or glyph correlate. Color is the accelerator, not the carrier.
 
+### Workers active (Agents view)
+
+The calm "what is working right now" section at the top of the Agents view.
+
+- **Session-driven, not bead-driven.** It counts the live worker sessions, not the in-progress beads. The work-beads churn to zero within seconds (focus-reviews finish fast) and live in rig stores the dashboard's bead fetch doesn't reliably aggregate, while the worker sessions stay active across that churn. A worker session is the stable signal.
+- **Summary line.** One calm sentence: "N workers active across rig (n), rig (n), ..." — active worker sessions grouped by clean rig name, most workers first. Orchestration (mayor, control-dispatchers, project-leads, chief-of-staff) is excluded; it directs work, it doesn't perform it.
+- **Per-worker rows.** One row per active worker session: "rig · clean-worker · relative-activity". The worker name is cleaned (no path, no -gc-XXXXX session suffix). When an in-progress bead's assignee embeds that session id, the bead is appended as secondary context: "→ bead-id: title". The common case is no bead; the worker being active is the signal, so there is never an "unassigned" row.
+- **One mark.** An active worker is the normal, calm case, so worker state reads neutral. At most one accent (maroon) badge per viewport: only the first stuck/failed worker, an actual anomaly, renders its state in tone.
+- **Empty state.** "No workers active right now." Calm, not an alert.
+
 ## 6. Do's and Don'ts
 
 ### Do:

--- a/frontend/src/components/SessionPeek.render.test.tsx
+++ b/frontend/src/components/SessionPeek.render.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SessionPeekContent } from './SessionPeek';
+import type { SessionTranscriptView } from '../supervisor/sessionReads';
+
+// gascity-dashboard-5e5v / xl07: raw terminal control bytes leaked into the
+// rendered peek transcript (Stephanie saw `... then proceed.^[`). These tests
+// mount the real render path and assert the artifacts never reach the DOM.
+
+afterEach(cleanup);
+
+function viewWithTurn(text: string): SessionTranscriptView {
+  return {
+    turns: [{ role: 'assistant', text }],
+    total_chars: text.length,
+    captured_at: '2026-06-03T00:00:00Z',
+    truncated: false,
+  } as SessionTranscriptView;
+}
+
+describe('SessionPeekContent — terminal control stripping', () => {
+  it('renders the leaked transcript without escape artifacts', () => {
+    const dirty =
+      '... then proceed.\x1b\x1b]0;evil-title\x07 colour \x1b[31mred\x1b[0m tail\x9chere';
+    const { container } = render(
+      <SessionPeekContent loading={false} error={null} result={viewWithTurn(dirty)} />,
+    );
+    const rendered = container.textContent ?? '';
+
+    // The visible, printable content survives.
+    expect(rendered).toContain('... then proceed.');
+    expect(rendered).toContain('colour');
+    expect(rendered).toContain('red');
+    expect(rendered).toContain('tailhere');
+
+    // No raw control bytes reach the DOM.
+    expect(rendered).not.toContain('\x1b');
+    expect(rendered).not.toContain('\x9c');
+    expect(rendered).not.toContain('evil-title');
+    // The literal `^[` glyph form must not appear either.
+    expect(rendered).not.toContain('^[');
+    // SGR parameter text must not leak as visible characters.
+    expect(rendered).not.toContain('[31m');
+    expect(rendered).not.toContain('[0m');
+  });
+
+  it('colorizes the surviving SGR sequence via ansi_up classes', () => {
+    const dirty = 'plain \x1b[31mred-text\x1b[0m done';
+    const { container } = render(
+      <SessionPeekContent loading={false} error={null} result={viewWithTurn(dirty)} />,
+    );
+    // ansi_up with use_classes emits ansi-* class spans for SGR colour.
+    expect(container.querySelector('[class*="ansi-"]')).not.toBeNull();
+    expect(container.textContent).toContain('red-text');
+  });
+});

--- a/frontend/src/components/SessionPeek.tsx
+++ b/frontend/src/components/SessionPeek.tsx
@@ -137,7 +137,7 @@ function ansiToReactNodes(text: string): ReactNode[] {
   const renderer = new AnsiUp();
   renderer.use_classes = true;
   const html = renderer.ansi_to_html(cleaned);
-  if (typeof DOMParser === 'undefined') return [text];
+  if (typeof DOMParser === 'undefined') return [cleaned];
 
   const doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html');
   return Array.from(doc.body.childNodes).map((node, index) => htmlNodeToReact(node, String(index)));

--- a/frontend/src/components/SessionPeek.tsx
+++ b/frontend/src/components/SessionPeek.tsx
@@ -3,6 +3,7 @@ import { useMemo, type ReactNode } from 'react';
 import type { OutputTurn } from '../generated/gc-supervisor-client/types.gen';
 import { formatClockTime, formatRelative, formatShortDate } from '../hooks/time';
 import { PROMPT_INJECTION_NOTICE } from '../lib/constants';
+import { stripTerminalControls } from '../lib/stripTerminalControls';
 import type { SessionTranscriptView } from '../supervisor/sessionReads';
 
 // Render layer for a session's transcript snapshot. Used by:
@@ -127,9 +128,15 @@ function TurnBlock({ turn, index, now }: { turn: OutputTurn; index: number; now:
 }
 
 function ansiToReactNodes(text: string): ReactNode[] {
+  // Strip OSC / non-SGR CSI / lone-ESC / bare C1 control bytes before
+  // ansi_up runs. ansi_up colorizes SGR but passes every other control
+  // sequence through as visible text, leaking `^[`, `\x9c`, OSC titles, etc.
+  // into the peek (gascity-dashboard-5e5v / xl07). SGR is preserved here so
+  // ansi_up can still render colour.
+  const cleaned = stripTerminalControls(text);
   const renderer = new AnsiUp();
   renderer.use_classes = true;
-  const html = renderer.ansi_to_html(text);
+  const html = renderer.ansi_to_html(cleaned);
   if (typeof DOMParser === 'undefined') return [text];
 
   const doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html');

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -70,3 +70,33 @@ export function beadStatusTone(status: string): StatusTone {
       return 'warn';
   }
 }
+
+// Single source of truth for session/agent state → tone mapping. Aligned with
+// how the gc supervisor emits agent (and session) states. Unknown states
+// default to neutral so we don't lie about them. 'detached' is explicit (not a
+// silent default) so reviewers see the intent. Co-located with the other tone
+// mappers here so display components depend only on StatusBadge, not on the
+// Agents route (which would be an import cycle: Agents imports WorkInFlight,
+// WorkInFlight imported stateTone from Agents).
+export function stateTone(state: string): StatusTone {
+  switch (state) {
+    case 'active':
+    case 'running':
+      return 'ok';
+    case 'rate-limited':
+    case 'rate_limited':
+    case 'waiting':
+      return 'warn';
+    case 'failed':
+    case 'closed':
+    case 'errored':
+    case 'stuck':
+      return 'stuck';
+    case 'detached':
+    case 'asleep':
+    case 'idle':
+    case 'creating':
+    default:
+      return 'neutral';
+  }
+}

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -36,11 +36,20 @@ function session(partial: Partial<SupervisorSession> & { id: string }): Supervis
   } as SupervisorSession;
 }
 
-function renderSection(beads: SupervisorBead[], sessions: SupervisorSession[]) {
+function renderSection(
+  beads: SupervisorBead[],
+  sessions: SupervisorSession[],
+  opts: { loading?: boolean; error?: string | null } = {},
+) {
   return render(
     <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <NowProvider intervalMs={1_000_000}>
-        <WorkInFlight beads={beads} sessions={sessions} />
+        <WorkInFlight
+          beads={beads}
+          sessions={sessions}
+          sessionsLoading={opts.loading ?? false}
+          sessionsError={opts.error ?? null}
+        />
       </NowProvider>
     </MemoryRouter>,
   );
@@ -182,5 +191,31 @@ describe('WorkInFlight (Workers active)', () => {
     );
     expect(screen.getByText('No workers active right now.')).toBeTruthy();
     expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  // Fail-safe: when the sessions fetch has not delivered data, the section must
+  // NOT render the calm "No workers active" all-clear — that would mask a dead
+  // aggregator on the exact surface the work-in-flight signal is meant to make
+  // trustworthy. Distinguish a failed fetch from an in-flight one.
+  it('renders explicit unavailable (not the all-clear) when the sessions fetch failed with no data', () => {
+    renderSection([], [], { error: 'sessions backend unavailable' });
+    expect(screen.getByText('Worker status unavailable.')).toBeTruthy();
+    expect(screen.queryByText('No workers active right now.')).toBeNull();
+  });
+
+  it('renders a loading state (not the all-clear) while the initial sessions fetch is in flight', () => {
+    renderSection([], [], { loading: true });
+    expect(screen.getByText('Checking worker status…')).toBeTruthy();
+    expect(screen.queryByText('No workers active right now.')).toBeNull();
+  });
+
+  it('keeps rendering stale workers when a re-fetch errors but prior data is retained', () => {
+    // useCachedData holds the last good data across a re-fetch failure, so the
+    // false-all-clear window is only the no-data case — stale data still counts.
+    renderSection([], [session({ id: 'gc-1', template: 'polecat', rig: 'gascity' })], {
+      error: 're-fetch failed',
+    });
+    expect(screen.queryByText('Worker status unavailable.')).toBeNull();
+    expect(screen.getByText('1 worker active across gascity (1).')).toBeTruthy();
   });
 });

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -36,10 +36,7 @@ function session(partial: Partial<SupervisorSession> & { id: string }): Supervis
   } as SupervisorSession;
 }
 
-function renderSection(
-  beads: SupervisorBead[],
-  sessions: SupervisorSession[],
-) {
+function renderSection(beads: SupervisorBead[], sessions: SupervisorSession[]) {
   return render(
     <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <NowProvider intervalMs={1_000_000}>
@@ -141,7 +138,7 @@ describe('WorkInFlight (Workers active)', () => {
     expect(screen.queryByRole('link')).toBeNull();
   });
 
-  it('opens the peek for the worker\'s own session id when its Peek control is clicked', async () => {
+  it("opens the peek for the worker's own session id when its Peek control is clicked", async () => {
     stubTranscriptFetch();
     const sessions = [
       session({ id: 'gc-335825', template: 'polecat', rig: 'gascity', state: 'active' }),

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WorkInFlight } from './WorkInFlight';
+import { NowProvider } from '../contexts/NowContext';
+import type { SupervisorBead } from '../supervisor/beadReads';
+import type { SupervisorSession } from '../supervisor/sessionReads';
+
+// The Work-in-flight section is driven by the IN-PROGRESS beads joined to their
+// live worker session via the session id embedded in the assignee. These tests
+// use the real verified examples as fixtures (see shared/work-in-flight.ts).
+
+function bead(partial: Partial<SupervisorBead> & { id: string }): SupervisorBead {
+  return {
+    title: `title for ${partial.id}`,
+    status: 'in_progress',
+    issue_type: 'task',
+    created_at: '2026-06-03T00:00:00Z',
+    ...partial,
+  } as SupervisorBead;
+}
+
+function session(partial: Partial<SupervisorSession> & { id: string }): SupervisorSession {
+  return {
+    template: 'worker',
+    session_name: partial.id,
+    title: partial.id,
+    state: 'active',
+    created_at: '2026-06-03T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+    ...partial,
+  } as SupervisorSession;
+}
+
+function renderSection(
+  beads: SupervisorBead[],
+  sessions: SupervisorSession[],
+) {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <NowProvider intervalMs={1_000_000}>
+        <WorkInFlight beads={beads} sessions={sessions} />
+      </NowProvider>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe('WorkInFlight', () => {
+  it('renders a clean "<rig> · <role>" label, bead id + title, and live session state', () => {
+    const beads = [bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' })];
+    const sessions = [session({ id: 'gc-335825', rig: '/home/ds/gascity', state: 'active' })];
+    renderSection(beads, sessions);
+
+    const link = screen.getByRole('link', { name: /gc-5rarj/ });
+    // Worker label is cleaned: rig basename + role (no path, no -gc suffix).
+    expect(link.textContent).toContain('gascity · polecat');
+    expect(link.textContent).toContain('gc-5rarj');
+    expect(link.textContent).toContain('fix the thing');
+    // Live session state badge present.
+    expect(screen.getByText('active')).toBeTruthy();
+    // Links to the bead board with the bead pre-selected.
+    expect(link.getAttribute('href')).toBe('/beads?bead=gc-5rarj');
+  });
+
+  it('strips a -main rig suffix in the worker label (gascity-main → gascity)', () => {
+    const beads = [bead({ id: 'gc-1', assignee: 'polecat-gc-2222' })];
+    const sessions = [session({ id: 'gc-2222', rig: '/home/ds/gascity-main' })];
+    renderSection(beads, sessions);
+    expect(screen.getByRole('link', { name: /gc-1/ }).textContent).toContain('gascity · polecat');
+  });
+
+  it('orders rows by most-recent session activity first', () => {
+    const beads = [
+      bead({ id: 'older-1', assignee: 'polecat-gc-100' }),
+      bead({ id: 'newer-2', assignee: 'worker-gc-200' }),
+    ];
+    const sessions = [
+      session({ id: 'gc-100', rig: 'gascity', last_active: '2026-06-03T10:00:00Z' }),
+      session({ id: 'gc-200', rig: 'scix', last_active: '2026-06-03T11:00:00Z' }),
+    ];
+    renderSection(beads, sessions);
+    const links = screen.getAllByRole('link');
+    expect(links[0]?.textContent).toContain('newer-2');
+    expect(links[1]?.textContent).toContain('older-1');
+  });
+
+  it('degrades gracefully when the embedded session id does not resolve (keeps the row)', () => {
+    const beads = [bead({ id: 'EnterpriseBench-mda', assignee: 'enterprisebench-worker-gc-335808' })];
+    renderSection(beads, []); // no live session for gc-335808
+    const link = screen.getByRole('link', { name: /EnterpriseBench-mda/ });
+    // Falls back to the bead-derived rig + parsed role; no live state badge.
+    expect(link.textContent).toContain('EnterpriseBench · enterprisebench-worker');
+    expect(screen.getByText(/no live session/i)).toBeTruthy();
+  });
+
+  it('shows a calm empty state when nothing is in flight', () => {
+    const beads = [bead({ id: 'open-1', status: 'open', assignee: 'polecat-gc-1' })];
+    renderSection(beads, []);
+    expect(screen.getByText('Nothing is in flight right now.')).toBeTruthy();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -6,9 +6,10 @@ import { NowProvider } from '../contexts/NowContext';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
 
-// The Work-in-flight section is driven by the IN-PROGRESS beads joined to their
-// live worker session via the session id embedded in the assignee. These tests
-// use the real verified examples as fixtures (see shared/work-in-flight.ts).
+// The "Workers active" section is SESSION-driven: it counts the live worker
+// sessions, groups them by rig for the calm summary, and best-effort attaches an
+// in-progress bead when one is captured. Orchestration sessions are excluded;
+// an unassigned in-progress bead is NOT surfaced (the worker is the signal).
 
 function bead(partial: Partial<SupervisorBead> & { id: string }): SupervisorBead {
   return {
@@ -22,7 +23,7 @@ function bead(partial: Partial<SupervisorBead> & { id: string }): SupervisorBead
 
 function session(partial: Partial<SupervisorSession> & { id: string }): SupervisorSession {
   return {
-    template: 'worker',
+    template: 'polecat',
     session_name: partial.id,
     title: partial.id,
     state: 'active',
@@ -49,58 +50,70 @@ function renderSection(
 
 afterEach(() => cleanup());
 
-describe('WorkInFlight', () => {
-  it('renders a clean "<rig> · <role>" label, bead id + title, and live session state', () => {
-    const beads = [bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' })];
-    const sessions = [session({ id: 'gc-335825', rig: '/home/ds/gascity', state: 'active' })];
-    renderSection(beads, sessions);
-
-    const link = screen.getByRole('link', { name: /gc-5rarj/ });
-    // Worker label is cleaned: rig basename + role (no path, no -gc suffix).
-    expect(link.textContent).toContain('gascity · polecat');
-    expect(link.textContent).toContain('gc-5rarj');
-    expect(link.textContent).toContain('fix the thing');
-    // Live session state badge present.
-    expect(screen.getByText('active')).toBeTruthy();
-    // Links to the bead board with the bead pre-selected.
-    expect(link.getAttribute('href')).toBe('/beads?bead=gc-5rarj');
-  });
-
-  it('strips a -main rig suffix in the worker label (gascity-main → gascity)', () => {
-    const beads = [bead({ id: 'gc-1', assignee: 'polecat-gc-2222' })];
-    const sessions = [session({ id: 'gc-2222', rig: '/home/ds/gascity-main' })];
-    renderSection(beads, sessions);
-    expect(screen.getByRole('link', { name: /gc-1/ }).textContent).toContain('gascity · polecat');
-  });
-
-  it('orders rows by most-recent session activity first', () => {
-    const beads = [
-      bead({ id: 'older-1', assignee: 'polecat-gc-100' }),
-      bead({ id: 'newer-2', assignee: 'worker-gc-200' }),
-    ];
+describe('WorkInFlight (Workers active)', () => {
+  it('renders the calm session-driven summary line grouped by rig', () => {
     const sessions = [
-      session({ id: 'gc-100', rig: 'gascity', last_active: '2026-06-03T10:00:00Z' }),
-      session({ id: 'gc-200', rig: 'scix', last_active: '2026-06-03T11:00:00Z' }),
+      session({ id: 'gc-1', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-2', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-3', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-4', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-5', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-6', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-7', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-8', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-9', template: 'worker', rig: 'zeldascension' }),
+      // Orchestration — excluded from the count.
+      session({ id: 'gc-m', template: 'mayor', rig: '' }),
     ];
+    renderSection([], sessions);
+    expect(screen.getByText('Workers active')).toBeTruthy();
+    expect(
+      screen.getByText(
+        '9 workers active across gascity (3), scix_experiments (3), gascity-packs (2), zeldascension (1).',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders a per-worker row "<rig> · <clean-worker>" with relative activity', () => {
+    const sessions = [
+      session({
+        id: 'gc-335825',
+        template: 'polecat',
+        rig: '/home/ds/gascity-main',
+        last_active: '2026-06-03T00:00:00Z',
+      }),
+    ];
+    renderSection([], sessions);
+    // -main rig suffix stripped, role cleaned.
+    expect(screen.getByText('gascity')).toBeTruthy();
+    expect(screen.getByText('polecat')).toBeTruthy();
+  });
+
+  it('appends "→ <bead-id>: <title>" when an in-progress bead embeds the session id', () => {
+    const sessions = [session({ id: 'gc-335825', template: 'polecat', rig: 'gascity' })];
+    const beads = [bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' })];
     renderSection(beads, sessions);
-    const links = screen.getAllByRole('link');
-    expect(links[0]?.textContent).toContain('newer-2');
-    expect(links[1]?.textContent).toContain('older-1');
+    const link = screen.getByRole('link', { name: /gc-5rarj/ });
+    expect(link.getAttribute('href')).toBe('/beads?bead=gc-5rarj');
+    expect(link.textContent).toContain('fix the thing');
   });
 
-  it('degrades gracefully when the embedded session id does not resolve (keeps the row)', () => {
-    const beads = [bead({ id: 'EnterpriseBench-mda', assignee: 'enterprisebench-worker-gc-335808' })];
-    renderSection(beads, []); // no live session for gc-335808
-    const link = screen.getByRole('link', { name: /EnterpriseBench-mda/ });
-    // Falls back to the bead-derived rig + parsed role; no live state badge.
-    expect(link.textContent).toContain('EnterpriseBench · enterprisebench-worker');
-    expect(screen.getByText(/no live session/i)).toBeTruthy();
+  it('does NOT surface an unassigned in-progress bead as a row', () => {
+    const sessions = [session({ id: 'gc-1', template: 'polecat', rig: 'gascity' })];
+    // A stalled, unassigned in-progress bead is not a working worker.
+    renderSection([bead({ id: 'gc-stalled' })], sessions);
+    expect(screen.queryByText(/gc-stalled/)).toBeNull();
+    // No bead link rendered for the worker without a captured bead.
+    expect(screen.queryByRole('link')).toBeNull();
   });
 
-  it('shows a calm empty state when nothing is in flight', () => {
-    const beads = [bead({ id: 'open-1', status: 'open', assignee: 'polecat-gc-1' })];
-    renderSection(beads, []);
-    expect(screen.getByText('Nothing is in flight right now.')).toBeTruthy();
+  it('shows the calm empty state when no workers are active', () => {
+    // Only orchestration + an in-progress bead present: still empty.
+    renderSection(
+      [bead({ id: 'gc-1', assignee: 'polecat-gc-1' })],
+      [session({ id: 'gc-m', template: 'mayor', rig: '' })],
+    );
+    expect(screen.getByText('No workers active right now.')).toBeTruthy();
     expect(screen.queryByRole('link')).toBeNull();
   });
 });

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WorkInFlight } from './WorkInFlight';
 import { NowProvider } from '../contexts/NowContext';
+import { setActiveCity } from '../api/cityBase';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
 
@@ -48,7 +49,40 @@ function renderSection(
   );
 }
 
-afterEach(() => cleanup());
+const transcriptUrls: string[] = [];
+
+function stubTranscriptFetch() {
+  transcriptUrls.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const path = url.startsWith(window.location.origin)
+        ? url.slice(window.location.origin.length)
+        : url;
+      transcriptUrls.push(path);
+      return new Response(
+        JSON.stringify({
+          id: 'gc-335825',
+          template: 'polecat',
+          provider: 'claude',
+          format: 'conversation',
+          turns: [{ role: 'assistant', text: 'worker transcript snapshot' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }),
+  );
+}
+
+beforeEach(() => {
+  setActiveCity('test-city');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('WorkInFlight (Workers active)', () => {
   it('renders the calm session-driven summary line grouped by rig', () => {
@@ -105,6 +139,42 @@ describe('WorkInFlight (Workers active)', () => {
     expect(screen.queryByText(/gc-stalled/)).toBeNull();
     // No bead link rendered for the worker without a captured bead.
     expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('opens the peek for the worker\'s own session id when its Peek control is clicked', async () => {
+    stubTranscriptFetch();
+    const sessions = [
+      session({ id: 'gc-335825', template: 'polecat', rig: 'gascity', state: 'active' }),
+    ];
+    renderSection([], sessions);
+
+    fireEvent.click(screen.getByRole('button', { name: /peek/i }));
+
+    // The worker row carries session.id directly (no name→id remap), so the
+    // peek must hit the transcript route for THAT exact session id.
+    await waitFor(() => {
+      expect(transcriptUrls).toContain(
+        '/gc-supervisor/v0/city/test-city/session/gc-335825/transcript?format=conversation',
+      );
+    });
+  });
+
+  it('surfaces the captured bead as a link beside the peek transcript', async () => {
+    stubTranscriptFetch();
+    const sessions = [session({ id: 'gc-335825', template: 'polecat', rig: 'gascity' })];
+    const beads = [bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' })];
+    renderSection(beads, sessions);
+
+    fireEvent.click(screen.getByRole('button', { name: /peek/i }));
+
+    // The peek caption links the worker's captured bead to its detail view.
+    const beadLinks = await screen.findAllByRole('link', { name: /gc-5rarj/ });
+    expect(beadLinks.some((l) => l.getAttribute('href') === '/beads?bead=gc-5rarj')).toBe(true);
+  });
+
+  it('renders no Peek control when there are no active workers', () => {
+    renderSection([], [session({ id: 'gc-m', template: 'mayor', rig: '' })]);
+    expect(screen.queryByRole('button', { name: /peek/i })).toBeNull();
   });
 
   it('shows the calm empty state when no workers are active', () => {

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -1,101 +1,69 @@
 import { Link } from 'react-router-dom';
-import {
-  deriveWorkInFlight,
-  type WorkInFlightRow,
-} from 'gas-city-dashboard-shared';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
 import { useNow } from '../contexts/NowContext';
 import { formatRelative } from '../hooks/time';
 import {
-  beadProject,
-  canonicalRigLabel,
-  cleanWorkerName,
-  sessionProject,
-} from '../hooks/projectOf';
-import { stateTone } from '../routes/Agents';
-import { StatusBadge } from './StatusBadge';
+  deriveActiveWorkers,
+  summarizeActiveWorkers,
+  type ActiveWorker,
+} from '../hooks/activeWorkers';
+import { StatusBadge, stateTone } from './StatusBadge';
 
-// Concrete row type for this surface — the shared generic specialized to the
-// generated supervisor wire types the dashboard actually holds.
-type Row = WorkInFlightRow<SupervisorBead, SupervisorSession>;
-
-// "Work in flight" — the operator's at-a-glance answer to "what is actually
-// working right now". Driven by the IN-PROGRESS BEADS (the real units of work),
-// each joined to its live worker session via the session id embedded in the
-// bead's assignee (see shared/work-in-flight.ts). One row per unit of work:
+// "Workers active" — the operator's calm at-a-glance answer to "what is
+// actually working right now".
 //
-//     <rig> · <role>  →  <bead-id>: <title>          [session state · 12m]
+// SESSION-DRIVEN, not bead-driven. The work-beads churn to zero within seconds
+// (focus-reviews finish fast) and live in rig stores the dashboard's bead fetch
+// doesn't reliably aggregate, while the worker SESSIONS stay active across that
+// churn. So the primary signal is the live worker sessions, grouped by rig:
 //
-// The roster (configured agent slots) is deliberately NOT the source: it
-// reports nearly every worker as stopped with no active bead because the live
-// work happens in dynamically-spawned sessions, not the slots.
+//     7 workers active across gascity (3), scix-experiments (3), gascity-packs (2).
+//
+// Per-worker rows below the summary, most-recently-active first:
+//
+//     gascity · polecat · 2m              [→ gc-5rarj: fix the thing]
+//
+// The bead is best-effort secondary context — attached only when an in-progress
+// bead's assignee embeds this session's id. The common case is no bead; the
+// worker being active IS the signal, so there is never an "unassigned" row.
 
 interface WorkInFlightProps {
   beads: readonly SupervisorBead[];
   sessions: readonly SupervisorSession[];
 }
 
-/**
- * The rig label for a row. Prefer the live session's rig (the authoritative
- * source once joined); fall back to the bead's project prefix when the session
- * didn't resolve. Both are run through canonicalRigLabel to strip a `-main`
- * build-tree/worktree suffix so the operator sees `gascity`, not `gascity-main`.
- */
-function rigLabelFor(row: Row): string {
-  if (row.session) {
-    return canonicalRigLabel(sessionProject(row.session).label);
-  }
-  return canonicalRigLabel(beadProject(row.bead));
-}
-
-/**
- * Clean worker label `<rig> · <role>` (e.g. `gascity · polecat`). The role is
- * the parsed assignee prefix, run through cleanWorkerName so any leaked path or
- * `-gc-XXXXX` session suffix is stripped. Falls back to just the rig when the
- * bead has no assignee/role.
- */
-function workerLabelFor(row: Row): string {
-  const rig = rigLabelFor(row);
-  if (!row.role) return rig;
-  const role = cleanWorkerName(row.role);
-  return role.length > 0 ? `${rig} · ${role}` : rig;
-}
-
-function WorkInFlightItem({ row }: { row: Row }) {
+function WorkerRow({ worker, accent }: { worker: ActiveWorker; accent: boolean }) {
   const now = useNow();
-  const worker = workerLabelFor(row);
-  const lastActivity = row.session?.last_active;
+  const { session, rig, bead } = worker;
+  // Workers being "active" is normal, not an alert. Per the One Mark Rule, only
+  // the FIRST stuck/failed worker (accent === true) renders its state badge in
+  // tone; every other worker reads as neutral state text so at most one maroon
+  // mark appears per viewport.
+  const tone = accent ? stateTone(session.state) : 'neutral';
   return (
     <li className="px-2 py-2 -mx-2 rounded-sm transition-colors duration-150 ease-out-quart hover:bg-surface-tint/60">
       <div className="flex items-baseline justify-between gap-4">
-        <div className="min-w-0">
-          <Link
-            to={`/beads?bead=${encodeURIComponent(row.bead.id)}`}
-            className="block text-body text-fg hover:text-accent focus-mark truncate"
-            title={`Open ${row.bead.id}`}
-          >
-            <span className="font-medium">{worker}</span>
-            <span className="text-fg-faint" aria-hidden="true"> → </span>
-            <span className="tnum text-fg-muted">{row.bead.id}</span>
-            <span className="text-fg-muted">: {row.bead.title}</span>
-          </Link>
+        <div className="min-w-0 text-body text-fg">
+          <span className="font-medium">{rig}</span>
+          <span className="text-fg-faint" aria-hidden="true"> · </span>
+          <span className="text-fg-muted">{worker.worker}</span>
+          {bead && (
+            <Link
+              to={`/beads?bead=${encodeURIComponent(bead.id)}`}
+              className="hover:text-accent focus-mark"
+              title={`Open ${bead.id}`}
+            >
+              <span className="text-fg-faint" aria-hidden="true"> → </span>
+              <span className="tnum text-fg-muted">{bead.id}</span>
+              <span className="text-fg-muted">: {bead.title}</span>
+            </Link>
+          )}
         </div>
         <div className="flex items-baseline gap-3 shrink-0">
-          {row.session ? (
-            <StatusBadge tone={stateTone(row.session.state)} label={row.session.state} />
-          ) : (
-            // The embedded session id didn't resolve to a live session: show the
-            // raw assignee so the work stays visible (degrade, never drop).
-            <span
-              className="text-label uppercase tracking-wider text-fg-faint truncate max-w-[16rem]"
-              title={row.assignee ? `assignee ${row.assignee}` : 'no live session'}
-            >
-              {row.assignee ? 'no live session' : 'unassigned'}
-            </span>
-          )}
+          <StatusBadge tone={tone} label={session.state} />
           <span className="tnum text-fg-muted w-10 text-right">
-            {formatRelative(lastActivity, now)}
+            {formatRelative(session.last_active, now)}
           </span>
         </div>
       </div>
@@ -104,22 +72,37 @@ function WorkInFlightItem({ row }: { row: Row }) {
 }
 
 export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
-  const rows = deriveWorkInFlight(beads, sessions);
+  const active = deriveActiveWorkers(sessions, beads);
+  const summary = summarizeActiveWorkers(active);
+
+  // One Mark Rule: render at most one accent state badge — the first worker
+  // whose state is stuck/failed (an actual anomaly). Every other worker's state
+  // is neutral, since an active worker is the expected, calm case.
+  const accentIndex = active.workers.findIndex(
+    (w) => stateTone(w.session.state) === 'stuck',
+  );
 
   return (
-    <section className="mb-10" aria-label="Work in flight">
+    <section className="mb-10" aria-label="Workers active">
       <header className="flex items-baseline justify-between border-b border-rule pb-2 mb-4">
-        <h2 className="text-headline text-fg">Work in flight</h2>
-        <span className="text-label tnum text-fg-muted">{rows.length}</span>
+        <h2 className="text-headline text-fg">Workers active</h2>
+        <span className="text-label tnum text-fg-muted">{active.total}</span>
       </header>
-      {rows.length === 0 ? (
-        <p className="text-body text-fg-muted">Nothing is in flight right now.</p>
+      {active.total === 0 ? (
+        <p className="text-body text-fg-muted">No workers active right now.</p>
       ) : (
-        <ul className="space-y-1">
-          {rows.map((row) => (
-            <WorkInFlightItem key={row.bead.id} row={row} />
-          ))}
-        </ul>
+        <>
+          <p className="text-body text-fg-muted mb-4">{summary}</p>
+          <ul className="space-y-1">
+            {active.workers.map((worker, i) => (
+              <WorkerRow
+                key={worker.session.id}
+                worker={worker}
+                accent={i === accentIndex}
+              />
+            ))}
+          </ul>
+        </>
       )}
     </section>
   );

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
@@ -104,20 +104,28 @@ function isWorkerStreamable(session: SupervisorSession): boolean {
 }
 
 export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
-  const active = deriveActiveWorkers(sessions, beads);
-  const summary = summarizeActiveWorkers(active);
+  // Memoized on the fetched inputs: the parent AgentsPage re-renders every
+  // second on the useNow tick, and the derivation walks the full bead +
+  // session lists — only recompute when a fetch/SSE refresh changes them.
+  const active = useMemo(() => deriveActiveWorkers(sessions, beads), [sessions, beads]);
+  const summary = useMemo(() => summarizeActiveWorkers(active), [active]);
 
   // Peek key is the worker's live session id (directly available on the row).
   const [peekSessionId, setPeekSessionId] = useState<string | null>(null);
-  const peekWorker = peekSessionId
-    ? active.workers.find((w) => w.session.id === peekSessionId) ?? null
-    : null;
+  const peekWorker = useMemo(
+    () =>
+      peekSessionId
+        ? (active.workers.find((w) => w.session.id === peekSessionId) ?? null)
+        : null,
+    [active.workers, peekSessionId],
+  );
 
   // One Mark Rule: render at most one accent state badge — the first worker
   // whose state is stuck/failed (an actual anomaly). Every other worker's state
   // is neutral, since an active worker is the expected, calm case.
-  const accentIndex = active.workers.findIndex(
-    (w) => stateTone(w.session.state) === 'stuck',
+  const accentIndex = useMemo(
+    () => active.workers.findIndex((w) => stateTone(w.session.state) === 'stuck'),
+    [active.workers],
   );
 
   return (

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
@@ -8,6 +9,9 @@ import {
   summarizeActiveWorkers,
   type ActiveWorker,
 } from '../hooks/activeWorkers';
+import { Button } from './Button';
+import { Modal } from './Modal';
+import { LiveSessionPeek } from './LiveSessionPeek';
 import { StatusBadge, stateTone } from './StatusBadge';
 
 // "Workers active" — the operator's calm at-a-glance answer to "what is
@@ -33,7 +37,15 @@ interface WorkInFlightProps {
   sessions: readonly SupervisorSession[];
 }
 
-function WorkerRow({ worker, accent }: { worker: ActiveWorker; accent: boolean }) {
+function WorkerRow({
+  worker,
+  accent,
+  onPeek,
+}: {
+  worker: ActiveWorker;
+  accent: boolean;
+  onPeek: (sessionId: string) => void;
+}) {
   const now = useNow();
   const { session, rig, bead } = worker;
   // Workers being "active" is normal, not an alert. Per the One Mark Rule, only
@@ -65,15 +77,41 @@ function WorkerRow({ worker, accent }: { worker: ActiveWorker; accent: boolean }
           <span className="tnum text-fg-muted w-10 text-right">
             {formatRelative(session.last_active, now)}
           </span>
+          {/* The worker row IS a live session, so its session.id is directly
+              available — no name→id remap (unlike the Agents roster, where
+              SessionInfo carries only the name). Peek opens that session's
+              transcript in the shared LiveSessionPeek modal. */}
+          <Button size="sm" tone="quiet" onClick={() => onPeek(session.id)}>
+            Peek
+          </Button>
         </div>
       </div>
     </li>
   );
 }
 
+// A worker session is worth a live stream when it carries the running signal
+// (mirrors isSessionStreamable / isRunningAgent: process `running`, or gc state
+// `active`/`running`). Workers in this section are active by construction, but
+// a freshly-stuck worker may not be — gate the stream so a dead session shows a
+// snapshot instead of a perpetual "connecting" badge.
+function isWorkerStreamable(session: SupervisorSession): boolean {
+  return (
+    session.running === true ||
+    session.state === 'active' ||
+    session.state === 'running'
+  );
+}
+
 export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
   const active = deriveActiveWorkers(sessions, beads);
   const summary = summarizeActiveWorkers(active);
+
+  // Peek key is the worker's live session id (directly available on the row).
+  const [peekSessionId, setPeekSessionId] = useState<string | null>(null);
+  const peekWorker = peekSessionId
+    ? active.workers.find((w) => w.session.id === peekSessionId) ?? null
+    : null;
 
   // One Mark Rule: render at most one accent state badge — the first worker
   // whose state is stuck/failed (an actual anomaly). Every other worker's state
@@ -99,11 +137,46 @@ export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
                 key={worker.session.id}
                 worker={worker}
                 accent={i === accentIndex}
+                onPeek={setPeekSessionId}
               />
             ))}
           </ul>
         </>
       )}
+
+      <Modal
+        open={peekWorker !== null}
+        onClose={() => setPeekSessionId(null)}
+        title={
+          peekWorker
+            ? `${peekWorker.rig} · ${peekWorker.worker}`
+            : 'Transcript'
+        }
+        caption={
+          peekWorker?.bead ? (
+            // Surface the worker's captured bead beside the peek so its work
+            // is one click away from the transcript.
+            <Link
+              to={`/beads?bead=${encodeURIComponent(peekWorker.bead.id)}`}
+              className="text-fg-muted hover:text-accent focus-mark"
+              title={`Open ${peekWorker.bead.id}`}
+            >
+              <span className="tnum">{peekWorker.bead.id}</span>
+              <span>: {peekWorker.bead.title}</span>
+            </Link>
+          ) : (
+            "Live transcript from the supervisor's session stream."
+          )
+        }
+        widthClass="max-w-5xl"
+      >
+        <LiveSessionPeek
+          sessionId={peekSessionId}
+          stream={peekWorker ? isWorkerStreamable(peekWorker.session) : false}
+          showBadge
+          showCaption
+        />
+      </Modal>
     </section>
   );
 }

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -58,7 +58,10 @@ function WorkerRow({
       <div className="flex items-baseline justify-between gap-4">
         <div className="min-w-0 text-body text-fg">
           <span className="font-medium">{rig}</span>
-          <span className="text-fg-faint" aria-hidden="true"> · </span>
+          <span className="text-fg-faint" aria-hidden="true">
+            {' '}
+            ·{' '}
+          </span>
           <span className="text-fg-muted">{worker.worker}</span>
           {bead && (
             <Link
@@ -66,7 +69,10 @@ function WorkerRow({
               className="hover:text-accent focus-mark"
               title={`Open ${bead.id}`}
             >
-              <span className="text-fg-faint" aria-hidden="true"> → </span>
+              <span className="text-fg-faint" aria-hidden="true">
+                {' '}
+                →{' '}
+              </span>
               <span className="tnum text-fg-muted">{bead.id}</span>
               <span className="text-fg-muted">: {bead.title}</span>
             </Link>
@@ -96,11 +102,7 @@ function WorkerRow({
 // a freshly-stuck worker may not be — gate the stream so a dead session shows a
 // snapshot instead of a perpetual "connecting" badge.
 function isWorkerStreamable(session: SupervisorSession): boolean {
-  return (
-    session.running === true ||
-    session.state === 'active' ||
-    session.state === 'running'
-  );
+  return session.running === true || session.state === 'active' || session.state === 'running';
 }
 
 export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
@@ -114,9 +116,7 @@ export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
   const [peekSessionId, setPeekSessionId] = useState<string | null>(null);
   const peekWorker = useMemo(
     () =>
-      peekSessionId
-        ? (active.workers.find((w) => w.session.id === peekSessionId) ?? null)
-        : null,
+      peekSessionId ? (active.workers.find((w) => w.session.id === peekSessionId) ?? null) : null,
     [active.workers, peekSessionId],
   );
 
@@ -155,11 +155,7 @@ export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
       <Modal
         open={peekWorker !== null}
         onClose={() => setPeekSessionId(null)}
-        title={
-          peekWorker
-            ? `${peekWorker.rig} · ${peekWorker.worker}`
-            : 'Transcript'
-        }
+        title={peekWorker ? `${peekWorker.rig} · ${peekWorker.worker}` : 'Transcript'}
         caption={
           peekWorker?.bead ? (
             // Surface the worker's captured bead beside the peek so its work

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -22,7 +22,7 @@ import { StatusBadge, stateTone } from './StatusBadge';
 // doesn't reliably aggregate, while the worker SESSIONS stay active across that
 // churn. So the primary signal is the live worker sessions, grouped by rig:
 //
-//     7 workers active across gascity (3), scix-experiments (3), gascity-packs (2).
+//     8 workers active across gascity (3), scix-experiments (3), gascity-packs (2).
 //
 // Per-worker rows below the summary, most-recently-active first:
 //

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -1,0 +1,126 @@
+import { Link } from 'react-router-dom';
+import {
+  deriveWorkInFlight,
+  type WorkInFlightRow,
+} from 'gas-city-dashboard-shared';
+import type { SupervisorBead } from '../supervisor/beadReads';
+import type { SupervisorSession } from '../supervisor/sessionReads';
+import { useNow } from '../contexts/NowContext';
+import { formatRelative } from '../hooks/time';
+import {
+  beadProject,
+  canonicalRigLabel,
+  cleanWorkerName,
+  sessionProject,
+} from '../hooks/projectOf';
+import { stateTone } from '../routes/Agents';
+import { StatusBadge } from './StatusBadge';
+
+// Concrete row type for this surface — the shared generic specialized to the
+// generated supervisor wire types the dashboard actually holds.
+type Row = WorkInFlightRow<SupervisorBead, SupervisorSession>;
+
+// "Work in flight" — the operator's at-a-glance answer to "what is actually
+// working right now". Driven by the IN-PROGRESS BEADS (the real units of work),
+// each joined to its live worker session via the session id embedded in the
+// bead's assignee (see shared/work-in-flight.ts). One row per unit of work:
+//
+//     <rig> · <role>  →  <bead-id>: <title>          [session state · 12m]
+//
+// The roster (configured agent slots) is deliberately NOT the source: it
+// reports nearly every worker as stopped with no active bead because the live
+// work happens in dynamically-spawned sessions, not the slots.
+
+interface WorkInFlightProps {
+  beads: readonly SupervisorBead[];
+  sessions: readonly SupervisorSession[];
+}
+
+/**
+ * The rig label for a row. Prefer the live session's rig (the authoritative
+ * source once joined); fall back to the bead's project prefix when the session
+ * didn't resolve. Both are run through canonicalRigLabel to strip a `-main`
+ * build-tree/worktree suffix so the operator sees `gascity`, not `gascity-main`.
+ */
+function rigLabelFor(row: Row): string {
+  if (row.session) {
+    return canonicalRigLabel(sessionProject(row.session).label);
+  }
+  return canonicalRigLabel(beadProject(row.bead));
+}
+
+/**
+ * Clean worker label `<rig> · <role>` (e.g. `gascity · polecat`). The role is
+ * the parsed assignee prefix, run through cleanWorkerName so any leaked path or
+ * `-gc-XXXXX` session suffix is stripped. Falls back to just the rig when the
+ * bead has no assignee/role.
+ */
+function workerLabelFor(row: Row): string {
+  const rig = rigLabelFor(row);
+  if (!row.role) return rig;
+  const role = cleanWorkerName(row.role);
+  return role.length > 0 ? `${rig} · ${role}` : rig;
+}
+
+function WorkInFlightItem({ row }: { row: Row }) {
+  const now = useNow();
+  const worker = workerLabelFor(row);
+  const lastActivity = row.session?.last_active;
+  return (
+    <li className="px-2 py-2 -mx-2 rounded-sm transition-colors duration-150 ease-out-quart hover:bg-surface-tint/60">
+      <div className="flex items-baseline justify-between gap-4">
+        <div className="min-w-0">
+          <Link
+            to={`/beads?bead=${encodeURIComponent(row.bead.id)}`}
+            className="block text-body text-fg hover:text-accent focus-mark truncate"
+            title={`Open ${row.bead.id}`}
+          >
+            <span className="font-medium">{worker}</span>
+            <span className="text-fg-faint" aria-hidden="true"> → </span>
+            <span className="tnum text-fg-muted">{row.bead.id}</span>
+            <span className="text-fg-muted">: {row.bead.title}</span>
+          </Link>
+        </div>
+        <div className="flex items-baseline gap-3 shrink-0">
+          {row.session ? (
+            <StatusBadge tone={stateTone(row.session.state)} label={row.session.state} />
+          ) : (
+            // The embedded session id didn't resolve to a live session: show the
+            // raw assignee so the work stays visible (degrade, never drop).
+            <span
+              className="text-label uppercase tracking-wider text-fg-faint truncate max-w-[16rem]"
+              title={row.assignee ? `assignee ${row.assignee}` : 'no live session'}
+            >
+              {row.assignee ? 'no live session' : 'unassigned'}
+            </span>
+          )}
+          <span className="tnum text-fg-muted w-10 text-right">
+            {formatRelative(lastActivity, now)}
+          </span>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
+  const rows = deriveWorkInFlight(beads, sessions);
+
+  return (
+    <section className="mb-10" aria-label="Work in flight">
+      <header className="flex items-baseline justify-between border-b border-rule pb-2 mb-4">
+        <h2 className="text-headline text-fg">Work in flight</h2>
+        <span className="text-label tnum text-fg-muted">{rows.length}</span>
+      </header>
+      {rows.length === 0 ? (
+        <p className="text-body text-fg-muted">Nothing is in flight right now.</p>
+      ) : (
+        <ul className="space-y-1">
+          {rows.map((row) => (
+            <WorkInFlightItem key={row.bead.id} row={row} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -35,6 +35,16 @@ import { StatusBadge, stateTone } from './StatusBadge';
 interface WorkInFlightProps {
   beads: readonly SupervisorBead[];
   sessions: readonly SupervisorSession[];
+  // The "Workers active" count is SESSION-driven, so the section's honesty
+  // depends on the sessions fetch having actually delivered. Thread its
+  // loading/error state through: when sessions data is absent (initial load or
+  // a fetch that never succeeded) the section must render an explicit
+  // unavailable/loading state — never the calm "No workers active" all-clear,
+  // which would mask a dead aggregator (the fail-safe invariant: failure must
+  // read as explicit unavailable, never silent all-clear). Beads are
+  // best-effort secondary context and do not gate this signal.
+  sessionsLoading: boolean;
+  sessionsError: string | null;
 }
 
 function WorkerRow({
@@ -105,7 +115,12 @@ function isWorkerStreamable(session: SupervisorSession): boolean {
   return session.running === true || session.state === 'active' || session.state === 'running';
 }
 
-export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
+export function WorkInFlight({
+  beads,
+  sessions,
+  sessionsLoading,
+  sessionsError,
+}: WorkInFlightProps) {
   // Memoized on the fetched inputs: the parent AgentsPage re-renders every
   // second on the useNow tick, and the derivation walks the full bead +
   // session lists — only recompute when a fetch/SSE refresh changes them.
@@ -128,13 +143,32 @@ export function WorkInFlight({ beads, sessions }: WorkInFlightProps) {
     [active.workers],
   );
 
+  // Fail-safe: the all-clear ("No workers active") is only honest once the
+  // sessions fetch has delivered data. With no data yet, distinguish a failed
+  // fetch (explicit "unavailable") from an in-flight one (loading) — the mirror
+  // of the Agents roster's rosterUnavailable pattern. useCachedData retains
+  // stale data across a re-fetch error, so this window is only the initial-load
+  // / never-succeeded case; a prior success keeps rendering its workers.
+  const sessionsAbsent = sessions.length === 0;
+  const sessionsUnavailable = sessionsError !== null && sessionsAbsent;
+  const sessionsPending = sessionsLoading && sessionsAbsent;
+  const countLabel = sessionsUnavailable || sessionsPending ? '—' : active.total;
+
   return (
     <section className="mb-10" aria-label="Workers active">
       <header className="flex items-baseline justify-between border-b border-rule pb-2 mb-4">
         <h2 className="text-headline text-fg">Workers active</h2>
-        <span className="text-label tnum text-fg-muted">{active.total}</span>
+        <span className="text-label tnum text-fg-muted">{countLabel}</span>
       </header>
-      {active.total === 0 ? (
+      {sessionsUnavailable ? (
+        <p className="text-body text-fg-muted" role="status">
+          Worker status unavailable.
+        </p>
+      ) : sessionsPending ? (
+        <p className="text-body text-fg-muted" role="status">
+          Checking worker status…
+        </p>
+      ) : active.total === 0 ? (
         <p className="text-body text-fg-muted">No workers active right now.</p>
       ) : (
         <>

--- a/frontend/src/hooks/activeWorkers.test.ts
+++ b/frontend/src/hooks/activeWorkers.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { SupervisorBead } from '../supervisor/beadReads';
+import type { SupervisorSession } from '../supervisor/sessionReads';
+import { deriveActiveWorkers, summarizeActiveWorkers } from './activeWorkers';
+
+// "Workers active" is SESSION-driven: count the live worker sessions, group by
+// rig, and best-effort attach an in-progress bead when one is captured. The
+// orchestration sessions (mayor, dispatchers, project-leads) are excluded.
+
+function session(partial: Partial<SupervisorSession> & { id: string }): SupervisorSession {
+  return {
+    template: 'polecat',
+    session_name: partial.id,
+    title: partial.id,
+    state: 'active',
+    created_at: '2026-06-03T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+    ...partial,
+  } as SupervisorSession;
+}
+
+function bead(partial: Partial<SupervisorBead> & { id: string }): SupervisorBead {
+  return {
+    title: `title for ${partial.id}`,
+    status: 'in_progress',
+    issue_type: 'task',
+    created_at: '2026-06-03T00:00:00Z',
+    ...partial,
+  } as SupervisorBead;
+}
+
+describe('deriveActiveWorkers', () => {
+  it('counts active worker sessions grouped by rig, most workers first', () => {
+    const sessions = [
+      session({ id: 'gc-1', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-2', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-3', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-4', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-5', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-6', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-7', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-8', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-9', template: 'worker', rig: 'zeldascension' }),
+      // Orchestration — excluded.
+      session({ id: 'gc-m', template: 'mayor', rig: '' }),
+      session({ id: 'gc-pl', template: 'gascity.project-lead', rig: 'gascity' }),
+    ];
+    const result = deriveActiveWorkers(sessions, []);
+    expect(result.total).toBe(9);
+    expect(result.byRig).toEqual([
+      { rig: 'gascity', count: 3 },
+      { rig: 'scix_experiments', count: 3 },
+      { rig: 'gascity-packs', count: 2 },
+      { rig: 'zeldascension', count: 1 },
+    ]);
+  });
+
+  it('excludes suspended / non-active sessions', () => {
+    const sessions = [
+      session({ id: 'gc-1', template: 'polecat', rig: 'gascity' }),
+      session({ id: 'gc-2', template: 'polecat', rig: 'gascity', state: 'asleep' }),
+      session({ id: 'gc-3', template: 'polecat', rig: 'gascity', state: 'closed' }),
+    ];
+    const result = deriveActiveWorkers(sessions, []);
+    expect(result.total).toBe(1);
+    expect(result.workers[0]?.session.id).toBe('gc-1');
+  });
+
+  it('attaches an in-progress bead when its assignee embeds the worker session id', () => {
+    const sessions = [
+      session({ id: 'gc-335825', template: 'polecat', rig: '/home/ds/gascity' }),
+    ];
+    const beads = [
+      bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' }),
+    ];
+    const result = deriveActiveWorkers(sessions, beads);
+    expect(result.workers[0]?.bead?.id).toBe('gc-5rarj');
+    expect(result.workers[0]?.rig).toBe('gascity');
+    expect(result.workers[0]?.worker).toBe('polecat');
+  });
+
+  it('leaves bead undefined when no in-progress bead matches the worker (the common case)', () => {
+    const sessions = [session({ id: 'gc-1', template: 'polecat', rig: 'gascity' })];
+    // A closed bead must NOT attach, and an unassigned in-progress bead must not
+    // surface anywhere — the worker being active is the signal.
+    const beads = [
+      bead({ id: 'gc-closed', status: 'closed', assignee: 'polecat-gc-1' }),
+      bead({ id: 'gc-stalled' }), // in_progress, unassigned
+    ];
+    const result = deriveActiveWorkers(sessions, beads);
+    expect(result.total).toBe(1);
+    expect(result.workers[0]?.bead).toBeUndefined();
+  });
+
+  it('orders worker rows by most-recent activity first', () => {
+    const sessions = [
+      session({ id: 'gc-1', rig: 'gascity', last_active: '2026-06-03T10:00:00Z' }),
+      session({ id: 'gc-2', rig: 'gascity', last_active: '2026-06-03T11:00:00Z' }),
+    ];
+    const result = deriveActiveWorkers(sessions, []);
+    expect(result.workers.map((w) => w.session.id)).toEqual(['gc-2', 'gc-1']);
+  });
+});
+
+describe('summarizeActiveWorkers', () => {
+  it('produces the calm grouped summary line', () => {
+    const sessions = [
+      session({ id: 'gc-1', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-2', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-3', template: 'polecat', rig: '/home/ds/gascity' }),
+      session({ id: 'gc-4', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-5', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-6', template: 'scix-worker', rig: 'scix_experiments' }),
+      session({ id: 'gc-7', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-8', template: 'polecat', rig: '/home/ds/gascity-packs-main' }),
+      session({ id: 'gc-9', template: 'worker', rig: 'zeldascension' }),
+    ];
+    const result = deriveActiveWorkers(sessions, []);
+    expect(summarizeActiveWorkers(result)).toBe(
+      '9 workers active across gascity (3), scix_experiments (3), gascity-packs (2), zeldascension (1).',
+    );
+  });
+
+  it('uses the singular noun for one worker', () => {
+    const result = deriveActiveWorkers(
+      [session({ id: 'gc-1', template: 'polecat', rig: 'gascity' })],
+      [],
+    );
+    expect(summarizeActiveWorkers(result)).toBe('1 worker active across gascity (1).');
+  });
+
+  it('returns the calm empty-state sentence when no workers are active', () => {
+    expect(summarizeActiveWorkers(deriveActiveWorkers([], []))).toBe(
+      'No workers active right now.',
+    );
+  });
+});

--- a/frontend/src/hooks/activeWorkers.test.ts
+++ b/frontend/src/hooks/activeWorkers.test.ts
@@ -69,12 +69,8 @@ describe('deriveActiveWorkers', () => {
   });
 
   it('attaches an in-progress bead when its assignee embeds the worker session id', () => {
-    const sessions = [
-      session({ id: 'gc-335825', template: 'polecat', rig: '/home/ds/gascity' }),
-    ];
-    const beads = [
-      bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' }),
-    ];
+    const sessions = [session({ id: 'gc-335825', template: 'polecat', rig: '/home/ds/gascity' })];
+    const beads = [bead({ id: 'gc-5rarj', title: 'fix the thing', assignee: 'polecat-gc-335825' })];
     const result = deriveActiveWorkers(sessions, beads);
     expect(result.workers[0]?.bead?.id).toBe('gc-5rarj');
     expect(result.workers[0]?.rig).toBe('gascity');

--- a/frontend/src/hooks/activeWorkers.ts
+++ b/frontend/src/hooks/activeWorkers.ts
@@ -1,12 +1,7 @@
 import { parseAssignee, IN_PROGRESS_STATUS } from 'gas-city-dashboard-shared';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
-import {
-  canonicalRigLabel,
-  cleanWorkerName,
-  isWorkerSession,
-  sessionProject,
-} from './projectOf';
+import { canonicalRigLabel, cleanWorkerName, isWorkerSession, sessionProject } from './projectOf';
 
 // Session-driven "Workers active" derivation.
 //
@@ -128,8 +123,6 @@ export function deriveActiveWorkers(
 export function summarizeActiveWorkers(workers: ActiveWorkers): string {
   if (workers.total === 0) return 'No workers active right now.';
   const noun = workers.total === 1 ? 'worker' : 'workers';
-  const groups = workers.byRig
-    .map((g) => `${g.rig} (${g.count})`)
-    .join(', ');
+  const groups = workers.byRig.map((g) => `${g.rig} (${g.count})`).join(', ');
   return `${workers.total} ${noun} active across ${groups}.`;
 }

--- a/frontend/src/hooks/activeWorkers.ts
+++ b/frontend/src/hooks/activeWorkers.ts
@@ -1,0 +1,135 @@
+import { parseAssignee, IN_PROGRESS_STATUS } from 'gas-city-dashboard-shared';
+import type { SupervisorBead } from '../supervisor/beadReads';
+import type { SupervisorSession } from '../supervisor/sessionReads';
+import {
+  canonicalRigLabel,
+  cleanWorkerName,
+  isWorkerSession,
+  sessionProject,
+} from './projectOf';
+
+// Session-driven "Workers active" derivation.
+//
+// The primary signal is the live WORKER SESSIONS, not the in-progress beads:
+// the work-beads churn to zero within seconds (focus-reviews finish fast) and
+// live in rig stores the dashboard's bead fetch doesn't reliably aggregate,
+// while the worker sessions stay active across that churn. So we count the
+// active worker sessions and group them by rig for the calm summary line.
+//
+// A bead, when one is captured for a worker, is attached as secondary context
+// (`→ <bead-id>: <title>`). The common case is no bead — the worker being
+// active IS the signal, so we never surface "unassigned" rows here.
+
+/** A live worker session, plus the in-progress bead it is running when one is
+ *  captured (best effort — usually absent, since the beads churn). */
+export interface ActiveWorker {
+  session: SupervisorSession;
+  /** Clean rig label (e.g. `gascity`), `-main` suffix stripped. */
+  rig: string;
+  /** Clean worker role (e.g. `polecat`), no path / no `-gc-XXXXX` suffix. */
+  worker: string;
+  /** The in-progress bead assigned to this session, when one was captured. */
+  bead?: SupervisorBead;
+}
+
+/** A rig and its active-worker count, for the summary line. */
+export interface WorkerRigCount {
+  rig: string;
+  count: number;
+}
+
+export interface ActiveWorkers {
+  /** Per-worker rows, most-recently-active first. */
+  workers: ActiveWorker[];
+  /** Rig counts, most workers first (ties broken alphabetically). */
+  byRig: WorkerRigCount[];
+  /** Total active worker sessions. */
+  total: number;
+}
+
+/** The clean rig label for a worker session (session rig basename, `-main`
+ *  suffix stripped). */
+function rigOf(session: SupervisorSession): string {
+  return canonicalRigLabel(sessionProject(session).label);
+}
+
+/** The clean worker role for a worker session. Prefer the template (the stable
+ *  role name, e.g. `polecat`, `scix-worker`); fall back to the runtime
+ *  session_name for a dynamically-spawned slot. Run through cleanWorkerName so
+ *  no path / no `-gc-XXXXX` handle leaks into the display. */
+function workerOf(session: SupervisorSession): string {
+  const fromTemplate = cleanWorkerName(session.template ?? '');
+  if (fromTemplate.length > 0) return fromTemplate;
+  return cleanWorkerName(session.session_name ?? session.id);
+}
+
+function activityKey(w: ActiveWorker): number {
+  const ms = w.session.last_active ? Date.parse(w.session.last_active) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Derive the active-worker rows + the per-rig summary from the live sessions,
+ * best-effort joining each worker to its in-progress bead.
+ *
+ * Steps (mechanical, no semantic judgment):
+ *  1. Keep only active worker sessions (isWorkerSession excludes orchestration).
+ *  2. Index in-progress beads by the session id embedded in their assignee.
+ *  3. For each worker session, attach its bead when one is indexed.
+ *  4. Sort rows by most-recent activity; build rig counts (most workers first).
+ */
+export function deriveActiveWorkers(
+  sessions: readonly SupervisorSession[],
+  beads: readonly SupervisorBead[],
+): ActiveWorkers {
+  // Map a live session id -> the in-progress bead assigned to it (if any).
+  const beadBySession = new Map<string, SupervisorBead>();
+  for (const bead of beads) {
+    if (bead.status !== IN_PROGRESS_STATUS) continue;
+    const assignee = bead.assignee?.trim();
+    if (!assignee) continue;
+    const { sessionId } = parseAssignee(assignee);
+    // First bead wins for a given session — deterministic, and a session runs
+    // one unit of work at a time.
+    if (sessionId && !beadBySession.has(sessionId)) {
+      beadBySession.set(sessionId, bead);
+    }
+  }
+
+  const workers: ActiveWorker[] = [];
+  for (const session of sessions) {
+    if (!isWorkerSession(session)) continue;
+    const bead = beadBySession.get(session.id);
+    workers.push({
+      session,
+      rig: rigOf(session),
+      worker: workerOf(session),
+      ...(bead ? { bead } : {}),
+    });
+  }
+
+  workers.sort((a, b) => activityKey(b) - activityKey(a));
+
+  const counts = new Map<string, number>();
+  for (const w of workers) counts.set(w.rig, (counts.get(w.rig) ?? 0) + 1);
+  const byRig: WorkerRigCount[] = Array.from(counts, ([rig, count]) => ({
+    rig,
+    count,
+  })).sort((a, b) => b.count - a.count || a.rig.localeCompare(b.rig));
+
+  return { workers, byRig, total: workers.length };
+}
+
+/**
+ * The calm one-line summary, e.g.
+ *   "7 workers active across gascity (3), scix-experiments (3), gascity-packs (2)".
+ * Returns the empty-state sentence when no workers are active.
+ */
+export function summarizeActiveWorkers(workers: ActiveWorkers): string {
+  if (workers.total === 0) return 'No workers active right now.';
+  const noun = workers.total === 1 ? 'worker' : 'workers';
+  const groups = workers.byRig
+    .map((g) => `${g.rig} (${g.count})`)
+    .join(', ');
+  return `${workers.total} ${noun} active across ${groups}.`;
+}

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it } from 'vitest';
+import { getActiveCity, setActiveCity } from '../api/cityBase';
 import {
+  ORCHESTRATION_PROJECT,
   agentProject,
   beadProject,
+  cleanWorkerName,
   isAgentOutsideRig,
   isOrchestrationAgent,
   isOrchestrationSession,
   isPerRigDispatcherAgent,
   mailProject,
+  orchestrationLabel,
   sessionProject,
 } from './projectOf';
+
+// The cross-rig orchestration bucket now LABELS with the active city name
+// (the operator thinks "the city", not "Orchestration"); the KEY stays the
+// stable ORCHESTRATION_PROJECT constant. The global test setup sets the active
+// city to 'test-city'. Resolved lazily (a function, not a module-load const)
+// so it reads the city AFTER setup has run, not at import time.
+const cityLabel = (): string => getActiveCity() ?? ORCHESTRATION_PROJECT;
 
 describe('beadProject', () => {
   it.each([
@@ -85,18 +96,18 @@ describe('mailProject', () => {
 
 // ── Agent grouping (gascity-dashboard-ay6 + Phase-4 H3/M3 follow-up) ──
 describe('agentProject', () => {
-  it('routes cross-rig orchestration agents to the Orchestration pinned group', () => {
+  it('routes cross-rig orchestration agents to the pinned group, labelled with the city name', () => {
     expect(agentProject({ name: 'mayor' } as never)).toEqual({
-      key: 'Orchestration',
-      label: 'Orchestration',
+      key: ORCHESTRATION_PROJECT,
+      label: cityLabel(),
     });
     expect(agentProject({ name: 'control-dispatcher' } as never)).toEqual({
-      key: 'Orchestration',
-      label: 'Orchestration',
+      key: ORCHESTRATION_PROJECT,
+      label: cityLabel(),
     });
     expect(agentProject({ name: 'oversight-rig.chief-of-staff' } as never)).toEqual({
-      key: 'Orchestration',
-      label: 'Orchestration',
+      key: ORCHESTRATION_PROJECT,
+      label: cityLabel(),
     });
   });
 
@@ -223,5 +234,55 @@ describe('agentProject -main canonicalization', () => {
     expect(agentProject({ name: 'z', rig: '/home/ds/gascity-packs' } as never).label).toBe(
       'gascity-packs',
     );
+  });
+});
+
+describe('orchestrationLabel', () => {
+  it('returns the active city name (operator thinks "the city", not "Orchestration")', () => {
+    const prior = getActiveCity();
+    try {
+      setActiveCity('ds-research');
+      expect(orchestrationLabel()).toBe('ds-research');
+      // The KEY is unaffected — only the display label tracks the city.
+      expect(agentProject({ name: 'mayor' } as never).key).toBe(ORCHESTRATION_PROJECT);
+      expect(agentProject({ name: 'mayor' } as never).label).toBe('ds-research');
+      // sessionProject mirrors the same label change for orchestration sessions.
+      expect(sessionProject({ template: 'mayor' } as never)).toEqual({
+        key: ORCHESTRATION_PROJECT,
+        label: 'ds-research',
+      });
+    } finally {
+      if (prior !== null) setActiveCity(prior);
+    }
+  });
+});
+
+describe('cleanWorkerName', () => {
+  it('strips a trailing -gc-XXXXX live-session suffix to the role', () => {
+    expect(cleanWorkerName('polecat-gc-335825')).toBe('polecat');
+    expect(cleanWorkerName('scix-worker-gc-335812')).toBe('scix-worker');
+    expect(cleanWorkerName('enterprisebench-worker-gc-335808')).toBe('enterprisebench-worker');
+  });
+
+  it('strips a leading filesystem path to the basename', () => {
+    expect(cleanWorkerName('/home/ds/gas-city/city-infra-polecat')).toBe('city-infra-polecat');
+  });
+
+  it('strips both a path and a session suffix together', () => {
+    expect(cleanWorkerName('/home/ds/gas-city/polecat-gc-335825')).toBe('polecat');
+  });
+
+  it('also strips td-/th-/4-letter-prefixed session handles', () => {
+    expect(cleanWorkerName('worker-td-9abc')).toBe('worker');
+    expect(cleanWorkerName('worker-fddc-12xy')).toBe('worker');
+  });
+
+  it('leaves a clean name unchanged', () => {
+    expect(cleanWorkerName('polecat-1')).toBe('polecat-1');
+    expect(cleanWorkerName('mayor')).toBe('mayor');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(cleanWorkerName('  polecat-gc-335825  ')).toBe('polecat');
   });
 });

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -335,9 +335,9 @@ describe('isWorkerSession', () => {
   it('excludes cross-rig orchestration (mayor, control-dispatcher, chief-of-staff)', () => {
     expect(isWorkerSession(gcSession({ template: 'mayor', rig: '' }))).toBe(false);
     expect(isWorkerSession(gcSession({ template: 'control-dispatcher', rig: '' }))).toBe(false);
-    expect(
-      isWorkerSession(gcSession({ template: 'oversight-rig.chief-of-staff', rig: '' })),
-    ).toBe(false);
+    expect(isWorkerSession(gcSession({ template: 'oversight-rig.chief-of-staff', rig: '' }))).toBe(
+      false,
+    );
   });
 
   it('excludes per-rig dispatchers and project-leads', () => {
@@ -346,9 +346,9 @@ describe('isWorkerSession', () => {
         gcSession({ template: 'worker', rig: 'gascity', alias: 'gascity/control-dispatcher' }),
       ),
     ).toBe(false);
-    expect(
-      isWorkerSession(gcSession({ template: 'gascity.project-lead', rig: 'gascity' })),
-    ).toBe(false);
+    expect(isWorkerSession(gcSession({ template: 'gascity.project-lead', rig: 'gascity' }))).toBe(
+      false,
+    );
   });
 
   it('excludes a non-worker rig session (no worker/pool role)', () => {

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -294,6 +294,17 @@ describe('cleanWorkerName', () => {
     expect(cleanWorkerName('worker-fddc-12xy')).toBe('worker');
   });
 
+  it('does NOT strip a hyphenated role whose penultimate segment is 4 letters but carries no session digit', () => {
+    // `-scix-worker` matches the `<4-letter-prefix>-<body>` shape, but the body
+    // (`worker`) has no digit, so it is a role suffix, not a live-session handle
+    // (live ids always carry a numeric handle). Stripping it would truncate the
+    // label and mis-classify the worker.
+    expect(cleanWorkerName('city-scix-worker')).toBe('city-scix-worker');
+    expect(cleanWorkerName('infra-scix-worker')).toBe('infra-scix-worker');
+    // The genuine handle (digit body) on the same role still strips cleanly.
+    expect(cleanWorkerName('city-scix-worker-gc-335812')).toBe('city-scix-worker');
+  });
+
   it('leaves a clean name unchanged', () => {
     expect(cleanWorkerName('polecat-1')).toBe('polecat-1');
     expect(cleanWorkerName('mayor')).toBe('mayor');
@@ -320,6 +331,15 @@ describe('isWorkerSession', () => {
           rig: 'gascity',
         }),
       ),
+    ).toBe(true);
+  });
+
+  it("counts a worker reported in the 'running' state", () => {
+    // isRunningAgent / isSessionStreamable / stateTone all honour 'running';
+    // isWorkerSession must too, or a worker in that state is silently dropped
+    // from the Workers-active count.
+    expect(
+      isWorkerSession(gcSession({ template: 'polecat', rig: 'gascity', state: 'running' })),
     ).toBe(true);
   });
 

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -9,10 +9,27 @@ import {
   isOrchestrationAgent,
   isOrchestrationSession,
   isPerRigDispatcherAgent,
+  isWorkerSession,
   mailProject,
   orchestrationLabel,
   sessionProject,
 } from './projectOf';
+import type { GcSession } from 'gas-city-dashboard-shared';
+
+function gcSession(partial: Partial<GcSession>): GcSession {
+  return {
+    id: partial.id ?? 'gc-1',
+    template: '',
+    session_name: partial.id ?? 'gc-1',
+    title: '',
+    state: 'active',
+    created_at: '2026-06-03T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+    ...partial,
+  } as GcSession;
+}
 
 // The cross-rig orchestration bucket now LABELS with the active city name
 // (the operator thinks "the city", not "Orchestration"); the KEY stays the
@@ -284,5 +301,57 @@ describe('cleanWorkerName', () => {
 
   it('trims surrounding whitespace', () => {
     expect(cleanWorkerName('  polecat-gc-335825  ')).toBe('polecat');
+  });
+});
+
+describe('isWorkerSession', () => {
+  it('counts active polecat / worker sessions', () => {
+    expect(isWorkerSession(gcSession({ template: 'polecat', rig: 'gascity' }))).toBe(true);
+    expect(isWorkerSession(gcSession({ template: 'scix-worker', rig: 'scix' }))).toBe(true);
+    expect(isWorkerSession(gcSession({ template: 'worker-1', rig: 'geo' }))).toBe(true);
+  });
+
+  it('counts a dynamically-spawned slot named by its session handle', () => {
+    expect(
+      isWorkerSession(
+        gcSession({
+          template: 'pool',
+          session_name: 'polecat-gc-335825',
+          rig: 'gascity',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('excludes a worker session that is not active', () => {
+    expect(
+      isWorkerSession(gcSession({ template: 'polecat', rig: 'gascity', state: 'asleep' })),
+    ).toBe(false);
+    expect(
+      isWorkerSession(gcSession({ template: 'polecat', rig: 'gascity', state: 'closed' })),
+    ).toBe(false);
+  });
+
+  it('excludes cross-rig orchestration (mayor, control-dispatcher, chief-of-staff)', () => {
+    expect(isWorkerSession(gcSession({ template: 'mayor', rig: '' }))).toBe(false);
+    expect(isWorkerSession(gcSession({ template: 'control-dispatcher', rig: '' }))).toBe(false);
+    expect(
+      isWorkerSession(gcSession({ template: 'oversight-rig.chief-of-staff', rig: '' })),
+    ).toBe(false);
+  });
+
+  it('excludes per-rig dispatchers and project-leads', () => {
+    expect(
+      isWorkerSession(
+        gcSession({ template: 'worker', rig: 'gascity', alias: 'gascity/control-dispatcher' }),
+      ),
+    ).toBe(false);
+    expect(
+      isWorkerSession(gcSession({ template: 'gascity.project-lead', rig: 'gascity' })),
+    ).toBe(false);
+  });
+
+  it('excludes a non-worker rig session (no worker/pool role)', () => {
+    expect(isWorkerSession(gcSession({ template: 'reviewer', rig: 'gascity' }))).toBe(false);
   });
 });

--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -14,9 +14,9 @@ import {
   orchestrationLabel,
   sessionProject,
 } from './projectOf';
-import type { GcSession } from 'gas-city-dashboard-shared';
+import type { DashboardSession } from 'gas-city-dashboard-shared';
 
-function gcSession(partial: Partial<GcSession>): GcSession {
+function gcSession(partial: Partial<DashboardSession>): DashboardSession {
   return {
     id: partial.id ?? 'gc-1',
     template: '',
@@ -28,7 +28,7 @@ function gcSession(partial: Partial<GcSession>): GcSession {
     running: true,
     provider: 'claude',
     ...partial,
-  } as GcSession;
+  } as DashboardSession;
 }
 
 // The cross-rig orchestration bucket now LABELS with the active city name

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -77,6 +77,56 @@ export function isPerRigDispatcher(s: DashboardSession): boolean {
   return PER_RIG_DISPATCHER_RX.test(s.alias ?? '');
 }
 
+// ── Worker-session classification (Work-in-flight signal) ─────────────────
+//
+// The Work-in-flight section counts the live WORKER sessions, not the
+// in-progress beads: the work-beads churn to zero within seconds (focus-reviews
+// finish fast) and live in rig stores the dashboard's bead fetch doesn't
+// reliably aggregate, while the worker SESSIONS stay active across that churn.
+// A worker session is the stable "what is working" signal.
+//
+// Orchestration sessions (mayor, the global + per-rig control dispatchers, the
+// per-rig project leads, the oversight chief-of-staff) are excluded: they
+// direct work, they don't perform it. The exclusion reuses the orchestration
+// predicates above plus the role markers below.
+
+// A worker session's template/name ends in a worker/pool role — `polecat`,
+// `scix-worker`, `worker-1` — optionally with a numeric slot suffix, and may
+// carry a trailing `-gc-XXXXX` spawned-session handle. Anchored to the END so a
+// role like `oversight-worker-review` (not a worker) doesn't slip through on a
+// mid-string match.
+const WORKER_ROLE_RX = /(?:worker|polecat)(?:-\d+)?$/;
+
+// Per-rig orchestration markers that DON'T live in ORCHESTRATION_TEMPLATES
+// (which only covers the rig-less cross-rig set). A rig-scoped project-lead or
+// chief-of-staff directs that rig's work; it is not a worker.
+const RIG_ORCHESTRATION_RX = /(?:\.project-lead|chief-of-staff)$/;
+
+/**
+ * True when a session is a live worker actively performing work — the signal
+ * the Work-in-flight section counts. Requires state `active`, a worker/pool
+ * role in the template or runtime name, and that the session is NOT any flavour
+ * of orchestration (cross-rig, per-rig dispatcher, project-lead, chief-of-staff).
+ */
+export function isWorkerSession(s: DashboardSession): boolean {
+  if (s.state !== 'active') return false;
+  if (isOrchestrationSession(s) || isPerRigDispatcher(s)) return false;
+  const template = s.template ?? '';
+  const alias = s.alias ?? '';
+  if (RIG_ORCHESTRATION_RX.test(template) || RIG_ORCHESTRATION_RX.test(alias)) {
+    return false;
+  }
+  // The worker role can surface in the template (`polecat`, `scix-worker`) or,
+  // for a dynamically-spawned slot, in the runtime session_name
+  // (`polecat-gc-335825`). Strip any `-gc-XXXXX` handle first so the role
+  // anchor matches the cleaned name.
+  const sessionName = (s as { session_name?: string }).session_name ?? '';
+  const candidates = [template, alias, sessionName]
+    .filter((c) => c.length > 0)
+    .map((c) => cleanWorkerName(c));
+  return candidates.some((c) => WORKER_ROLE_RX.test(c));
+}
+
 function normalizeRigKey(name: string): string {
   return name.toLowerCase().replace(/_/g, '-');
 }

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -120,7 +120,7 @@ export function isWorkerSession(s: DashboardSession): boolean {
   // for a dynamically-spawned slot, in the runtime session_name
   // (`polecat-gc-335825`). Strip any `-gc-XXXXX` handle first so the role
   // anchor matches the cleaned name.
-  const sessionName = (s as { session_name?: string }).session_name ?? '';
+  const sessionName = s.session_name;
   const candidates = [template, alias, sessionName]
     .filter((c) => c.length > 0)
     .map((c) => cleanWorkerName(c));

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -104,12 +104,15 @@ const RIG_ORCHESTRATION_RX = /(?:\.project-lead|chief-of-staff)$/;
 
 /**
  * True when a session is a live worker actively performing work — the signal
- * the Work-in-flight section counts. Requires state `active`, a worker/pool
- * role in the template or runtime name, and that the session is NOT any flavour
- * of orchestration (cross-rig, per-rig dispatcher, project-lead, chief-of-staff).
+ * the Work-in-flight section counts. Requires a live state (`active` or
+ * `running` — the same running signal isRunningAgent / isSessionStreamable /
+ * stateTone honour, so a worker reported as `running` is not silently dropped),
+ * a worker/pool role in the template or runtime name, and that the session is
+ * NOT any flavour of orchestration (cross-rig, per-rig dispatcher,
+ * project-lead, chief-of-staff).
  */
 export function isWorkerSession(s: DashboardSession): boolean {
-  if (s.state !== 'active') return false;
+  if (s.state !== 'active' && s.state !== 'running') return false;
   if (isOrchestrationSession(s) || isPerRigDispatcher(s)) return false;
   const template = s.template ?? '';
   const alias = s.alias ?? '';
@@ -223,8 +226,12 @@ export function canonicalRigLabel(name: string): string {
 // slot by its session (e.g. `polecat-gc-335825`). Mirrors the session-id
 // alphabet; anchored to the END so only a real suffix is cut. The id body is
 // hyphen-free (`gc-335825`, not `gc-33-5825`) so the match binds to the minimal
-// trailing handle and never swallows a hyphenated role like `scix-worker`.
-const WORKER_SESSION_SUFFIX_RX = /-(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
+// trailing handle. The body MUST contain a digit (mirroring BARE_SESSION_ID_RX
+// in shared/work-in-flight.ts): live session ids always carry a numeric handle,
+// so requiring a digit stops the `[a-z]{4}` prefix branch from false-stripping a
+// hyphenated role whose penultimate segment is four letters (e.g. the `-scix-`
+// in `*-scix-worker`, which has no digit in `worker`).
+const WORKER_SESSION_SUFFIX_RX = /-(?:gc|td|th|[a-z]{4})-[a-z0-9]*[0-9][a-z0-9]*$/;
 
 /**
  * Clean a worker/agent/assignee name for display: strip any leading filesystem

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -224,8 +224,7 @@ export function canonicalRigLabel(name: string): string {
 // alphabet; anchored to the END so only a real suffix is cut. The id body is
 // hyphen-free (`gc-335825`, not `gc-33-5825`) so the match binds to the minimal
 // trailing handle and never swallows a hyphenated role like `scix-worker`.
-const WORKER_SESSION_SUFFIX_RX =
-  /-(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
+const WORKER_SESSION_SUFFIX_RX = /-(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
 
 /**
  * Clean a worker/agent/assignee name for display: strip any leading filesystem

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -1,4 +1,5 @@
 import type { DashboardSession } from 'gas-city-dashboard-shared';
+import { getActiveCity } from '../api/cityBase';
 import type { AgentResponse } from '../generated/gc-supervisor-client/types.gen';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorMailItem } from '../supervisor/mailReads';
@@ -31,7 +32,23 @@ export function beadProject(bead: SupervisorBead): string {
   return m?.[1] ?? bead.id;
 }
 
+// Stable grouping KEY for cross-rig orchestration agents/sessions. This is an
+// internal identity used for bucketing + collapse state and never shown raw to
+// the operator: the displayed LABEL is the active city name (see
+// `orchestrationLabel`). The key stays a constant so grouping is independent of
+// whichever city is currently mounted.
 export const ORCHESTRATION_PROJECT = 'Orchestration';
+
+/**
+ * Display label for the cross-rig orchestration bucket. The operator thinks of
+ * mayor / dispatchers / PLs as "the city", not as an abstract "Orchestration"
+ * group, so we render the active city name (e.g. `ds-research`). Falls back to
+ * the constant before the router has resolved a city — a degraded label is
+ * better than an empty one.
+ */
+export function orchestrationLabel(): string {
+  return getActiveCity() ?? ORCHESTRATION_PROJECT;
+}
 
 // Residual bucket for a row with no rig association and no orchestration role.
 export const NO_RIG_PROJECT = '(no rig)';
@@ -73,7 +90,7 @@ export interface ProjectBucket {
 
 export function sessionProject(session: DashboardSession): ProjectBucket {
   if (isOrchestrationSession(session)) {
-    return { key: ORCHESTRATION_PROJECT, label: ORCHESTRATION_PROJECT };
+    return { key: ORCHESTRATION_PROJECT, label: orchestrationLabel() };
   }
   const candidate = session.rig ?? session.pool ?? session.template;
   if (!candidate) {
@@ -125,7 +142,7 @@ export function isPerRigDispatcherAgent(a: AgentResponse): boolean {
 
 export function agentProject(agent: AgentResponse): ProjectBucket {
   if (isOrchestrationAgent(agent)) {
-    return { key: ORCHESTRATION_PROJECT, label: ORCHESTRATION_PROJECT };
+    return { key: ORCHESTRATION_PROJECT, label: orchestrationLabel() };
   }
   // Agents — unlike sessions — never carry a `template` field; rig/pool are
   // the only grouping candidates. Empty-string `rig` is treated as absent
@@ -149,6 +166,31 @@ export function agentProject(agent: AgentResponse): ProjectBucket {
  */
 export function canonicalRigLabel(name: string): string {
   return name.endsWith('-main') ? name.slice(0, -'-main'.length) : name;
+}
+
+// Trailing `-gc-XXXXX` (or other 2/4-letter-prefixed) live-session handle that
+// leaks into a worker name when the supervisor labels a dynamically-spawned
+// slot by its session (e.g. `polecat-gc-335825`). Mirrors the session-id
+// alphabet; anchored to the END so only a real suffix is cut. The id body is
+// hyphen-free (`gc-335825`, not `gc-33-5825`) so the match binds to the minimal
+// trailing handle and never swallows a hyphenated role like `scix-worker`.
+const WORKER_SESSION_SUFFIX_RX =
+  /-(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
+
+/**
+ * Clean a worker/agent/assignee name for display: strip any leading filesystem
+ * path (keep the basename) and any trailing `-gc-XXXXX` live-session suffix, so
+ * `/home/ds/gas-city/city-infra-polecat` shows as `city-infra-polecat` and
+ * `polecat-gc-335825` shows as `polecat`. Returns the trimmed input unchanged
+ * when neither a path nor a session suffix is present.
+ */
+export function cleanWorkerName(name: string): string {
+  const trimmed = name.trim();
+  // basename — handle both '/' and '\' for cross-platform safety.
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  const basename = parts[parts.length - 1] ?? trimmed;
+  const stripped = basename.replace(WORKER_SESSION_SUFFIX_RX, '');
+  return stripped.length > 0 ? stripped : basename;
 }
 
 /**

--- a/frontend/src/lib/stripTerminalControls.test.ts
+++ b/frontend/src/lib/stripTerminalControls.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { stripTerminalControls } from './stripTerminalControls';
+
+// gascity-dashboard-5e5v / xl07: raw terminal control bytes leaked into the
+// rendered session-peek transcript. These cases are anchored on the real leak
+// Stephanie reported (`... then proceed.^[`) plus the OSC / SGR / bare-C1
+// classes that share the same path.
+
+describe('stripTerminalControls', () => {
+  it("strips the trailing lone ESC Stephanie saw (`... then proceed.^[`)", () => {
+    const dirty = '... then proceed.\x1b';
+    expect(stripTerminalControls(dirty)).toBe('... then proceed.');
+  });
+
+  it('cleans a turn carrying ESC, OSC, SGR colour, and a bare \\x9c at once', () => {
+    const dirty =
+      'start\x1b]0;evil-title\x07 mid \x1b[31mred\x1b[0m tail.\x1b done\x9chere';
+    // SGR sequences are preserved (ansi_up renders them); every other control
+    // byte is removed. Printable text and spaces survive intact.
+    expect(stripTerminalControls(dirty)).toBe(
+      'start mid \x1b[31mred\x1b[0m tail. donehere',
+    );
+  });
+
+  it('strips a bare \\x9c (8-bit C1 OSC string terminator)', () => {
+    expect(stripTerminalControls('before\x9cafter')).toBe('beforeafter');
+  });
+
+  it('strips BEL-terminated OSC (ESC ] ... BEL)', () => {
+    expect(stripTerminalControls('a\x1b]0;title\x07b')).toBe('ab');
+  });
+
+  it('strips ST-terminated OSC (ESC ] ... ESC \\)', () => {
+    expect(stripTerminalControls('a\x1b]0;title\x1b\\b')).toBe('ab');
+  });
+
+  it('strips C1-ST-terminated OSC (ESC ] ... \\x9c)', () => {
+    expect(stripTerminalControls('a\x1b]0;title\x9cb')).toBe('ab');
+  });
+
+  it('strips non-SGR CSI (cursor/erase) but keeps SGR colour', () => {
+    const dirty = '\x1b[2J\x1b[1;1H\x1b[32mgreen\x1b[0m';
+    expect(stripTerminalControls(dirty)).toBe('\x1b[32mgreen\x1b[0m');
+  });
+
+  it('preserves SGR sequences untouched', () => {
+    const sgr = '\x1b[0m\x1b[1;31mbold-red\x1b[0m';
+    expect(stripTerminalControls(sgr)).toBe(sgr);
+  });
+
+  it('preserves newlines and tabs', () => {
+    const text = 'line one\nline two\tcol\r\nline three';
+    expect(stripTerminalControls(text)).toBe(text);
+  });
+
+  it('does not over-strip ordinary printable text', () => {
+    const text = 'plain text with [brackets] and 0;1;2 numbers — émojis 🚀';
+    expect(stripTerminalControls(text)).toBe(text);
+  });
+
+  it('strips residual C0 controls but keeps whitespace', () => {
+    expect(stripTerminalControls('a\x00b\x08c\x07d\te')).toBe('abcd\te');
+  });
+
+  it('an unterminated OSC does not swallow a following SGR', () => {
+    // The OSC payload class excludes ESC, so an unterminated OSC fails to
+    // match as a whole; the lone-ESC pass then strips its orphaned `ESC ]`
+    // opener while the following SGR is preserved for ansi_up. The defense
+    // property is that no ESC survives except the real SGR.
+    const out = stripTerminalControls('\x1b]0;no-end\x1b[31mred\x1b[0m');
+    expect(out).toBe('0;no-end\x1b[31mred\x1b[0m');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(stripTerminalControls('')).toBe('');
+  });
+});

--- a/frontend/src/lib/stripTerminalControls.test.ts
+++ b/frontend/src/lib/stripTerminalControls.test.ts
@@ -7,19 +7,16 @@ import { stripTerminalControls } from './stripTerminalControls';
 // classes that share the same path.
 
 describe('stripTerminalControls', () => {
-  it("strips the trailing lone ESC Stephanie saw (`... then proceed.^[`)", () => {
+  it('strips the trailing lone ESC Stephanie saw (`... then proceed.^[`)', () => {
     const dirty = '... then proceed.\x1b';
     expect(stripTerminalControls(dirty)).toBe('... then proceed.');
   });
 
   it('cleans a turn carrying ESC, OSC, SGR colour, and a bare \\x9c at once', () => {
-    const dirty =
-      'start\x1b]0;evil-title\x07 mid \x1b[31mred\x1b[0m tail.\x1b done\x9chere';
+    const dirty = 'start\x1b]0;evil-title\x07 mid \x1b[31mred\x1b[0m tail.\x1b done\x9chere';
     // SGR sequences are preserved (ansi_up renders them); every other control
     // byte is removed. Printable text and spaces survive intact.
-    expect(stripTerminalControls(dirty)).toBe(
-      'start mid \x1b[31mred\x1b[0m tail. donehere',
-    );
+    expect(stripTerminalControls(dirty)).toBe('start mid \x1b[31mred\x1b[0m tail. donehere');
   });
 
   it('strips a bare \\x9c (8-bit C1 OSC string terminator)', () => {

--- a/frontend/src/lib/stripTerminalControls.ts
+++ b/frontend/src/lib/stripTerminalControls.ts
@@ -1,0 +1,59 @@
+// Strip terminal control bytes from a session transcript turn before it is
+// rendered. This is the DISPLAY-ONLY sibling of the backend's
+// exec.ts::sanitiseTerminalOutput / lib/strip-non-printable — it does not
+// alter what the supervisor stores, it only cleans operator-facing text in
+// the peek/transcript path (gascity-dashboard-5e5v / xl07).
+//
+// Stephanie saw raw bytes leak into peeks — e.g. `... then proceed.^[`
+// (a trailing lone ESC), OSC title sequences, and a bare `\x9c` (the 8-bit
+// C1 OSC string terminator). `ansi_up.ansi_to_html` colorizes SGR (`\x1b[…m`)
+// but passes every other control sequence through as visible text, so those
+// bytes reach the `<pre>` verbatim.
+//
+// Contract: SGR colour sequences are PRESERVED so ansi_up can still render
+// colour; `\t`, `\n`, `\r` are PRESERVED so layout survives. Everything else
+// in the control range is removed. This mirrors the backend OSC/CSI/C1
+// handling but keeps SGR and whitespace, because this output is multi-line
+// rendered terminal text, not a single-line audit/argv record.
+
+// OSC: ESC ] … terminated by BEL (\x07, xterm-legacy), ST as ESC \\ (the
+// spec form modern terminals emit), or the single-byte C1 ST \x9c. The
+// payload class excludes \x1b so an unterminated OSC cannot swallow a
+// following ANSI escape. Mirrors strip-non-printable.ts::OSC_RE, extended
+// with the \x9c terminator so a complete OSC is consumed in one pass rather
+// than leaving the \x9c for the C1 strip.
+const OSC_RE = /\x1b\][^\x07\x1b\x9c]*(?:\x07|\x1b\\|\x9c)/g;
+// CSI that is NOT an SGR (colour) sequence: ESC [ params <final> where the
+// final byte is anything except `m`. SGR (`…m`) is left for ansi_up to turn
+// into coloured spans. Covers cursor moves, erase, scroll-region, etc.
+const CSI_NON_SGR_RE = /\x1b\[[?0-9;]*[a-ln-zA-Z]/g;
+// Any ESC that does NOT introduce a surviving SGR sequence. Runs after the
+// OSC and non-SGR-CSI passes have consumed those forms, so the only ESC worth
+// keeping is a valid SGR (`\x1b[ params m`); the negative lookahead preserves
+// exactly that and removes everything else — stray ST (ESC \\), charset
+// selects (ESC ( ), ESC = / ESC >, an unterminated OSC's leading ESC, and the
+// bare trailing ESC (`^[`) Stephanie saw. The optional final byte consumes a
+// single ESC-Fe/Fp byte (e.g. the `\\` of ESC \\) when present.
+const LONE_ESC_RE = /\x1b(?!\[[?0-9;]*m)[@-Z\\-_]?/g;
+// Residual control bytes after the ESC-based passes: C0 below 0x20 except \t
+// (\x09) \n (\x0a) \r (\x0d) and ESC (\x1b, already handled above and possibly
+// part of a kept SGR), DEL (\x7f), and the C1 range (\x80-\x9f) — including
+// the bare \x9c that leaked into Stephanie's peek. SGR digits/semicolons and
+// ordinary printable text are all >= 0x20, so this never touches kept content.
+const RESIDUAL_CTRL_RE = /[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f-\x9f]/g;
+
+/**
+ * Remove terminal control sequences from transcript text while preserving
+ * SGR colour sequences, printable content, and `\t` / `\n` / `\r`.
+ *
+ * Order matters: OSC first (so a complete title sequence is consumed before
+ * its bytes are seen as a stray ESC / C1), then non-SGR CSI, then any lone ESC
+ * that is not a surviving SGR, then residual control bytes. Exported for tests.
+ */
+export function stripTerminalControls(text: string): string {
+  return text
+    .replace(OSC_RE, '')
+    .replace(CSI_NON_SGR_RE, '')
+    .replace(LONE_ESC_RE, '')
+    .replace(RESIDUAL_CTRL_RE, '');
+}

--- a/frontend/src/routes/AgentDetail.tsx
+++ b/frontend/src/routes/AgentDetail.tsx
@@ -6,7 +6,7 @@ import { BeadDetailModal } from '../components/BeadDetailModal';
 import { Button } from '../components/Button';
 import { PageHeader } from '../components/PageHeader';
 import { RelatedEntities } from '../components/RelatedEntities';
-import { StatusBadge } from '../components/StatusBadge';
+import { StatusBadge, stateTone } from '../components/StatusBadge';
 import { AgentBeadsAssigned } from '../components/agent/AgentBeadsAssigned';
 import { AgentChatThread } from '../components/agent/AgentChatThread';
 import { AgentDirectives, type AgentDirectivesError } from '../components/agent/AgentDirectives';
@@ -22,7 +22,6 @@ import { fetchSupervisorAgentPrime } from '../supervisor/agentReads';
 import { listSupervisorBeadsAssignedTo, type SupervisorBead } from '../supervisor/beadReads';
 import { listSupervisorMail, type SupervisorMailItem } from '../supervisor/mailReads';
 import { listSupervisorSessions, type SupervisorSession } from '../supervisor/sessionReads';
-import { stateTone } from './Agents';
 
 // Read-only drilldown for a single agent. Route: /agents/:slug where
 // slug resolves against session_name, alias, then id (see sessionSlug).

--- a/frontend/src/routes/Agents.chips.test.ts
+++ b/frontend/src/routes/Agents.chips.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentResponse } from '../generated/gc-supervisor-client/types.gen';
-import { agentRowLabel, buildAgentSynopsis, isRunningAgent, stateTone } from './Agents';
+import {
+  agentRowLabel,
+  buildAgentSynopsis,
+  isRunningAgent,
+  isVisibleUnderRunning,
+  stateTone,
+} from './Agents';
 
 // gascity-dashboard-fgzf: the Agents view was reverted from the flat
 // sortable/filterable table (chips + sort + rig dropdown) to the older,
@@ -42,6 +48,30 @@ describe('isRunningAgent', () => {
   it('never counts a suspended agent as running, even if its state reads alive', () => {
     expect(isRunningAgent(mkAgent('active', { suspended: true }))).toBe(false);
     expect(isRunningAgent(mkAgent('detached', { running: true, suspended: true }))).toBe(false);
+  });
+});
+
+describe('isVisibleUnderRunning', () => {
+  it('shows running agents regardless of attention severity', () => {
+    expect(isVisibleUnderRunning(mkAgent('active'), null)).toBe(true);
+    expect(isVisibleUnderRunning(mkAgent('running'), 'watch')).toBe(true);
+  });
+
+  it('excludes a suspended agent under the running filter even with a watch item', () => {
+    // Regression: /home/ds/gas-city/city-infra-polecat was suspended=true,
+    // running=false, state=suspended, yet showed under 'running'. The registry
+    // raises a passive 'watch' (idle) item for suspended agents; keying the
+    // carve-out on any-non-null severity kept it visible. Only 'attention'
+    // should bypass the filter.
+    const suspended = mkAgent('suspended', { suspended: true, running: false });
+    expect(isVisibleUnderRunning(suspended, 'watch')).toBe(false);
+    expect(isVisibleUnderRunning(suspended, null)).toBe(false);
+  });
+
+  it('still surfaces a non-running agent that has an urgent attention item', () => {
+    // A stuck agent blocked on a pending interaction is usually NOT running but
+    // must never be hidden by the 'running' default.
+    expect(isVisibleUnderRunning(mkAgent('asleep'), 'attention')).toBe(true);
   });
 });
 

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -115,6 +115,12 @@ function stubFetch(options: StubFetchOptions = {}) {
           },
         });
       }
+      // Work-in-flight section fans out typed bead queries (feature/bug/task).
+      // None of the post-ay6 regression cases assert on it, so return an empty
+      // board — the section renders its calm "Nothing is in flight" empty state.
+      if (url.startsWith('/gc-supervisor/v0/city/test-city/beads') && method === 'GET') {
+        return jsonResponse({ items: [], total: 0 });
+      }
       if (url === '/gc-supervisor/v0/city/test-city/session/gc-2568/respond' && method === 'POST') {
         return jsonResponse({ id: 'gc-2568', status: 'accepted' }, { status: 202 });
       }
@@ -190,6 +196,7 @@ beforeEach(() => {
   fetchCalls.length = 0;
   invalidate('agents');
   invalidate('sessions');
+  invalidate('beads:in-flight');
   stubFetch();
 });
 

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -115,9 +115,10 @@ function stubFetch(options: StubFetchOptions = {}) {
           },
         });
       }
-      // Work-in-flight section fans out typed bead queries (feature/bug/task).
-      // None of the post-ay6 regression cases assert on it, so return an empty
-      // board — the section renders its calm "Nothing is in flight" empty state.
+      // The "Workers active" section reads sessions (+ beads as best-effort
+      // context). None of the post-ay6 regression cases assert on it; the stub
+      // sessions list carries only orchestration, so it renders its calm
+      // "No workers active right now." empty state.
       if (url.startsWith('/gc-supervisor/v0/city/test-city/beads') && method === 'GET') {
         return jsonResponse({ items: [], total: 0 });
       }

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -8,6 +8,7 @@ import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { PartialDataNotice } from '../components/PartialDataNotice';
+import { WorkInFlight } from '../components/WorkInFlight';
 import { LiveSessionPeek, isAgentStreamable } from '../components/LiveSessionPeek';
 import { SseIndicator } from '../components/SseIndicator';
 import { StatusBadge, type StatusTone } from '../components/StatusBadge';
@@ -23,8 +24,14 @@ import {
   type AgentPendingInteraction,
 } from '../supervisor/agentPending';
 import { listSupervisorSessions } from '../supervisor/sessionReads';
+import { listSupervisorBeads } from '../supervisor/beadReads';
 import { listSupervisorAgents, type SupervisorAgent } from '../supervisor/agentReads';
-import { agentProject, isAgentOutsideRig, isPerRigDispatcherAgent } from '../hooks/projectOf';
+import {
+  agentProject,
+  cleanWorkerName,
+  isAgentOutsideRig,
+  isPerRigDispatcherAgent,
+} from '../hooks/projectOf';
 import { agentSlug } from '../hooks/sessionSlug';
 
 // gascity-dashboard-ay6: the Agents view consumes the supervisor's
@@ -48,10 +55,14 @@ export function isRunningAgent(a: SupervisorAgent): boolean {
 
 // Display label for the row: 'rig · agent' (e.g. 'gascity-packs · polecat-1').
 // Agents outside a rig (cross-rig orchestration or the residual no-rig
-// bucket) carry no rig prefix — just the alias.
+// bucket) carry no rig prefix — just the (cleaned) alias. The alias is run
+// through cleanWorkerName so a path-leaking or session-suffixed name
+// (e.g. `/home/ds/gas-city/city-infra-polecat`, `polecat-gc-335825`) renders
+// as a clean role, never the raw path or `-gc-XXXXX` suffix.
 export function agentRowLabel(a: SupervisorAgent): string {
-  if (isAgentOutsideRig(a)) return a.name;
-  return `${agentProject(a).label} · ${a.name}`;
+  const name = cleanWorkerName(a.name);
+  if (isAgentOutsideRig(a)) return name;
+  return `${agentProject(a).label} · ${name}`;
 }
 
 const AGENT_SEARCH_FIELDS = (a: SupervisorAgent): ReadonlyArray<string> =>
@@ -68,6 +79,13 @@ export function AgentsPage() {
   // Fetch the sessions list in parallel so we can map agent.session.name
   // -> session.id at peek time.
   const sessionsCache = useCachedData('sessions', listSupervisorSessions);
+  // Work-in-flight is driven by the IN-PROGRESS beads, NOT the agent roster
+  // (the roster reports nearly every worker as stopped with no active bead,
+  // because live work runs in dynamically-spawned sessions). The default
+  // listSupervisorBeads() returns the non-closed engineering beads, from which
+  // the WorkInFlight section keeps only the in-progress units and joins each to
+  // its live session via the session id embedded in the assignee.
+  const beadsCache = useCachedData('beads:in-flight', () => listSupervisorBeads());
   const rows = useMemo<SupervisorAgent[]>(() => data?.items ?? [], [data]);
   const sessionIds = useMemo(
     () => (sessionsCache.data?.items ?? []).map((session) => session.id).sort(),
@@ -119,7 +137,16 @@ export function AgentsPage() {
     return sessionsById.get(sessionName) ?? null;
   }, [peekAgent, sessionsById]);
 
-  const sseState = useGcEventRefresh([GC_EVENT_PREFIX.session, 'agent.'], () => void refresh());
+  const sseState = useGcEventRefresh(
+    [GC_EVENT_PREFIX.session, GC_EVENT_PREFIX.bead, 'agent.'],
+    () => {
+      void refresh();
+      // The Work-in-flight section reads beads + sessions; keep both fresh on a
+      // bead/session transition so the in-flight rows track the live work.
+      void beadsCache.refresh();
+      void sessionsCache.refresh();
+    },
+  );
 
   const synopsis = useMemo(() => buildAgentSynopsis(rows), [rows]);
   const handlePendingResponse = useCallback(
@@ -391,6 +418,11 @@ export function AgentsPage() {
             </Button>
           </>
         }
+      />
+
+      <WorkInFlight
+        beads={beadsCache.data?.items ?? []}
+        sessions={sessionsCache.data?.items ?? []}
       />
 
       <div className="mb-6 space-y-3">

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -11,7 +11,7 @@ import { PartialDataNotice } from '../components/PartialDataNotice';
 import { WorkInFlight } from '../components/WorkInFlight';
 import { LiveSessionPeek, isAgentStreamable } from '../components/LiveSessionPeek';
 import { SseIndicator } from '../components/SseIndicator';
-import { StatusBadge, type StatusTone } from '../components/StatusBadge';
+import { StatusBadge, stateTone } from '../components/StatusBadge';
 import { Table, type TableColumn } from '../components/Table';
 import { useNow } from '../contexts/NowContext';
 import { useCachedData } from '../hooks/useCachedData';
@@ -53,6 +53,19 @@ export function isRunningAgent(a: SupervisorAgent): boolean {
   return !a.suspended && (a.state === 'active' || a.state === 'running' || a.running === true);
 }
 
+// Whether an agent is visible while the 'running' toggle is on. Running agents
+// always show; a non-running agent shows ONLY if it has an urgent ('attention')
+// item (e.g. blocked on a pending interaction) so a genuinely stuck agent is
+// never hidden. A passive 'watch' item (suspended / asleep / idle) does NOT
+// keep a non-running agent visible — keying on any-non-null severity is what
+// let a suspended=true agent leak through the 'running' filter.
+export function isVisibleUnderRunning(
+  a: SupervisorAgent,
+  severity: 'attention' | 'watch' | null,
+): boolean {
+  return isRunningAgent(a) || severity === 'attention';
+}
+
 // Display label for the row: 'rig · agent' (e.g. 'gascity-packs · polecat-1').
 // Agents outside a rig (cross-rig orchestration or the residual no-rig
 // bucket) carry no rig prefix — just the (cleaned) alias. The alias is run
@@ -79,12 +92,12 @@ export function AgentsPage() {
   // Fetch the sessions list in parallel so we can map agent.session.name
   // -> session.id at peek time.
   const sessionsCache = useCachedData('sessions', listSupervisorSessions);
-  // Work-in-flight is driven by the IN-PROGRESS beads, NOT the agent roster
-  // (the roster reports nearly every worker as stopped with no active bead,
-  // because live work runs in dynamically-spawned sessions). The default
-  // listSupervisorBeads() returns the non-closed engineering beads, from which
-  // the WorkInFlight section keeps only the in-progress units and joins each to
-  // its live session via the session id embedded in the assignee.
+  // The "Workers active" section is SESSION-driven: it counts the live worker
+  // sessions (stable across the bead churn), grouped by rig. Beads are fetched
+  // as best-effort secondary context only — when an in-progress bead's assignee
+  // embeds a worker session's id, the section appends it to that worker's row.
+  // The beads churn to zero within seconds and aren't reliably aggregated, so a
+  // worker with no captured bead is the common (and still-valid) case.
   const beadsCache = useCachedData('beads:in-flight', () => listSupervisorBeads());
   const rows = useMemo<SupervisorAgent[]>(() => data?.items ?? [], [data]);
   const sessionIds = useMemo(
@@ -190,11 +203,12 @@ export function AgentsPage() {
     const q = search.trim().toLowerCase();
     return rows.filter((a) => {
       if (rigFilter !== '' && agentProject(a).label !== rigFilter) return false;
-      // Always surface agents that need attention (e.g. blocked on a pending
-      // interaction) — they must never be hidden by the 'running' default,
-      // since a stuck agent is usually NOT running.
-      const needsAttention = resourceAttentionSeverity(attention, 'agents', a.name) !== null;
-      if (runningOnly && !isRunningAgent(a) && !needsAttention) return false;
+      // Only 'attention' severity (e.g. blocked on a pending interaction)
+      // bypasses the 'running' filter, never a passive 'watch' (suspended /
+      // asleep / idle). Keying on any-non-null severity is what let a
+      // suspended=true agent leak through the toggle. See isVisibleUnderRunning.
+      const severity = resourceAttentionSeverity(attention, 'agents', a.name);
+      if (runningOnly && !isVisibleUnderRunning(a, severity)) return false;
       if (q.length === 0) return true;
       return AGENT_SEARCH_FIELDS(a).some((field) => field.toLowerCase().includes(q));
     });
@@ -550,32 +564,10 @@ async function copyAttachCommand(
   }
 }
 
-// Single source of truth for state → tone mapping. Aligned with how the
-// gc supervisor emits agent (and session) states. Unknown states default
-// to neutral so we don't lie about them. 'detached' is explicit (not a
-// silent default) so reviewers see the intent.
-export function stateTone(state: string): StatusTone {
-  switch (state) {
-    case 'active':
-    case 'running':
-      return 'ok';
-    case 'rate-limited':
-    case 'rate_limited':
-    case 'waiting':
-      return 'warn';
-    case 'failed':
-    case 'closed':
-    case 'errored':
-    case 'stuck':
-      return 'stuck';
-    case 'detached':
-    case 'asleep':
-    case 'idle':
-    case 'creating':
-    default:
-      return 'neutral';
-  }
-}
+// stateTone moved to components/StatusBadge.tsx (alongside StatusTone /
+// beadStatusTone) to break the Agents → WorkInFlight → Agents import cycle.
+// Re-exported here so existing importers of `./Agents` keep working.
+export { stateTone } from '../components/StatusBadge';
 
 // Buckets a raw state into the synopsis category. Distinct from
 // stateTone because 'detached' and 'idle' share a tone (neutral) but the

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -437,6 +437,8 @@ export function AgentsPage() {
       <WorkInFlight
         beads={beadsCache.data?.items ?? []}
         sessions={sessionsCache.data?.items ?? []}
+        sessionsLoading={sessionsCache.loading}
+        sessionsError={sessionsCache.error}
       />
 
       {/* The bottom roster is the "available agents" view — the mayor, PLs, and

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -439,6 +439,15 @@ export function AgentsPage() {
         sessions={sessionsCache.data?.items ?? []}
       />
 
+      {/* The bottom roster is the "available agents" view — the mayor, PLs, and
+          dispatchers that are running-but-idle, distinct from the working
+          sessions above. A calm section header (matching the "Workers active"
+          style) keeps the two groups from bleeding into one. */}
+      <header className="flex items-baseline justify-between border-b border-rule pb-2 mb-4">
+        <h2 className="text-headline text-fg">Available agents</h2>
+        <span className="text-label tnum text-fg-muted">{rows.length}</span>
+      </header>
+
       <div className="mb-6 space-y-3">
         <ListSearchBar
           value={search}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from './run-detail.js';
 export type * from './run-snapshot.js';
 export * from './run-scope.js';
 export * from './session-id.js';
+export * from './work-in-flight.js';
 export type * from './viewing-as.js';
 export * from './runs/bead-fields.js';
 export * from './runs/display-state.js';

--- a/shared/src/work-in-flight.test.ts
+++ b/shared/src/work-in-flight.test.ts
@@ -87,8 +87,16 @@ test('parseAssignee trims surrounding whitespace', () => {
 });
 
 test('deriveWorkInFlight joins in-progress beads to their live session, newest first', () => {
-  const polecat = session({ id: 'gc-335825', rig: '/home/ds/gascity', last_active: '2026-06-03T10:00:00Z' });
-  const scixWorker = session({ id: 'gc-335812', rig: 'scix_experiments', last_active: '2026-06-03T11:00:00Z' });
+  const polecat = session({
+    id: 'gc-335825',
+    rig: '/home/ds/gascity',
+    last_active: '2026-06-03T10:00:00Z',
+  });
+  const scixWorker = session({
+    id: 'gc-335812',
+    rig: 'scix_experiments',
+    last_active: '2026-06-03T11:00:00Z',
+  });
   const beads = [
     bead({ id: 'gc-5rarj', assignee: 'polecat-gc-335825' }),
     bead({ id: 'scix_experiments-4if7h', assignee: 'scix-worker-gc-335812' }),
@@ -111,7 +119,10 @@ test('deriveWorkInFlight includes only in-progress beads', () => {
     bead({ id: 'a-3', status: 'in_progress', assignee: 'polecat-gc-335825' }),
   ];
   const rows = deriveWorkInFlight(beads, []);
-  assert.deepEqual(rows.map((r) => r.bead.id), ['a-3']);
+  assert.deepEqual(
+    rows.map((r) => r.bead.id),
+    ['a-3'],
+  );
 });
 
 test('deriveWorkInFlight retains a row when the embedded session id does not resolve', () => {

--- a/shared/src/work-in-flight.test.ts
+++ b/shared/src/work-in-flight.test.ts
@@ -6,33 +6,30 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { GcBead } from './gc-beads.js';
-import type { GcSession } from './gc-client-types.js';
-import { deriveWorkInFlight, parseAssignee } from './work-in-flight.js';
+import {
+  deriveWorkInFlight,
+  parseAssignee,
+  type WorkInFlightBead,
+  type WorkInFlightSession,
+} from './work-in-flight.js';
 
-function bead(partial: Partial<GcBead> & { id: string }): GcBead {
+// Fixtures are typed against the structural minimums the derivation reads
+// (WorkInFlightBead/Session), not a full supervisor wire shape — the
+// generated client types are the wire authority and aren't mirrored here.
+function bead(partial: Partial<WorkInFlightBead> & { id: string }): WorkInFlightBead {
   return {
     title: `title for ${partial.id}`,
     status: 'in_progress',
-    issue_type: 'task',
-    priority: null,
     created_at: '2026-06-03T00:00:00Z',
     ...partial,
   };
 }
 
-function session(partial: Partial<GcSession> & { id: string }): GcSession {
+function session(partial: Partial<WorkInFlightSession> & { id: string }): WorkInFlightSession {
   return {
-    template: 'worker',
-    session_name: partial.id,
-    title: partial.id,
     state: 'active',
-    created_at: '2026-06-03T00:00:00Z',
-    attached: false,
-    running: true,
-    provider: 'claude',
     ...partial,
-  } as GcSession;
+  };
 }
 
 test('parseAssignee splits the real verified examples into role + session id', () => {

--- a/shared/src/work-in-flight.test.ts
+++ b/shared/src/work-in-flight.test.ts
@@ -1,0 +1,146 @@
+// Run with: npx tsx --test shared/src/work-in-flight.test.ts
+//
+// "Work in flight" derivation: parse the live session id out of a bead's
+// assignee, join the in-progress beads to their sessions, and order by recency.
+// Fixtures use the real verified examples (see work-in-flight.ts header).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { GcBead } from './gc-beads.js';
+import type { GcSession } from './gc-client-types.js';
+import { deriveWorkInFlight, parseAssignee } from './work-in-flight.js';
+
+function bead(partial: Partial<GcBead> & { id: string }): GcBead {
+  return {
+    title: `title for ${partial.id}`,
+    status: 'in_progress',
+    issue_type: 'task',
+    priority: null,
+    created_at: '2026-06-03T00:00:00Z',
+    ...partial,
+  };
+}
+
+function session(partial: Partial<GcSession> & { id: string }): GcSession {
+  return {
+    template: 'worker',
+    session_name: partial.id,
+    title: partial.id,
+    state: 'active',
+    created_at: '2026-06-03T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+    ...partial,
+  } as GcSession;
+}
+
+test('parseAssignee splits the real verified examples into role + session id', () => {
+  assert.deepEqual(parseAssignee('polecat-gc-335825'), {
+    role: 'polecat',
+    sessionId: 'gc-335825',
+  });
+  assert.deepEqual(parseAssignee('scix-worker-gc-335812'), {
+    role: 'scix-worker',
+    sessionId: 'gc-335812',
+  });
+  assert.deepEqual(parseAssignee('enterprisebench-worker-gc-335808'), {
+    role: 'enterprisebench-worker',
+    sessionId: 'gc-335808',
+  });
+});
+
+test('parseAssignee extracts td-/th-/4-letter-prefixed handles too', () => {
+  assert.deepEqual(parseAssignee('polecat-td-9abc'), {
+    role: 'polecat',
+    sessionId: 'td-9abc',
+  });
+  assert.deepEqual(parseAssignee('worker-fddc-12xy'), {
+    role: 'worker',
+    sessionId: 'fddc-12xy',
+  });
+});
+
+test('parseAssignee backfills role with the session id when the assignee is only a handle', () => {
+  assert.deepEqual(parseAssignee('gc-335825'), {
+    role: 'gc-335825',
+    sessionId: 'gc-335825',
+  });
+});
+
+test('parseAssignee falls back to the whole string when no session handle is present', () => {
+  assert.deepEqual(parseAssignee('mayor'), { role: 'mayor' });
+  assert.deepEqual(parseAssignee('/home/ds/gas-city/city-infra-polecat'), {
+    role: '/home/ds/gas-city/city-infra-polecat',
+  });
+});
+
+test('parseAssignee trims surrounding whitespace', () => {
+  assert.deepEqual(parseAssignee('  polecat-gc-335825  '), {
+    role: 'polecat',
+    sessionId: 'gc-335825',
+  });
+});
+
+test('deriveWorkInFlight joins in-progress beads to their live session, newest first', () => {
+  const polecat = session({ id: 'gc-335825', rig: '/home/ds/gascity', last_active: '2026-06-03T10:00:00Z' });
+  const scixWorker = session({ id: 'gc-335812', rig: 'scix_experiments', last_active: '2026-06-03T11:00:00Z' });
+  const beads = [
+    bead({ id: 'gc-5rarj', assignee: 'polecat-gc-335825' }),
+    bead({ id: 'scix_experiments-4if7h', assignee: 'scix-worker-gc-335812' }),
+  ];
+  const rows = deriveWorkInFlight(beads, [polecat, scixWorker]);
+  assert.deepEqual(
+    rows.map((r) => r.bead.id),
+    ['scix_experiments-4if7h', 'gc-5rarj'], // 11:00 before 10:00
+  );
+  const scixRow = rows.find((r) => r.bead.id === 'scix_experiments-4if7h');
+  assert.equal(scixRow?.role, 'scix-worker');
+  assert.equal(scixRow?.session?.id, 'gc-335812');
+  assert.equal(scixRow?.assignee, 'scix-worker-gc-335812');
+});
+
+test('deriveWorkInFlight includes only in-progress beads', () => {
+  const beads = [
+    bead({ id: 'a-1', status: 'open', assignee: 'polecat-gc-335825' }),
+    bead({ id: 'a-2', status: 'closed', assignee: 'polecat-gc-335825' }),
+    bead({ id: 'a-3', status: 'in_progress', assignee: 'polecat-gc-335825' }),
+  ];
+  const rows = deriveWorkInFlight(beads, []);
+  assert.deepEqual(rows.map((r) => r.bead.id), ['a-3']);
+});
+
+test('deriveWorkInFlight retains a row when the embedded session id does not resolve', () => {
+  const beads = [bead({ id: 'EnterpriseBench-mda', assignee: 'enterprisebench-worker-gc-335808' })];
+  const rows = deriveWorkInFlight(beads, []); // gc-335808 absent
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.session, undefined);
+  assert.equal(rows[0]?.role, 'enterprisebench-worker');
+  assert.equal(rows[0]?.assignee, 'enterprisebench-worker-gc-335808');
+});
+
+test('deriveWorkInFlight retains an in-progress bead with no assignee', () => {
+  const rows = deriveWorkInFlight([bead({ id: 'orphan-1' })], []);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.assignee, undefined);
+  assert.equal(rows[0]?.role, undefined);
+  assert.equal(rows[0]?.session, undefined);
+});
+
+test('deriveWorkInFlight falls back to bead timestamps when no session activity', () => {
+  const polecat = session({ id: 'gc-100', last_active: '2026-06-03T10:00:00Z' });
+  const noSession = bead({
+    id: 'no-sess',
+    assignee: 'worker-gc-999999',
+    updated_at: '2026-06-03T12:00:00Z', // newer than the joined session's activity
+  });
+  const rows = deriveWorkInFlight(
+    [bead({ id: 'gc-5rarj', assignee: 'polecat-gc-100' }), noSession],
+    [polecat],
+  );
+  assert.equal(rows[0]?.bead.id, 'no-sess'); // 12:00 update beats 10:00 activity
+});
+
+test('deriveWorkInFlight returns empty when nothing is in progress', () => {
+  assert.deepEqual(deriveWorkInFlight([bead({ id: 'a-1', status: 'open' })], []), []);
+});

--- a/shared/src/work-in-flight.test.ts
+++ b/shared/src/work-in-flight.test.ts
@@ -75,6 +75,13 @@ test('parseAssignee falls back to the whole string when no session handle is pre
   });
 });
 
+test('parseAssignee does NOT misparse a plain role as a bare session id', () => {
+  // `scix-worker` is a worker ROLE, not a session id: its body has no digit, so
+  // the bare-handle branch must reject it and leave sessionId undefined. (A live
+  // session id always carries a numeric handle, e.g. `gc-335812`.)
+  assert.deepEqual(parseAssignee('scix-worker'), { role: 'scix-worker' });
+});
+
 test('parseAssignee trims surrounding whitespace', () => {
   assert.deepEqual(parseAssignee('  polecat-gc-335825  '), {
     role: 'polecat',

--- a/shared/src/work-in-flight.test.ts
+++ b/shared/src/work-in-flight.test.ts
@@ -1,36 +1,12 @@
 // Run with: npx tsx --test shared/src/work-in-flight.test.ts
 //
-// "Work in flight" derivation: parse the live session id out of a bead's
-// assignee, join the in-progress beads to their sessions, and order by recency.
-// Fixtures use the real verified examples (see work-in-flight.ts header).
+// Work-in-flight assignee parsing: split a bead assignee into its worker role
+// and the live session id it embeds. Fixtures use the real verified examples
+// (see work-in-flight.ts header).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  deriveWorkInFlight,
-  parseAssignee,
-  type WorkInFlightBead,
-  type WorkInFlightSession,
-} from './work-in-flight.js';
-
-// Fixtures are typed against the structural minimums the derivation reads
-// (WorkInFlightBead/Session), not a full supervisor wire shape — the
-// generated client types are the wire authority and aren't mirrored here.
-function bead(partial: Partial<WorkInFlightBead> & { id: string }): WorkInFlightBead {
-  return {
-    title: `title for ${partial.id}`,
-    status: 'in_progress',
-    created_at: '2026-06-03T00:00:00Z',
-    ...partial,
-  };
-}
-
-function session(partial: Partial<WorkInFlightSession> & { id: string }): WorkInFlightSession {
-  return {
-    state: 'active',
-    ...partial,
-  };
-}
+import { parseAssignee } from './work-in-flight.js';
 
 test('parseAssignee splits the real verified examples into role + session id', () => {
   assert.deepEqual(parseAssignee('polecat-gc-335825'), {
@@ -84,78 +60,4 @@ test('parseAssignee trims surrounding whitespace', () => {
     role: 'polecat',
     sessionId: 'gc-335825',
   });
-});
-
-test('deriveWorkInFlight joins in-progress beads to their live session, newest first', () => {
-  const polecat = session({
-    id: 'gc-335825',
-    rig: '/home/ds/gascity',
-    last_active: '2026-06-03T10:00:00Z',
-  });
-  const scixWorker = session({
-    id: 'gc-335812',
-    rig: 'scix_experiments',
-    last_active: '2026-06-03T11:00:00Z',
-  });
-  const beads = [
-    bead({ id: 'gc-5rarj', assignee: 'polecat-gc-335825' }),
-    bead({ id: 'scix_experiments-4if7h', assignee: 'scix-worker-gc-335812' }),
-  ];
-  const rows = deriveWorkInFlight(beads, [polecat, scixWorker]);
-  assert.deepEqual(
-    rows.map((r) => r.bead.id),
-    ['scix_experiments-4if7h', 'gc-5rarj'], // 11:00 before 10:00
-  );
-  const scixRow = rows.find((r) => r.bead.id === 'scix_experiments-4if7h');
-  assert.equal(scixRow?.role, 'scix-worker');
-  assert.equal(scixRow?.session?.id, 'gc-335812');
-  assert.equal(scixRow?.assignee, 'scix-worker-gc-335812');
-});
-
-test('deriveWorkInFlight includes only in-progress beads', () => {
-  const beads = [
-    bead({ id: 'a-1', status: 'open', assignee: 'polecat-gc-335825' }),
-    bead({ id: 'a-2', status: 'closed', assignee: 'polecat-gc-335825' }),
-    bead({ id: 'a-3', status: 'in_progress', assignee: 'polecat-gc-335825' }),
-  ];
-  const rows = deriveWorkInFlight(beads, []);
-  assert.deepEqual(
-    rows.map((r) => r.bead.id),
-    ['a-3'],
-  );
-});
-
-test('deriveWorkInFlight retains a row when the embedded session id does not resolve', () => {
-  const beads = [bead({ id: 'EnterpriseBench-mda', assignee: 'enterprisebench-worker-gc-335808' })];
-  const rows = deriveWorkInFlight(beads, []); // gc-335808 absent
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0]?.session, undefined);
-  assert.equal(rows[0]?.role, 'enterprisebench-worker');
-  assert.equal(rows[0]?.assignee, 'enterprisebench-worker-gc-335808');
-});
-
-test('deriveWorkInFlight retains an in-progress bead with no assignee', () => {
-  const rows = deriveWorkInFlight([bead({ id: 'orphan-1' })], []);
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0]?.assignee, undefined);
-  assert.equal(rows[0]?.role, undefined);
-  assert.equal(rows[0]?.session, undefined);
-});
-
-test('deriveWorkInFlight falls back to bead timestamps when no session activity', () => {
-  const polecat = session({ id: 'gc-100', last_active: '2026-06-03T10:00:00Z' });
-  const noSession = bead({
-    id: 'no-sess',
-    assignee: 'worker-gc-999999',
-    updated_at: '2026-06-03T12:00:00Z', // newer than the joined session's activity
-  });
-  const rows = deriveWorkInFlight(
-    [bead({ id: 'gc-5rarj', assignee: 'polecat-gc-100' }), noSession],
-    [polecat],
-  );
-  assert.equal(rows[0]?.bead.id, 'no-sess'); // 12:00 update beats 10:00 activity
-});
-
-test('deriveWorkInFlight returns empty when nothing is in progress', () => {
-  assert.deepEqual(deriveWorkInFlight([bead({ id: 'a-1', status: 'open' })], []), []);
 });

--- a/shared/src/work-in-flight.ts
+++ b/shared/src/work-in-flight.ts
@@ -1,47 +1,18 @@
-// "Work in flight" derivation — the operator's at-a-glance view of what is
-// actually being worked on right now.
+// Work-in-flight assignee parsing — the primitives the "Workers active" section
+// uses to tie an in-progress bead to the live worker session that owns it.
 //
-// The agent roster (configured agent slots) is the WRONG signal for this:
-// the supervisor reports nearly every worker slot as state=stopped with no
-// active bead, because the live work happens in dynamically-spawned worker
-// SESSIONS, not the configured slots. Driving off the roster makes "working"
-// read as 0 even when the city is busy.
-//
-// The RIGHT signal is the in-progress beads — the actual units of work. Each
-// in-progress bead carries an `assignee` that embeds the live session id:
+// Each in-progress bead carries an `assignee` that embeds the live session id:
 //
 //   bead gc-5rarj               assignee polecat-gc-335825          → gc-335825
 //   bead scix_experiments-4if7h assignee scix-worker-gc-335812      → gc-335812
 //   bead EnterpriseBench-mda    assignee enterprisebench-worker-gc-335808 → gc-335808
 //
 // Pattern: `<worker-role>-<session-id>` where the session id is the trailing
-// `gc-…` (or other 2/4-letter-prefixed) handle. Extract the session id, join
-// it to the live sessions list, and the result is one row per unit of work:
-// who (role), where (rig), what (bead id + title), and the live session state.
+// `gc-…` (or other 2/4-letter-prefixed) handle. The frontend derives the live
+// Workers-active list from the SESSIONS (see hooks/activeWorkers), using
+// parseAssignee only to best-effort attach a captured bead to a worker row.
 //
-// Pure over the shared wire types (GcBead + GcSession) — no IO, no React, no
-// DOM. The frontend layers display-label cleaning on top via projectOf helpers.
-
-// The derivation reads only a handful of fields. Parametrize over these
-// structural minimums (rather than the full GcBead/GcSession) so both the
-// shared wire types AND the generated supervisor client types — which differ
-// in optionality under exactOptionalPropertyTypes — can be passed without a
-// cast at the call sites.
-export interface WorkInFlightBead {
-  id: string;
-  title: string;
-  status: string;
-  assignee?: string;
-  created_at: string;
-  updated_at?: string;
-}
-
-export interface WorkInFlightSession {
-  id: string;
-  state: string;
-  rig?: string;
-  last_active?: string;
-}
+// Pure over plain strings — no IO, no React, no DOM.
 
 /**
  * The trailing supervisor session-handle embedded in an assignee. Anchored to
@@ -105,73 +76,7 @@ export function parseAssignee(assignee: string): ParsedAssignee {
 }
 
 /**
- * One unit of work in flight: an in-progress bead joined to the live worker
- * session it is assigned to. `session` is undefined when the embedded session
- * id does not resolve to a live session (completed/closed/never-spawned) — the
- * row is still emitted so the bead + assignee remain visible (graceful
- * degradation; never silently drop work).
- */
-export interface WorkInFlightRow<
-  B extends WorkInFlightBead = WorkInFlightBead,
-  S extends WorkInFlightSession = WorkInFlightSession,
-> {
-  bead: B;
-  /** Raw assignee string, or undefined when the bead carries none. */
-  assignee?: string;
-  /** Worker role parsed from the assignee (e.g. `polecat`). Undefined when the
-   *  bead has no assignee at all. */
-  role?: string;
-  /** Live session joined by the embedded id, or undefined when unresolved. */
-  session?: S;
-}
-
-/**
  * The bead status that means "actively being worked on". A single literal so
  * the work-in-flight filter and the status badge stay in lockstep.
  */
 export const IN_PROGRESS_STATUS = 'in_progress';
-
-function recencyKey(row: WorkInFlightRow): number {
-  // Read through the structural minimum (WorkInFlightBead/Session).
-  // Prefer the live session's last activity (the freshest signal of work), then
-  // fall back to the bead's update/create time. Unparseable timestamps sort
-  // oldest so rows with real activity float to the top.
-  const candidate = row.session?.last_active ?? row.bead.updated_at ?? row.bead.created_at;
-  const ms = candidate ? Date.parse(candidate) : NaN;
-  return Number.isFinite(ms) ? ms : 0;
-}
-
-/**
- * Derive the work-in-flight rows from the raw beads + sessions lists.
- *
- * Steps (mechanical, no semantic judgment):
- *  1. Keep only in-progress beads.
- *  2. Parse each bead's assignee into role + embedded session id.
- *  3. Join the session id to the live sessions list by `session.id`.
- *  4. Sort newest-/most-recently-active first.
- *
- * Beads whose embedded session id does not resolve are retained (session
- * undefined) so nothing in flight is dropped.
- */
-export function deriveWorkInFlight<B extends WorkInFlightBead, S extends WorkInFlightSession>(
-  beads: readonly B[],
-  sessions: readonly S[],
-): WorkInFlightRow<B, S>[] {
-  const sessionsById = new Map<string, S>();
-  for (const session of sessions) sessionsById.set(session.id, session);
-
-  const rows: WorkInFlightRow<B, S>[] = [];
-  for (const bead of beads) {
-    if (bead.status !== IN_PROGRESS_STATUS) continue;
-    const assignee = bead.assignee?.trim();
-    if (assignee === undefined || assignee.length === 0) {
-      rows.push({ bead });
-      continue;
-    }
-    const { role, sessionId } = parseAssignee(assignee);
-    const session = sessionId ? sessionsById.get(sessionId) : undefined;
-    rows.push({ bead, assignee, role, ...(session ? { session } : {}) });
-  }
-
-  return rows.sort((a, b) => recencyKey(b) - recencyKey(a));
-}

--- a/shared/src/work-in-flight.ts
+++ b/shared/src/work-in-flight.ts
@@ -64,7 +64,13 @@ const ASSIGNEE_SESSION_ID_RX =
 // alphabet as ASSIGNEE_SESSION_ID_RX but whole-string. NOT SESSION_ID_RE: that
 // validator permits internal hyphens in the body, which would let a composite
 // like `scix-worker-gc-335812` masquerade as one bare handle.
-const BARE_SESSION_ID_RX = /^(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
+//
+// The id body MUST contain at least one digit. Live session ids always carry a
+// numeric handle (`gc-335825`, `td-9abc`); a plain 4-letter-prefixed *role* like
+// `scix-worker` would otherwise match (`scix` prefix + `worker` body) and be
+// misparsed as a bare session id. Requiring a digit keeps roles out.
+const BARE_SESSION_ID_RX =
+  /^(?:gc|td|th|[a-z]{4})-[a-z0-9]*[0-9][a-z0-9]*$/;
 
 export interface ParsedAssignee {
   /** The extracted live session id (e.g. `gc-335825`), or undefined when the

--- a/shared/src/work-in-flight.ts
+++ b/shared/src/work-in-flight.ts
@@ -57,8 +57,7 @@ export interface WorkInFlightSession {
  * session ids are hyphen-free after the prefix dash (`gc-335825`, `td-9abc`),
  * so this loses nothing real.
  */
-const ASSIGNEE_SESSION_ID_RX =
-  /[-_/]((?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32})$/;
+const ASSIGNEE_SESSION_ID_RX = /[-_/]((?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32})$/;
 
 // A bare session handle (the assignee IS a session id, no role prefix). Same
 // alphabet as ASSIGNEE_SESSION_ID_RX but whole-string. NOT SESSION_ID_RE: that
@@ -69,8 +68,7 @@ const ASSIGNEE_SESSION_ID_RX =
 // numeric handle (`gc-335825`, `td-9abc`); a plain 4-letter-prefixed *role* like
 // `scix-worker` would otherwise match (`scix` prefix + `worker` body) and be
 // misparsed as a bare session id. Requiring a digit keeps roles out.
-const BARE_SESSION_ID_RX =
-  /^(?:gc|td|th|[a-z]{4})-[a-z0-9]*[0-9][a-z0-9]*$/;
+const BARE_SESSION_ID_RX = /^(?:gc|td|th|[a-z]{4})-[a-z0-9]*[0-9][a-z0-9]*$/;
 
 export interface ParsedAssignee {
   /** The extracted live session id (e.g. `gc-335825`), or undefined when the
@@ -138,8 +136,7 @@ function recencyKey(row: WorkInFlightRow): number {
   // Prefer the live session's last activity (the freshest signal of work), then
   // fall back to the bead's update/create time. Unparseable timestamps sort
   // oldest so rows with real activity float to the top.
-  const candidate =
-    row.session?.last_active ?? row.bead.updated_at ?? row.bead.created_at;
+  const candidate = row.session?.last_active ?? row.bead.updated_at ?? row.bead.created_at;
   const ms = candidate ? Date.parse(candidate) : NaN;
   return Number.isFinite(ms) ? ms : 0;
 }
@@ -156,10 +153,7 @@ function recencyKey(row: WorkInFlightRow): number {
  * Beads whose embedded session id does not resolve are retained (session
  * undefined) so nothing in flight is dropped.
  */
-export function deriveWorkInFlight<
-  B extends WorkInFlightBead,
-  S extends WorkInFlightSession,
->(
+export function deriveWorkInFlight<B extends WorkInFlightBead, S extends WorkInFlightSession>(
   beads: readonly B[],
   sessions: readonly S[],
 ): WorkInFlightRow<B, S>[] {

--- a/shared/src/work-in-flight.ts
+++ b/shared/src/work-in-flight.ts
@@ -1,0 +1,177 @@
+// "Work in flight" derivation — the operator's at-a-glance view of what is
+// actually being worked on right now.
+//
+// The agent roster (configured agent slots) is the WRONG signal for this:
+// the supervisor reports nearly every worker slot as state=stopped with no
+// active bead, because the live work happens in dynamically-spawned worker
+// SESSIONS, not the configured slots. Driving off the roster makes "working"
+// read as 0 even when the city is busy.
+//
+// The RIGHT signal is the in-progress beads — the actual units of work. Each
+// in-progress bead carries an `assignee` that embeds the live session id:
+//
+//   bead gc-5rarj               assignee polecat-gc-335825          → gc-335825
+//   bead scix_experiments-4if7h assignee scix-worker-gc-335812      → gc-335812
+//   bead EnterpriseBench-mda    assignee enterprisebench-worker-gc-335808 → gc-335808
+//
+// Pattern: `<worker-role>-<session-id>` where the session id is the trailing
+// `gc-…` (or other 2/4-letter-prefixed) handle. Extract the session id, join
+// it to the live sessions list, and the result is one row per unit of work:
+// who (role), where (rig), what (bead id + title), and the live session state.
+//
+// Pure over the shared wire types (GcBead + GcSession) — no IO, no React, no
+// DOM. The frontend layers display-label cleaning on top via projectOf helpers.
+
+// The derivation reads only a handful of fields. Parametrize over these
+// structural minimums (rather than the full GcBead/GcSession) so both the
+// shared wire types AND the generated supervisor client types — which differ
+// in optionality under exactOptionalPropertyTypes — can be passed without a
+// cast at the call sites.
+export interface WorkInFlightBead {
+  id: string;
+  title: string;
+  status: string;
+  assignee?: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface WorkInFlightSession {
+  id: string;
+  state: string;
+  rig?: string;
+  last_active?: string;
+}
+
+/**
+ * The trailing supervisor session-handle embedded in an assignee. Anchored to
+ * the END of the string and preceded by a boundary (`-`, `_`, `/`, or start),
+ * so `polecat-gc-335825` yields `gc-335825` and the role prefix is whatever
+ * comes before.
+ *
+ * The handle prefix mirrors SESSION_ID_RE (`gc`/`td`/`th` literal or any
+ * 4-letter city code). The id BODY is deliberately tightened to `[a-z0-9]`
+ * (no internal hyphen) so the match binds to the MINIMAL trailing handle:
+ * without that, a role like `scix-worker` (whose `scix` is itself a 4-letter
+ * token) would let the greedy body swallow `scix-worker-gc-335812` whole. Live
+ * session ids are hyphen-free after the prefix dash (`gc-335825`, `td-9abc`),
+ * so this loses nothing real.
+ */
+const ASSIGNEE_SESSION_ID_RX =
+  /[-_/]((?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32})$/;
+
+// A bare session handle (the assignee IS a session id, no role prefix). Same
+// alphabet as ASSIGNEE_SESSION_ID_RX but whole-string. NOT SESSION_ID_RE: that
+// validator permits internal hyphens in the body, which would let a composite
+// like `scix-worker-gc-335812` masquerade as one bare handle.
+const BARE_SESSION_ID_RX = /^(?:gc|td|th|[a-z]{4})-[a-z0-9]{1,32}$/;
+
+export interface ParsedAssignee {
+  /** The extracted live session id (e.g. `gc-335825`), or undefined when the
+   *  assignee carries no recognizable session handle. */
+  sessionId?: string;
+  /** The worker-role prefix with the session-id suffix stripped
+   *  (e.g. `polecat`, `scix-worker`, `enterprisebench-worker`). Falls back to
+   *  the whole assignee when no session suffix is present. */
+  role: string;
+}
+
+/**
+ * Split a bead assignee into its worker role and embedded session id.
+ *
+ * `polecat-gc-335825` → `{ role: 'polecat', sessionId: 'gc-335825' }`.
+ * An assignee with no session handle (e.g. a bare alias) yields the whole
+ * string as the role and no sessionId — the caller degrades gracefully.
+ */
+export function parseAssignee(assignee: string): ParsedAssignee {
+  const trimmed = assignee.trim();
+  // Bare handle: the assignee IS a session id with no role prefix. Name the row
+  // with the id itself so it still reads.
+  if (BARE_SESSION_ID_RX.test(trimmed)) {
+    return { role: trimmed, sessionId: trimmed };
+  }
+  const match = ASSIGNEE_SESSION_ID_RX.exec(trimmed);
+  const sessionId = match?.[1];
+  if (match === null || sessionId === undefined) {
+    return { role: trimmed };
+  }
+  // Strip the matched `<sep>gc-…` tail to recover the role. The match starts at
+  // the separator boundary, so slice up to match.index.
+  return { role: trimmed.slice(0, match.index), sessionId };
+}
+
+/**
+ * One unit of work in flight: an in-progress bead joined to the live worker
+ * session it is assigned to. `session` is undefined when the embedded session
+ * id does not resolve to a live session (completed/closed/never-spawned) — the
+ * row is still emitted so the bead + assignee remain visible (graceful
+ * degradation; never silently drop work).
+ */
+export interface WorkInFlightRow<
+  B extends WorkInFlightBead = WorkInFlightBead,
+  S extends WorkInFlightSession = WorkInFlightSession,
+> {
+  bead: B;
+  /** Raw assignee string, or undefined when the bead carries none. */
+  assignee?: string;
+  /** Worker role parsed from the assignee (e.g. `polecat`). Undefined when the
+   *  bead has no assignee at all. */
+  role?: string;
+  /** Live session joined by the embedded id, or undefined when unresolved. */
+  session?: S;
+}
+
+/**
+ * The bead status that means "actively being worked on". A single literal so
+ * the work-in-flight filter and the status badge stay in lockstep.
+ */
+export const IN_PROGRESS_STATUS = 'in_progress';
+
+function recencyKey(row: WorkInFlightRow): number {
+  // Read through the structural minimum (WorkInFlightBead/Session).
+  // Prefer the live session's last activity (the freshest signal of work), then
+  // fall back to the bead's update/create time. Unparseable timestamps sort
+  // oldest so rows with real activity float to the top.
+  const candidate =
+    row.session?.last_active ?? row.bead.updated_at ?? row.bead.created_at;
+  const ms = candidate ? Date.parse(candidate) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Derive the work-in-flight rows from the raw beads + sessions lists.
+ *
+ * Steps (mechanical, no semantic judgment):
+ *  1. Keep only in-progress beads.
+ *  2. Parse each bead's assignee into role + embedded session id.
+ *  3. Join the session id to the live sessions list by `session.id`.
+ *  4. Sort newest-/most-recently-active first.
+ *
+ * Beads whose embedded session id does not resolve are retained (session
+ * undefined) so nothing in flight is dropped.
+ */
+export function deriveWorkInFlight<
+  B extends WorkInFlightBead,
+  S extends WorkInFlightSession,
+>(
+  beads: readonly B[],
+  sessions: readonly S[],
+): WorkInFlightRow<B, S>[] {
+  const sessionsById = new Map<string, S>();
+  for (const session of sessions) sessionsById.set(session.id, session);
+
+  const rows: WorkInFlightRow<B, S>[] = [];
+  for (const bead of beads) {
+    if (bead.status !== IN_PROGRESS_STATUS) continue;
+    const assignee = bead.assignee?.trim();
+    if (assignee === undefined || assignee.length === 0) {
+      rows.push({ bead });
+      continue;
+    }
+    const { role, sessionId } = parseAssignee(assignee);
+    const session = sessionId ? sessionsById.get(sessionId) : undefined;
+    rows.push({ bead, assignee, role, ...(session ? { session } : {}) });
+  }
+
+  return rows.sort((a, b) => recencyKey(b) - recencyKey(a));
+}


### PR DESCRIPTION
## Summary
Makes the Agents view answer "what's actually working" — driven by **live worker sessions** (stable) rather than the agent roster (which reports workers as stopped) or in-progress beads (which churn to zero in seconds).

**Workers active** (new section, top of Agents page):
- Calm summary line: *"N workers active across rig (n), …"* counted from live worker **sessions** grouped by clean rig name — doesn't flicker as beads churn.
- Per-worker rows (`rig · worker · age`), each **peekable** (opens the live session transcript) and showing `→ gc-xyz: title` (linked to the bead detail) **only when** an in-progress bead's assignee embeds that session id. No "unassigned" rows.
- `shared/src/work-in-flight.ts` + `hooks/activeWorkers.ts` are the tested SSOT derivations (assignee→session-id parse, the bead join).

**Roster** ("Available agents" heading) stays below — mayor/PLs/dispatchers, the warm/idle agents you peek for history.

**Fixes folded in:**
- Running-filter bug: a `suspended` agent raised a passive `watch` attention item that leaked it past the running toggle. New `isVisibleUnderRunning` — only a true `attention` item bypasses the filter.
- City-wide agents now labeled with the **city name** (`ds-research`), not "Orchestration."
- Worker names cleaned (no paths, no `-gc-XXXXX` session suffixes).
- **Peek transcript no longer leaks raw control codes** — `stripTerminalControls` removes OSC / non-SGR CSI / lone ESC (`^[`) / C1 bytes while preserving newlines, tabs, and SGR color.
- `stateTone` moved to `StatusBadge.tsx` (broke a route↔component import cycle); One-Mark cap on stuck-worker badges; DESIGN.md entry for the new section.

## Tests
Frontend 692 / shared 63, typecheck (src+test), lint, build all green. New: `activeWorkers`, `work-in-flight`, `stripTerminalControls`, `SessionPeek.render`, peek-wiring + running-filter-suspended regression.

## Review
Reviewed by code + typescript reviewers — **approve**, 0 blockers/majors. Cosmetic nits applied (SSR fallback, dropped cast, comment arithmetic). ReDoS-checked the stripper; no import cycle; minimal-shape generics satisfy both wire types without casts.
