### PR TITLE
feat(health): per-rig bead-store + dolt health on Health tab (u6d0)

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -8,6 +8,11 @@ import { GcClient } from '../gc-client.js';
 import { csrfValidate } from '../middleware/csrf.js';
 import { runsRouter } from '../routes/runs.js';
 import { createDoltNomsSampler, doltRouter, type DoltNomsSampler } from '../routes/dolt.js';
+import {
+  createRigStoreHealthSampler,
+  rigStoreHealthRouter,
+  type RigStoreHealthSampler,
+} from '../routes/rig-store-health.js';
 import { ALL_MODULES } from '../views/registry.js';
 import { resolveEnabledFirstPartyIds } from '../views/enabled.js';
 import { bind, type CityContext } from '../views/types.js';
@@ -117,17 +122,33 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
   });
   router.use('/dolt-noms', doltRouter(doltNomsSampler));
 
+  // gascity-dashboard-u6d0: per-rig bead-store + dolt health. Rig name+path
+  // come from the sanctioned host-local status read (status.rig_details) — the
+  // backend GcClient deliberately does not list GC-owned rigs directly — then
+  // each rig's local `.beads` store is probed. Periodic sampler: the route
+  // serves the cached snapshot so a Health page load never forks one
+  // `bd doctor` per rig.
+  const rigStoreHealthSampler: RigStoreHealthSampler = createRigStoreHealthSampler({
+    listRigs: async () => {
+      const status = await gc.getStatus();
+      return (status.rig_details ?? []).map((rig) => ({ name: rig.name, path: rig.path }));
+    },
+  });
+  router.use('/rig-store-health', rigStoreHealthRouter(rigStoreHealthSampler));
+
   return {
     cityName,
     router,
     dashboardConfig,
     start() {
       doltNomsSampler.start();
+      rigStoreHealthSampler.start();
       for (const w of moduleWorkers) w.start();
     },
     async stop() {
       await Promise.all(moduleWorkers.map((w) => w.stop()));
       doltNomsSampler.stop();
+      rigStoreHealthSampler.stop();
     },
   };
 }

--- a/backend/src/exec.ts
+++ b/backend/src/exec.ts
@@ -442,11 +442,7 @@ export async function execBdDoctor(beadsPath: string): Promise<ExecResult> {
   if (!isValidHostPath(beadsPath) || !beadsPath.endsWith('/.beads')) {
     throw new ExecError('invalid beads store path', 'validation');
   }
-  return runExec(
-    'bd',
-    ['doctor', '--readonly', '--db', beadsPath, '--json'],
-    BD_DOCTOR_TIMEOUT_MS,
-  );
+  return runExec('bd', ['doctor', '--readonly', '--db', beadsPath, '--json'], BD_DOCTOR_TIMEOUT_MS);
 }
 
 export { sanitiseTerminalOutput };

--- a/backend/src/exec.ts
+++ b/backend/src/exec.ts
@@ -60,6 +60,9 @@ const GIT_LOG_TIMEOUT_MS = 10_000;
 const RUN_GIT_TIMEOUT_MS = 5_000;
 const GH_LIST_TIMEOUT_MS = 30_000;
 const GH_HISTORY_LIST_TIMEOUT_MS = 60_000;
+// `bd doctor` connects to the store's dolt server and runs ~30 checks; it is
+// heavier than a version probe but bounded. Read-only, no `--fix`.
+const BD_DOCTOR_TIMEOUT_MS = 15_000;
 function sanitiseTerminalOutput(raw: string): string {
   return raw
     .replace(OSC_RE, '')
@@ -419,6 +422,30 @@ export async function execGhPrList(repo: string, limit: number): Promise<ExecRes
     ],
     GH_LIST_TIMEOUT_MS,
     MAX_BYTES_LARGE,
+  );
+}
+
+// ── Per-rig bead-store health: `bd doctor` ───────────────────────────────
+//
+// gascity-dashboard-u6d0. Read-only health probe of a rig's embedded-dolt
+// `.beads` store. The store path originates from supervisor-reported rig
+// metadata (rig.path + '/.beads'), never from a browser parameter, but it is
+// still validated at this subprocess boundary like every other host path the
+// dashboard shells against (mirrors isValidRunCwd). `--readonly` blocks
+// writes; `--fix` is intentionally never passed, so doctor only inspects —
+// it never mutates the probed store. `--json` makes the output machine
+// parseable; a store whose server is unreachable makes bd fall back to
+// embedded mode and emit non-JSON text, which the caller treats as a
+// degraded signal rather than a parse error.
+
+export async function execBdDoctor(beadsPath: string): Promise<ExecResult> {
+  if (!isValidHostPath(beadsPath) || !beadsPath.endsWith('/.beads')) {
+    throw new ExecError('invalid beads store path', 'validation');
+  }
+  return runExec(
+    'bd',
+    ['doctor', '--readonly', '--db', beadsPath, '--json'],
+    BD_DOCTOR_TIMEOUT_MS,
   );
 }
 

--- a/backend/src/logging.ts
+++ b/backend/src/logging.ts
@@ -17,6 +17,7 @@ export const LOG_COMPONENT = {
   links: 'links',
   maintainer: 'maintainer',
   metrics: 'metrics',
+  rigStoreHealth: 'rig-store-health',
   runs: 'runs',
 } as const;
 

