### PR TITLE
fix(runs): never feed an invalid session id to the Session tab route (0kkn)

### DIFF
--- a/shared/src/runs/session-link.test.ts
+++ b/shared/src/runs/session-link.test.ts
@@ -32,10 +32,24 @@ describe('runSessionLinkFor — session id normalization', () => {
     assert.equal(link?.sessionId, 'gc-333573');
   });
 
-  test('falls back to the raw value when it carries no extractable supervisor id', () => {
+  test('degrades to no link when an unresolvable value carries no supervisor id', () => {
+    // A completed run whose recorded handle carries no extractable supervisor
+    // id and is absent from the live session index must NOT leak that handle
+    // into link.sessionId — the session route would reject it as "invalid
+    // session id". The link degrades so the Session tab shows a clean
+    // "session not available" empty state instead.
     const bead = { metadata: { session_id: 'mystery-handle' } } as never;
-    const link = runSessionLinkFor(bead, 'done');
-    assert.equal(link?.sessionId, 'mystery-handle');
+    assert.equal(runSessionLinkFor(bead, 'done'), undefined);
+  });
+
+  test('degrades a runtime-derived bare assignee that cannot yield a supervisor id', () => {
+    // The runtime-derived path: a completed pool/rig-store run records only an
+    // assignee (no session_id metadata), and that assignee is a bare worker
+    // name with no embedded supervisor id. With no live index match there is
+    // no usable id, so the link degrades rather than feeding "polecat" to the
+    // route as an "invalid session id".
+    const bead = { assignee: 'polecat' } as never;
+    assert.equal(runSessionLinkFor(bead, 'done'), undefined);
   });
 
   test('returns undefined for pending/ready nodes (no session yet)', () => {

--- a/shared/src/runs/session-link.ts
+++ b/shared/src/runs/session-link.ts
@@ -64,7 +64,16 @@ export function runSessionLinkFor(
     sessionName: sessionName ?? sessionId ?? '',
     assignee: assignee ?? sessionName ?? sessionId ?? '',
   };
-  return resolveRunSessionLink(rawLink, context.sessionIndex);
+  const link = resolveRunSessionLink(rawLink, context.sessionIndex);
+  // Final gate: link.sessionId is fed straight to the supervisor session
+  // routes, which reject anything outside SESSION_ID_RE as "invalid session
+  // id". When the index could not resolve the run to a real session (a
+  // completed pool/rig-store run has dropped out of the live index) and the
+  // recorded handle carries no extractable supervisor id, drop the link so the
+  // Session tab degrades to a clean "session not available" state instead of
+  // leaking an unvalidated handle into the route.
+  if (!SESSION_ID_RE.test(link.sessionId)) return undefined;
+  return link;
 }
 
 function supervisorSessionIdFrom(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Problem

Opening a **completed** pool/rig-store run's **Session tab** could show `invalid session id` (e.g. `gc-r97inq` / `mol-focus-review`, polecat). A polecat run records a pool-qualified session **name** like `polecat-gc-333573` (real supervisor id `gc-333573`). Once the run completes, its session drops out of the live session index, so it can't be resolved by name — and `runSessionLinkFor` fell back to the **raw** recorded handle as `link.sessionId`. The Session tab passes that straight to the supervisor session routes, which reject anything outside `SESSION_ID_RE` as `invalid session id`.

PR #52 normalized pool-qualified ids that *contain* an extractable supervisor id. The gap that remained: handles with **no** extractable id (and no live-index match) still leaked into the id slot.

## Fix

Add a final gate in `runSessionLinkFor` — the single producer of the Session tab link for **both** the static-bead metadata path and the runtime-derived `assignee` path. After resolution, if `link.sessionId` does not satisfy `SESSION_ID_RE`, drop the link (`undefined`). The execution-instance then renders the existing clean `session_unresolved` empty state ("Session unresolved for this node.") instead of erroring.

- Valid id available (via the live index or pool-name normalization) → link kept, transcript stays reachable.
- No usable id → clean "session not available" state, never `invalid session id`.

## Acceptance criteria

> Completed pool/rig-store runs' Session tab resolves the transcript or shows a clean 'session not available' — never 'invalid session id'; covers the runtime-derived path, not just static-bead metadata.

Met: the gate sits at the single link producer, so it covers the runtime-derived (`assignee`) path as well as static metadata.

## Tests

`shared/src/runs/session-link.test.ts`:
- Replaced the obsolete "falls back to the raw value" test (which documented the bug) with a degrade assertion.
- Added a runtime-derived degrade case (bare `polecat` assignee → no link).
- Existing normalization cases (pool-qualified metadata / assignee → `gc-333573`) still pass.

## Verification (CI parity, all green)

- `npm run typecheck` (src + `typecheck:test`)
- `npm run format:check`
- `npm --workspace shared test` (62)
- `npm --workspace frontend test` (733)
- `npm --workspace backend test` (509)
- `npm --workspace frontend run build`
- `npm run openapi:gc-supervisor:check`

Closes gascity-dashboard-0kkn.