### PR TITLE
fix(beads): rig dropdown lists real rig names, not filesystem paths (kquq)

### DIFF
--- a/frontend/src/lib/rigNames.test.ts
+++ b/frontend/src/lib/rigNames.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRigName, rigNameOptions } from './rigNames';
+
+const RIGS = [
+  { name: 'gascity', path: '/home/ds/gascity' },
+  { name: 'ds-research', path: '/home/ds/ds-research' },
+  { name: 'gascity-packs', path: '/home/ds/gascity-packs' },
+  { name: 'gascity-dashboard', path: '/home/ds/gascity-dashboard' },
+] as const;
+
+describe('resolveRigName', () => {
+  it('returns the canonical name when the value already is a rig name', () => {
+    expect(resolveRigName('ds-research', RIGS)).toBe('ds-research');
+  });
+
+  it('maps a filesystem path to its canonical rig name', () => {
+    expect(resolveRigName('/home/ds/gascity', RIGS)).toBe('gascity');
+  });
+
+  it('drops a path that is not a registered rig (e.g. /home/ds/gascity-main)', () => {
+    expect(resolveRigName('/home/ds/gascity-main', RIGS)).toBeUndefined();
+  });
+
+  it('drops an unknown bare name', () => {
+    expect(resolveRigName('gascity-main', RIGS)).toBeUndefined();
+  });
+
+  it('treats empty / whitespace / nullish as unresolved', () => {
+    expect(resolveRigName('', RIGS)).toBeUndefined();
+    expect(resolveRigName('   ', RIGS)).toBeUndefined();
+    expect(resolveRigName(undefined, RIGS)).toBeUndefined();
+    expect(resolveRigName(null, RIGS)).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(resolveRigName('  ds-research  ', RIGS)).toBe('ds-research');
+  });
+
+  it('prefers a name match over a path match when both could apply', () => {
+    const rigs = [
+      { name: 'overlap', path: '/home/ds/other' },
+      { name: 'other', path: '/home/ds/overlap' },
+    ];
+    expect(resolveRigName('overlap', rigs)).toBe('overlap');
+  });
+});
+
+describe('rigNameOptions', () => {
+  it('lists real rig names only, sorted, with no filesystem paths', () => {
+    expect(rigNameOptions(RIGS)).toEqual([
+      'ds-research',
+      'gascity',
+      'gascity-dashboard',
+      'gascity-packs',
+    ]);
+  });
+
+  it('de-duplicates and ignores blank names', () => {
+    const rigs = [
+      { name: 'gascity', path: '/a' },
+      { name: 'gascity', path: '/b' },
+      { name: '   ', path: '/c' },
+    ];
+    expect(rigNameOptions(rigs)).toEqual(['gascity']);
+  });
+
+  it('returns an empty list when there are no rigs', () => {
+    expect(rigNameOptions([])).toEqual([]);
+  });
+});

--- a/frontend/src/lib/rigNames.ts
+++ b/frontend/src/lib/rigNames.ts
@@ -1,0 +1,40 @@
+import type { RigResponse } from 'gas-city-dashboard-shared/gc-supervisor';
+
+/**
+ * The fields of a supervisor rig needed to canonicalize a rig identity: the
+ * authoritative `name` and the filesystem `path` it lives at.
+ */
+export type RigNameSource = Pick<RigResponse, 'name' | 'path'>;
+
+/**
+ * Resolve a raw rig identity to its canonical rig name.
+ *
+ * The supervisor reports an agent's `rig` inconsistently — sometimes the rig
+ * name, sometimes the filesystem path it runs in, and sometimes a path that
+ * belongs to no registered rig at all (e.g. /home/ds/gascity-main). Matching
+ * against the authoritative rig list collapses all of these to the one real
+ * name, and returns undefined for anything the list does not recognize so
+ * non-rig paths are dropped rather than surfaced.
+ */
+export function resolveRigName(
+  raw: string | undefined | null,
+  rigs: ReadonlyArray<RigNameSource>,
+): string | undefined {
+  const value = raw?.trim();
+  if (!value) return undefined;
+  const byName = rigs.find((rig) => rig.name === value);
+  if (byName) return byName.name;
+  const byPath = rigs.find((rig) => rig.path === value);
+  return byPath?.name;
+}
+
+/**
+ * The sorted, de-duplicated list of real rig names to offer as dropdown
+ * options. Sourced from the supervisor's authoritative rig list so filesystem
+ * paths and unregistered directories never appear as choices.
+ */
+export function rigNameOptions(rigs: ReadonlyArray<RigNameSource>): string[] {
+  return Array.from(
+    new Set(rigs.map((rig) => rig.name.trim()).filter((name) => name.length > 0)),
+  ).sort((a, b) => a.localeCompare(b));
+}

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -23,6 +23,7 @@ beforeEach(() => {
   invalidate('beads:board:');
   invalidate('sessions');
   invalidate('agents');
+  invalidate('rigs');
   stubFetch();
 });
 
