### PR TITLE
test(maintainer): de-flake needs-you page test against the live stall clock

### DIFF
--- a/frontend/src/views/modules/maintainer/Maintainer.needs-you.test.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.needs-you.test.tsx
@@ -180,7 +180,11 @@ describe('MaintainerPage — needs-you mode (dw8)', () => {
       number: 2,
       status: 'open',
       title: 'drop open-only',
-      updated_at: '2026-05-29T00:00:00.000Z', // fresh, not stalled
+      // Fresh (well under the 7-day stall threshold), expressed relative to the
+      // page's live clock so the case stays deterministic as the calendar
+      // advances. A fixed past date eventually crosses the threshold and the
+      // item is wrongly surfaced as stalled.
+      updated_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     });
     mockTriage.mockResolvedValue(envelope([keep, drop]));
     mount(['/maintainer?view=needs-you']);


### PR DESCRIPTION
## Problem

`frontend/src/views/modules/maintainer/Maintainer.needs-you.test.tsx` → *'shows only items that match the composite predicate'* hardcoded the drop item's `updated_at` to `2026-05-29` ("fresh, not stalled"). The page-level test mounts `MaintainerPage` under a **real-clock** `NowProvider` (no fixed-now prop), and `isStalledUnvetted()` surfaces items older than `NEEDS_YOU_STALL_THRESHOLD_DAYS = 7`.

As of **2026-06-05** that item is **7.14 days** old, so it is classified stalled/needs-you instead of dropped, and the assertion `expect(queryByText(/drop open-only/)).toBeNull()` fails. This is a **repo-wide CI blocker** — it now fails on `main` for every PR, independent of any feature work. (Surfaced while rebasing PR #62.)

## Fix

Express `updated_at` relative to `Date.now()` (1 day ago) so the case stays deterministically *fresh* as the calendar advances — matching how the pure predicate tests in `needsYou.test.ts` build their fixtures relative to a known `now`.

## Test plan

- [x] `npm --workspace frontend test -- Maintainer.needs-you.test.tsx` → 8/8 pass
- [ ] CI: full frontend suite green

Tracked by bead `gascity-dashboard-wqyi`.