### PR TITLE
test(runs): restore r1fg snap diff/session checks; guard the run-diff path (gascity-dashboard-3ozw)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,7 +9,33 @@ import react from '@vitejs/plugin-react';
 // DEV_BACKEND_TARGET lets an isolated worktree stack proxy to its own
 // backend port (pair with `vite --port <n>`), so the snap harness can
 // drive it via SNAP_BASE without touching the primary :5174/:8081 pair.
-export const BACKEND_TARGET = process.env.DEV_BACKEND_TARGET ?? 'http://127.0.0.1:8081';
+const DEFAULT_BACKEND_TARGET = 'http://127.0.0.1:8081';
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+
+// The backend binds 127.0.0.1 only and must never be exposed, so a custom dev
+// proxy target must still resolve to loopback. Validate at config load — a
+// non-loopback or malformed DEV_BACKEND_TARGET fails loudly here rather than
+// silently proxying dev traffic off-host.
+function resolveBackendTarget(): string {
+  const raw = process.env.DEV_BACKEND_TARGET;
+  if (raw === undefined) return DEFAULT_BACKEND_TARGET;
+  let hostname: string;
+  try {
+    hostname = new URL(raw).hostname;
+  } catch {
+    throw new Error(`DEV_BACKEND_TARGET is not a valid URL: ${JSON.stringify(raw)}`);
+  }
+  // URL parsing wraps IPv6 hosts in brackets ([::1]); strip them before compare.
+  const normalized = hostname.replace(/^\[|\]$/g, '');
+  if (!LOOPBACK_HOSTS.has(normalized)) {
+    throw new Error(
+      `DEV_BACKEND_TARGET must resolve to loopback (127.0.0.1, localhost, or ::1); got ${JSON.stringify(hostname)}`,
+    );
+  }
+  return raw;
+}
+
+export const BACKEND_TARGET = resolveBackendTarget();
 
 interface ProxyRequest {
   hasHeader(name: string): boolean;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,10 @@ import react from '@vitejs/plugin-react';
 // needs to know about cross-origin — everything is same-origin both in
 // dev and prod, which keeps the Host-allowlist + Origin check + CSP
 // simple.
-export const BACKEND_TARGET = 'http://127.0.0.1:8081';
+// DEV_BACKEND_TARGET lets an isolated worktree stack proxy to its own
+// backend port (pair with `vite --port <n>`), so the snap harness can
+// drive it via SNAP_BASE without touching the primary :5174/:8081 pair.
+export const BACKEND_TARGET = process.env.DEV_BACKEND_TARGET ?? 'http://127.0.0.1:8081';
 
 interface ProxyRequest {
   hasHeader(name: string): boolean;

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -116,21 +116,39 @@ async function runTheme(browser, theme) {
     // somewhere on the page. These were downgraded during the #63
     // integration and restored per gascity-dashboard-3ozw.
     await page.getByRole('heading', { name: /^local changes$/i }).waitFor({ timeout: 5_000 });
-    await page.locator('.formula-run-diff-view summary').filter({
-      hasText: 'shared/src/runs/enrich.ts',
-    }).waitFor({ timeout: 5_000 });
-    await page.locator('.formula-run-diff-view summary').filter({
-      hasText: 'docs/plan.md',
-    }).waitFor({ timeout: 5_000 });
-    await page.locator('.diff-code-insert').filter({
-      hasText: 'preserve failed attempt transcript links',
-    }).first().waitFor({ timeout: 5_000 });
-    await page.locator('.diff-code-delete').filter({
-      hasText: 'old session guard',
-    }).first().waitFor({ timeout: 5_000 });
-    await page.locator('.diff-code-insert').filter({
-      hasText: '# Plan',
-    }).first().waitFor({ timeout: 5_000 });
+    await page
+      .locator('.formula-run-diff-view summary')
+      .filter({
+        hasText: 'shared/src/runs/enrich.ts',
+      })
+      .waitFor({ timeout: 5_000 });
+    await page
+      .locator('.formula-run-diff-view summary')
+      .filter({
+        hasText: 'docs/plan.md',
+      })
+      .waitFor({ timeout: 5_000 });
+    await page
+      .locator('.diff-code-insert')
+      .filter({
+        hasText: 'preserve failed attempt transcript links',
+      })
+      .first()
+      .waitFor({ timeout: 5_000 });
+    await page
+      .locator('.diff-code-delete')
+      .filter({
+        hasText: 'old session guard',
+      })
+      .first()
+      .waitFor({ timeout: 5_000 });
+    await page
+      .locator('.diff-code-insert')
+      .filter({
+        hasText: '# Plan',
+      })
+      .first()
+      .waitFor({ timeout: 5_000 });
     // Related section (gascity-dashboard-j4x) — RK3 density gate. The
     // high-volume fixture (40 molecule members + 3 unresolved links) must
     // render exactly one aggregate maroon mark in the Related section, cap
@@ -220,13 +238,16 @@ async function runTheme(browser, theme) {
     // so the unresolved explanation stays reachable.
     const sessionTabAvailable = await page
       .getByRole('tab', { name: /session/i })
-      .evaluate((node) =>
-        node instanceof HTMLButtonElement &&
-        !node.disabled &&
-        node.getAttribute('aria-disabled') !== 'true',
+      .evaluate(
+        (node) =>
+          node instanceof HTMLButtonElement &&
+          !node.disabled &&
+          node.getAttribute('aria-disabled') !== 'true',
       );
     if (!sessionTabAvailable) {
-      result.errors.push('Session tab was unavailable for a selected node with unresolved session state');
+      result.errors.push(
+        'Session tab was unavailable for a selected node with unresolved session state',
+      );
     }
 
     await page.goto(`${CITY_BASE}/runs/gc-adopt-pr-partial`, {
@@ -339,7 +360,9 @@ async function installApiFixtureRoutes(context) {
   );
   await context.route(
     '**/api/city/*/maintainer/triage',
-    fulfillJson(JSON.stringify({ computed_at: null, repo: 'fixture/fixture', tiers: [], totals: {} })),
+    fulfillJson(
+      JSON.stringify({ computed_at: null, repo: 'fixture/fixture', tiers: [], totals: {} }),
+    ),
   );
 
   // The city switcher (Header) lists managed cities directly through the
@@ -385,11 +408,13 @@ async function installApiFixtureRoutes(context) {
 
   await context.route(
     '**/api/city/*/config',
-    fulfillJson(JSON.stringify({
-      cityName: 'racoon-city',
-      cityRoot: '/tmp/gascity',
-      useFixtures: false,
-    })),
+    fulfillJson(
+      JSON.stringify({
+        cityName: 'racoon-city',
+        cityRoot: '/tmp/gascity',
+        useFixtures: false,
+      }),
+    ),
   );
 
   await context.route('**/api/client-errors', async (route) => {

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -110,11 +110,27 @@ async function runTheme(browser, theme) {
     await page.getByRole('heading', { name: /adopt pr #42/i }).waitFor({ timeout: 5_000 });
     await page.getByText(/v11 · seq 91/i).waitFor({ timeout: 5_000 });
     await page.getByRole('heading', { name: /formula graph/i }).waitFor({ timeout: 5_000 });
-    await page.getByRole('heading', { name: /local changes/i }).waitFor({ timeout: 5_000 });
-    await page
-      .getByText('preserve failed attempt transcript links', { exact: true })
-      .waitFor({ timeout: 5_000 });
-    await page.getByText('old session guard').waitFor({ timeout: 5_000 });
+    // Diff-rendering checks (gascity-dashboard-r1fg): assert the patch
+    // actually renders as a structured diff — per-file <summary> rows and
+    // insert/delete code lines — not merely that the patch text appears
+    // somewhere on the page. These were downgraded during the #63
+    // integration and restored per gascity-dashboard-3ozw.
+    await page.getByRole('heading', { name: /^local changes$/i }).waitFor({ timeout: 5_000 });
+    await page.locator('.formula-run-diff-view summary').filter({
+      hasText: 'shared/src/runs/enrich.ts',
+    }).waitFor({ timeout: 5_000 });
+    await page.locator('.formula-run-diff-view summary').filter({
+      hasText: 'docs/plan.md',
+    }).waitFor({ timeout: 5_000 });
+    await page.locator('.diff-code-insert').filter({
+      hasText: 'preserve failed attempt transcript links',
+    }).first().waitFor({ timeout: 5_000 });
+    await page.locator('.diff-code-delete').filter({
+      hasText: 'old session guard',
+    }).first().waitFor({ timeout: 5_000 });
+    await page.locator('.diff-code-insert').filter({
+      hasText: '# Plan',
+    }).first().waitFor({ timeout: 5_000 });
     // Related section (gascity-dashboard-j4x) — RK3 density gate. The
     // high-volume fixture (40 molecule members + 3 unresolved links) must
     // render exactly one aggregate maroon mark in the Related section, cap
@@ -199,6 +215,19 @@ async function runTheme(browser, theme) {
 
     await page.getByRole('button', { name: /pre-approval ci repair loop/i }).click();
     await page.getByText(/session unresolved for this node/i).waitFor({ timeout: 5_000 });
+    // Session-tab availability check (gascity-dashboard-r1fg): a selected
+    // node with unresolved session state must keep the Session tab enabled
+    // so the unresolved explanation stays reachable.
+    const sessionTabAvailable = await page
+      .getByRole('tab', { name: /session/i })
+      .evaluate((node) =>
+        node instanceof HTMLButtonElement &&
+        !node.disabled &&
+        node.getAttribute('aria-disabled') !== 'true',
+      );
+    if (!sessionTabAvailable) {
+      result.errors.push('Session tab was unavailable for a selected node with unresolved session state');
+    }
 
     await page.goto(`${CITY_BASE}/runs/gc-adopt-pr-partial`, {
       waitUntil: 'domcontentloaded',
@@ -282,18 +311,43 @@ function recordApiFailures(result, apiCalls, apiFailures) {
 }
 
 async function installApiFixtureRoutes(context) {
+  // Ambient city-scoped surfaces (Header/Home modules: agents, mail, events,
+  // health, dolt-noms, maintainer triage). The harness focuses on the
+  // run-detail journey, but the strict any-API-failure tripwire observes the
+  // whole page — without these mocks every ambient call 404s against the
+  // fixture city and fails the run before the diff checks mean anything
+  // (gascity-dashboard-3ozw). Playwright matches the most-recently-registered
+  // handler first, so these ambient routes go in FIRST and the journey-specific
+  // routes registered below win on any overlap.
+  const emptyListBody = JSON.stringify({ items: [], partial: false, total: 0 });
+  const fulfillJson = (body) => async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body });
+  };
+  await context.route(/\/gc-supervisor\/v0\/city\/[^/]+\/agents(\?|$)/, fulfillJson(emptyListBody));
+  await context.route(/\/gc-supervisor\/v0\/city\/[^/]+\/mail(\?|$)/, fulfillJson(emptyListBody));
+  await context.route(/\/gc-supervisor\/v0\/city\/[^/]+\/events(\?|$)/, fulfillJson(emptyListBody));
+  await context.route(
+    /\/gc-supervisor\/v0\/city\/[^/]+\/health(\?|$)/,
+    // Shape mirrors the generated HealthOutputBody (gc-supervisor-client
+    // zod.gen.ts) — re-check after an OpenAPI regen; the tripwire only
+    // observes HTTP status, so body drift here fails silently.
+    fulfillJson(JSON.stringify({ city: CITY, status: 'ok', uptime_sec: 1, version: 'fixture' })),
+  );
+  await context.route(
+    '**/api/city/*/dolt-noms/trend',
+    fulfillJson(JSON.stringify({ available: false, samples: [] })),
+  );
+  await context.route(
+    '**/api/city/*/maintainer/triage',
+    fulfillJson(JSON.stringify({ computed_at: null, repo: 'fixture/fixture', tiers: [], totals: {} })),
+  );
+
   // The city switcher (Header) lists managed cities directly through the
   // supervisor transport proxy. Mock it so the harness needs no live supervisor.
-  await context.route('**/gc-supervisor/v0/cities', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        items: [{ name: CITY, running: true }],
-        total: 1,
-      }),
-    });
-  });
+  await context.route(
+    '**/gc-supervisor/v0/cities',
+    fulfillJson(JSON.stringify({ items: [{ name: CITY, running: true }], total: 1 })),
+  );
 
   // Dashboard-local city-scoped endpoints ride `/api/city/:cityName/*`.
   // Supervisor-owned reads use `/gc-supervisor/v0/city/:cityName/*`.
@@ -329,17 +383,14 @@ async function installApiFixtureRoutes(context) {
     });
   });
 
-  await context.route('**/api/city/*/config', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        cityName: 'racoon-city',
-        cityRoot: '/tmp/gascity',
-        useFixtures: false,
-      }),
-    });
-  });
+  await context.route(
+    '**/api/city/*/config',
+    fulfillJson(JSON.stringify({
+      cityName: 'racoon-city',
+      cityRoot: '/tmp/gascity',
+      useFixtures: false,
+    })),
+  );
 
   await context.route('**/api/client-errors', async (route) => {
     await route.fulfill({
@@ -364,45 +415,30 @@ async function installApiFixtureRoutes(context) {
     });
   });
 
-  await context.route('**/api/city/*/runs/gc-adopt-pr-active/diff**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(fixture.diff),
-    });
-  });
+  await context.route(
+    '**/api/city/*/runs/gc-adopt-pr-active/diff**',
+    fulfillJson(JSON.stringify(fixture.diff)),
+  );
 
