### PR TITLE
test(runs): de-flake Runs.test.tsx SSE-wiring suite under parallel load (fc3k)

### DIFF
--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -210,6 +210,14 @@ async function waitForMount() {
   // wait stable across copy changes and avoids substring collisions
   // (the page renders both "Active" in CountsHeader and "active
   // runs" in the synopsis line).
+  //
+  // gascity-dashboard-fc3k: this only proves the preview fetch resolved
+  // and the button enabled — the run-summary lanes / rig headers / counts
+  // / error banner paint on a LATER state commit, and the full refresh is
+  // dispatched from a useEffect that runs after that. So any assertion
+  // that reads loaded run-summary data must use an async query
+  // (findByText / findByRole / waitFor), not a synchronous getBy*, or it
+  // races the paint under full-suite parallel load.
   const btn = (await screen.findByRole('button', { name: /refresh/i })) as HTMLButtonElement;
   await waitFor(() => expect(btn.disabled).toBe(false));
 }
@@ -231,7 +239,10 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     expect(await screen.findByRole('link', { name: /Preview formula run/i })).toBeTruthy();
     expect(screen.queryByText(/Loading formula runs/i)).toBeNull();
     expect(mockLoadRunSummaryPreview).toHaveBeenCalledTimes(1);
-    expect(mockLoadRunSummary).toHaveBeenCalledTimes(1);
+    // waitFor (see waitForMount): the full refresh fires from a useEffect a
+    // commit after the preview link paints. Mock is called once, so this
+    // still pins "exactly one" without weakening the assertion.
+    await waitFor(() => expect(mockLoadRunSummary).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       full.resolve(buildRunSource('fresh'));
@@ -251,7 +262,7 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     mount();
     await waitForMount();
     // SseIndicator with state='open' renders a StatusBadge with label 'live'.
-    expect(screen.getByText(/^live$/i)).toBeTruthy();
+    expect(await screen.findByText(/^live$/i)).toBeTruthy();
   });
 
   it('marks run lanes that match composed run attention without hiding other runs', async () => {
@@ -316,7 +327,7 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     await waitForMount();
 
     expect(
-      screen.getByText(/Run counts unavailable: run collector unavailable in test/i),
+      await screen.findByText(/Run counts unavailable: run collector unavailable in test/i),
     ).toBeTruthy();
     expect(screen.queryByText(/^0 active runs/i)).toBeNull();
   });
@@ -371,10 +382,10 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     // History view (?history=1): the historical section renders the lane.
     mount('/runs?history=1');
     await waitForMount();
-    expect(screen.getByText('Completed formula run')).toBeTruthy();
-    const toggleHistory = screen.getByRole('button', {
+    expect(await screen.findByText('Completed formula run')).toBeTruthy();
+    const toggleHistory = (await screen.findByRole('button', {
       name: /hide historical/i,
-    }) as HTMLButtonElement;
+    })) as HTMLButtonElement;
     expect(toggleHistory.getAttribute('aria-expanded')).toBe('true');
     expect(toggleHistory.getAttribute('aria-controls')).toBeTruthy();
   });
@@ -408,20 +419,20 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     mount();
     await waitForMount();
     // Rig section headers (the `rig:` prefix is stripped for display).
-    expect(screen.getByText('gascity')).toBeTruthy();
-    expect(screen.getByText('gascity-packs')).toBeTruthy();
+    expect(await screen.findByText('gascity')).toBeTruthy();
+    expect(await screen.findByText('gascity-packs')).toBeTruthy();
     // Each run's root bead id is rendered so same-formula runs are distinguishable.
