### PR TITLE
fix(supervisor-client): accept version-less formula responses (3eo8)

### DIFF
--- a/backend/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/backend/src/generated/gc-supervisor-client/zod.gen.ts
@@ -569,7 +569,7 @@ export const zFormulaDetailResponse = z.object({
     preview: zFormulaPreviewResponse,
     steps: z.array(zFormulaStepResponse).nullable(),
     var_defs: z.array(zFormulaVarDefResponse).nullable(),
-    version: z.string()
+    version: z.string().optional()
 });
 
 export const zFormulaSummaryResponse = z.object({
@@ -578,7 +578,7 @@ export const zFormulaSummaryResponse = z.object({
     recent_runs: z.array(zFormulaRecentRunResponse).nullable(),
     run_count: z.coerce.bigint().min(BigInt('-9223372036854775808'), { error: 'Invalid value: Expected int64 to be >= -9223372036854775808' }).max(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' }),
     var_defs: z.array(zFormulaVarDefResponse).nullable(),
-    version: z.string()
+    version: z.string().optional()
 });
 
 export const zFormulaListBody = z.object({

--- a/backend/test/gc-supervisor-generation-config.test.ts
+++ b/backend/test/gc-supervisor-generation-config.test.ts
@@ -153,7 +153,7 @@ test('gc supervisor generation enables generated Zod response validators', async
   assert.doesNotMatch(config, /validator:\s*false/);
 });
 
-test('gc supervisor generated client post-processing is limited to RFC3339 offset datetimes', async () => {
+test('gc supervisor generated client post-processing is limited to known schema relaxations', async () => {
   const generator = await readFile(generatorUrl, 'utf8');
 
   assert.doesNotMatch(generator, /ts-nocheck/);
@@ -161,6 +161,15 @@ test('gc supervisor generated client post-processing is limited to RFC3339 offse
   assert.doesNotMatch(generator, /source\.replace/);
   assert.match(generator, /allowRfc3339OffsetDateTimes/);
   assert.match(generator, /z\.iso\.datetime\(\{ offset: true \}\)/);
+  // The only other sanctioned post-process relaxes `version` to optional on the
+  // two formula response schemas (the supervisor omits it for title-inferred
+  // formulas — gascity-dashboard-3eo8). It must stay scoped to those schemas so
+  // every other required `version` keeps validating.
+  assert.match(generator, /allowVersionlessFormulaResponses/);
+  assert.match(
+    generator,
+    /FORMULA_VERSION_SCHEMAS = \['zFormulaDetailResponse', 'zFormulaSummaryResponse'\]/,
+  );
   for (const rootUrl of [generatedClientUrl, frontendGeneratedClientUrl]) {
     for (const { path, source } of await readTsFiles(rootUrl)) {
       assert.doesNotMatch(
@@ -169,6 +178,22 @@ test('gc supervisor generated client post-processing is limited to RFC3339 offse
         `${path} should be generator output without ts-nocheck`,
       );
     }
+  }
+});
+
+test('gc supervisor formula response schemas accept version-less payloads', async () => {
+  const generatedFiles = await readTsFiles(generatedClientUrl);
+  const zodFile = generatedFiles.find(({ path }) => path === 'zod.gen.ts');
+  assert.ok(zodFile, 'zod.gen.ts should be generated from the supervisor OpenAPI schema');
+
+  // The two formula schemas must declare `version` optional; no other schema
+  // should have been relaxed by the post-process (a stray match would loosen an
+  // unrelated required field).
+  for (const schemaName of ['zFormulaDetailResponse', 'zFormulaSummaryResponse']) {
+    const block = new RegExp(
+      `export const ${schemaName} = z\\.object\\(\\{[\\s\\S]*?version: z\\.string\\(\\)\\.optional\\(\\)[\\s\\S]*?\\}\\);`,
+    );
+    assert.match(zodFile.source, block, `${schemaName} should mark version optional`);
   }
 });
 

--- a/frontend/src/generated/gc-supervisor-client/zod.gen.ts
+++ b/frontend/src/generated/gc-supervisor-client/zod.gen.ts
@@ -569,7 +569,7 @@ export const zFormulaDetailResponse = z.object({
     preview: zFormulaPreviewResponse,
     steps: z.array(zFormulaStepResponse).nullable(),
     var_defs: z.array(zFormulaVarDefResponse).nullable(),
-    version: z.string()
+    version: z.string().optional()
 });
 
 export const zFormulaSummaryResponse = z.object({
@@ -578,7 +578,7 @@ export const zFormulaSummaryResponse = z.object({
     recent_runs: z.array(zFormulaRecentRunResponse).nullable(),
     run_count: z.coerce.bigint().min(BigInt('-9223372036854775808'), { error: 'Invalid value: Expected int64 to be >= -9223372036854775808' }).max(BigInt('9223372036854775807'), { error: 'Invalid value: Expected int64 to be <= 9223372036854775807' }),
     var_defs: z.array(zFormulaVarDefResponse).nullable(),
-    version: z.string()
+    version: z.string().optional()
 });
 
 export const zFormulaListBody = z.object({

--- a/frontend/src/supervisor/formulaDetailSchema.test.ts
+++ b/frontend/src/supervisor/formulaDetailSchema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  zGetV0CityByCityNameFormulasByNameResponse,
+  zGetV0CityByCityNameFormulaByNameResponse,
+  zPostV0CityByCityNameFormulasByNamePreviewResponse,
+} from '../generated/gc-supervisor-client/zod.gen';
+
+// gascity-dashboard-3eo8: the supervisor omits `version` from formula
+// responses whose definition is inferred from a bead title (e.g.
+// mol-focus-review). The generated zod validator the SDK runs on the formula
+// detail response previously required `version`, so it rejected those valid 200
+// payloads as `invalid_payload` and degraded the run-detail Formula Detail
+// panel. The generated client is post-processed to make `version` optional on
+// the formula response schemas; this guards that relaxation.
+const versionlessFormulaDetail = {
+  name: 'mol-focus-review',
+  description: 'inferred from bead title',
+  var_defs: null,
+  steps: null,
+  deps: null,
+  preview: { nodes: null, edges: null },
+};
+
+describe('generated formula detail response schema', () => {
+  it('accepts a version-less formula payload', () => {
+    for (const schema of [
+      zGetV0CityByCityNameFormulasByNameResponse,
+      zGetV0CityByCityNameFormulaByNameResponse,
+      zPostV0CityByCityNameFormulasByNamePreviewResponse,
+    ]) {
+      const parsed = schema.safeParse(versionlessFormulaDetail);
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it('still accepts a versioned formula payload', () => {
+    const parsed = zGetV0CityByCityNameFormulasByNameResponse.safeParse({
+      ...versionlessFormulaDetail,
+      version: '1',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('still rejects a payload missing a genuinely required field', () => {
+    const { name: _name, ...withoutName } = versionlessFormulaDetail;
+    const parsed = zGetV0CityByCityNameFormulasByNameResponse.safeParse(withoutName);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/scripts/generate-gc-supervisor-client.mjs
+++ b/scripts/generate-gc-supervisor-client.mjs
@@ -34,6 +34,7 @@ async function generateHeyApiClient(toPath) {
     throw new Error(`@hey-api/openapi-ts failed with exit code ${result.status ?? 'unknown'}`);
   }
   await allowRfc3339OffsetDateTimes(toPath);
+  await allowVersionlessFormulaResponses(toPath);
 }
 
 async function allowRfc3339OffsetDateTimes(toPath) {
@@ -44,6 +45,36 @@ async function allowRfc3339OffsetDateTimes(toPath) {
     throw new Error(
       `${path.relative(process.cwd(), zodPath)} did not contain generated date-time validators`,
     );
+  }
+  await writeFile(zodPath, patched);
+}
+
+// The supervisor omits `version` from formula responses whose definition is
+// inferred from a bead title rather than a versioned recipe (e.g.
+// mol-focus-review). The OpenAPI snapshot still marks FormulaDetailResponse and
+// FormulaSummaryResponse `version` as required, so the generated zod validator
+// rejected those valid 200 payloads as `invalid_payload`, degrading the
+// run-detail Formula Detail panel (gascity-dashboard-3eo8). Relax `version` to
+// optional on the two formula response schemas only — every other schema keeps
+// its required `version`. The durable fix is upstream marking these optional in
+// the supervisor OpenAPI; remove this patch once the regenerated snapshot does.
+const FORMULA_VERSION_SCHEMAS = ['zFormulaDetailResponse', 'zFormulaSummaryResponse'];
+
+async function allowVersionlessFormulaResponses(toPath) {
+  const zodPath = path.join(toPath, 'zod.gen.ts');
+  const content = await readFile(zodPath, 'utf8');
+  let patched = content;
+  for (const schemaName of FORMULA_VERSION_SCHEMAS) {
+    const requiredVersion = new RegExp(
+      `(export const ${schemaName} = z\\.object\\(\\{[\\s\\S]*?\\bversion: z\\.string\\(\\))(?!\\.optional\\(\\))`,
+    );
+    const next = patched.replace(requiredVersion, '$1.optional()');
+    if (next === patched) {
+      throw new Error(
+        `${path.relative(process.cwd(), zodPath)} did not contain a required ${schemaName} version validator`,
+      );
+    }
+    patched = next;
   }
   await writeFile(zodPath, patched);
 }


### PR DESCRIPTION
## Problem

The run-detail **Formula Detail** panel renders `invalid_payload` (completeness reason `formula_detail_fetch_failed`) for formulas whose supervisor response has no `version` field — e.g. `mol-focus-review`, which is *inferred from a bead title* rather than a versioned recipe.

**Root cause:** the generated SDK validates the formula detail response with zod (`backend/openapi-ts.config.ts` → `validator.response: 'zod'`). The generated `zFormulaDetailResponse` / `zFormulaSummaryResponse` declare `version: z.string()` **required**, but the live supervisor payload for these formulas is `{name, description, var_defs, steps, deps, preview}` with **no `version` key**. So `getV0CityByCityNameFormulasByName`'s `responseValidator` throws on a valid 200 → classified `invalid_payload`. Verified: direct supervisor GET (city and rig scope) returns 200 without `version`.

Affects every formula-detail fetch whose response lacks `version` (and the formulas-feed path via `zFormulaSummaryResponse`). The rest of run detail renders fine.

## Fix

Took the dashboard-workaround route (option 2 in the bead), mirroring the existing RFC3339 offset-datetime post-process precedent in `scripts/generate-gc-supervisor-client.mjs`:

- **Scoped post-process** `allowVersionlessFormulaResponses` relaxes `version` to `.optional()` on `zFormulaDetailResponse` and `zFormulaSummaryResponse` **only** — every other schema keeps its required `version`. The patch throws if the schema shape changes or upstream makes `version` optional, self-deprecating once the regenerated snapshot makes it redundant.
- **Regenerated** backend + frontend zod clients (drift check green; diff is exactly 2 lines per client).
- **Meta-test** widened (`...post-processing is limited to known schema relaxations`) with a scope guard asserting the patch targets only the two formula schemas.
- **Regression test** (`frontend/src/supervisor/formulaDetailSchema.test.ts`) parses a version-less `mol-focus-review`-shaped payload through the actual SDK response schemas and asserts success, that versioned payloads still pass, and that a genuinely-required field (`name`) still fails.

The durable fix remains upstream: mark `FormulaDetailResponse`/`FormulaSummaryResponse` `version` optional in the supervisor OpenAPI, then regenerate and drop this patch.

## Test plan

- [x] `npm run openapi:gc-supervisor:check` (generated-client drift) — green
- [x] `npm run typecheck` (src + test) — green
- [x] `npm --workspace backend test` — 510 pass / 0 fail
- [x] `npm --workspace frontend test` (regression + runDetail) — green
- [x] `npm run format:check` + `npm run lint --max-warnings=0` — green

Resolves gascity-dashboard-3eo8.