-  await context.route('**/api/city/*/runs/gc-no-graph/diff**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(fixture.diff),
-    });
-  });
+  await context.route(
+    '**/api/city/*/runs/gc-no-graph/diff**',
+    fulfillJson(JSON.stringify(fixture.diff)),
+  );
 
-  await context.route('**/api/city/*/runs/gc-not-git/diff**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(unavailableDiff('not_git')),
-    });
-  });
+  await context.route(
+    '**/api/city/*/runs/gc-not-git/diff**',
+    fulfillJson(JSON.stringify(unavailableDiff('not_git'))),
+  );
 
-  await context.route('**/api/city/*/runs/gc-path-unknown/diff**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(unavailableDiff('path_unknown')),
-    });
-  });
+  await context.route(
+    '**/api/city/*/runs/gc-path-unknown/diff**',
+    fulfillJson(JSON.stringify(unavailableDiff('path_unknown'))),
+  );
 
-  await context.route('**/api/city/*/runs/gc-clean-worktree/diff**', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(cleanWorktreeDiff()),
-    });
-  });
+  await context.route(
+    '**/api/city/*/runs/gc-clean-worktree/diff**',
+    fulfillJson(JSON.stringify(cleanWorktreeDiff())),
+  );
 
   await context.route('**/gc-supervisor/v0/city/*/workflow/**', async (route) => {
     const runId = workflowRunId(route.request().url());
@@ -449,13 +485,10 @@ async function installApiFixtureRoutes(context) {
     });
   });
 