--- a/backend/src/routes/rig-store-health.test.ts
+++ b/backend/src/routes/rig-store-health.test.ts
@@ -1,0 +1,317 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ExecResult } from '../exec.js';
+import {
+  createRigStoreHealthSampler,
+  issueCountFromChecks,
+  parseDoctorChecks,
+  probeRigStore,
+  rollupFor,
+  storeProblems,
+  type RigStoreProbeDeps,
+  type SamplerRuntime,
+  type SamplerTimer,
+  type SupervisorRigDescriptor,
+} from './rig-store-health.js';
+
+function execOk(stdout: string): ExecResult {
+  return { exitCode: 0, stdout, stderr: '', truncated: false, durationMs: 1 };
+}
+
+const HEALTHY_DOCTOR = JSON.stringify({
+  checks: [
+    { category: 'Core System', name: 'Installation', status: 'ok', message: '.beads/ found' },
+    { category: 'Core System', name: 'Dolt Connection', status: 'ok', message: 'Connected' },
+    { category: 'Data & Config', name: 'Dolt Issue Count', status: 'ok', message: '129 issues' },
+    { category: 'Git Integration', name: 'Git Hooks', status: 'warning', message: 'no hooks' },
+    { category: 'Integrations', name: 'Claude Plugin', status: 'warning', message: 'not installed' },
+  ],
+});
+
+describe('parseDoctorChecks', () => {
+  test('parses well-formed doctor JSON', () => {
+    const checks = parseDoctorChecks(HEALTHY_DOCTOR);
+    assert.ok(checks);
+    assert.equal(checks.length, 5);
+    assert.equal(checks[0].name, 'Installation');
+    assert.equal(checks[0].status, 'ok');
+  });
+
+  test('returns null on the embedded-mode fallback (non-JSON)', () => {
+    assert.equal(parseDoctorChecks("Note: 'bd doctor' is not yet supported in embedded mode."), null);
+  });
+
+  test('returns null on empty output', () => {
+    assert.equal(parseDoctorChecks('   '), null);
+  });
+
+  test('normalizes failure statuses to error and unknown to warning', () => {
+    const checks = parseDoctorChecks(
+      JSON.stringify({
+        checks: [
+          { category: 'X', name: 'A', status: 'fail', message: '' },
+          { category: 'X', name: 'B', status: 'mystery', message: '' },
+        ],
+      }),
+    );
+    assert.ok(checks);
+    assert.equal(checks[0].status, 'error');
+    assert.equal(checks[1].status, 'warning');
+  });
+});
+
+describe('storeProblems', () => {
+  test('drops ok checks and benign hygiene categories', () => {
+    const checks = parseDoctorChecks(HEALTHY_DOCTOR);
+    assert.ok(checks);
+    // The two warnings are Git Integration + Integrations — both benign.
+    assert.deepEqual(storeProblems(checks), []);
+  });
+
+  test('keeps non-ok store/dolt checks', () => {
+    const checks = parseDoctorChecks(
+      JSON.stringify({
+        checks: [
+          { category: 'Core System', name: 'Dolt Schema', status: 'error', message: 'drift' },
+          { category: 'Git Integration', name: 'Git Hooks', status: 'warning', message: 'x' },
+        ],
+      }),
+    );
+    assert.ok(checks);
+    const problems = storeProblems(checks);
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].name, 'Dolt Schema');
+  });
+});
+
+describe('issueCountFromChecks', () => {
+  test('extracts the row count from the Issue Count check', () => {
+    const checks = parseDoctorChecks(HEALTHY_DOCTOR);
+    assert.ok(checks);
+    assert.equal(issueCountFromChecks(checks), 129);
+  });
+
+  test('parses thousands separators', () => {
+    const checks = parseDoctorChecks(
+      JSON.stringify({ checks: [{ category: 'X', name: 'Dolt Issue Count', status: 'ok', message: '1,204 issues' }] }),
+    );
+    assert.ok(checks);
+    assert.equal(issueCountFromChecks(checks), 1204);
+  });
+
+  test('returns null when absent', () => {
+    assert.equal(issueCountFromChecks([]), null);
+  });
+});
+
+describe('rollupFor', () => {
+  test('down when unreachable', () => {
+    assert.equal(rollupFor({ reachable: false, doltConnected: null, problems: [], incomplete: false }), 'down');
+  });
+
+  test('down when the dolt server is not connected', () => {
+    assert.equal(rollupFor({ reachable: true, doltConnected: false, problems: [], incomplete: false }), 'down');
+  });
+
+  test('down on an error-tier problem even if the server is up', () => {
+    assert.equal(
+      rollupFor({
+        reachable: true,
+        doltConnected: true,
+        problems: [{ category: 'Core System', name: 'Dolt Schema', status: 'error', message: '' }],
+        incomplete: false,
+      }),
+      'down',
+    );
+  });
+
+  test('warn on a warning-tier problem', () => {
+    assert.equal(
+      rollupFor({
+        reachable: true,
+        doltConnected: true,
+        problems: [{ category: 'Core System', name: 'Sync', status: 'warning', message: '' }],
+        incomplete: false,
+      }),
+      'warn',
+    );
+  });
+
+  test('warn when the probe is incomplete', () => {
+    assert.equal(rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: true }), 'warn');
+  });
+
+  test('ok when healthy and complete', () => {
+    assert.equal(rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: false }), 'ok');
+  });
+});
+
+function depsFor(overrides: Partial<RigStoreProbeDeps> = {}): RigStoreProbeDeps {
+  return {
+    statBeads: async () => true,
+    readPort: async () => 29620,
+    tcpProbe: async () => true,
+    runDoctor: async () => execOk(HEALTHY_DOCTOR),
+    ...overrides,
+  };
+}
+
+const RIG: SupervisorRigDescriptor = { name: 'codeprobe', path: '/home/ds/projects/codeprobe' };
+
+describe('probeRigStore', () => {
+  test('healthy server-mode store rolls up ok with endpoint + issue count', async () => {
+    const health = await probeRigStore(RIG, depsFor());
+    assert.equal(health.rig, 'codeprobe');
+    assert.equal(health.beadsPath, '/home/ds/projects/codeprobe/.beads');
+    assert.equal(health.reachable, true);
+    assert.equal(health.rollup, 'ok');
+    assert.equal(health.doltEndpoint, '127.0.0.1:29620');
+    assert.equal(health.doltConnected, true);
+    assert.equal(health.issueCount, 129);
+    assert.deepEqual(health.problems, []);
+  });
+
+  test('missing .beads is down + unreachable without probing further', async () => {
+    let doctorCalled = false;
+    const health = await probeRigStore(
+      RIG,
+      depsFor({
+        statBeads: async () => false,
+        runDoctor: async () => {
+          doctorCalled = true;
+          return execOk(HEALTHY_DOCTOR);
+        },
+      }),
+    );
+    assert.equal(health.reachable, false);
+    assert.equal(health.rollup, 'down');
+    assert.equal(doctorCalled, false);
+  });
+
+  test('dolt server down (TCP refused) rolls up down regardless of doctor', async () => {
+    const health = await probeRigStore(RIG, depsFor({ tcpProbe: async () => false }));
+    assert.equal(health.doltConnected, false);
+    assert.equal(health.rollup, 'down');
+  });
+
+  test('embedded-mode doctor fallback is warn + noted, not a crash', async () => {
+    const health = await probeRigStore(
+      RIG,
+      depsFor({
+        readPort: async () => null,
+        runDoctor: async () => execOk("Note: not supported in embedded mode."),
+      }),
+    );
+    assert.equal(health.doltEndpoint, null);
+    assert.equal(health.doltConnected, null);
+    assert.equal(health.rollup, 'warn');
+    assert.ok(health.note);
+  });
+
+  test('never throws when a dep rejects (degrades to down)', async () => {
+    const health = await probeRigStore(
+      RIG,
+      depsFor({
+        runDoctor: async () => {
+          throw new Error('spawn failed');
+        },
+      }),
+    );
+    // doctor failure is noted; server still probed up via TCP, so not down on
+    // connection — but incomplete makes it warn.
+    assert.equal(health.rollup, 'warn');
+    assert.ok(health.note?.includes('spawn failed'));
+  });
+});
+
+const manualRuntime = (): SamplerRuntime & { fire(): void } => {
+  let cb: (() => void) | null = null;
+  return {
+    setInterval(callback: () => void): SamplerTimer {
+      cb = callback;
+      return { unref() {} };
+    },
+    clearInterval() {
+      cb = null;
+    },
+    fire() {
+      cb?.();
+    },
+  };
+};
+
+describe('createRigStoreHealthSampler', () => {
+  test('reports not_sampled_yet before the first sample', () => {
+    const sampler = createRigStoreHealthSampler({ listRigs: async () => [] });
+    const report = sampler.report();
+    assert.equal(report.available, false);
+    assert.deepEqual(report.rigs, []);
+  });
+
+  test('samples all rigs and reports available', async () => {
+    const sampler = createRigStoreHealthSampler({
+      listRigs: async () => [RIG, { name: 'geo', path: '/home/ds/projects/GEO' }],
+      probe: async (rig) => ({
+        rig: rig.name,
+        beadsPath: `${rig.path}/.beads`,
+        rollup: 'ok',
+        reachable: true,
+        doltEndpoint: '127.0.0.1:29620',
+        doltConnected: true,
+        issueCount: 1,
+        problems: [],
+      }),
+      now: () => '2026-06-06T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+    const report = sampler.report();
+    assert.equal(report.available, true);
+    assert.equal(report.rigs.length, 2);
+    if (report.available) assert.equal(report.sampledAt, '2026-06-06T00:00:00.000Z');
+  });
+
+  test('rig_list failure keeps the prior snapshot but flips available=false', async () => {
+    let fail = false;
+    const sampler = createRigStoreHealthSampler({
+      listRigs: async () => {
+        if (fail) throw new Error('supervisor down');
+        return [RIG];
+      },
+      probe: async (rig) => ({
+        rig: rig.name,
+        beadsPath: `${rig.path}/.beads`,
+        rollup: 'ok',
+        reachable: true,
+        doltEndpoint: null,
+        doltConnected: true,
+        issueCount: 0,
+        problems: [],
+      }),
+    });
+    await sampler.sampleOnce();
+    fail = true;
+    await sampler.sampleOnce();
+    const report = sampler.report();
+    assert.equal(report.available, false);
+    assert.equal(report.rigs.length, 1); // prior snapshot retained
+    if (!report.available) assert.equal(report.reason, 'rig_list_failed');
+  });
+
+  test('start triggers an immediate sample and schedules the interval', () => {
+    const runtime = manualRuntime();
+    let calls = 0;
+    const sampler = createRigStoreHealthSampler({
+      listRigs: async () => {
+        calls += 1;
+        return [];
+      },
+      runtime,
+    });
+    sampler.start();
+    assert.equal(sampler.running, true);
+    runtime.fire();
+    sampler.stop();
+    assert.equal(sampler.running, false);
+    assert.ok(calls >= 1);
+  });
+});

--- a/backend/src/routes/rig-store-health.test.ts
+++ b/backend/src/routes/rig-store-health.test.ts
@@ -24,7 +24,12 @@ const HEALTHY_DOCTOR = JSON.stringify({
     { category: 'Core System', name: 'Dolt Connection', status: 'ok', message: 'Connected' },
     { category: 'Data & Config', name: 'Dolt Issue Count', status: 'ok', message: '129 issues' },
     { category: 'Git Integration', name: 'Git Hooks', status: 'warning', message: 'no hooks' },
-    { category: 'Integrations', name: 'Claude Plugin', status: 'warning', message: 'not installed' },
+    {
+      category: 'Integrations',
+      name: 'Claude Plugin',
+      status: 'warning',
+      message: 'not installed',
+    },
   ],
 });
 
@@ -38,7 +43,10 @@ describe('parseDoctorChecks', () => {
   });
 
   test('returns null on the embedded-mode fallback (non-JSON)', () => {
-    assert.equal(parseDoctorChecks("Note: 'bd doctor' is not yet supported in embedded mode."), null);
+    assert.equal(
+      parseDoctorChecks("Note: 'bd doctor' is not yet supported in embedded mode."),
+      null,
+    );
   });
 
   test('returns null on empty output', () => {
@@ -93,7 +101,11 @@ describe('issueCountFromChecks', () => {
 
   test('parses thousands separators', () => {
     const checks = parseDoctorChecks(
-      JSON.stringify({ checks: [{ category: 'X', name: 'Dolt Issue Count', status: 'ok', message: '1,204 issues' }] }),
+      JSON.stringify({
+        checks: [
+          { category: 'X', name: 'Dolt Issue Count', status: 'ok', message: '1,204 issues' },
+        ],
+      }),
     );
     assert.ok(checks);
     assert.equal(issueCountFromChecks(checks), 1204);
@@ -106,11 +118,17 @@ describe('issueCountFromChecks', () => {
 
 describe('rollupFor', () => {
   test('down when unreachable', () => {
-    assert.equal(rollupFor({ reachable: false, doltConnected: null, problems: [], incomplete: false }), 'down');
+    assert.equal(
+      rollupFor({ reachable: false, doltConnected: null, problems: [], incomplete: false }),
+      'down',
+    );
   });
 
   test('down when the dolt server is not connected', () => {
-    assert.equal(rollupFor({ reachable: true, doltConnected: false, problems: [], incomplete: false }), 'down');
+    assert.equal(
+      rollupFor({ reachable: true, doltConnected: false, problems: [], incomplete: false }),
+      'down',
+    );
   });
 
   test('down on an error-tier problem even if the server is up', () => {
@@ -138,11 +156,17 @@ describe('rollupFor', () => {
   });
 
   test('warn when the probe is incomplete', () => {
-    assert.equal(rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: true }), 'warn');
+    assert.equal(
+      rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: true }),
+      'warn',
+    );
   });
 
   test('ok when healthy and complete', () => {
-    assert.equal(rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: false }), 'ok');
+    assert.equal(
+      rollupFor({ reachable: true, doltConnected: true, problems: [], incomplete: false }),
+      'ok',
+    );
   });
 });
 
@@ -199,7 +223,7 @@ describe('probeRigStore', () => {
       RIG,
       depsFor({
         readPort: async () => null,
-        runDoctor: async () => execOk("Note: not supported in embedded mode."),
+        runDoctor: async () => execOk('Note: not supported in embedded mode.'),
       }),
     );
     assert.equal(health.doltEndpoint, null);

--- a/backend/src/routes/rig-store-health.ts
+++ b/backend/src/routes/rig-store-health.ts
@@ -123,7 +123,12 @@ interface RollupInput {
 }
 
 /** One red/green-per-rig roll-up tone from the gathered signals. */
-export function rollupFor({ reachable, doltConnected, problems, incomplete }: RollupInput): RigStoreRollup {
+export function rollupFor({
+  reachable,
+  doltConnected,
+  problems,
+  incomplete,
+}: RollupInput): RigStoreRollup {
   if (!reachable) return 'down';
   if (doltConnected === false) return 'down';
   if (problems.some((p) => p.status === 'error')) return 'down';

--- a/backend/src/routes/rig-store-health.ts
+++ b/backend/src/routes/rig-store-health.ts
@@ -1,0 +1,384 @@
+import { Router } from 'express';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import type {
+  RigStoreCheck,
+  RigStoreCheckStatus,
+  RigStoreHealth,
+  RigStoreHealthReport,
+  RigStoreHealthUnavailableReason,
+  RigStoreRollup,
+} from 'gas-city-dashboard-shared';
+import { execBdDoctor } from '../exec.js';
+import type { ExecResult } from '../exec.js';
+import { recordAudit } from '../audit.js';
+import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
+
+// Per-rig bead-store + dolt health (gascity-dashboard-u6d0). Each rig owns its
+// own embedded-dolt `.beads` store, so — unlike the supervisor's single
+// city-level store_health — this is a dashboard-local probe of host state:
+//   1. `.beads` present on disk            → reachable
+//   2. dolt-server.port + TCP connect      → dolt sql-server up + endpoint
+//   3. `bd doctor --json` (read-only)      → schema drift / integrity / count
+// rolled up to one red/green-per-rig tone. The probe runs on a periodic
+// server-side sampler (heavy: one `bd doctor` per rig) and the route serves
+// the cached snapshot, mirroring the dolt-noms sampler — never one fork-storm
+// per page load.
+
+const SAMPLE_INTERVAL_MS = 5 * 60 * 1_000;
+const TCP_PROBE_TIMEOUT_MS = 2_000;
+
+// `bd doctor` categories that are not bead-store/dolt health and that the
+// dashboard operator cannot act on from a store-health view (git-hook hygiene,
+// editor plugins). Excluded from both the surfaced problems and the roll-up so
+// a healthy store does not read amber for an uninstalled git hook.
+const BENIGN_CATEGORIES: ReadonlySet<string> = new Set(['Git Integration', 'Integrations']);
+
+const DOLT_CONNECTION_CHECK = 'Dolt Connection';
+
+/** A rig's name + untrusted supervisor host path, the input to a store probe.
+ *  Sourced from the sanctioned backend status read (StatusBody.rig_details),
+ *  not a backend rig list — the GcClient is deliberately limited to host-local
+ *  reads (see gc-supervisor-generation-config guard). */
+export interface SupervisorRigDescriptor {
+  name: string;
+  path: string;
+}
+
+interface RawDoctorCheck {
+  category?: unknown;
+  name?: unknown;
+  status?: unknown;
+  message?: unknown;
+}
+
+/**
+ * Parse `bd doctor --json` stdout into checks. Returns null when the output is
+ * not the expected JSON object — which is itself a signal: a store whose dolt
+ * server is unreachable makes `bd` fall back to embedded mode and print a
+ * human "not supported in embedded mode" note instead of JSON. The caller
+ * treats null as an incomplete probe, not a hard error.
+ */
+export function parseDoctorChecks(stdout: string): RigStoreCheck[] | null {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0 || trimmed[0] !== '{') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const checks = (parsed as { checks?: unknown }).checks;
+  if (!Array.isArray(checks)) return null;
+  return checks
+    .filter((c): c is RawDoctorCheck => typeof c === 'object' && c !== null)
+    .map((c) => ({
+      category: typeof c.category === 'string' ? c.category : 'unknown',
+      name: typeof c.name === 'string' ? c.name : 'unknown',
+      status: normalizeStatus(c.status),
+      message: typeof c.message === 'string' ? c.message : '',
+    }));
+}
+
+function normalizeStatus(status: unknown): RigStoreCheckStatus {
+  const s = typeof status === 'string' ? status.toLowerCase() : '';
+  if (s === 'ok' || s === 'pass' || s === 'passed') return 'ok';
+  if (s === 'warning' || s === 'warn') return 'warning';
+  if (s === 'error' || s === 'fail' || s === 'failed' || s === 'critical') return 'error';
+  // Unknown vocabulary: surface it, but at the lower (warning) tier rather
+  // than declaring the store down on a status string bd may add later.
+  return 'warning';
+}
+
+/** Store/dolt checks worth surfacing: non-ok and not a benign hygiene category. */
+export function storeProblems(checks: readonly RigStoreCheck[]): RigStoreCheck[] {
+  return checks.filter((c) => c.status !== 'ok' && !BENIGN_CATEGORIES.has(c.category));
+}
+
+/** Live bead row count from the doctor "Dolt Issue Count" check, when present. */
+export function issueCountFromChecks(checks: readonly RigStoreCheck[]): number | null {
+  const check = checks.find((c) => c.name.includes('Issue Count'));
+  if (check === undefined) return null;
+  const match = /(\d[\d,]*)/.exec(check.message);
+  const digits = match?.[1];
+  if (digits === undefined) return null;
+  const n = Number.parseInt(digits.replace(/,/g, ''), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Fallback dolt-server liveness from doctor when no port file exists to probe. */
+function doltConnectedFromChecks(checks: readonly RigStoreCheck[]): boolean | null {
+  const check = checks.find((c) => c.name === DOLT_CONNECTION_CHECK);
+  if (check === undefined) return null;
+  return check.status === 'ok';
+}
+
+interface RollupInput {
+  reachable: boolean;
+  doltConnected: boolean | null;
+  problems: readonly RigStoreCheck[];
+  incomplete: boolean;
+}
+
+/** One red/green-per-rig roll-up tone from the gathered signals. */
+export function rollupFor({ reachable, doltConnected, problems, incomplete }: RollupInput): RigStoreRollup {
+  if (!reachable) return 'down';
+  if (doltConnected === false) return 'down';
+  if (problems.some((p) => p.status === 'error')) return 'down';
+  if (problems.some((p) => p.status === 'warning')) return 'warn';
+  if (incomplete) return 'warn';
+  return 'ok';
+}
+
+// ── Probe dependencies (injectable for tests) ────────────────────────────
+
+export interface RigStoreProbeDeps {
+  /** True when `<beadsPath>` is an existing directory. */
+  statBeads(beadsPath: string): Promise<boolean>;
+  /** Configured dolt server port from `<beadsPath>/dolt-server.port`, or null. */
+  readPort(beadsPath: string): Promise<number | null>;
+  /** True when a TCP connection to 127.0.0.1:port succeeds within the timeout. */
+  tcpProbe(port: number): Promise<boolean>;
+  /** `bd doctor --readonly --db <beadsPath> --json`. */
+  runDoctor(beadsPath: string): Promise<ExecResult>;
+}
+
+export const defaultRigStoreProbeDeps: RigStoreProbeDeps = {
+  async statBeads(beadsPath) {
+    try {
+      const st = await fs.promises.stat(beadsPath);
+      return st.isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  async readPort(beadsPath) {
+    try {
+      const raw = await fs.promises.readFile(path.join(beadsPath, 'dolt-server.port'), 'utf-8');
+      const port = Number.parseInt(raw.trim(), 10);
+      return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null;
+    } catch {
+      return null;
+    }
+  },
+  tcpProbe(port) {
+    return new Promise<boolean>((resolve) => {
+      const socket = net.connect({ host: '127.0.0.1', port });
+      const done = (ok: boolean) => {
+        socket.destroy();
+        resolve(ok);
+      };
+      socket.setTimeout(TCP_PROBE_TIMEOUT_MS);
+      socket.once('connect', () => done(true));
+      socket.once('timeout', () => done(false));
+      socket.once('error', () => done(false));
+    });
+  },
+  runDoctor: execBdDoctor,
+};
+
+/**
+ * Probe one rig's `.beads` store into a RigStoreHealth. Doctor failures and a
+ * non-JSON (embedded-mode) fallback are caught here and folded into the result
+ * rather than thrown; the default deps' fs/net probes resolve instead of
+ * rejecting. The sampler still wraps this in `safeProbe` so an unexpected
+ * throw from an injected dep cannot abort the whole sample.
+ */
+export async function probeRigStore(
+  rig: SupervisorRigDescriptor,
+  deps: RigStoreProbeDeps,
+): Promise<RigStoreHealth> {
+  const beadsPath = path.join(rig.path, '.beads');
+  const reachable = await deps.statBeads(beadsPath);
+  if (!reachable) {
+    return {
+      rig: rig.name,
+      beadsPath,
+      rollup: 'down',
+      reachable: false,
+      doltEndpoint: null,
+      doltConnected: null,
+      issueCount: null,
+      problems: [],
+      note: '.beads store not found on disk',
+    };
+  }
+
+  const port = await deps.readPort(beadsPath);
+  const doltEndpoint = port !== null ? `127.0.0.1:${port}` : null;
+
+  let checks: RigStoreCheck[] | null = null;
+  let note: string | undefined;
+  try {
+    const result = await deps.runDoctor(beadsPath);
+    checks = parseDoctorChecks(result.stdout);
+    if (checks === null) {
+      note = 'bd doctor returned no JSON (embedded mode or dolt server unreachable)';
+    }
+  } catch (err) {
+    note = `bd doctor probe failed: ${errorMessage(err)}`;
+  }
+
+  let doltConnected: boolean | null;
+  if (port !== null) {
+    doltConnected = await deps.tcpProbe(port);
+  } else {
+    doltConnected = checks !== null ? doltConnectedFromChecks(checks) : null;
+  }
+
+  const problems = checks !== null ? storeProblems(checks) : [];
+  const issueCount = checks !== null ? issueCountFromChecks(checks) : null;
+  const rollup = rollupFor({
+    reachable,
+    doltConnected,
+    problems,
+    incomplete: note !== undefined,
+  });
+
+  return {
+    rig: rig.name,
+    beadsPath,
+    rollup,
+    reachable,
+    doltEndpoint,
+    doltConnected,
+    issueCount,
+    problems,
+    ...(note !== undefined ? { note } : {}),
+  };
+}
+
+// ── Sampler ──────────────────────────────────────────────────────────────
+
+export interface SamplerTimer {
+  unref(): void;
+}
+
+export interface SamplerRuntime {
+  setInterval(callback: () => void, delayMs: number): SamplerTimer;
+  clearInterval(timer: SamplerTimer): void;
+}
+
+const nodeRuntime: SamplerRuntime = {
+  setInterval: (callback, delayMs) => setInterval(callback, delayMs),
+  clearInterval: (timer) => clearInterval(timer as NodeJS.Timeout),
+};
+
+export interface RigStoreHealthSampler {
+  readonly running: boolean;
+  start(): void;
+  stop(): void;
+  sampleOnce(): Promise<void>;
+  report(): RigStoreHealthReport;
+}
+
+export interface RigStoreHealthSamplerOptions {
+  listRigs: () => Promise<readonly SupervisorRigDescriptor[]>;
+  probe?: (rig: SupervisorRigDescriptor) => Promise<RigStoreHealth>;
+  deps?: RigStoreProbeDeps;
+  runtime?: SamplerRuntime;
+  intervalMs?: number;
+  now?: () => string;
+}
+
+type SamplerTimerState = { status: 'idle' } | { status: 'scheduled'; timer: SamplerTimer };
+
+export function createRigStoreHealthSampler(
+  opts: RigStoreHealthSamplerOptions,
+): RigStoreHealthSampler {
+  const deps = opts.deps ?? defaultRigStoreProbeDeps;
+  const probe = opts.probe ?? ((rig: SupervisorRigDescriptor) => probeRigStore(rig, deps));
+  const runtime = opts.runtime ?? nodeRuntime;
+  const intervalMs = opts.intervalMs ?? SAMPLE_INTERVAL_MS;
+  const now = opts.now ?? (() => new Date().toISOString());
+
+  // Last successful per-rig snapshot. Retained across a later failed rig-list
+  // read so the report can still carry prior data (degraded, not blank).
+  let rigs: RigStoreHealth[] = [];
+  let sampledAt: string | null = null;
+  let lastReason: RigStoreHealthUnavailableReason = 'not_sampled_yet';
+  let available = false;
+  let timerState: SamplerTimerState = { status: 'idle' };
+
+  const sampleOnce = async (): Promise<void> => {
+    let descriptors: readonly SupervisorRigDescriptor[];
+    try {
+      descriptors = await opts.listRigs();
+    } catch (err) {
+      available = false;
+      lastReason = 'rig_list_failed';
+      logWarn(LOG_COMPONENT.rigStoreHealth, `rig list failed: ${errorMessage(err)}`);
+      return;
+    }
+    rigs = await Promise.all(descriptors.map((rig) => safeProbe(probe, rig)));
+    sampledAt = now();
+    available = true;
+  };
+
+  return {
+    get running() {
+      return timerState.status === 'scheduled';
+    },
+    start() {
+      if (timerState.status === 'scheduled') return;
+      void sampleOnce();
+      timerState = {
+        status: 'scheduled',
+        timer: runtime.setInterval(() => {
+          void sampleOnce();
+        }, intervalMs),
+      };
+      timerState.timer.unref();
+    },
+    stop() {
+      if (timerState.status === 'idle') return;
+      runtime.clearInterval(timerState.timer);
+      timerState = { status: 'idle' };
+    },
+    sampleOnce,
+    report(): RigStoreHealthReport {
+      if (available && sampledAt !== null) {
+        return { available: true, sampledAt, rigs };
+      }
+      return { available: false, reason: lastReason, rigs };
+    },
+  };
+}
+
+async function safeProbe(
+  probe: (rig: SupervisorRigDescriptor) => Promise<RigStoreHealth>,
+  rig: SupervisorRigDescriptor,
+): Promise<RigStoreHealth> {
+  try {
+    return await probe(rig);
+  } catch (err) {
+    return {
+      rig: rig.name,
+      beadsPath: path.join(rig.path, '.beads'),
+      rollup: 'down',
+      reachable: false,
+      doltEndpoint: null,
+      doltConnected: null,
+      issueCount: null,
+      problems: [],
+      note: `probe failed: ${errorMessage(err)}`,
+    };
+  }
+}
+
+export function rigStoreHealthRouter(sampler: RigStoreHealthSampler): Router {
+  const router = Router();
+  router.get('/', (_req, res) => {
+    const payload = sampler.report();
+    void recordAudit({
+      type: 'dashboard.fetch',
+      endpoint: 'GET /api/city/:cityName/rig-store-health',
+      parsed_args: { rigs: String(payload.rigs.length) },
+      duration_ms: 0,
+    });
+    res.json(payload);
+  });
+  return router;
+}

--- a/backend/test/logging.test.ts
+++ b/backend/test/logging.test.ts
@@ -25,6 +25,7 @@ describe('logging component vocabulary', () => {
         LOG_COMPONENT.links,
         LOG_COMPONENT.maintainer,
         LOG_COMPONENT.metrics,
+        LOG_COMPONENT.rigStoreHealth,
         LOG_COMPONENT.runs,
       ].sort(),
     );

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   SystemHealth,
   LocalToolVersions,
   DoltNomsTrend,
+  RigStoreHealthReport,
   MaintainerTriage,
   MaintainerSlingRecordRequest,
   ContributorStat,
@@ -268,6 +269,13 @@ const decodeDoltTrend = objectDecoder<DoltNomsTrend>('dolt trend', (record, url)
   requireBooleanField(record, url, 'dolt trend', 'available');
   requireArrayField(record, url, 'dolt trend', 'samples');
 });
+const decodeRigStoreHealth = objectDecoder<RigStoreHealthReport>(
+  'rig store health',
+  (record, url) => {
+    requireBooleanField(record, url, 'rig store health', 'available');
+    requireArrayField(record, url, 'rig store health', 'rigs');
+  },
+);
 const decodeRunDiff = objectDecoder<RunDiffResponse>('run diff', (record, url) => {
   requireStringField(record, url, 'run diff', 'kind');
   requireObjectField(record, url, 'run diff', 'rootPath');
@@ -342,6 +350,9 @@ export const api = {
   },
   doltTrend(): Promise<DoltNomsTrend> {
     return request('GET', cityPath('/dolt-noms/trend'), decodeDoltTrend);
+  },
+  rigStoreHealth(): Promise<RigStoreHealthReport> {
+    return request('GET', cityPath('/rig-store-health'), decodeRigStoreHealth);
   },
   runDiff(
     runId: string,

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -6,7 +6,12 @@ import { invalidate } from '../api/cache';
 import { AttentionProvider } from '../attention/context';
 import { createAttentionContributors, type HealthAttentionFacts } from '../attention/registry';
 import type { HealthOutputBody, StatusBody } from 'gas-city-dashboard-shared/gc-supervisor';
-import type { DoltNomsTrend, LocalToolVersions, SystemHealth } from 'gas-city-dashboard-shared';
+import type {
+  DoltNomsTrend,
+  LocalToolVersions,
+  RigStoreHealthReport,
+  SystemHealth,
+} from 'gas-city-dashboard-shared';
 import { supervisorApiForRequestBudget } from '../supervisor/client';
 
 const mockCityHealth = vi.fn<(cityName: string) => Promise<HealthOutputBody>>();
@@ -30,8 +35,10 @@ vi.mock('../supervisor/client', () => ({
 let currentHealth: SystemHealth = baseHealth();
 let currentLocalTools: LocalToolVersions = baseLocalTools();
 let currentTrend: DoltNomsTrend = baseTrend();
+let currentRigStores: RigStoreHealthReport = baseRigStores();
 let systemHealthMode: 'ok' | 'fail' = 'ok';
 let trendMode: 'ok' | 'fail' = 'ok';
+let rigStoreMode: 'ok' | 'fail' = 'ok';
 
 beforeEach(() => {
   invalidate('health');
@@ -43,8 +50,10 @@ beforeEach(() => {
   currentHealth = baseHealth();
   currentLocalTools = baseLocalTools();
   currentTrend = baseTrend();
+  currentRigStores = baseRigStores();
   systemHealthMode = 'ok';
   trendMode = 'ok';
+  rigStoreMode = 'ok';
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL) => {
@@ -63,6 +72,12 @@ beforeEach(() => {
           return errorResponse('dolt trend offline');
         }
         return jsonResponse(currentTrend);
+      }
+      if (url === '/api/city/test-city/rig-store-health') {
+        if (rigStoreMode === 'fail') {
+          return errorResponse('rig store health offline');
+        }
+        return jsonResponse(currentRigStores);
       }
       throw new Error(`unexpected fetch: ${url}`);
     }),
@@ -219,6 +234,36 @@ describe('HealthPage', () => {
     expect(screen.getByText('5')).toBeTruthy();
     expect(screen.getByText('Dolt MB-per-row ratio')).toBeTruthy();
     expect(screen.getByText('<= 1')).toBeTruthy();
+  });
+
+  it('surfaces per-rig bead-store health with a down rig flagged', async () => {
+    const { container } = renderPage();
+
+    await screen.findByRole('heading', { name: /bead stores · per rig/i });
+
+    // Both rigs render; the down rig surfaces its dolt-down state.
+    expect(screen.getByText('codeprobe')).toBeTruthy();
+    expect(screen.getByText('geo')).toBeTruthy();
+    expect(screen.getByText('dolt down')).toBeTruthy();
+    expect(screen.getByText(/DOWN · 127\.0\.0\.1:29620/)).toBeTruthy();
+    // The ok rig surfaces an up endpoint.
+    expect(screen.getByText(/up · 127\.0\.0\.1:29620/)).toBeTruthy();
+
+    // Worst-first ordering: the down rig (geo) renders before the ok rig.
+    const names = Array.from(container.querySelectorAll('span'))
+      .map((s) => s.textContent)
+      .filter((t) => t === 'codeprobe' || t === 'geo');
+    expect(names[0]).toBe('geo');
+  });
+
+  it('keeps other Health sections visible when rig-store health fails', async () => {
+    rigStoreMode = 'fail';
+
+    renderPage();
+
+    await screen.findByRole('heading', { name: /supervisor/i });
+    await screen.findByRole('heading', { name: /bead stores · per rig/i });
+    expect(screen.getByText(/per-rig store health unavailable/i)).toBeTruthy();
   });
 
   it('highlights Health sections that match composed attention facts', async () => {
@@ -415,5 +460,34 @@ function baseTrend(): DoltNomsTrend {
     available: true,
     samples: [],
     source: '/var/gc/.dolt/noms',
+  };
+}
+
+function baseRigStores(): RigStoreHealthReport {
+  return {
+    available: true,
+    sampledAt: '2026-06-06T00:00:00.000Z',
+    rigs: [
+      {
+        rig: 'codeprobe',
+        beadsPath: '/home/ds/projects/codeprobe/.beads',
+        rollup: 'ok',
+        reachable: true,
+        doltEndpoint: '127.0.0.1:29620',
+        doltConnected: true,
+        issueCount: 129,
+        problems: [],
+      },
+      {
+        rig: 'geo',
+        beadsPath: '/home/ds/projects/GEO/.beads',
+        rollup: 'down',
+        reachable: true,
+        doltEndpoint: '127.0.0.1:29620',
+        doltConnected: false,
+        issueCount: null,
+        problems: [],
+      },
+    ],
   };
 }

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -473,9 +473,7 @@ function RigStoreRow({ rig }: { rig: RigStoreHealth }) {
           ))}
         </ul>
       )}
-      {rig.note !== undefined && (
-        <p className="text-label text-fg-muted italic">{rig.note}</p>
-      )}
+      {rig.note !== undefined && <p className="text-label text-fg-muted italic">{rig.note}</p>}
     </div>
   );
 }

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -3,6 +3,10 @@ import type {
   DoltNomsTrend,
   LocalToolVersion,
   LocalToolVersions,
+  RigStoreHealth,
+  RigStoreHealthReport,
+  RigStoreHealthUnavailableReason,
+  RigStoreRollup,
   SystemHealth,
 } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
@@ -43,17 +47,23 @@ export function HealthPage() {
     `health:dolt-noms-trend:${cityName ?? 'no-city'}`,
     fetchDoltNomsTrend,
   );
+  const rigStoreHealth = useCachedData(
+    `health:rig-store:${cityName ?? 'no-city'}`,
+    fetchRigStoreHealth,
+  );
   const refreshSystemHealth = systemHealth.refresh;
   const refreshSupervisorHealth = supervisorHealth.refresh;
   const refreshSupervisorStatus = supervisorStatusCache.refresh;
   const refreshLocalToolVersions = localToolVersions.refresh;
   const refreshDoltNomsTrend = doltNomsTrend.refresh;
+  const refreshRigStoreHealth = rigStoreHealth.refresh;
   const sourceLoading =
     systemHealth.loading ||
     supervisorHealth.loading ||
     supervisorStatusCache.loading ||
     localToolVersions.loading ||
-    doltNomsTrend.loading;
+    doltNomsTrend.loading ||
+    rigStoreHealth.loading;
   const error =
     [
       systemHealth.error,
@@ -61,6 +71,7 @@ export function HealthPage() {
       supervisorStatusCache.error,
       localToolVersions.error,
       doltNomsTrend.error,
+      rigStoreHealth.error,
     ]
       .filter((value): value is string => value !== null)
       .join('; ') || null;
@@ -71,10 +82,12 @@ export function HealthPage() {
       refreshSupervisorStatus(),
       refreshLocalToolVersions(),
       refreshDoltNomsTrend(),
+      refreshRigStoreHealth(),
     ]);
   }, [
     refreshDoltNomsTrend,
     refreshLocalToolVersions,
+    refreshRigStoreHealth,
     refreshSupervisorHealth,
     refreshSupervisorStatus,
     refreshSystemHealth,
@@ -86,12 +99,15 @@ export function HealthPage() {
   const status = supervisorStatusCache.data ?? null;
   const localTools = localToolVersions.data ?? null;
   const trend = doltNomsTrend.data ?? null;
+  const rigStores = rigStoreHealth.data ?? null;
+  const rigStoreSummary = rigStores ? rigStoreSummaryStatus(rigStores) : undefined;
   const hasAnyData =
     healthState !== null ||
     supervisor !== null ||
     status !== null ||
     localTools !== null ||
-    trend !== null;
+    trend !== null ||
+    rigStores !== null;
   const hostHealthStatus = health ? hostStatus(health) : undefined;
   const supervisorAttention = prefixedAttentionSeverity(attention, 'health', [
     'health:supervisor-',
@@ -237,6 +253,14 @@ export function HealthPage() {
               <DoltUsageBlock usage={doltUsageOf(status)} />
               <BeadsUsageBlock usage={beadsUsageOf(status)} />
             </div>
+          </Section>
+
+          <Section
+            title="Bead stores · per rig"
+            meta={rigStoreMeta(rigStores)}
+            {...(rigStoreSummary ? { status: rigStoreSummary } : {})}
+          >
+            <RigStoreHealthBlock report={rigStores} />
           </Section>
 
           <Section title="Recommended vs loaded">
@@ -390,6 +414,121 @@ function BeadsUsageBlock({ usage }: { usage: DiagnosticDatum<StatusWorkCounts> }
       </KvList>
     </div>
   );
+}
+
+function RigStoreHealthBlock({ report }: { report: RigStoreHealthReport | null }) {
+  if (report === null) {
+    return <p className="text-body text-fg-muted italic">Loading per-rig store health.</p>;
+  }
+  if (!report.available && report.rigs.length === 0) {
+    return (
+      <p className="text-body text-fg-muted italic">
+        Per-rig store health unavailable: {rigStoreUnavailableCopy(report.reason)}.
+      </p>
+    );
+  }
+  // Sort worst-first so a degraded store is never buried below healthy ones.
+  const rigs = [...report.rigs].sort((a, b) => rollupRank(b.rollup) - rollupRank(a.rollup));
+  return (
+    <div className="space-y-6 max-w-prose">
+      {!report.available && (
+        <p className="text-body text-warn italic">
+          Showing the last sample — refresh failed: {rigStoreUnavailableCopy(report.reason)}.
+        </p>
+      )}
+      {rigs.map((rig) => (
+        <RigStoreRow key={rig.rig} rig={rig} />
+      ))}
+    </div>
+  );
+}
+
+function RigStoreRow({ rig }: { rig: RigStoreHealth }) {
+  const status = rigRollupStatus(rig);
+  return (
+    <div className="space-y-2 border-b border-rule pb-4 last:border-b-0">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-body font-medium text-fg">{rig.rig}</span>
+        <StatusBadge tone={status.tone} label={status.label} />
+      </div>
+      <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1">
+        <Kv
+          label="Dolt server"
+          value={rigDoltServerValue(rig)}
+          {...(rig.doltConnected === false ? { tone: 'stuck' as const } : {})}
+        />
+        {rig.issueCount !== null && (
+          <Kv label="Live issues" value={rig.issueCount.toLocaleString()} />
+        )}
+      </dl>
+      {rig.problems.length > 0 && (
+        <ul className="space-y-1">
+          {rig.problems.map((p) => (
+            <li
+              key={`${p.category}/${p.name}`}
+              className={`text-label ${p.status === 'error' ? 'text-accent' : 'text-warn'}`}
+            >
+              {p.name}: {p.message}
+            </li>
+          ))}
+        </ul>
+      )}
+      {rig.note !== undefined && (
+        <p className="text-label text-fg-muted italic">{rig.note}</p>
+      )}
+    </div>
+  );
+}
+
+function rigDoltServerValue(rig: RigStoreHealth): string {
+  const endpoint = rig.doltEndpoint ?? 'no endpoint reported';
+  if (rig.doltConnected === true) return `up · ${endpoint}`;
+  if (rig.doltConnected === false) return `DOWN · ${endpoint}`;
+  return `unknown · ${endpoint}`;
+}
+
+function rigRollupStatus(rig: RigStoreHealth): { tone: StatusTone; label: string } {
+  switch (rig.rollup) {
+    case 'ok':
+      return { tone: 'ok', label: 'healthy' };
+    case 'warn':
+      return { tone: 'warn', label: 'warnings' };
+    case 'down':
+      if (!rig.reachable) return { tone: 'stuck', label: 'unreachable' };
+      if (rig.doltConnected === false) return { tone: 'stuck', label: 'dolt down' };
+      return { tone: 'stuck', label: 'errors' };
+  }
+}
+
+function rollupRank(rollup: RigStoreRollup): number {
+  return rollup === 'down' ? 2 : rollup === 'warn' ? 1 : 0;
+}
+
+function rigStoreMeta(report: RigStoreHealthReport | null): string | undefined {
+  if (report === null || report.rigs.length === 0) return undefined;
+  const counts = { ok: 0, warn: 0, down: 0 };
+  for (const rig of report.rigs) counts[rig.rollup] += 1;
+  return `${counts.ok} ok · ${counts.warn} warn · ${counts.down} down`;
+}
+
+function rigStoreSummaryStatus(
+  report: RigStoreHealthReport,
+): { tone: StatusTone; label: string } | undefined {
+  if (report.rigs.some((r) => r.rollup === 'down')) return { tone: 'stuck', label: 'attention' };
+  if (report.rigs.some((r) => r.rollup === 'warn')) return { tone: 'warn', label: 'warnings' };
+  if (report.rigs.length > 0) return { tone: 'ok', label: 'healthy' };
+  return undefined;
+}
+
+function rigStoreUnavailableCopy(reason: RigStoreHealthUnavailableReason): string {
+  switch (reason) {
+    case 'not_sampled_yet':
+      return 'backend just started; first sample is in flight';
+    case 'rig_list_failed':
+      return 'the supervisor rig list could not be read';
+    case 'fetch_failed':
+      return 'the dashboard backend could not be reached';
+  }
 }
 
 function ConfigComparison({ comparison }: { comparison: DiagnosticDatum<ConfigComparisonRow[]> }) {
@@ -580,6 +719,17 @@ async function fetchDoltNomsTrend(): Promise<DoltNomsTrend> {
       reason: 'sample_failed',
       samples: [],
     };
+  }
+}
+
+async function fetchRigStoreHealth(): Promise<RigStoreHealthReport> {
+  try {
+    return await api.rigStoreHealth();
+  } catch {
+    // Transport-level failure (backend unreachable / 5xx / decode) — a
+    // distinct root cause from the backend's own 'rig_list_failed', so it must
+    // not borrow that reason and point the operator at the supervisor.
+    return { available: false, reason: 'fetch_failed', rigs: [] };
   }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -46,6 +46,7 @@ export type * from './transcript.js';
 export type * from './dashboard-beads.js';
 export type * from './activity.js';
 export type * from './dashboard-health.js';
+export type * from './rig-store-health.js';
 export type * from './api-error.js';
 export type * from './maintainer-triage.js';
 export type * from './views.js';

--- a/shared/src/rig-store-health.ts
+++ b/shared/src/rig-store-health.ts
@@ -1,0 +1,70 @@
+import type { IsoTimestamp } from './dashboard-sessions.js';
+
+// Per-rig bead-store + dolt health, surfaced on the Health tab so the class of
+// incident the city hit (dolt outage, store bloat, schema drift) is visible
+// per rig before it bites. Unlike the supervisor's single city-level
+// store_health, each rig carries its own embedded-dolt `.beads` store, so this
+// is a dashboard-local probe (host-FS reachability + dolt endpoint liveness +
+// `bd doctor` health checks), not supervisor wire data.
+
+/** Per-rig roll-up tone for the status dot. */
+export type RigStoreRollup = 'ok' | 'warn' | 'down';
+
+/** Status of a single `bd doctor` check, mirroring its own vocabulary. */
+export type RigStoreCheckStatus = 'ok' | 'warning' | 'error';
+
+/** One non-ok store/dolt health check, surfaced for the operator. */
+export interface RigStoreCheck {
+  /** `bd doctor` category, e.g. "Core System", "Data & Config". */
+  category: string;
+  /** `bd doctor` check name, e.g. "Dolt Connection". */
+  name: string;
+  status: RigStoreCheckStatus;
+  message: string;
+}
+
+export interface RigStoreHealth {
+  /** Rig name as reported by the supervisor. */
+  rig: string;
+  /** Absolute host path of the rig's `.beads` store. */
+  beadsPath: string;
+  /** Roll-up tone driving the per-rig status dot. */
+  rollup: RigStoreRollup;
+  /** `.beads` store directory present on disk. */
+  reachable: boolean;
+  /** Configured dolt sql-server endpoint (host:port), or null when the store
+   *  declares no server endpoint (e.g. embedded / jsonl-only mode). */
+  doltEndpoint: string | null;
+  /** Dolt sql-server reachable at its endpoint. `null` when there is no
+   *  endpoint to probe (no outage to report for an embedded store). */
+  doltConnected: boolean | null;
+  /** Live bead row count when `bd doctor` reported it. */
+  issueCount: number | null;
+  /** Store/dolt checks that are not `ok`. Benign hygiene categories
+   *  (git hooks, editor integrations) are excluded — they are not store
+   *  health and the dashboard operator cannot act on them here. */
+  problems: RigStoreCheck[];
+  /** Set when the probe could not fully assess the store (e.g. `bd doctor`
+   *  fell back to embedded mode, which it cannot health-check). */
+  note?: string;
+}
+
+export type RigStoreHealthUnavailableReason =
+  | 'not_sampled_yet'
+  /** Backend sampled, but the supervisor rig list read failed. */
+  | 'rig_list_failed'
+  /** The browser could not reach the dashboard backend for the snapshot. */
+  | 'fetch_failed';
+
+export type RigStoreHealthReport =
+  | {
+      available: true;
+      sampledAt: IsoTimestamp;
+      rigs: RigStoreHealth[];
+    }
+  | {
+      available: false;
+      reason: RigStoreHealthUnavailableReason;
+      /** Rigs from the prior successful sample, if any. */
+      rigs: RigStoreHealth[];
+    };


### PR DESCRIPTION
## Summary

Adds a per-rig bead-store + Dolt health roll-up to the Health tab.

- **Per-rig roll-up + sampler**: for each rig, probes the bead store's filesystem reachability, the Dolt `sql-server` (TCP probe) availability, and runs `bd doctor` to surface store integrity.
- **Cached-snapshot, no-fork design**: the sampler reads from a cached health snapshot rather than forking per-request work, keeping the Health tab responsive and the supervisor unburdened.
- Surfaces results in the Health tab with the editorial register the dashboard uses elsewhere.

## CI

Fresh CI parity run vs **current `main`** (rebased onto latest origin/main), all green:

- `npm run typecheck` (src + test) ✅
- `npm run lint` ✅
- `npm --workspace backend test` — 533 pass ✅
- `npm --workspace frontend test` — 749 pass ✅
- `npm --workspace shared test` — 62 pass ✅
- `npm --workspace frontend run build` ✅
- openapi supervisor client drift check ✅

## Review status

Reviewed SHIP; gates were green at author time and re-verified fresh against current main. **Mayor merge-gates** — do not merge without mayor sign-off.