### PR TITLE
fix(runs): restore expand-in-place history toggle dropped by supervisor migration (l9q9)

### DIFF
--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { emptyRunSummary } from 'gas-city-dashboard-shared';
+import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
+import { RunMap } from './RunMap';
+
+afterEach(() => cleanup());
+
+function historicalLane(id: string): RunLane {
+  return {
+    id,
+    title: `Completed run ${id}`,
+    formula: { status: 'known', name: 'mol-focus-review' },
+    scope: {
+      status: 'available',
+      kind: 'city',
+      ref: 'racoon-city',
+      rootStoreRef: 'city:racoon-city',
+    },
+    external: { status: 'unavailable', error: 'external unavailable in test' },
+    phase: 'complete',
+    phaseLabel: 'complete',
+    statusCounts: { closed: 1 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-05-24T12:00:00Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable in test' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+  };
+}
+
+function runsSource(historicalLanes: RunLane[]): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-05-24T12:00:00Z',
+    staleAt: '2026-05-24T12:01:00Z',
+    error: { kind: 'none' },
+    data: {
+      ...emptyRunSummary(),
+      totalHistorical: historicalLanes.length,
+      historicalLanes,
+    },
+  };
+}
+
+function makeLanes(count: number): RunLane[] {
+  return Array.from({ length: count }, (_, i) => historicalLane(`gc-hist-${i}`));
+}
+
+function renderHistory(historicalLanes: RunLane[]) {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <RunMap
+        source={runsSource(historicalLanes)}
+        now={Date.parse('2026-05-24T12:01:00Z')}
+        showHistory={true}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('RunMap historical expand-in-place (gascity-dashboard-l9q9)', () => {
+  it('previews 5 lanes with a Show-more toggle instead of a static footnote', () => {
+    const lanes = makeLanes(7);
+    renderHistory(lanes);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getAllByRole('listitem')).toHaveLength(5);
+    expect(screen.queryByText(/more not shown/i)).toBeNull();
+
+    const toggle = within(section).getByRole('button', { name: /show 2 more/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('expands to all lanes in place and collapses back', () => {
+    const lanes = makeLanes(7);
+    renderHistory(lanes);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    fireEvent.click(within(section).getByRole('button', { name: /show 2 more/i }));
+
+    expect(within(section).getAllByRole('listitem')).toHaveLength(7);
+    const collapse = within(section).getByRole('button', { name: /show fewer/i });
+    expect(collapse.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(collapse);
+    expect(within(section).getAllByRole('listitem')).toHaveLength(5);
+  });
+
+  it('renders no toggle when the historical set fits the preview', () => {
+    const lanes = makeLanes(5);
+    renderHistory(lanes);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getAllByRole('listitem')).toHaveLength(5);
+    expect(within(section).queryByRole('button')).toBeNull();
+  });
+});

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import type { AttentionSeverity } from '../../attention/compose';
 import { LaneCard } from './LaneCard';
@@ -29,6 +30,11 @@ const COUNT_LABELS: Array<[keyof RunSummary['runCounts'], string]> = [
 ];
 
 const HISTORICAL_SECTION_ID = 'runs-historical-section';
+const HISTORICAL_LIST_ID = 'runs-historical-list';
+// How many completed runs show before the operator opts into the rest.
+// The wire carries every historical lane (gascity-dashboard-l9q9); this
+// preview keeps the section ambient by default per DESIGN.md.
+const HISTORICAL_PREVIEW = 5;
 
 export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapProps) {
   if (source.status === 'error') {
@@ -145,17 +151,21 @@ function HistoricalSection({
   now: number;
   attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
 }) {
+  const [expanded, setExpanded] = useState(false);
+  const lanes = summary.historicalLanes;
+  const shown = expanded ? lanes : lanes.slice(0, HISTORICAL_PREVIEW);
+
   return (
     <section id={HISTORICAL_SECTION_ID} aria-label="Historical runs" className="mt-12">
       <h2 className="text-label uppercase tracking-wider text-fg-faint">Historical</h2>
-      {summary.historicalLanes.length === 0 ? (
+      {lanes.length === 0 ? (
         <p className="mt-3 text-body text-fg-muted italic">
           No completed runs in the current window.
         </p>
       ) : (
         <>
-          <ol className="mt-3 divide-y divide-rule">
-            {summary.historicalLanes.map((lane) => (
+          <ol id={HISTORICAL_LIST_ID} className="mt-3 divide-y divide-rule">
+            {shown.map((lane) => (
               <LaneCard
                 key={lane.id}
                 lane={lane}
@@ -166,10 +176,16 @@ function HistoricalSection({
               />
             ))}
           </ol>
-          {summary.totalHistorical > summary.historicalLanes.length && (
-            <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
-              {summary.totalHistorical - summary.historicalLanes.length} more not shown
-            </p>
+          {lanes.length > HISTORICAL_PREVIEW && (
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={expanded}
+              aria-controls={HISTORICAL_LIST_ID}
+              className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum hover:text-fg focus-mark"
+            >
+              {expanded ? 'Show fewer' : `Show ${lanes.length - HISTORICAL_PREVIEW} more`}
+            </button>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary

The Historical-runs Show-more/Show-fewer toggle (PR #29, bead `gascity-dashboard-l9q9`) was silently dropped by the direct-supervisor migration rewrites (#44, #61). Current main renders **every** historical lane unsliced, with the old `N more not shown` footnote restored as dead code (the wire ships all lanes, so `totalHistorical > historicalLanes.length` never fires).

It regressed silently because PR #29 only added backend tests — no frontend test pinned the toggle.

## Changes

- Restore the 5-lane preview + expand-in-place toggle in `RunMap.tsx` `HistoricalSection` (collapsed by default keeps the section ambient per DESIGN.md; `aria-expanded` + `aria-controls` on the button, editorial tracked-uppercase register).
- Remove the dead `more not shown` footnote from the historical section. The ActiveSection footnote stays — active lanes remain wire-capped, explicitly out of scope per the bead.
- **New `RunMap.test.tsx`** pinning the behavior: 5-lane preview + `Show 2 more` at 7 lanes, expand/collapse round-trip, no toggle at ≤5, footnote text absent. Removing the toggle again fails CI.

## Test plan

- [x] `npm --workspace frontend test` — 87 files / 736 tests green
- [x] `npm run typecheck` (source + test)
- [x] `npm run lint` (`--max-warnings=0`)
- [x] `npm --workspace frontend run build`

Bug: gascity-dashboard-l9q9