-  await context.route('**/gc-supervisor/v0/city/*/sessions', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(sessionListFixture()),
-    });
-  });
+  await context.route(
+    '**/gc-supervisor/v0/city/*/sessions',
+    fulfillJson(JSON.stringify(sessionListFixture())),
+  );
 
   await context.route('**/gc-supervisor/v0/city/*/session/*/transcript**', async (route) => {
     const sessionId = route

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -350,18 +350,26 @@ async function installApiFixtureRoutes(context) {
   await context.route(
     /\/gc-supervisor\/v0\/city\/[^/]+\/health(\?|$)/,
     // Shape mirrors the generated HealthOutputBody (gc-supervisor-client
-    // zod.gen.ts) — re-check after an OpenAPI regen; the tripwire only
-    // observes HTTP status, so body drift here fails silently.
+    // zod.gen.ts) — re-check after an OpenAPI regen. The tripwire only
+    // observes HTTP status for THIS health route, so body drift here fails
+    // silently. The trend/triage mocks below are different: their bodies are
+    // run through shared/ decoders client-side, so their shapes must match
+    // shared/src/{dashboard-health,maintainer-triage}.ts or the page breaks.
     fulfillJson(JSON.stringify({ city: CITY, status: 'ok', uptime_sec: 1, version: 'fixture' })),
   );
   await context.route(
     '**/api/city/*/dolt-noms/trend',
-    fulfillJson(JSON.stringify({ available: false, samples: [] })),
+    fulfillJson(JSON.stringify({ available: false, samples: [], reason: 'store_health_absent' })),
   );
   await context.route(
     '**/api/city/*/maintainer/triage',
     fulfillJson(
-      JSON.stringify({ computed_at: null, repo: 'fixture/fixture', tiers: [], totals: {} }),
+      JSON.stringify({
+        computed_at: null,
+        repo: 'fixture/fixture',
+        tiers: [],
+        totals: { issues_open: 0, prs_open: 0 },
+      }),
     ),
   );
 


### PR DESCRIPTION
## Summary

Closes the dashboard-side work for **gascity-dashboard-3ozw** ([runs][bug] Run diffs broke again).

### Investigation (what actually broke)
- The per-run diff pipeline on main **works end-to-end for a current formula run** — verified live in a real browser against the ds-research supervisor on post-#61 main: `resolveRunExecutionPath` picks up `gc.work_dir` from the snapshot root bead, `POST /api/city/:city/runs/:id/diff` returns 200, and RunDiffPanel renders the structured patch (14 file summaries).
- What makes diffs *appear* broken recurringly:
  - The supervisor **scrubs `gc.work_dir`/`gc.session_name` from run beads when a run closes** (verified: pending runs carry it, done runs don't) → every completed run shows the calm 'No diff available' state (#59). Upstream-gated: gascity-dashboard-j7np / gastownhall/gascity#2823.
  - The snap harness — the only e2e guard on the diff path — had its diff assertions **downgraded to surface text matching** during the #63 integration (gascity-dashboard-r1fg) and had rotted to the point of failing on unmocked ambient endpoints, so it guarded nothing.
  - The operator's dashboard backend on :8081 had been SIGTERM'd (Jun 3 22:41) and left down, which breaks every diff (and everything else) on the live dashboard regardless of code.

### Changes
- **scripts/snap-formula-run-detail.mjs**
  - Restore r1fg's richer checks: exact `/^local changes$/i` heading, per-file `.formula-run-diff-view summary` rows, `.diff-code-insert`/`.diff-code-delete` content assertions, and the session-tab availability check on unresolved-session nodes.
  - Mock the ambient city-scoped surfaces (agents, mail, events, health, dolt-noms trend, maintainer triage) that Header/Home modules now call, so the any-API-failure tripwire fails on *real* contract drift instead of fixture-city 404s. Enumerated mocks (not a catch-all) keep unmocked new calls failing loudly.
  - Route pre-existing static-body handlers through the new `fulfillJson` helper (one idiom for 'fulfill JSON 200').
- **frontend/vite.config.ts**: `BACKEND_TARGET` overridable via `DEV_BACKEND_TARGET` so an isolated worktree stack (own backend port + `vite --port <n>`) can be driven by the snap harness via `SNAP_BASE` without touching the primary :5174/:8081 pair. Existing vite-config tests assert relative to the exported value and stay meaningful.

## Test plan
- [x] `SNAP_BASE=http://127.0.0.1:5184 node scripts/snap-formula-run-detail.mjs --test` → PASS (light + dark) against a live worktree stack (worktree backend :8181 + vite :5184)
- [x] `--inject-late-api-failure` → correctly FAILS (tripwire intact)
- [x] Live browser probe: current run `gascity-dashboard-idcza` renders a structured diff end-to-end (POST /diff 200)
- [x] `npm run typecheck` + `npm run typecheck:test` (backend+frontend) clean
- [x] `npm run lint` clean
- [x] backend tests 509 pass / frontend tests 679 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)