### PR TITLE
feat(dashboard): TranscriptBox expand/collapse overlay for session transcripts

### DIFF
--- a/frontend/src/components/LiveSessionPeek.test.tsx
+++ b/frontend/src/components/LiveSessionPeek.test.tsx
@@ -205,6 +205,17 @@ describe('LiveSessionPeek (streaming)', () => {
     expect(screen.getByText('snapshot')).toBeTruthy();
     expect(eventSources).toHaveLength(0);
   });
+
+  it('forwards the caption (turn count + captured age) into the TranscriptBox header', async () => {
+    // Guards the one-line caption spread in SessionPeekContent: showCaption must
+    // surface the turn-count / captured-age string in the transcript header, not
+    // drop it silently.
+    render(<LiveSessionPeek sessionId="s1" stream={false} showBadge showCaption />);
+    await screen.findByText('snapshot turn body');
+    const caption = screen.getByText(/turn\(s\)/);
+    expect(caption.textContent).toMatch(/1 turn\(s\)/);
+    expect(caption.textContent).toMatch(/captured/);
+  });
 });
 
 function requestUrl(input: RequestInfo | URL): string {

--- a/frontend/src/components/LiveSessionPeek.tsx
+++ b/frontend/src/components/LiveSessionPeek.tsx
@@ -66,12 +66,12 @@ export function LiveSessionPeek({
           />
         </div>
       )}
-      {captionParts.length > 0 && (
-        <p className="text-label uppercase tracking-wider text-fg-faint tnum">
-          {captionParts.join(' · ')}
-        </p>
-      )}
-      <SessionPeekContent loading={loading} error={error} result={result} />
+      <SessionPeekContent
+        loading={loading}
+        error={error}
+        result={result}
+        {...(captionParts.length > 0 ? { caption: captionParts.join(' · ') } : {})}
+      />
     </div>
   );
 }

--- a/frontend/src/components/SessionPeek.render.test.tsx
+++ b/frontend/src/components/SessionPeek.render.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { SessionPeekContent } from './SessionPeek';
 import type { SessionTranscriptView } from '../supervisor/sessionReads';
