### PR TITLE
fix(beads): coalesce board SSE refresh into a wide trailing window

### DIFF
--- a/frontend/src/hooks/useGcEvents.test.tsx
+++ b/frontend/src/hooks/useGcEvents.test.tsx
@@ -281,9 +281,7 @@ describe('useGcEventRefresh', () => {
 
     it('honors a caller-supplied coalesceMs to widen the trailing window', () => {
       const onMatch = vi.fn();
-      renderHook(() =>
-        useGcEventRefresh([GC_EVENT_PREFIX.bead], onMatch, { coalesceMs: 10_000 }),
-      );
+      renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], onMatch, { coalesceMs: 10_000 }));
       act(() => eventSources[0]?.open());
 
       const emit = () =>

--- a/frontend/src/hooks/useGcEvents.test.tsx
+++ b/frontend/src/hooks/useGcEvents.test.tsx
@@ -278,6 +278,36 @@ describe('useGcEventRefresh', () => {
       emit();
       expect(onMatch).toHaveBeenCalledTimes(2);
     });
+
+    it('honors a caller-supplied coalesceMs to widen the trailing window', () => {
+      const onMatch = vi.fn();
+      renderHook(() =>
+        useGcEventRefresh([GC_EVENT_PREFIX.bead], onMatch, { coalesceMs: 10_000 }),
+      );
+      act(() => eventSources[0]?.open());
+
+      const emit = () =>
+        act(() => eventSources[0]?.emitNamed('event', JSON.stringify({ type: 'bead.updated' })));
+
+      // Leading edge still fires the first match immediately.
+      emit();
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // A burst that would have flushed under the default 2.5s window is held
+      // back: nothing extra fires until the wider 10s window closes.
+      emit();
+      emit();
+      act(() => {
+        vi.advanceTimersByTime(9_999);
+      });
+      expect(onMatch).toHaveBeenCalledTimes(1);
+
+      // At the widened window edge the single trailing fire lands.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onMatch).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/frontend/src/hooks/useGcEvents.ts
+++ b/frontend/src/hooks/useGcEvents.ts
@@ -23,9 +23,18 @@ export type GcEventEnvelope = {
 
 export interface GcEventRefreshOptions {
   matches?: (event: GcEventEnvelope) => boolean;
+  /**
+   * Trailing-throttle window for event-driven refreshes. A burst of matching
+   * events yields at most one onMatch per window (leading + trailing). Defaults
+   * to {@link DEFAULT_COALESCE_MS}; widen it for consumers whose refresh is an
+   * expensive full refetch (e.g. the beads board's ~1.3MB list) so normal city
+   * churn and supervisor latency spikes don't trigger a refetch per event.
+   */
+  coalesceMs?: number;
 }
 
 const CONNECTING_GRACE_MS = 2_000;
+const DEFAULT_COALESCE_MS = 2_500;
 
 /**
  * Subscribe to gc events. When an event whose type starts with any of
@@ -42,6 +51,8 @@ export function useGcEventRefresh(
   onMatchRef.current = onMatch;
   const matchesRef = useRef(options.matches);
   matchesRef.current = options.matches;
+  const coalesceMsRef = useRef(options.coalesceMs);
+  coalesceMsRef.current = options.coalesceMs;
   // Stable hash of prefixes for the effect dep array.
   const prefixKey = prefixes.join(',');
 
@@ -51,8 +62,9 @@ export function useGcEventRefresh(
   // Kanban) refetch /beads ungated (~1/sec), which both hammered the
   // supervisor's city-store read AND amplified its partial-read flicker
   // (td- beads vanish/reappear). Throttle to at most one onMatch per
-  // COALESCE_MS (leading + trailing): a burst yields one refetch now and
-  // one after it settles, never a per-event storm.
+  // coalesce window (leading + trailing): a burst yields one refetch now
+  // and one after it settles, never a per-event storm. Consumers with an
+  // expensive refresh widen the window via options.coalesceMs.
   const lastFireRef = useRef(0);
   const coalesceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -69,7 +81,6 @@ export function useGcEventRefresh(
     let retryDelayMs = 1_000;
     let malformedEventReported = false;
 
-    const COALESCE_MS = 2_500;
     const clearConnectGraceTimer = () => {
       if (connectGraceTimer === null) return;
       clearTimeout(connectGraceTimer);
@@ -87,10 +98,11 @@ export function useGcEventRefresh(
     // Leading + trailing throttle: fire immediately when outside the
     // window, otherwise schedule a single trailing fire at the window
     // edge. Coalesces a burst of matching events into <=1 onMatch per
-    // COALESCE_MS.
+    // coalesce window.
     const scheduleMatch = () => {
+      const coalesceMs = coalesceMsRef.current ?? DEFAULT_COALESCE_MS;
       const elapsed = Date.now() - lastFireRef.current;
-      if (elapsed >= COALESCE_MS) {
+      if (elapsed >= coalesceMs) {
         if (coalesceTimerRef.current) {
           clearTimeout(coalesceTimerRef.current);
           coalesceTimerRef.current = null;
@@ -100,7 +112,7 @@ export function useGcEventRefresh(
         coalesceTimerRef.current = setTimeout(() => {
           coalesceTimerRef.current = null;
           if (!cancelled) fireMatch();
-        }, COALESCE_MS - elapsed);
+        }, coalesceMs - elapsed);
       }
     };
 

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -31,6 +31,14 @@ import { listSupervisorSessions } from '../supervisor/sessionReads';
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 const RIG_FILTER_ALL = '';
 const CLOSED_CHIP_ID = 'closed';
+// The board's refresh is a full list refetch (~1.3MB on a busy city). A busy
+// city emits bead.* events roughly every few seconds, so the default ~2.5s
+// coalesce window still drives a near-continuous full refetch — wasteful under
+// normal churn and, when the supervisor's task query spikes to 14-21s, enough
+// to keep superseding each in-flight slow fetch before it lands. Coalesce the
+// board's SSE-driven refresh into a much wider trailing window so churn yields
+// at most one refetch per window and a latency spike can no longer empty it.
+const BOARD_REFRESH_COALESCE_MS = 10_000;
 
 type BeadAction = 'claim' | 'close' | 'nudge';
 
@@ -169,7 +177,9 @@ export function BeadsPage() {
     [toggleChip],
   );
 
-  useGcEventRefresh([GC_EVENT_PREFIX.bead], () => void refresh());
+  useGcEventRefresh([GC_EVENT_PREFIX.bead], () => void refresh(), {
+    coalesceMs: BOARD_REFRESH_COALESCE_MS,
+  });
 
   useEffect(() => {
     if (selectedBeadParam !== null) setSelectedId(selectedBeadParam);


### PR DESCRIPTION
## What

The Beads board refetches the **full** bead list (~1.3MB on a busy city) on every `bead.*` SSE event, throttled only by the shared 2.5s coalesce window in `useGcEventRefresh`. On a busy city (an event roughly every few seconds) that drives a near-continuous full refetch — wasteful under normal churn, and when the supervisor's `task` query spikes to 14–21s it keeps superseding each in-flight slow fetch before it lands (the latency-spike empty-board failure mode from gascity-dashboard-9f4l).

## Change

- `useGcEvents.ts`: add an optional `coalesceMs` to `GcEventRefreshOptions` (default `2_500`, read per-fire from a ref so the EventSource effect never re-binds). All other consumers (Runs / Agents / FormulaRunDetail / AgentDetail) keep the 2.5s default.
- `Beads.tsx`: the board opts into a **10s** trailing window (`BOARD_REFRESH_COALESCE_MS`). Under normal churn the board now refetches at most once per 10s; a multi-second latency spike can no longer empty it (combined with the existing `useCachedData` first-paint rescue).

The "4-way typed fan-out" in the bead description is **already gone** — `listSupervisorBeads` issues a single query with client-side type filtering (AC option (c) already in tree), so coalescing (AC option (a)) is the remaining durable fix.

## Drive-by: unblock CI

`Maintainer.needs-you.test.tsx` was failing on `main` (wallclock-dependent): the needs-you predicate reads the live `useNow()` clock against a 7-day stall threshold, so the `2026-05-29` "fresh" fixture crossed the threshold as real time advanced and red-lit CI for every PR. Pinned `Date.now` to a fixed instant (shared with the attention `nowMs`) — determinism fix, assertion unchanged.

## Acceptance criteria

- [x] Board no longer triggers a full refetch on every `bead.*` SSE event (coalesced to a 10s trailing window).
- [x] Default behavior preserved for all other `useGcEventRefresh` consumers.
- [x] A multi-second supervisor latency spike no longer empties the board.

## Test plan

- [x] `npm --workspace frontend test` — 733 pass (new coalesceMs test + Maintainer fix).
- [x] `npm run typecheck` (src + test) — clean.
- [x] `eslint --max-warnings=0` on touched files — clean.

bead: gascity-dashboard-9f4l