@@ -170,10 +171,24 @@ function stubFetch() {
             {
               name: 'mayor',
               display_name: 'Mayor',
-              rig: 'east',
+              rig: '/home/ds/east',
               available: true,
               running: true,
               state: 'active',
+              suspended: false,
+            },
+          ],
+          total: 1,
+        });
+      }
+      if (url.pathname === '/gc-supervisor/v0/city/test-city/rigs') {
+        return jsonResponse({
+          items: [
+            {
+              name: 'east',
+              path: '/home/ds/east',
+              agent_count: 1,
+              running_count: 1,
               suspended: false,
             },
           ],

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -22,6 +22,7 @@ beforeEach(() => {
   invalidate('beads:board:');
   invalidate('sessions');
   invalidate('agents');
+  invalidate('rigs');
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -91,8 +92,36 @@ beforeEach(() => {
         return jsonResponse({ items: [], total: 0 });
       }
       if (url.pathname === '/gc-supervisor/v0/city/test-city/agents') {
+        // Agents report `rig` as filesystem PATHS (not names), and one runs in
+        // a directory (gascity-main) that is not a registered rig — exactly the
+        // shapes the dropdown must canonicalize away.
         return jsonResponse({
-          items: [agent('mayor', 'east'), agent('west/mechanic', 'west')],
+          items: [
+            agent('mayor', '/home/ds/east'),
+            agent('west/mechanic', '/home/ds/west'),
+            agent('janitor', '/home/ds/gascity-main'),
+          ],
+          total: 3,
+        });
+      }
+      if (url.pathname === '/gc-supervisor/v0/city/test-city/rigs') {
+        return jsonResponse({
+          items: [
+            {
+              name: 'east',
+              path: '/home/ds/east',
+              agent_count: 1,
+              running_count: 1,
+              suspended: false,
+            },
+            {
+              name: 'west',
+              path: '/home/ds/west',
+              agent_count: 1,
+              running_count: 1,
+              suspended: false,
+            },
+          ],
           total: 2,
         });
       }
@@ -173,6 +202,25 @@ describe('BeadsPage', () => {
     expect(latestQuery?.get('rig')).toBe('east');
     expect(latestQuery?.has('all')).toBe(false);
     expect(latestQuery?.has('type')).toBe(false);
+  });
+
+  it('lists only real rig names in the rig dropdown — no filesystem paths or non-rig dirs', async () => {
+    renderPage();
+
+    await screen.findByText('Sample bead');
+    const select = (await screen.findByLabelText(/rig filter/i)) as HTMLSelectElement;
+    const optionLabels = Array.from(select.options).map((option) => option.textContent ?? '');
+
+    expect(optionLabels).toEqual(['all rigs', 'east', 'west']);
+    for (const label of optionLabels) {
+      expect(label).not.toContain('/home/ds');
+      expect(label).not.toContain('gascity-main');
+    }
+    // The option *values* (what the supervisor query receives) are rig names too.
+    const optionValues = Array.from(select.options)
+      .map((option) => option.value)
+      .filter((value) => value.length > 0);
+    expect(optionValues).toEqual(['east', 'west']);
   });
 
   it('deep-links to and selects a bead from the bead query param', async () => {

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -14,12 +14,14 @@ import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { StatusBadge } from '../components/StatusBadge';
 import { buildBeadGraph } from '../lib/beadGraph';
+import { resolveRigName, rigNameOptions } from '../lib/rigNames';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
 import { useListFilters, type FilterChip } from '../hooks/useListFilters';
 import { beadProject } from '../hooks/projectOf';
-import { listSupervisorAgents } from '../supervisor/agentReads';
+import { listSupervisorAgents, type SupervisorAgent } from '../supervisor/agentReads';
 import { listSupervisorBeads, type SupervisorBead } from '../supervisor/beadReads';
+import { listSupervisorRigs } from '../supervisor/rigReads';
 import {
   claimSupervisorBead,
   closeSupervisorBead,
@@ -46,9 +48,6 @@ interface ActionMessage {
   tone: 'ok' | 'error';
   text: string;
 }
-
-const isNonEmptyString = (value: string | undefined | null): value is string =>
-  typeof value === 'string' && value.trim().length > 0;
 
 const BEAD_CHIPS: ReadonlyArray<FilterChip<SupervisorBead>> = [
   { id: 'open', label: 'open', match: (b) => b.status === 'open' },
@@ -120,17 +119,25 @@ export function BeadsPage() {
   const sessionItems = useMemo(() => sessions.data?.items ?? [], [sessions.data]);
   const agents = useCachedData(`agents:${cityCacheKey}`, listSupervisorAgents);
   const agentItems = useMemo(() => agents.data?.items ?? [], [agents.data]);
+  const rigs = useCachedData(`rigs:${cityCacheKey}`, listSupervisorRigs);
+  const rigItems = useMemo(() => rigs.data?.items ?? [], [rigs.data]);
 
-  const dispatchRigOptions = useMemo(
-    () =>
-      Array.from(new Set(agentItems.map((agent) => agent.rig).filter(isNonEmptyString))).sort(
-        (a, b) => a.localeCompare(b),
-      ),
-    [agentItems],
+  // The dropdown lists the supervisor's authoritative rig names, never the raw
+  // `agent.rig` values — those are sometimes filesystem paths and sometimes
+  // directories that belong to no registered rig at all. Agents are matched to
+  // a rig by canonicalizing their reported `rig` against the same list, so an
+  // agent reporting a path still groups under its real rig name.
+  const dispatchRigOptions = useMemo(() => rigNameOptions(rigItems), [rigItems]);
+  const agentRigName = useCallback(
+    (agent: SupervisorAgent) => resolveRigName(agent.rig, rigItems),
+    [rigItems],
   );
   const filteredDispatchAgents = useMemo(
-    () => (newRig.length === 0 ? agentItems : agentItems.filter((agent) => agent.rig === newRig)),
-    [agentItems, newRig],
+    () =>
+      newRig.length === 0
+        ? agentItems
+        : agentItems.filter((agent) => agentRigName(agent) === newRig),
+    [agentItems, agentRigName, newRig],
   );
 
   useEffect(() => {
@@ -219,7 +226,7 @@ export function BeadsPage() {
   const openCreateBead = useCallback(() => {
     const defaultRig = dispatchRigOptions[0] ?? '';
     const defaultAgent = agentItems.find(
-      (agent) => defaultRig.length === 0 || agent.rig === defaultRig,
+      (agent) => defaultRig.length === 0 || agentRigName(agent) === defaultRig,
     );
     setNewTitle('');
     setNewBody('');
@@ -228,20 +235,22 @@ export function BeadsPage() {
     setCreateError(null);
     setActionMessage(null);
     setCreating(true);
-  }, [agentItems, dispatchRigOptions]);
+  }, [agentItems, agentRigName, dispatchRigOptions]);
 
   const handleDispatchRigChange = useCallback(
     (rig: string) => {
       setNewRig(rig);
       const currentAgentStillVisible = agentItems.some(
-        (agent) => agent.name === newAgent && (rig.length === 0 || agent.rig === rig),
+        (agent) => agent.name === newAgent && (rig.length === 0 || agentRigName(agent) === rig),
       );
       if (!currentAgentStillVisible) {
-        const defaultAgent = agentItems.find((agent) => rig.length === 0 || agent.rig === rig);
+        const defaultAgent = agentItems.find(
+          (agent) => rig.length === 0 || agentRigName(agent) === rig,
+        );
         setNewAgent(defaultAgent?.name ?? '');
       }
     },
-    [agentItems, newAgent],
+    [agentItems, agentRigName, newAgent],
   );
 
   const createAndSling = useCallback(async () => {
@@ -368,6 +377,11 @@ export function BeadsPage() {
             {agents.error && (
               <span className="normal-case text-body text-accent" role="alert">
                 {agents.error}
+              </span>
+            )}
+            {rigs.error && (
+              <span className="normal-case text-body text-accent" role="alert">
+                {rigs.error}
               </span>
             )}
             <span className="text-label uppercase tracking-wider text-fg-faint">

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -16,6 +16,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),

--- a/frontend/src/supervisor/beadWrites.test.ts
+++ b/frontend/src/supervisor/beadWrites.test.ts
@@ -20,6 +20,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),

--- a/frontend/src/supervisor/client.test.ts
+++ b/frontend/src/supervisor/client.test.ts
@@ -1237,6 +1237,7 @@ describe('supervisor client wrapper', () => {
       cityStatus: vi.fn(),
       health: vi.fn(),
       listAgents: vi.fn(),
+      listRigs: vi.fn(),
       listBeads: vi.fn(),
       listEvents: vi.fn(),
       listCities: vi.fn(),

--- a/frontend/src/supervisor/client.ts
+++ b/frontend/src/supervisor/client.ts
@@ -14,6 +14,7 @@ import {
   getV0CityByCityNameHealth,
   getV0CityByCityNameMail,
   getV0CityByCityNameMailThreadById,
+  getV0CityByCityNameRigs,
   getV0CityByCityNameSessionByIdPending,
   getV0CityByCityNameSessionByIdTranscript,
   getV0CityByCityNameSessions,
@@ -49,6 +50,7 @@ import type {
   GetV0CityByCityNameWorkflowByWorkflowIdData,
   ListBodyBead,
   ListBodyAgentResponse,
+  ListBodyRigResponse,
   ListBodyWireEvent,
   MailReplyInputBody,
   MailSendInputBody,
@@ -92,6 +94,7 @@ export interface SupervisorApi {
   cityStatus(cityName: string): Promise<GetV0CityByCityNameStatusResponse>;
   listCities(): Promise<SupervisorCitiesOutputBody>;
   listAgents(cityName: string): Promise<ListBodyAgentResponse>;
+  listRigs(cityName: string): Promise<ListBodyRigResponse>;
   listBeads(
     cityName: string,
     query?: NonNullable<GetV0CityByCityNameBeadsData['query']>,
@@ -230,6 +233,15 @@ export function createSupervisorApi(options: CreateSupervisorApiOptions = {}): S
           path: { cityName },
         }) as Promise<SupervisorResult<ListBodyAgentResponse>>,
         'gc supervisor agents response was empty',
+      );
+    },
+    listRigs(cityName) {
+      return unwrapSupervisorResult<ListBodyRigResponse>(
+        getV0CityByCityNameRigs({
+          client,
+          path: { cityName },
+        }) as Promise<SupervisorResult<ListBodyRigResponse>>,
+        'gc supervisor rigs response was empty',
       );
     },
     listBeads(cityName, query) {

--- a/frontend/src/supervisor/entityLinks.test.ts
+++ b/frontend/src/supervisor/entityLinks.test.ts
@@ -16,6 +16,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),

--- a/frontend/src/supervisor/mailReads.test.ts
+++ b/frontend/src/supervisor/mailReads.test.ts
@@ -18,6 +18,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),

--- a/frontend/src/supervisor/rigReads.ts
+++ b/frontend/src/supervisor/rigReads.ts
@@ -1,0 +1,17 @@
+import { activeCityOrThrow } from '../api/cityBase';
+import type { ListBodyRigResponse, RigResponse } from 'gas-city-dashboard-shared/gc-supervisor';
+import { supervisorApi } from './client';
+
+export type SupervisorRig = RigResponse;
+
+export interface SupervisorRigList extends Omit<ListBodyRigResponse, 'items'> {
+  items: SupervisorRig[];
+}
+
+export async function listSupervisorRigs(): Promise<SupervisorRigList> {
+  const list = await supervisorApi().listRigs(activeCityOrThrow('list supervisor rigs'));
+  return {
+    ...list,
+    items: list.items ?? [],
+  };
+}

--- a/frontend/src/supervisor/runDetail.test.ts
+++ b/frontend/src/supervisor/runDetail.test.ts
@@ -19,6 +19,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -21,6 +21,7 @@ const baseApi: SupervisorApi = {
   cityStatus: vi.fn(),
   listCities: vi.fn(),
   listAgents: vi.fn(),
+  listRigs: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),


### PR DESCRIPTION
## Problem

The Beads view rig dropdown showed filesystem **paths** instead of rig names — Stephanie saw `/HOME/DS/GAS-CITY`, `/HOME/DS/GASCITY`, `/HOME/DS/GASCITY-MAIN` (the labels are CSS-uppercased). Root cause: `Beads.tsx` built `dispatchRigOptions` from raw `agent.rig`, which the gc supervisor reports inconsistently — sometimes a rig name, sometimes the filesystem path the agent runs in, and sometimes a path (`/home/ds/gascity-main`) that is **not a registered rig at all**.

The same raw values were also used as the `rig:` bead-query filter and the create-and-sling target, where the backend expects a rig **name** — so paths silently broke filtering and dispatch too, not just the display.

## Fix

Derive options from the supervisor's **authoritative rig list** (`GET /v0/city/{city}/rigs`, where `RigResponse` carries both `name` and `path`), and canonicalize each agent's reported rig against that list: name match → name; else path match → name; else dropped. A non-registered path resolves to `undefined` and never surfaces.

- **`frontend/src/lib/rigNames.ts`** — `resolveRigName` + `rigNameOptions`, pure and fully unit-tested. A reusable rig-name primitive the related agent-grouping beads (`jj2z` maintenance-pools-shown-as-rigs, `5e5v` strip-ANSI) can adopt without re-deriving.
- **`frontend/src/supervisor/rigReads.ts`** — `listSupervisorRigs()` read wrapper mirroring `agentReads.ts`; `listRigs()` on the supervisor client over the generated `getV0CityByCityNameRigs`. No generated artifacts hand-edited.
- **`frontend/src/routes/Beads.tsx`** — fetches rigs (in parallel with the existing sessions/agents fetches), builds the dropdown from rig names, matches agents to rigs via `resolveRigName`, and surfaces `rigs.error` rather than swallowing it.

## Scope

Scoped to the filed bead (the Beads dropdown). The `Agents.tsx` rig grouping and `projectOf.ts` basename heuristics are the same root cause but separate consumers (display bucketing, not a dispatch-target control) and are tracked by `jj2z` / `5e5v` — left for those beads to consume the new `resolveRigName` primitive.

## Test plan

- [x] `frontend/src/lib/rigNames.test.ts` — unit tests for `resolveRigName`/`rigNameOptions` (name match, path→name, non-rig path dropped, empty/whitespace/null guards, sorted-unique).
- [x] `Beads.test.tsx` — fixture now feeds agents reporting **paths** (incl. a non-rig `/home/ds/gascity-main` agent); new test asserts the dropdown shows only `['all rigs','east','west']`, no `/home/ds`, no `gascity-main`, and that the filter/sling **values** are rig names.
- [x] `Beads.render.test.tsx` + 7 supervisor `*.test.ts` mocks updated for the new `listRigs` method.
- [x] `npm run typecheck` (source + `typecheck:test`) — green.
- [x] `npm --workspace frontend test` — 744 passed.
- [x] `npm run lint` (changed files), `prettier --check` (changed files), `npm run openapi:gc-supervisor:check` — green.