-    expect(screen.getByText('gc-aaa')).toBeTruthy();
-    expect(screen.getByText('gc-bbb')).toBeTruthy();
+    expect(await screen.findByText('gc-aaa')).toBeTruthy();
+    expect(await screen.findByText('gc-bbb')).toBeTruthy();
   });
 
   it('yh5i: toggle button is disabled when totalHistorical is 0', async () => {
     // Default run source has totalHistorical = 0.
     mount();
     await waitForMount();
-    const toggle = screen.getByRole('button', {
+    const toggle = (await screen.findByRole('button', {
       name: /no completed formula runs in the current window/i,
-    }) as HTMLButtonElement;
+    })) as HTMLButtonElement;
     expect(toggle.disabled).toBe(true);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     // aria-controls must NOT reference a non-existent DOM id when the
@@ -435,9 +446,11 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     // able to dismiss the historical section.
     mount('/runs?history=1');
     await waitForMount();
-    const toggle = screen.getByRole('button', { name: /hide historical/i }) as HTMLButtonElement;
+    const toggle = (await screen.findByRole('button', {
+      name: /hide historical/i,
+    })) as HTMLButtonElement;
     expect(toggle.disabled).toBe(false);
-    expect(screen.getByText(/No completed runs in the current window/i)).toBeTruthy();
+    expect(await screen.findByText(/No completed runs in the current window/i)).toBeTruthy();
   });
 
   it('manual Refresh button refetches the direct supervisor run summary', async () => {
@@ -539,8 +552,8 @@ describe('RunsPage — partial lane set (gascity-dashboard-n6f1)', () => {
     mount();
     await waitForMount();
 
-    const marker = screen.getByText(/runs partial/i);
-    const live = screen.getByText(/^live$/i);
+    const marker = await screen.findByText(/runs partial/i);
+    const live = await screen.findByText(/^live$/i);
     expect(marker).toBeTruthy();
     expect(marker.getAttribute('role')).toBe('status');
     expect(live.compareDocumentPosition(marker) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();


### PR DESCRIPTION
## What

De-flakes `frontend/src/routes/Runs.test.tsx` (the `RunsPage — SSE wiring (gascity-dashboard-bqn)` and `partial lane set (n6f1)` describe blocks), which fails non-deterministically in the full `Frontend tests` (`vitest run`, 82 files) step but **passes in isolation**.

## Root cause

`waitForMount()` only waits for the Refresh button to mount and become enabled — i.e. it proves the *preview* fetch resolved. It does **not** wait for the run-summary data (lanes, rig section headers, root-bead ids, run counts, the error banner) to paint, nor for the full-refresh `useEffect` to dispatch. Those land on later React commits. Several tests then made **synchronous** `screen.getByText()` / `getByRole()` assertions (and one synchronous `toHaveBeenCalledTimes(1)` mock-count check) immediately after `await waitForMount()`, so under full-suite parallel scheduling the query ran before the paint and threw `Unable to find element` (or the call count was still 0).

Observed failing sub-tests: `7hek: groups active lanes by rig` (`getByText('gascity')`), `does not flatten an unavailable run count into zero` (`getByText(/Run counts unavailable/)`), and `paints from the fast preview source` (`mockLoadRunSummary` call count).

## Fix

- Convert every run-summary-data-dependent synchronous query to its async `findByText` / `findByRole` equivalent (retry-until-present).
- Wrap the racing `mockLoadRunSummary` call-count assertion in `waitFor(...)`, mirroring the idiom already used by the manual-Refresh test in the same file.
- Centralize the *why* in `waitForMount()`'s docstring instead of repeating it per call site.

**No assertion is weakened and coverage intent is identical** — each assertion still pins the same element/call, only with retry. Assertion count is unchanged (38 → 38). Remaining synchronous queries are all `queryBy*…toBeNull()` absence checks (cannot false-fail from a not-yet-painted element) or are guarded by a preceding `await`.

## Verification

- `vitest run src/routes/Runs.test.tsx` — passes in isolation.
- **24 consecutive full-suite `vitest run` (82 files / 679 tests) runs — 0 failures** (the flake reproduced ~1/8 before the fix).
- `npm run typecheck` (source + `typecheck:test`) — clean.

This flake was the remaining red on PR #64 CI. The change is byte-identical to `main` and was not introduced by #64; landing it on `main` lets #64 (and any other branch) pick it up on rebase.

Fixes gascity-dashboard-fc3k.