### PR TITLE
test(maintainer): de-time-bomb the needs-you stall fixture (gascity-dashboard-qy6x)

### DIFF
--- a/frontend/src/views/modules/maintainer/Maintainer.needs-you.test.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.needs-you.test.tsx
@@ -180,7 +180,12 @@ describe('MaintainerPage — needs-you mode (dw8)', () => {
       number: 2,
       status: 'open',
       title: 'drop open-only',
-      updated_at: '2026-05-29T00:00:00.000Z', // fresh, not stalled
+      // Fresh relative to the REAL clock: MaintainerPage's needs-you
+      // predicate reads wall-clock time from NowProvider, so a pinned
+      // ISO date here turns "stalled unvetted" (and matches the
+      // composite) once it ages past NEEDS_YOU_STALL_THRESHOLD_MS —
+      // which is exactly how this fixture broke CI on 2026-06-05.
+      updated_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h old, far below the 7-day stall threshold
     });
     mockTriage.mockResolvedValue(envelope([keep, drop]));
     mount(['/maintainer?view=needs-you']);


### PR DESCRIPTION
## Summary
Main CI has been red since 2026-06-05T00:00Z (first failing push run 26992030717; every push since fails the same way). Not a code regression — a **time-bomb test fixture**.

`Maintainer.needs-you.test.tsx > shows only items that match the composite predicate` pinned the 'drop open-only' fixture to `updated_at: '2026-05-29T00:00:00.000Z'` with the comment *fresh, not stalled*. MaintainerPage's needs-you predicate reads real wall-clock time from `NowProvider` (no injectable clock), and `isStalledUnvetted` fires once `now - updated_at > NEEDS_YOU_STALL_THRESHOLD_MS` (7 days). At 2026-06-05T00:00Z the fixture crossed the threshold, became stalled-unvetted, matched the needs-you composite, rendered, and broke the `toBeNull` assertion. That's why #61 was green on 06-04 and everything after is red with zero maintainer code changes in between.

Fix: derive the fixture's `updated_at` from `Date.now() - 1h` so 'fresh' is invariant to the date the suite runs, with a comment explaining the trap. The sibling needs-you fixtures match via time-independent clauses (`changes_requested`), so only this one needed it.

Tracked as bead gascity-dashboard-qy6x.

## Test plan
- [x] `npx vitest run src/views/modules/maintainer/Maintainer.needs-you.test.tsx` — 8/8 pass
- [x] full `npm --workspace frontend test` — 86 files / 732 tests pass
- [x] root `npm run typecheck` (src + backend/frontend test typechecks)
- [x] `npm run lint`, prettier check