@@ -42,6 +42,18 @@ describe('SessionPeekContent — terminal control stripping', () => {
     // SGR parameter text must not leak as visible characters.
     expect(rendered).not.toContain('[31m');
     expect(rendered).not.toContain('[0m');
+  });
+
+  it('shows an expand button for a non-empty transcript', () => {
+    render(
+      <SessionPeekContent loading={false} error={null} result={viewWithTurn('hello')} />,
+    );
+    expect(screen.getByRole('button', { name: /expand/i })).toBeTruthy();
+  });
+
+  it('does not show an expand button while loading', () => {
+    render(<SessionPeekContent loading={true} error={null} result={null} />);
+    expect(screen.queryByRole('button', { name: /expand/i })).toBeNull();
   });
 
   it('colorizes the surviving SGR sequence via ansi_up classes', () => {

--- a/frontend/src/components/SessionPeek.render.test.tsx
+++ b/frontend/src/components/SessionPeek.render.test.tsx
@@ -45,9 +45,7 @@ describe('SessionPeekContent — terminal control stripping', () => {
   });
 
   it('shows an expand button for a non-empty transcript', () => {
-    render(
-      <SessionPeekContent loading={false} error={null} result={viewWithTurn('hello')} />,
-    );
+    render(<SessionPeekContent loading={false} error={null} result={viewWithTurn('hello')} />);
     expect(screen.getByRole('button', { name: /expand/i })).toBeTruthy();
   });
 

--- a/frontend/src/components/SessionPeek.tsx
+++ b/frontend/src/components/SessionPeek.tsx
@@ -5,6 +5,7 @@ import { formatClockTime, formatRelative, formatShortDate } from '../hooks/time'
 import { PROMPT_INJECTION_NOTICE } from '../lib/constants';
 import { stripTerminalControls } from '../lib/stripTerminalControls';
 import type { SessionTranscriptView } from '../supervisor/sessionReads';
+import { TranscriptBox } from './TranscriptBox';
 
 // Render layer for a session's transcript snapshot. Used by:
 //   - Agents page peek modal (one-shot fetch)
@@ -53,9 +54,11 @@ interface SessionPeekContentProps {
   loading: boolean;
   error: string | null;
   result: SessionTranscriptView | null;
+  /** Caption text shown on the same row as the expand button. */
+  caption?: string;
 }
 
-export function SessionPeekContent({ loading, error, result }: SessionPeekContentProps) {
+export function SessionPeekContent({ loading, error, result, caption }: SessionPeekContentProps) {
   if (loading && result === null) {
     return <p className="text-fg-muted italic">Fetching transcript.</p>;
   }
@@ -77,27 +80,29 @@ export function SessionPeekContent({ loading, error, result }: SessionPeekConten
   const now = Date.now();
 
   return (
-    <div className="space-y-6">
-      <p
-        className="text-label uppercase tracking-wider text-fg-faint tnum"
-        title={result.captured_at}
-      >
-        {formatShortDate(result.captured_at)}
-      </p>
-      <p className="text-label uppercase tracking-wider text-warn">▲ {PROMPT_INJECTION_NOTICE}</p>
-      <ol className="space-y-5">
-        {result.turns.map((turn, idx) => (
-          <TurnBlock key={idx} turn={turn} index={idx} now={now} />
-        ))}
-      </ol>
-      {result.truncated && (
-        <p className="text-label uppercase tracking-wider text-fg-faint italic">
-          Some turns truncated at the per-turn or total cap. Run{' '}
-          <code className="text-fg-muted">gc session peek</code> in a terminal for the full
-          transcript.
+    <TranscriptBox {...(caption !== undefined ? { caption } : {})}>
+      <div className="space-y-6">
+        <p
+          className="text-label uppercase tracking-wider text-fg-faint tnum"
+          title={result.captured_at}
+        >
+          {formatShortDate(result.captured_at)}
         </p>
-      )}
-    </div>
+        <p className="text-label uppercase tracking-wider text-warn">▲ {PROMPT_INJECTION_NOTICE}</p>
+        <ol className="space-y-5">
+          {result.turns.map((turn, idx) => (
+            <TurnBlock key={idx} turn={turn} index={idx} now={now} />
+          ))}
+        </ol>
+        {result.truncated && (
+          <p className="text-label uppercase tracking-wider text-fg-faint italic">
+            Some turns truncated at the per-turn or total cap. Run{' '}
+            <code className="text-fg-muted">gc session peek</code> in a terminal for the full
+            transcript.
+          </p>
+        )}
+      </div>
+    </TranscriptBox>
   );
 }
 

--- a/frontend/src/components/SessionPeek.tsx
+++ b/frontend/src/components/SessionPeek.tsx
@@ -82,12 +82,17 @@ export function SessionPeekContent({ loading, error, result, caption }: SessionP
   return (
     <TranscriptBox {...(caption !== undefined ? { caption } : {})}>
       <div className="space-y-6">
-        <p
-          className="text-label uppercase tracking-wider text-fg-faint tnum"
-          title={result.captured_at}
-        >
-          {formatShortDate(result.captured_at)}
-        </p>
+        {/* When a caption is shown it already carries "captured X ago", so the
+            standalone captured-date line would be a duplicate timestamp; render
+            it only when there is no caption (e.g. the run-node panel). */}
+        {caption === undefined && (
+          <p
+            className="text-label uppercase tracking-wider text-fg-faint tnum"
+            title={result.captured_at}
+          >
+            {formatShortDate(result.captured_at)}
+          </p>
+        )}
         <p className="text-label uppercase tracking-wider text-warn">▲ {PROMPT_INJECTION_NOTICE}</p>
         <ol className="space-y-5">
           {result.turns.map((turn, idx) => (

--- a/frontend/src/components/TranscriptBox.test.tsx
+++ b/frontend/src/components/TranscriptBox.test.tsx
@@ -1,0 +1,63 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TranscriptBox } from './TranscriptBox';
+
+afterEach(cleanup);
+
+describe('TranscriptBox', () => {
+  it('renders children in a scrollable collapsed pane with an expand button', () => {
+    render(<TranscriptBox>transcript content</TranscriptBox>);
+    expect(screen.getByText('transcript content')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeTruthy();
+  });
+
+  it('opens an expanded overlay when expand is clicked', () => {
+    render(<TranscriptBox>content</TranscriptBox>);
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+    expect(screen.getByRole('dialog', { name: /transcript/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /collapse/i })).toBeTruthy();
+    // Content is still visible in the overlay.
+    expect(screen.getByText('content')).toBeTruthy();
+  });
+
+  it('collapses back when the collapse button is clicked', () => {
+    render(<TranscriptBox>content</TranscriptBox>);
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+    expect(screen.queryByRole('dialog')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /collapse/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.getByRole('button', { name: /expand/i })).toBeTruthy();
+  });
+
+  it('collapses when the backdrop is clicked', () => {
+    render(<TranscriptBox>content</TranscriptBox>);
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+    // The backdrop has aria-hidden so we query by the element preceding the dialog.
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('collapses on Escape key in capture phase without closing a parent dialog', () => {
+    // Simulate a parent modal's bubble-phase Escape handler.
+    const parentClose = vi.fn();
+    document.addEventListener('keydown', parentClose);
+
+    render(<TranscriptBox>content</TranscriptBox>);
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+    expect(screen.queryByRole('dialog')).toBeTruthy();
+
+    // Dispatch Escape — the TranscriptBox capture handler should fire and
+    // stop propagation before the bubble-phase parentClose.
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    // Parent bubble handler must NOT have fired.
+    expect(parentClose).not.toHaveBeenCalled();
+
+    document.removeEventListener('keydown', parentClose);
+  });
+});

--- a/frontend/src/components/TranscriptBox.test.tsx
+++ b/frontend/src/components/TranscriptBox.test.tsx
@@ -1,7 +1,26 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TranscriptBox } from './TranscriptBox';
 
+// jsdom has no matchMedia; the overlay's prefers-reduced-motion check needs it.
+// Mirrors the stub in Header.attention.test.tsx.
+function stubMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+beforeEach(() => stubMatchMedia(false));
 afterEach(cleanup);
 
 describe('TranscriptBox', () => {
@@ -59,5 +78,17 @@ describe('TranscriptBox', () => {
     expect(parentClose).not.toHaveBeenCalled();
 
     document.removeEventListener('keydown', parentClose);
+  });
+
+  it('shows the expanded overlay fully visible (no enter animation) when prefers-reduced-motion is set', () => {
+    // DESIGN.md §6: with reduced motion the overlay must appear at its final
+    // opacity/scale synchronously rather than tweening in via rAF.
+    stubMatchMedia(true);
+    render(<TranscriptBox>content</TranscriptBox>);
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+    const dialog = screen.getByRole('dialog', { name: /transcript/i });
+    expect(dialog.className).toContain('opacity-100');
+    expect(dialog.className).toContain('scale-100');
+    expect(dialog.className).toContain('motion-reduce:transition-none');
   });
 });

--- a/frontend/src/components/TranscriptBox.tsx
+++ b/frontend/src/components/TranscriptBox.tsx
@@ -1,0 +1,173 @@
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type ReactNode,
+} from "react";
+
+interface TranscriptBoxProps {
+	children: ReactNode;
+	/** Optional caption rendered on the same row as the expand button. */
+	caption?: string;
+}
+
+/**
+ * Scrollable, expandable container for transcript content.
+ *
+ * Collapsed: fixed-height scrolling pane with an expand button, auto-scrolling
+ * to the bottom when content grows (only if the user is already pinned there,
+ * i.e. `tail -f` style).
+ *
+ * Expanded: fixed full-screen-ish overlay (90% of the viewport) that fades
+ * and scales in. Escape collapses it in capture phase so it wins over any
+ * parent modal's Escape handler.
+ */
+export function TranscriptBox({ children, caption }: TranscriptBoxProps) {
+	const [expanded, setExpanded] = useState(false);
+	// Separate refs for each scroll container so the correct DOM node is always
+	// targeted regardless of which branch is mounted.
+	const collapsedRef = useRef<HTMLDivElement>(null);
+	const expandedRef = useRef<HTMLDivElement>(null);
+	// Whether the user is scrolled to the bottom of the active container.
+	const pinnedRef = useRef(true);
+	// Drives the enter animation for the expanded overlay.
+	const [visible, setVisible] = useState(false);
+
+	const activeRef = expanded ? expandedRef : collapsedRef;
+
+	// Sticky-bottom: scroll to bottom when content changes, but only if pinned.
+	// Runs after every render so new SSE turns are caught immediately.
+	useEffect(() => {
+		const el = activeRef.current;
+		if (!el || !pinnedRef.current) return;
+		el.scrollTop = el.scrollHeight;
+	});
+
+	// Update pinned flag as the user scrolls.
+	const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+		const el = e.currentTarget;
+		pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+	}, []);
+
+	// Trigger the enter animation on the frame after the overlay mounts.
+	useEffect(() => {
+		if (!expanded) {
+			setVisible(false);
+			return;
+		}
+		// rAF so the initial opacity-0/scale-95 classes are painted before we add
+		// the transition targets — without this the browser skips the animation.
+		const id = requestAnimationFrame(() => setVisible(true));
+		return () => cancelAnimationFrame(id);
+	}, [expanded]);
+
+	// Collapse on Escape in capture phase so this handler wins over any parent
+	// modal's Escape listener, which runs on the bubble phase.
+	useEffect(() => {
+		if (!expanded) return;
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				e.stopPropagation();
+				setExpanded(false);
+				pinnedRef.current = true;
+			}
+		};
+		document.addEventListener("keydown", handleKey, /* capture */ true);
+		return () => document.removeEventListener("keydown", handleKey, true);
+	}, [expanded]);
+
+	const handleExpand = () => {
+		pinnedRef.current = true;
+		setExpanded(true);
+	};
+
+	const handleCollapse = () => {
+		pinnedRef.current = true;
+		setExpanded(false);
+	};
+
+	if (expanded) {
+		return (
+			<>
+				{/* Backdrop — sits above parent-modal z-50 (z-[60]) */}
+				<div
+					className="fixed inset-0 z-[60] bg-fg/30"
+					aria-hidden="true"
+					onClick={handleCollapse}
+				/>
+				{/* Expanded panel — positioned above the backdrop */}
+				<div
+					role="dialog"
+					aria-modal="true"
+					aria-label="Transcript"
+					className={[
+						"fixed inset-[5%] z-[61] flex flex-col",
+						"bg-surface border border-rule rounded-md",
+						"transition-[opacity,transform] duration-150 ease-out",
+						visible ? "opacity-100 scale-100" : "opacity-0 scale-95",
+					].join(" ")}
+					onClick={(e) => e.stopPropagation()}
+				>
+					<div className="px-5 pt-4 pb-3 border-b border-rule shrink-0 space-y-1">
+						<h2 className="text-label uppercase tracking-wider text-fg-faint">
+							Chat Transcript
+						</h2>
+						<div className="flex items-baseline justify-between gap-3">
+							<span className="text-label uppercase tracking-wider text-fg-faint tnum">
+								{caption ?? ""}
+							</span>
+							<button
+								type="button"
+								onClick={handleCollapse}
+								aria-label="Collapse transcript"
+								className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm px-1"
+							>
+								collapse ×
+							</button>
+						</div>
+					</div>
+					<div
+						ref={expandedRef}
+						onScroll={handleScroll}
+						className="flex-1 overflow-y-auto p-5"
+					>
+						{children}
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	return (
+		<div>
+			<header className="flex items-baseline justify-between mb-4 gap-3">
+				<h2 className="text-label uppercase tracking-wider text-fg-faint">
+					Chat Transcript
+				</h2>
+				<div className="flex items-baseline gap-3 min-w-0">
+					{caption && (
+						<span className="text-label uppercase tracking-wider text-fg-faint tnum shrink-0">
+							{caption}
+						</span>
+					)}
+					<button
+						type="button"
+						onClick={handleExpand}
+						aria-label="Expand transcript"
+						className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm shrink-0"
+					>
+						expand ⤢
+					</button>
+				</div>
+			</header>
+			<div
+				ref={collapsedRef}
+				onScroll={handleScroll}
+				className="h-96 overflow-y-auto p-4 border border-rule"
+			>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/TranscriptBox.tsx
+++ b/frontend/src/components/TranscriptBox.tsx
@@ -1,15 +1,9 @@
-import {
-	useCallback,
-	useEffect,
-	useRef,
-	useState,
-	type ReactNode,
-} from "react";
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
 
 interface TranscriptBoxProps {
-	children: ReactNode;
-	/** Optional caption rendered on the same row as the expand button. */
-	caption?: string;
+  children: ReactNode;
+  /** Optional caption rendered on the same row as the expand button. */
+  caption?: string;
 }
 
 /**
@@ -24,150 +18,156 @@ interface TranscriptBoxProps {
  * parent modal's Escape handler.
  */
 export function TranscriptBox({ children, caption }: TranscriptBoxProps) {
-	const [expanded, setExpanded] = useState(false);
-	// Separate refs for each scroll container so the correct DOM node is always
-	// targeted regardless of which branch is mounted.
-	const collapsedRef = useRef<HTMLDivElement>(null);
-	const expandedRef = useRef<HTMLDivElement>(null);
-	// Whether the user is scrolled to the bottom of the active container.
-	const pinnedRef = useRef(true);
-	// Drives the enter animation for the expanded overlay.
-	const [visible, setVisible] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  // Separate refs for each scroll container so the correct DOM node is always
+  // targeted regardless of which branch is mounted.
+  const collapsedRef = useRef<HTMLDivElement>(null);
+  const expandedRef = useRef<HTMLDivElement>(null);
+  // Whether the user is scrolled to the bottom of the active container.
+  const pinnedRef = useRef(true);
+  // Drives the enter animation for the expanded overlay.
+  const [visible, setVisible] = useState(false);
+  // Stable id so the dialog's accessible name comes from the visible heading
+  // (aria-labelledby) instead of a diverging hard-coded aria-label.
+  const headingId = useId();
 
-	const activeRef = expanded ? expandedRef : collapsedRef;
+  const activeRef = expanded ? expandedRef : collapsedRef;
 
-	// Sticky-bottom: scroll to bottom when content changes, but only if pinned.
-	// Runs after every render so new SSE turns are caught immediately.
-	useEffect(() => {
-		const el = activeRef.current;
-		if (!el || !pinnedRef.current) return;
-		el.scrollTop = el.scrollHeight;
-	});
+  // Sticky-bottom: scroll to bottom when content changes, but only if pinned.
+  // Runs after every render so new SSE turns are caught immediately.
+  useEffect(() => {
+    const el = activeRef.current;
+    if (!el || !pinnedRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  });
 
-	// Update pinned flag as the user scrolls.
-	const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-		const el = e.currentTarget;
-		pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
-	}, []);
+  // Update pinned flag as the user scrolls.
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+  }, []);
 
-	// Trigger the enter animation on the frame after the overlay mounts.
-	useEffect(() => {
-		if (!expanded) {
-			setVisible(false);
-			return;
-		}
-		// rAF so the initial opacity-0/scale-95 classes are painted before we add
-		// the transition targets — without this the browser skips the animation.
-		const id = requestAnimationFrame(() => setVisible(true));
-		return () => cancelAnimationFrame(id);
-	}, [expanded]);
+  // Trigger the enter animation on the frame after the overlay mounts.
+  useEffect(() => {
+    if (!expanded) {
+      setVisible(false);
+      return;
+    }
+    // DESIGN.md §6: respect prefers-reduced-motion — skip the enter
+    // animation and show the overlay synchronously (matches the
+    // motion-reduce:transition-none class below, which removes the CSS tween).
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setVisible(true);
+      return;
+    }
+    // rAF so the initial opacity-0/scale-95 classes are painted before we add
+    // the transition targets — without this the browser skips the animation.
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
+  }, [expanded]);
 
-	// Collapse on Escape in capture phase so this handler wins over any parent
-	// modal's Escape listener, which runs on the bubble phase.
-	useEffect(() => {
-		if (!expanded) return;
-		const handleKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				e.stopPropagation();
-				setExpanded(false);
-				pinnedRef.current = true;
-			}
-		};
-		document.addEventListener("keydown", handleKey, /* capture */ true);
-		return () => document.removeEventListener("keydown", handleKey, true);
-	}, [expanded]);
+  // Collapse on Escape in capture phase so this handler wins over any parent
+  // modal's Escape listener, which runs on the bubble phase.
+  useEffect(() => {
+    if (!expanded) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setExpanded(false);
+        pinnedRef.current = true;
+      }
+    };
+    document.addEventListener('keydown', handleKey, /* capture */ true);
+    return () => document.removeEventListener('keydown', handleKey, true);
+  }, [expanded]);
 
-	const handleExpand = () => {
-		pinnedRef.current = true;
-		setExpanded(true);
-	};
+  const handleExpand = () => {
+    pinnedRef.current = true;
+    setExpanded(true);
+  };
 
-	const handleCollapse = () => {
-		pinnedRef.current = true;
-		setExpanded(false);
-	};
+  const handleCollapse = () => {
+    pinnedRef.current = true;
+    setExpanded(false);
+  };
 
-	if (expanded) {
-		return (
-			<>
-				{/* Backdrop — sits above parent-modal z-50 (z-[60]) */}
-				<div
-					className="fixed inset-0 z-[60] bg-fg/30"
-					aria-hidden="true"
-					onClick={handleCollapse}
-				/>
-				{/* Expanded panel — positioned above the backdrop */}
-				<div
-					role="dialog"
-					aria-modal="true"
-					aria-label="Transcript"
-					className={[
-						"fixed inset-[5%] z-[61] flex flex-col",
-						"bg-surface border border-rule rounded-md",
-						"transition-[opacity,transform] duration-150 ease-out",
-						visible ? "opacity-100 scale-100" : "opacity-0 scale-95",
-					].join(" ")}
-					onClick={(e) => e.stopPropagation()}
-				>
-					<div className="px-5 pt-4 pb-3 border-b border-rule shrink-0 space-y-1">
-						<h2 className="text-label uppercase tracking-wider text-fg-faint">
-							Chat Transcript
-						</h2>
-						<div className="flex items-baseline justify-between gap-3">
-							<span className="text-label uppercase tracking-wider text-fg-faint tnum">
-								{caption ?? ""}
-							</span>
-							<button
-								type="button"
-								onClick={handleCollapse}
-								aria-label="Collapse transcript"
-								className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm px-1"
-							>
-								collapse ×
-							</button>
-						</div>
-					</div>
-					<div
-						ref={expandedRef}
-						onScroll={handleScroll}
-						className="flex-1 overflow-y-auto p-5"
-					>
-						{children}
-					</div>
-				</div>
-			</>
-		);
-	}
+  if (expanded) {
+    return (
+      <>
+        {/* Backdrop — sits above parent-modal z-50 (z-[60]) */}
+        <div
+          className="fixed inset-0 z-[60] bg-fg/30"
+          aria-hidden="true"
+          onClick={handleCollapse}
+        />
+        {/* Expanded panel — positioned above the backdrop */}
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={headingId}
+          className={[
+            'fixed inset-[5%] z-[61] flex flex-col',
+            'bg-surface border border-rule rounded-md',
+            'transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none',
+            visible ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
+          ].join(' ')}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="px-5 pt-4 pb-3 border-b border-rule shrink-0 space-y-1">
+            <h2 id={headingId} className="text-label uppercase tracking-wider text-fg-faint">
+              Chat Transcript
+            </h2>
+            <div className="flex items-baseline gap-3">
+              {caption && (
+                <span className="text-label uppercase tracking-wider text-fg-faint tnum">
+                  {caption}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={handleCollapse}
+                aria-label="Collapse transcript"
+                className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm px-1 ml-auto"
+              >
+                collapse ×
+              </button>
+            </div>
+          </div>
+          <div ref={expandedRef} onScroll={handleScroll} className="flex-1 overflow-y-auto p-5">
+            {children}
+          </div>
+        </div>
+      </>
+    );
+  }
 
-	return (
-		<div>
-			<header className="flex items-baseline justify-between mb-4 gap-3">
-				<h2 className="text-label uppercase tracking-wider text-fg-faint">
-					Chat Transcript
-				</h2>
-				<div className="flex items-baseline gap-3 min-w-0">
-					{caption && (
-						<span className="text-label uppercase tracking-wider text-fg-faint tnum shrink-0">
-							{caption}
-						</span>
-					)}
-					<button
-						type="button"
-						onClick={handleExpand}
-						aria-label="Expand transcript"
-						className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm shrink-0"
-					>
-						expand ⤢
-					</button>
-				</div>
-			</header>
-			<div
-				ref={collapsedRef}
-				onScroll={handleScroll}
-				className="h-96 overflow-y-auto p-4 border border-rule"
-			>
-				{children}
-			</div>
-		</div>
-	);
+  return (
+    <div>
+      {/* Collapsed pane carries no section heading: each caller already labels
+          the surface (AgentLivePeek "Live peek", run-node title h3), so a
+          second "Chat Transcript" h2 was a duplicate label and a heading
+          inversion. The label lives only in the expanded dialog, which needs
+          it for its accessible name. */}
+      <header className="flex items-baseline justify-end mb-4 gap-3">
+        <div className="flex items-baseline gap-3 min-w-0">
+          {caption && (
+            <span className="text-label uppercase tracking-wider text-fg-faint tnum shrink-0">
+              {caption}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleExpand}
+            aria-label="Expand transcript"
+            className="text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out focus-mark rounded-sm shrink-0"
+          >
+            expand ⤢
+          </button>
+        </div>
+      </header>
+      <div ref={collapsedRef} onScroll={handleScroll} className="h-96 overflow-y-auto p-4">
+        {children}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Introduce a shared TranscriptBox component that wraps transcript content in a scrollable pane with an expand button and a full-screen overlay (expand/collapse, Escape-to-close, backdrop-click-to-close).

- **TranscriptBox**: collapsed fixed-height pane with auto-scroll ('tail -f' behaviour when pinned to bottom); expanded overlay at 90% vp with scale/fade enter animation, capture-phase Escape handler that wins over parent modals, and backdrop click to collapse.
- **SessionPeek / SessionPeekContent**: wrapped in TranscriptBox; caption (date/time) promoted from a standalone element to a prop plumbed through LiveSessionPeek.


https://github.com/user-attachments/assets/e9a9ecbe-b6ee-4e15-9ff4-e7c6fb12eb96

