### PR TITLE
fix(proxy): opt-in read-only proxy gate (z8n7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ Then open `http://127.0.0.1:5174`. The dashboard expects a Gas City `gc supervis
 ```bash
 npm install
 npm run build
-node backend/dist/server.js     # serves API + frontend on :8081
+PORT=8082 node backend/dist/server.js     # serves API + frontend on :8082
 ```
 
-For systemd-managed install: [`deploy/README.md`](deploy/README.md).
+Production runs on `:8082` (the systemd unit and the `dashboard:test` gate both
+target it), leaving `:8081` to the dev backend so the two coexist on one host.
+With no `PORT` the listener falls back to the `8081` default. For
+systemd-managed install: [`deploy/README.md`](deploy/README.md).
 
 ## Quality gates
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All knobs are environment variables. See [`backend/src/config.ts`](backend/src/c
 | Variable                    | Default                  | Purpose                                                                                                                                  |
 | --------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                      | `8081`                   | TCP port the dashboard listens on                                                                                                        |
-| `HOST`                      | `127.0.0.1`              | Bind interface. Set `0.0.0.0` for LAN access on a trusted network.                                                                       |
+| `HOST`                      | `127.0.0.1`              | Ignored — the backend always binds loopback. Expose beyond localhost via your own auth proxy (see Security model).                       |
 | `ADMIN_EXTRA_ALLOWED_HOSTS` | (empty)                  | CSV of extra hostnames allowed in the `Host:` header (e.g. `my-vm,192.168.1.58`). The floor `127.0.0.1` / `localhost` is always allowed. |
 | `GC_SUPERVISOR_URL`         | `http://127.0.0.1:8372`  | gc supervisor API base URL.                                                                                                              |
 | `GC_CITY_NAME`              | `racoon-city`            | Name of the city this dashboard manages. One dashboard per city.                                                                         |
@@ -125,6 +125,8 @@ Built for **single-operator** use on a **trusted network**.
 - **Origin check** — POST/PATCH/DELETE require an `Origin` matching the allowed-host set.
 - **Content Security Policy** — `script-src 'self'` plus a hash for the static theme bootstrap, no arbitrary inline scripts, no `eval`.
 - **Exec whitelist** — every shell-out is enumerated explicitly in [`backend/src/exec.ts`](backend/src/exec.ts). There is no general-purpose command execution path.
+
+**Exposing beyond localhost is operator-owned.** The default needs zero config and ships no auth. To reach the dashboard remotely you front it with your **own** authenticated proxy (nginx/Caddy/Tailscale Serve/Cloudflare Access/etc.) — the dashboard stays on loopback. Optionally enable the server-enforced read-only gate (`DASHBOARD_READONLY=1`), keep the gc supervisor loopback-only and patched, and rate-limit at your proxy. Full runbook: [`specs/architecture/exposure.md`](specs/architecture/exposure.md).
 
 Full threat model: [`specs/architecture/security.md`](specs/architecture/security.md).
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -56,6 +56,13 @@ export function createDashboardApp(config: AdminConfig): DashboardApp {
   });
 
   app.use('/gc-supervisor', supervisorTransportProxy(config.gcSupervisorUrl, config.readOnly));
+  if (config.readOnly) {
+    logInfo(
+      LOG_COMPONENT.admin,
+      'DASHBOARD_READONLY=1 — /gc-supervisor proxy is read-only: non-GET/HEAD → 405, ' +
+        'default-deny read allowlist, x-gc-request stripped',
+    );
+  }
   app.use(express.json({ limit: '64kb' }));
 
   // ── Top-level (non-city) routes ─────────────────────────────────────────

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -55,7 +55,7 @@ export function createDashboardApp(config: AdminConfig): DashboardApp {
     listCities: supervisorCityLister(supervisorGc),
   });
 
-  app.use('/gc-supervisor', supervisorTransportProxy(config.gcSupervisorUrl));
+  app.use('/gc-supervisor', supervisorTransportProxy(config.gcSupervisorUrl, config.readOnly));
   app.use(express.json({ limit: '64kb' }));
 
   // ── Top-level (non-city) routes ─────────────────────────────────────────

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -71,6 +71,16 @@ export interface AdminConfig {
   /** Kill-switch: set to '1' to refuse to start. */
   disabled: boolean;
   /**
+   * Opt-in read-only mode for the `/gc-supervisor` transport proxy
+   * (exposure-hardening PRD M1). When true the proxy rejects every non-GET/HEAD
+   * with 405, default-denies to an explicit supervisor read allowlist, and
+   * strips the write-authorizing `x-gc-request` header before forwarding —
+   * so an externally fronted instance cannot mutate the city. Default false
+   * keeps the zero-friction local operator experience unchanged.
+   * Env: `DASHBOARD_READONLY` (set to '1' to enable).
+   */
+  readOnly: boolean;
+  /**
    * Per-module configuration slices. Modules read their own slice in
    * `needs(config)`. See `MaintainerModuleConfig` for the maintainer
    * envelope — env-driven via MAINTAINER_GITHUB_REPO, MAINTAINER_CACHE_PATH,
@@ -225,6 +235,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AdminConfig {
     auditLogPath: env.ADMIN_AUDIT_LOG_PATH ?? defaultAuditLogPath(env),
     frontendDistPath: env.ADMIN_FRONTEND_DIST ?? '../frontend/dist',
     disabled: env.ADMIN_DASHBOARD_DISABLED === '1',
+    readOnly: env.DASHBOARD_READONLY === '1',
     modules: {
       maintainer: maintainerEnabled
         ? loadMaintainerModuleConfig(env)

--- a/backend/src/lib/http-status.ts
+++ b/backend/src/lib/http-status.ts
@@ -4,6 +4,7 @@ export const HTTP_STATUS = {
   badRequest: 400,
   forbidden: 403,
   notFound: 404,
+  methodNotAllowed: 405,
   misdirectedRequest: 421,
   unprocessableContent: 422,
   badGateway: 502,

--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -1,0 +1,60 @@
+// Default-deny read-endpoint allowlist for the `/gc-supervisor` transport proxy
+// when DASHBOARD_READONLY=1 (exposure-hardening PRD M1 / bead z8n7).
+//
+// Only GET/HEAD requests whose path matches one of these templates are
+// forwarded to the supervisor; every other path is rejected with 404. The list
+// is deliberately the *minimal* set of supervisor reads the dashboard SPA
+// performs — see the `getV0*` / SSE calls in `frontend/src/supervisor/*`. A new
+// read view must be added here to work under read-only mode; until then it
+// fails closed, which is the intended posture for an externally exposed
+// instance.
+//
+// Side-effecting GETs are excluded on purpose. `agent/{base}/prime` (and its
+// `{dir}/{base}` variant) is a state-changing GET flagged by the exposure
+// premortem, so neither it nor the dynamic two-segment agent-detail reads are
+// allowlisted — keeping the agent surface to the inert `agents` listing also
+// avoids a `[^/]+`-collision where `agent/{base}/prime` would otherwise match a
+// generic `agent/{dir}/{base}` pattern.
+const READ_ENDPOINT_TEMPLATES = [
+  '/health',
+  '/v0/cities',
+  '/v0/city/{cityName}/agents',
+  '/v0/city/{cityName}/beads',
+  '/v0/city/{cityName}/bead/{id}',
+  '/v0/city/{cityName}/events',
+  '/v0/city/{cityName}/events/stream',
+  '/v0/city/{cityName}/formulas/feed',
+  '/v0/city/{cityName}/formulas/{name}',
+  '/v0/city/{cityName}/health',
+  '/v0/city/{cityName}/mail',
+  '/v0/city/{cityName}/mail/thread/{id}',
+  '/v0/city/{cityName}/sessions',
+  '/v0/city/{cityName}/session/{id}/pending',
+  '/v0/city/{cityName}/session/{id}/stream',
+  '/v0/city/{cityName}/session/{id}/transcript',
+  '/v0/city/{cityName}/status',
+  '/v0/city/{cityName}/workflow/{workflow_id}',
+] as const;
+
+const READ_ENDPOINT_PATTERNS: readonly RegExp[] =
+  READ_ENDPOINT_TEMPLATES.map(templateToPattern);
+
+/** True when `path` (proxy-relative, query stripped) is an allowlisted read. */
+export function isAllowedReadPath(path: string): boolean {
+  return READ_ENDPOINT_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+// `{param}` segments match a single path segment; literal segments match
+// exactly. Anchored at both ends so a longer path (e.g. an action suffix) never
+// satisfies a shorter template.
+function templateToPattern(template: string): RegExp {
+  const body = template
+    .split('/')
+    .map((segment) =>
+      segment.startsWith('{') && segment.endsWith('}')
+        ? '[^/]+'
+        : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    )
+    .join('/');
+  return new RegExp(`^${body}$`);
+}

--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -53,11 +53,18 @@ export function isAllowedReadPath(path: string): boolean {
 // the GLOBAL `/v0/events/stream` cross-city stream, defeating read-only mode in
 // a multi-city deployment. No legitimate supervisor read path contains a `.`/`..`
 // segment, an encoded dot, or a backslash, so all fail closed — keeping the
-// checked path equal to the forwarded path regardless of how it was encoded.
+// checked path equal to the forwarded path regardless of how it was encoded. The
+// per-segment check compares each segment's matrix-parameter prefix (`..;x` →
+// `..`): a `..;`/`.;` segment is inert against the current Express supervisor
+// (it doesn't strip `;`-suffixes) but would resolve to a traversal if the
+// upstream framework ever did, so it fails closed now rather than latently.
 function hasTraversal(path: string): boolean {
   if (path.includes('\\')) return true;
   if (path.toLowerCase().includes('%2e')) return true;
-  return path.split('/').some((segment) => segment === '..' || segment === '.');
+  return path.split('/').some((segment) => {
+    const bare = segment.split(';')[0];
+    return bare === '..' || bare === '.';
+  });
 }
 
 // `{param}` segments match a single path segment; literal segments match

--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -36,12 +36,25 @@ const READ_ENDPOINT_TEMPLATES = [
   '/v0/city/{cityName}/workflow/{workflow_id}',
 ] as const;
 
-const READ_ENDPOINT_PATTERNS: readonly RegExp[] =
-  READ_ENDPOINT_TEMPLATES.map(templateToPattern);
+const READ_ENDPOINT_PATTERNS: readonly RegExp[] = READ_ENDPOINT_TEMPLATES.map(templateToPattern);
 
 /** True when `path` (proxy-relative, query stripped) is an allowlisted read. */
 export function isAllowedReadPath(path: string): boolean {
+  if (hasTraversal(path)) return false;
   return READ_ENDPOINT_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+// Express leaves `req.path` un-normalized, but the upstream URL is built with
+// `new URL(req.url, base)`, which resolves `..` segments (and treats `\` as `/`
+// for http URLs). Without this guard a path like `/v0/city/../events/stream`
+// would satisfy the per-city `{cityName}` template (`[^/]+` matches `..`) yet
+// forward to the GLOBAL `/v0/events/stream` cross-city stream — defeating
+// read-only mode in a multi-city deployment. No legitimate supervisor read path
+// contains a `..` segment or a backslash, so both fail closed and the checked
+// path always equals the forwarded path.
+function hasTraversal(path: string): boolean {
+  if (path.includes('\\')) return true;
+  return path.split('/').includes('..');
 }
 
 // `{param}` segments match a single path segment; literal segments match

--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -44,17 +44,20 @@ export function isAllowedReadPath(path: string): boolean {
   return READ_ENDPOINT_PATTERNS.some((pattern) => pattern.test(path));
 }
 
-// Express leaves `req.path` un-normalized, but the upstream URL is built with
-// `new URL(req.url, base)`, which resolves `..` segments (and treats `\` as `/`
-// for http URLs). Without this guard a path like `/v0/city/../events/stream`
-// would satisfy the per-city `{cityName}` template (`[^/]+` matches `..`) yet
-// forward to the GLOBAL `/v0/events/stream` cross-city stream — defeating
-// read-only mode in a multi-city deployment. No legitimate supervisor read path
-// contains a `..` segment or a backslash, so both fail closed and the checked
-// path always equals the forwarded path.
+// Reject anything that could resolve to a different upstream path than the one
+// being checked. `new URL(req.url, base)` (used to build the forwarded target)
+// resolves `..`/`.` segments, decodes percent-escapes (`%2e` → `.`), and treats
+// `\` as `/` for http URLs. A path like `/v0/city/../events/stream` — or its
+// encoded form `/v0/city/%2e%2e/events/stream` — would otherwise satisfy the
+// per-city `{cityName}` template (`[^/]+` matches `..`/`%2e%2e`) yet forward to
+// the GLOBAL `/v0/events/stream` cross-city stream, defeating read-only mode in
+// a multi-city deployment. No legitimate supervisor read path contains a `.`/`..`
+// segment, an encoded dot, or a backslash, so all fail closed — keeping the
+// checked path equal to the forwarded path regardless of how it was encoded.
 function hasTraversal(path: string): boolean {
   if (path.includes('\\')) return true;
-  return path.split('/').includes('..');
+  if (path.toLowerCase().includes('%2e')) return true;
+  return path.split('/').some((segment) => segment === '..' || segment === '.');
 }
 
 // `{param}` segments match a single path segment; literal segments match

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -46,14 +46,23 @@ export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = f
       // methods the resource does support.
       res.setHeader('Allow', 'GET, HEAD');
       res.status(HTTP_STATUS.methodNotAllowed).type('text/plain').send('read-only');
-      return;
-    }
-    if (!isAllowedPath(req.path, readOnly)) {
-      res.status(HTTP_STATUS.notFound).type('text/plain').send('not found');
+      logRejection(req, 'method not allowed');
       return;
     }
 
-    const target = new URL(req.url, baseUrl);
+    // Resolve the upstream target *first*, then gate on the resolved path. This
+    // is the normalize-and-compare invariant: the allowlist check and the
+    // forwarded request operate on the SAME string (`target.pathname`), so an
+    // encoded `..` (e.g. `%2e%2e`) cannot pass the gate as a `[^/]+` city
+    // segment yet resolve upstream to a different, global path — `new URL`
+    // decodes and collapses it before either the check or the forward sees it.
+    const target = resolveUpstreamTarget(req.url, baseUrl);
+    if (target === null || !isAllowedPath(target.pathname, readOnly)) {
+      res.status(HTTP_STATUS.notFound).type('text/plain').send('not found');
+      logRejection(req, 'not allowed');
+      return;
+    }
+
     try {
       const upstream = await fetch(target, requestInit(req, readOnly));
       await writeUpstreamResponse(upstream, res);
@@ -73,9 +82,32 @@ export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = f
   return router;
 }
 
+// Build the upstream URL the request will be forwarded to, failing closed
+// (`null`) on anything we will not proxy. `new URL` resolves `..`/encoded-dot
+// segments and decodes percent-escapes, so this is the canonical normalized
+// form to gate on. A malformed target throws, and an authority in `reqUrl`
+// (e.g. `//evil.example/v0/x`) retargets the proxy at a foreign host — both are
+// rejected so the proxy can only ever reach the configured supervisor origin.
+function resolveUpstreamTarget(reqUrl: string, baseUrl: URL): URL | null {
+  let target: URL;
+  try {
+    target = new URL(reqUrl, baseUrl);
+  } catch {
+    return null;
+  }
+  if (target.origin !== baseUrl.origin) return null;
+  return target;
+}
+
 function isAllowedPath(path: string, readOnly: boolean): boolean {
   if (readOnly) return isAllowedReadPath(path);
   return path === '/health' || path.startsWith('/v0/');
+}
+
+function logRejection(req: Request, reason: string): void {
+  // Surfaces method/path probes (traversal attempts, write attempts) so an
+  // externally-fronted instance leaves an audit trail of what it refused.
+  logWarn(LOG_COMPONENT.admin, `gc supervisor proxy rejected ${req.method} ${req.path}: ${reason}`);
 }
 
 function requestInit(req: Request, readOnly: boolean): RequestInit & { duplex?: 'half' } {

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -42,6 +42,9 @@ export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = f
 
   router.use(async (req, res) => {
     if (readOnly && req.method !== 'GET' && req.method !== 'HEAD') {
+      // RFC 9110 §15.5.6: a 405 MUST carry an Allow header advertising the
+      // methods the resource does support.
+      res.setHeader('Allow', 'GET, HEAD');
       res.status(HTTP_STATUS.methodNotAllowed).type('text/plain').send('read-only');
       return;
     }

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -5,6 +5,7 @@ import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 import { HTTP_STATUS } from '../lib/http-status.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
+import { isAllowedReadPath } from './supervisor-read-allowlist.js';
 
 const HOP_BY_HOP_HEADERS = new Set([
   'connection',
@@ -25,19 +26,33 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   'referer',
 ]);
 
-export function supervisorTransportProxy(supervisorBaseUrl: string): Router {
+// In read-only mode every forwarded request is a GET/HEAD read, so the
+// supervisor's write-authorizing `x-gc-request` header is removed unconditionally
+// (never depend on its absence) along with a body `content-type` that can no
+// longer apply.
+const READONLY_STRIPPED_REQUEST_HEADERS = new Set([
+  ...STRIPPED_REQUEST_HEADERS,
+  'x-gc-request',
+  'content-type',
+]);
+
+export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = false): Router {
   const router = Router();
   const baseUrl = new URL(supervisorBaseUrl);
 
   router.use(async (req, res) => {
-    if (!isAllowedSupervisorPath(req.path)) {
+    if (readOnly && req.method !== 'GET' && req.method !== 'HEAD') {
+      res.status(HTTP_STATUS.methodNotAllowed).type('text/plain').send('read-only');
+      return;
+    }
+    if (!isAllowedPath(req.path, readOnly)) {
       res.status(HTTP_STATUS.notFound).type('text/plain').send('not found');
       return;
     }
 
     const target = new URL(req.url, baseUrl);
     try {
-      const upstream = await fetch(target, requestInit(req));
+      const upstream = await fetch(target, requestInit(req, readOnly));
       await writeUpstreamResponse(upstream, res);
     } catch (err) {
       logWarn(LOG_COMPONENT.admin, `gc supervisor transport proxy failed: ${errorMessage(err)}`);
@@ -55,14 +70,15 @@ export function supervisorTransportProxy(supervisorBaseUrl: string): Router {
   return router;
 }
 
-function isAllowedSupervisorPath(path: string): boolean {
+function isAllowedPath(path: string, readOnly: boolean): boolean {
+  if (readOnly) return isAllowedReadPath(path);
   return path === '/health' || path.startsWith('/v0/');
 }
 
-function requestInit(req: Request): RequestInit & { duplex?: 'half' } {
+function requestInit(req: Request, readOnly: boolean): RequestInit & { duplex?: 'half' } {
   const init: RequestInit & { duplex?: 'half' } = {
     method: req.method,
-    headers: requestHeaders(req),
+    headers: requestHeaders(req, readOnly),
     redirect: 'manual',
   };
   if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -72,11 +88,12 @@ function requestInit(req: Request): RequestInit & { duplex?: 'half' } {
   return init;
 }
 
-function requestHeaders(req: Request): Headers {
+function requestHeaders(req: Request, readOnly: boolean): Headers {
+  const stripped = readOnly ? READONLY_STRIPPED_REQUEST_HEADERS : STRIPPED_REQUEST_HEADERS;
   const headers = new Headers();
   for (const [name, rawValue] of Object.entries(req.headers)) {
     const lower = name.toLowerCase();
-    if (STRIPPED_REQUEST_HEADERS.has(lower)) continue;
+    if (stripped.has(lower)) continue;
     if (rawValue === undefined) continue;
     headers.set(name, Array.isArray(rawValue) ? rawValue.join(', ') : rawValue);
   }

--- a/backend/test/app.test.ts
+++ b/backend/test/app.test.ts
@@ -19,6 +19,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,
+    readOnly: false,
     modules: {
       maintainer: {
         githubRepo: 'gastownhall/gascity',

--- a/backend/test/city-dispatch.test.ts
+++ b/backend/test/city-dispatch.test.ts
@@ -21,6 +21,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,
+    readOnly: false,
     modules: {
       maintainer: {
         githubRepo: 'gastownhall/gascity',

--- a/backend/test/config.test.ts
+++ b/backend/test/config.test.ts
@@ -55,6 +55,20 @@ describe('loadConfig', () => {
     assert.equal(loadConfig({ SNAPSHOT_USE_FIXTURES: '' }).useFixtures, false);
   });
 
+  test('readOnly is true when DASHBOARD_READONLY=1', () => {
+    assert.equal(loadConfig({ DASHBOARD_READONLY: '1' }).readOnly, true);
+  });
+
+  test('readOnly defaults to false so the local operator keeps full read/write', () => {
+    assert.equal(loadConfig({}).readOnly, false);
+  });
+
+  test('readOnly is false for any value other than the exact string "1"', () => {
+    assert.equal(loadConfig({ DASHBOARD_READONLY: 'true' }).readOnly, false);
+    assert.equal(loadConfig({ DASHBOARD_READONLY: '0' }).readOnly, false);
+    assert.equal(loadConfig({ DASHBOARD_READONLY: '' }).readOnly, false);
+  });
+
   test('runCwdAllowedRoots defaults to empty (shape-only, no regression) when unset', () => {
     assert.deepEqual(loadConfig({}).runCwdAllowedRoots, []);
   });

--- a/backend/test/gc-supervisor-origin.test.ts
+++ b/backend/test/gc-supervisor-origin.test.ts
@@ -29,6 +29,7 @@ function makeConfig(supervisorUrl: string): AdminConfig {
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,
+    readOnly: false,
     modules: {
       maintainer: {
         githubRepo: 'gastownhall/gascity',

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -53,4 +53,24 @@ describe('supervisor read allowlist', () => {
     assert.equal(isAllowedReadPath('/v0/city/test-city/beads/extra'), false);
     assert.equal(isAllowedReadPath('/v0/city/test-city/status/now'), false);
   });
+
+  test('rejects `..` traversal that would resolve to a cross-city upstream', () => {
+    // `{cityName}` ([^/]+) matches `..`, so without the traversal guard these
+    // pass the allowlist, yet `new URL(req.url, base)` resolves them to the
+    // GLOBAL `/v0/events` + `/v0/events/stream` cross-city reads — the exact
+    // bypass read-only mode must prevent in a multi-city deployment.
+    assert.equal(isAllowedReadPath('/v0/city/../events/stream'), false);
+    assert.equal(isAllowedReadPath('/v0/city/../events'), false);
+    // Backslash is converted to `/` for http URLs, so `..\events` collapses the
+    // same way — fail closed on any backslash too.
+    assert.equal(isAllowedReadPath('/v0/city/..\\events/stream'), false);
+  });
+
+  test('fails closed on a trailing slash rather than normalizing it', () => {
+    // Supervisor read paths the SPA emits never carry a trailing slash; an
+    // unexpected one is denied (404 upstream) instead of being silently
+    // normalized into a match.
+    assert.equal(isAllowedReadPath('/v0/city/test-city/beads/'), false);
+    assert.equal(isAllowedReadPath('/v0/cities/'), false);
+  });
 });

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -61,9 +61,26 @@ describe('supervisor read allowlist', () => {
     // bypass read-only mode must prevent in a multi-city deployment.
     assert.equal(isAllowedReadPath('/v0/city/../events/stream'), false);
     assert.equal(isAllowedReadPath('/v0/city/../events'), false);
+    // A bare `.` segment is normalized away by `new URL` too — fail closed.
+    assert.equal(isAllowedReadPath('/v0/city/./events/stream'), false);
     // Backslash is converted to `/` for http URLs, so `..\events` collapses the
     // same way — fail closed on any backslash too.
     assert.equal(isAllowedReadPath('/v0/city/..\\events/stream'), false);
+  });
+
+  test('rejects percent-encoded `..` that `new URL` would decode into a traversal', () => {
+    // Express 4 leaves `%2e` undecoded in `req.path`, so a guard that only looks
+    // for a literal `..` misses these — yet `new URL` decodes `%2e` → `.` and
+    // resolves the same cross-city escape. Fail closed on any encoded dot,
+    // regardless of case.
+    for (const path of [
+      '/v0/city/%2e%2e/events/stream',
+      '/v0/city/%2E%2E/events/stream',
+      '/v0/city/.%2e/events/stream',
+      '/v0/city/%2e./events/stream',
+    ]) {
+      assert.equal(isAllowedReadPath(path), false, `expected deny: ${path}`);
+    }
   });
 
   test('fails closed on a trailing slash rather than normalizing it', () => {

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -1,0 +1,56 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isAllowedReadPath } from '../src/routes/supervisor-read-allowlist.js';
+
+describe('supervisor read allowlist', () => {
+  test('allows the supervisor reads the dashboard SPA performs', () => {
+    for (const path of [
+      '/health',
+      '/v0/cities',
+      '/v0/city/test-city/agents',
+      '/v0/city/test-city/beads',
+      '/v0/city/test-city/bead/gascity-0001',
+      '/v0/city/test-city/events',
+      '/v0/city/test-city/events/stream',
+      '/v0/city/test-city/formulas/feed',
+      '/v0/city/test-city/formulas/my-formula',
+      '/v0/city/test-city/health',
+      '/v0/city/test-city/mail',
+      '/v0/city/test-city/mail/thread/m1',
+      '/v0/city/test-city/sessions',
+      '/v0/city/test-city/session/s1/pending',
+      '/v0/city/test-city/session/s1/stream',
+      '/v0/city/test-city/session/s1/transcript',
+      '/v0/city/test-city/status',
+      '/v0/city/test-city/workflow/w1',
+    ]) {
+      assert.equal(isAllowedReadPath(path), true, `expected allow: ${path}`);
+    }
+  });
+
+  test('denies side-effecting GETs and write/admin paths', () => {
+    for (const path of [
+      // agent prime is a state-changing GET — excluded on purpose.
+      '/v0/city/test-city/agent/mayor/prime',
+      '/v0/city/test-city/agent/pool/worker/prime',
+      // mutations that happen to be reachable by GET shape must not slip in.
+      '/v0/city/test-city/sling',
+      '/v0/city/test-city/bead/gascity-0001/close',
+      '/v0/city/test-city/agent/mayor/nudge',
+      // unknown / out-of-surface paths.
+      '/v0/city/test-city/agent/mayor',
+      '/admin',
+      '/v0/internal/secrets',
+    ]) {
+      assert.equal(isAllowedReadPath(path), false, `expected deny: ${path}`);
+    }
+  });
+
+  test('anchors templates so a longer action suffix never matches a shorter read', () => {
+    // `agent/{base}/prime` must not satisfy a generic two-segment agent read,
+    // and trailing segments past a known read are rejected.
+    assert.equal(isAllowedReadPath('/v0/city/test-city/beads/extra'), false);
+    assert.equal(isAllowedReadPath('/v0/city/test-city/status/now'), false);
+  });
+});

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -66,6 +66,13 @@ describe('supervisor read allowlist', () => {
     // Backslash is converted to `/` for http URLs, so `..\events` collapses the
     // same way — fail closed on any backslash too.
     assert.equal(isAllowedReadPath('/v0/city/..\\events/stream'), false);
+    // Matrix-parameter notation: `..;` is inert against the current Express
+    // supervisor (it doesn't strip `;`-suffixes) but would resolve to a global
+    // traversal under a `;`-stripping framework — fail closed on the bare `..`
+    // prefix now rather than ship the latent gap.
+    assert.equal(isAllowedReadPath('/v0/city/..;/events/stream'), false);
+    assert.equal(isAllowedReadPath('/v0/city/..;param=1/events/stream'), false);
+    assert.equal(isAllowedReadPath('/v0/city/.;/events/stream'), false);
   });
 
   test('rejects percent-encoded `..` that `new URL` would decode into a traversal', () => {

--- a/backend/test/supervisor-transport-proxy.test.ts
+++ b/backend/test/supervisor-transport-proxy.test.ts
@@ -163,6 +163,48 @@ describe('supervisor transport proxy — read-only mode (DASHBOARD_READONLY=1)',
     }
   });
 
+  // The literal `..` above was closed once, but the bypass survived in
+  // percent-encoded form: Express 4 leaves `%2e` undecoded in `req.path`, so a
+  // `req.path`-based guard misses it, while `new URL(req.url, base)` decodes
+  // `%2e` → `.` and resolves to the GLOBAL `/v0/events/stream`. These raw-socket
+  // cases drive the exact path where `new URL` runs and assert nothing reaches
+  // upstream. Each variant decodes to `/v0/city/../events/stream`.
+  for (const encoded of [
+    '%2e%2e', // lowercase
+    '%2E%2E', // uppercase
+    '.%2e', // mixed literal + encoded
+    '%2e.', // mixed encoded + literal
+  ]) {
+    test(`rejects encoded traversal (${encoded}) with 404, never forwarding upstream`, async () => {
+      const dashboard = await readOnlyDashboard();
+      try {
+        const res = await rawGet(dashboard.url, `/gc-supervisor/v0/city/${encoded}/events/stream`);
+
+        assert.equal(res.statusCode, 404, `expected 404 for ${encoded}`);
+        assert.deepEqual(calls, [], `expected zero upstream calls for ${encoded}`);
+      } finally {
+        await dashboard.close();
+      }
+    });
+  }
+
+  test('rejects an authority-bearing target (//host) instead of proxying a foreign origin', async () => {
+    // `new URL('//evil.example/...', base)` retargets at evil.example; the proxy
+    // must pin the supervisor origin and 404 rather than make the request.
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await rawGet(
+        dashboard.url,
+        '/gc-supervisor//evil.example/v0/city/test-city/beads',
+      );
+
+      assert.equal(res.statusCode, 404);
+      assert.deepEqual(calls, []);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
   test('forwards an allowlisted read but strips the write-authorizing headers', async () => {
     const dashboard = await readOnlyDashboard();
     try {

--- a/backend/test/supervisor-transport-proxy.test.ts
+++ b/backend/test/supervisor-transport-proxy.test.ts
@@ -81,6 +81,158 @@ describe('supervisor transport proxy', () => {
   });
 });
 
+interface UpstreamCall {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+}
+
+describe('supervisor transport proxy — read-only mode (DASHBOARD_READONLY=1)', () => {
+  let calls: UpstreamCall[];
+  let upstream: RunningServer;
+
+  beforeEach(async () => {
+    calls = [];
+    upstream = await startServer((req, res) => {
+      calls.push({ method: req.method ?? '', url: req.url ?? '', headers: req.headers });
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end('{"ok":true}');
+    });
+  });
+
+  afterEach(async () => {
+    await upstream.close();
+  });
+
+  function readOnlyDashboard(): Promise<RunningServer> {
+    const app = express();
+    app.use('/gc-supervisor', supervisorTransportProxy(upstream.url, true));
+    return startExpress(app);
+  }
+
+  test('rejects a mutation (POST sling carrying X-GC-Request) with 405, never forwarding it', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/sling`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-gc-request': 'dashboard' },
+        body: '{"target":"mayor"}',
+      });
+
+      assert.equal(res.status, 405);
+      assert.deepEqual(calls, []);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('forwards an allowlisted read but strips the write-authorizing headers', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/beads`, {
+        headers: { accept: 'application/json', 'content-type': 'application/json', 'x-gc-request': 'dashboard' },
+      });
+
+      assert.equal(res.status, 200);
+      assert.equal(calls.length, 1);
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.method, 'GET');
+      assert.equal(call.url, '/v0/city/test-city/beads');
+      assert.equal(call.headers['x-gc-request'], undefined);
+      assert.equal(call.headers['content-type'], undefined);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('default-denies a non-allowlisted read (the side-effecting agent prime GET) with 404', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/agent/mayor/prime`);
+
+      assert.equal(res.status, 404);
+      assert.deepEqual(calls, []);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('keeps both SSE streams (city events + session) on the read allowlist', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const events = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/events/stream`);
+      const session = await fetch(
+        `${dashboard.url}/gc-supervisor/v0/city/test-city/session/s1/stream`,
+      );
+
+      assert.equal(events.status, 200);
+      assert.equal(session.status, 200);
+      assert.deepEqual(
+        calls.map((c) => c.url),
+        ['/v0/city/test-city/events/stream', '/v0/city/test-city/session/s1/stream'],
+      );
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('still preserves the read query string when forwarding', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/beads?limit=5`);
+
+      assert.equal(res.status, 200);
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.url, '/v0/city/test-city/beads?limit=5');
+    } finally {
+      await dashboard.close();
+    }
+  });
+});
+
+describe('supervisor transport proxy — default (read/write) mode', () => {
+  let calls: UpstreamCall[];
+  let upstream: RunningServer;
+
+  beforeEach(async () => {
+    calls = [];
+    upstream = await startServer((req, res) => {
+      calls.push({ method: req.method ?? '', url: req.url ?? '', headers: req.headers });
+      res.statusCode = 200;
+      res.end('{"ok":true}');
+    });
+  });
+
+  afterEach(async () => {
+    await upstream.close();
+  });
+
+  test('forwards a mutation and preserves X-GC-Request so local writes still work', async () => {
+    const app = express();
+    app.use('/gc-supervisor', supervisorTransportProxy(upstream.url));
+    const dashboard = await startExpress(app);
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/sling`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-gc-request': 'dashboard' },
+        body: '{"target":"mayor"}',
+      });
+
+      assert.equal(res.status, 200);
+      assert.equal(calls.length, 1);
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.method, 'POST');
+      assert.equal(call.headers['x-gc-request'], 'dashboard');
+    } finally {
+      await dashboard.close();
+    }
+  });
+});
+
 test('direct supervisor boundary keeps city discovery out of dashboard /api routes', async () => {
   const appSource = await readFile(new URL('../src/app.ts', import.meta.url), 'utf8');
 

--- a/backend/test/supervisor-transport-proxy.test.ts
+++ b/backend/test/supervisor-transport-proxy.test.ts
@@ -121,6 +121,42 @@ describe('supervisor transport proxy — read-only mode (DASHBOARD_READONLY=1)',
       });
 
       assert.equal(res.status, 405);
+      // RFC 9110 §15.5.6: a 405 advertises the supported methods.
+      assert.equal(res.headers.get('allow'), 'GET, HEAD');
+      assert.deepEqual(calls, []);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('forwards an allowlisted HEAD read as HEAD', async () => {
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/beads`, {
+        method: 'HEAD',
+      });
+
+      assert.equal(res.status, 200);
+      assert.equal(calls.length, 1);
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.method, 'HEAD');
+      assert.equal(call.url, '/v0/city/test-city/beads');
+    } finally {
+      await dashboard.close();
+    }
+  });
+
+  test('rejects a `..` traversal read with 404, never forwarding it upstream', async () => {
+    // Sent over a raw socket so the `..` survives to the server — fetch/new URL
+    // would collapse it client-side before the request leaves. The proxy must
+    // reject it (404) instead of forwarding the resolved GLOBAL cross-city
+    // stream `/v0/events/stream`.
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await rawGet(dashboard.url, '/gc-supervisor/v0/city/../events/stream');
+
+      assert.equal(res.statusCode, 404);
       assert.deepEqual(calls, []);
     } finally {
       await dashboard.close();
@@ -131,7 +167,11 @@ describe('supervisor transport proxy — read-only mode (DASHBOARD_READONLY=1)',
     const dashboard = await readOnlyDashboard();
     try {
       const res = await fetch(`${dashboard.url}/gc-supervisor/v0/city/test-city/beads`, {
-        headers: { accept: 'application/json', 'content-type': 'application/json', 'x-gc-request': 'dashboard' },
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'x-gc-request': 'dashboard',
+        },
       });
 
       assert.equal(res.status, 200);
@@ -240,6 +280,22 @@ test('direct supervisor boundary keeps city discovery out of dashboard /api rout
   assert.match(appSource, /supervisorTransportProxy/);
   assert.match(appSource, /\/gc-supervisor/);
 });
+
+// Issue a GET with a literal, un-normalized request target (preserving `..`),
+// which fetch() / new URL() would otherwise collapse before sending.
+function rawGet(baseUrl: string, path: string): Promise<{ statusCode: number; body: string }> {
+  const { hostname, port } = new URL(baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname, port, path, method: 'GET' }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
 
 function startServer(handler: Handler): Promise<RunningServer> {
   return new Promise((resolve) => {

--- a/backend/test/supervisor-transport-proxy.test.ts
+++ b/backend/test/supervisor-transport-proxy.test.ts
@@ -205,6 +205,26 @@ describe('supervisor transport proxy — read-only mode (DASHBOARD_READONLY=1)',
     }
   });
 
+  test('rejects an absolute-URL request target (foreign origin) instead of proxying it', async () => {
+    // Absolute-form request target (`GET http://evil.example/gc-supervisor/... HTTP/1.1`):
+    // Express matches the mount on its pathname, so the router sees
+    // `req.url === 'http://evil.example/v0/city/test-city/beads'`, and
+    // `new URL(req.url, base)` resolves to the evil.example origin. The origin
+    // pin must 404 rather than forward to a foreign host. Locked in CI.
+    const dashboard = await readOnlyDashboard();
+    try {
+      const res = await rawGet(
+        dashboard.url,
+        'http://evil.example/gc-supervisor/v0/city/test-city/beads',
+      );
+
+      assert.equal(res.statusCode, 404);
+      assert.deepEqual(calls, []);
+    } finally {
+      await dashboard.close();
+    }
+  });
+
   test('forwards an allowlisted read but strips the write-authorizing headers', async () => {
     const dashboard = await readOnlyDashboard();
     try {

--- a/backend/test/views-registry.test.ts
+++ b/backend/test/views-registry.test.ts
@@ -24,6 +24,7 @@ function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
     auditLogPath: '.gc/events.jsonl',
     frontendDistPath: '../frontend/dist-does-not-exist',
     disabled: false,
+    readOnly: false,
     modules: {
       maintainer: {
         githubRepo: 'gastownhall/gascity',

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,7 +21,7 @@ systemctl --user daemon-reload
 systemctl --user enable --now gas-city-dashboard.service
 ```
 
-Browse to <http://127.0.0.1:8081>.
+Browse to <http://127.0.0.1:8082>.
 
 ## Updating
 
@@ -38,8 +38,8 @@ systemctl --user restart gas-city-dashboard.service
 ```bash
 systemctl --user status gas-city-dashboard.service
 journalctl --user -u gas-city-dashboard.service -f
-ss -tln 'sport = :8081'                       # port-in-use check
-curl -fsS http://127.0.0.1:8081/api/health    # smoke test
+ss -tln 'sport = :8082'                       # port-in-use check
+curl -fsS http://127.0.0.1:8082/api/health    # smoke test
 ```
 
 ## Kill switch
@@ -53,6 +53,6 @@ For permanent disable: `systemctl --user disable --now gas-city-dashboard.servic
 
 ## Notes
 
-- Bound to `127.0.0.1:8081` only (not `0.0.0.0`); see [`../specs/architecture/security.md`](../specs/architecture/security.md) for the DNS-rebinding posture.
+- Bound to `127.0.0.1:8082` only (not `0.0.0.0`); see [`../specs/architecture/security.md`](../specs/architecture/security.md) for the DNS-rebinding posture.
 - A `gc-supervisor` outage takes the dashboard's live data with it; the dashboard SHELL stays up (renders the cached / empty state) until supervisor returns.
 - Audit log is appended to `~/.gc/events.jsonl` by default — durable channel that survives dolt-hq corruption. Override with `ADMIN_AUDIT_LOG_PATH`.

--- a/deploy/gas-city-dashboard.service
+++ b/deploy/gas-city-dashboard.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=gas-city-dashboard — editorial ambient dashboard for a single gc operator (localhost-only, port 8081)
+Description=gas-city-dashboard — editorial ambient dashboard for a single gc operator (localhost-only, port 8082)
 Documentation=file://%h/gas-city-dashboard/specs/architecture/overview.md
 After=network-online.target
 Wants=network-online.target
@@ -12,7 +12,7 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory=%h/gas-city-dashboard
 Environment=NODE_ENV=production
-Environment=PORT=8081
+Environment=PORT=8082
 Environment=GC_SUPERVISOR_URL=http://127.0.0.1:8372
 Environment=GC_CITY_NAME=gas-city
 # GC_CITY_PATH pins the city root so the `gc bd` CLI write path
@@ -24,7 +24,7 @@ Environment=ADMIN_AUDIT_LOG_PATH=%h/.gc/events.jsonl
 Environment=ADMIN_FRONTEND_DIST=%h/gas-city-dashboard/frontend/dist
 # Refuse to start if a stale process holds the port. Bound to 127.0.0.1 only,
 # so the ss check is sufficient — no public-interface race.
-ExecStartPre=/bin/sh -c '! ss -tln "sport = :8081" | grep -q LISTEN || (echo "port 8081 already bound" >&2; exit 1)'
+ExecStartPre=/bin/sh -c '! ss -tln "sport = :8082" | grep -q LISTEN || (echo "port 8082 already bound" >&2; exit 1)'
 ExecStart=/usr/bin/node %h/gas-city-dashboard/backend/dist/server.js
 Restart=on-failure
 RestartSec=3

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -90,6 +90,8 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    // No prod source maps — an externally-fronted dist must not ship readable
+    // source. Keep false; see specs/architecture/exposure.md.
     sourcemap: false,
     emptyOutDir: true,
   },

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -45,6 +45,85 @@ Tailscale **Funnel** of the raw port — Funnel publishes to the public internet
 with no auth in front. Tailscale **Serve** (tailnet-only) is fine; Funnel is
 not.
 
+## Recipes
+
+Four concrete fronts, one per common environment. All assume the dashboard is
+the systemd-managed production listener on `127.0.0.1:8082` (see
+[`deploy/`](../../deploy/README.md)); swap the port if you run it elsewhere.
+Each terminates TLS and authenticates at the front, then proxies over loopback.
+Pair every one of them with `DASHBOARD_READONLY=1` and the
+[hardening checklist](#hardening-checklist-when-exposing) below.
+
+Forwarding `Host: 127.0.0.1` keeps the backend host-allowlist satisfied without
+touching `ADMIN_EXTRA_ALLOWED_HOSTS`; the SSE streams (`/gc-supervisor/**`
+events, `/api` event stream) need response buffering off or they stall.
+
+### nginx — basic-auth reverse proxy
+
+```nginx
+# htpasswd -c /etc/nginx/.gcd-htpasswd <user>   # create the credential first
+server {
+    listen 443 ssl;
+    server_name dash.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/dash.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dash.example.com/privkey.pem;
+
+    location / {
+        auth_basic           "gas-city-dashboard";
+        auth_basic_user_file /etc/nginx/.gcd-htpasswd;   # fails closed: no file → 403
+
+        proxy_pass         http://127.0.0.1:8082;
+        proxy_set_header   Host 127.0.0.1;               # satisfy the host-allowlist
+        proxy_http_version 1.1;
+        proxy_set_header   Connection "";                # keep SSE connections open
+        proxy_buffering    off;                          # stream events un-buffered
+    }
+}
+```
+
+### Caddy — forward-auth
+
+```caddy
+# Caddyfile — delegate auth to your own service (Authelia, tinyauth, …).
+# Caddy auto-provisions TLS; forward_auth fails closed if the auth service
+# is unreachable, so a blown auth backend denies rather than passes through.
+dash.example.com {
+    forward_auth 127.0.0.1:9091 {
+        uri /api/verify?rd=https://auth.example.com
+        copy_headers Remote-User Remote-Email Remote-Groups
+    }
+
+    reverse_proxy 127.0.0.1:8082 {
+        header_up Host 127.0.0.1     # satisfy the host-allowlist
+        flush_interval -1            # never buffer SSE
+    }
+}
+```
+
+### Tailscale Serve — tailnet-only
+
+```bash
+# Publish to your tailnet ONLY; Tailscale identity is the auth. Never Funnel.
+tailscale serve --bg --https=443 http://127.0.0.1:8082
+
+# Verify it is Serve (tailnet-scoped) and NOT Funnel (public internet):
+tailscale serve status      # must list the :8082 mapping
+tailscale funnel status     # must show NOTHING for this port
+```
+
+### Cloudflare Access — zero-trust gateway
+
+```bash
+# 1. Outbound-only tunnel from the host — no inbound port is opened:
+cloudflared tunnel --hostname dash.example.com --url http://127.0.0.1:8082
+
+# 2. In Cloudflare Zero Trust, add an Access application for dash.example.com
+#    with an allow policy (email / SSO / group). Access enforces identity at
+#    Cloudflare's edge BEFORE traffic reaches the tunnel; an unauthenticated
+#    request never reaches the host.
+```
+
 ## Hardening checklist when exposing
 
 Before you point an authenticated front at it:

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -1,0 +1,83 @@
+# Exposure — the operator-owned contract
+
+How to reach this dashboard from anywhere other than the machine it runs on.
+The short version: **you front it with your own authenticated proxy; the
+dashboard itself stays on loopback and ships no auth.**
+
+This guide is the deployment counterpart to the posture spec
+[`security.md`](./security.md). That file enumerates the controls and the
+test invariants that block merge; this file is the operator runbook for the one
+decision the dashboard deliberately leaves to you — network exposure.
+
+## Default posture (zero configuration)
+
+Out of the box, with no flags and no config file:
+
+- The backend binds `127.0.0.1` only. `HOST` is **ignored** — a non-loopback
+  value is logged and discarded (`backend/src/config.ts::parseBindHost`), so
+  there is no supported way to bind the raw port to a public interface.
+- There is **no auth and no login**. Full functionality is available to
+  anything that can reach the loopback port.
+
+This is the supported default and the zero-friction path: a single operator on
+their own host needs nothing more. **Do not add auth to use the dashboard
+locally** — there is intentionally none to configure.
+
+## Exposure is operator-owned
+
+The dashboard is a zero-auth control plane over the (also unauth) gc supervisor.
+There is no safe way to put the raw port on a network. To reach it remotely you
+**terminate exposure at a front you own and authenticate**, and let it connect
+to the dashboard over loopback:
+
+```
+your client ──TLS+auth──▶ your proxy (auth/SSO/allowlist) ──▶ 127.0.0.1:<port> dashboard
+```
+
+Any authenticated front works — a reverse proxy with basic-auth or
+forward-auth (nginx, Caddy), a tailnet-scoped share (Tailscale Serve), or a
+zero-trust gateway (Cloudflare Access), among others. The dashboard does not
+care which; it only ever sees a loopback connection.
+
+**Never put the raw port on a public interface.** That means no `0.0.0.0`
+bind (the backend refuses it anyway), no port-forward of the listener, and no
+Tailscale **Funnel** of the raw port — Funnel publishes to the public internet
+with no auth in front. Tailscale **Serve** (tailnet-only) is fine; Funnel is
+not.
+
+## Hardening checklist when exposing
+
+Before you point an authenticated front at it:
+
+1. **Enable read-only** — set `DASHBOARD_READONLY=1`. This turns on a
+   server-enforced gate on the `/gc-supervisor` transport proxy: every
+   non-`GET`/`HEAD` is rejected with `405`, reads are default-denied to an
+   explicit allowlist (`404` otherwise), and the write-authorizing
+   `x-gc-request` header is stripped unconditionally. It is the single
+   load-bearing control that survives a blown-open network layer — see
+   [`security.md` §Read-only transport-proxy mode](./security.md). Read-only is
+   opt-in; the local default stays read/write.
+2. **Keep the gc supervisor on loopback and patched.** The read-only gate sits
+   _upstream_ of the supervisor, so it only protects requests that go through
+   the dashboard. The supervisor's own port (`:8372` by default) must not be
+   independently reachable, and it must carry the host-header rebinding fix.
+3. **Your proxy must not fail-open.** If the auth backend is unreachable, the
+   front must deny — never pass the request through unauthenticated. The
+   dashboard's loopback hard-bind covers the default case, but once you put a
+   proxy in front, a fail-open proxy is the whole exposure.
+4. **Rate-limit at your proxy.** The dashboard has no per-IP throttle of its
+   own (only an in-process semaphore); apply limits at the authenticated edge.
+5. **Keep `ADMIN_EXTRA_ALLOWED_HOSTS` minimal.** Add only the `Host` value your
+   proxy actually forwards. The `127.0.0.1` / `localhost` floor is always
+   allowed; everything else is an opt-in you should keep as small as possible.
+
+## What the dashboard deliberately does not provide
+
+- **No built-in auth or login.** By design — exposure terminates at the front
+  you own, not in this codebase.
+- **No TLS.** Loopback only; your proxy terminates TLS.
+
+These are not gaps to be filled before exposing; they are the contract. The
+dashboard ships the loopback floor and the opt-in read-only gate, and leaves
+authentication, TLS, and rate-limiting to the authenticated front you place in
+front of it.

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -135,7 +135,11 @@ Before you point an authenticated front at it:
    `x-gc-request` header is stripped unconditionally. It is the single
    load-bearing control that survives a blown-open network layer — see
    [`security.md` §Read-only transport-proxy mode](./security.md). Read-only is
-   opt-in; the local default stays read/write.
+   opt-in; the local default stays read/write. Note: this gates the
+   `/gc-supervisor` proxy only — the dashboard's own `/api/*` maintainer writes
+   (client-error telemetry, `gh` actions, sling-record) are CSRF+Origin
+   protected, not covered by `DASHBOARD_READONLY`, so "read-only" means the
+   _supervisor_ surface, not the entire service.
 2. **Keep the gc supervisor on loopback and patched.** The read-only gate sits
    _upstream_ of the supervisor, so it only protects requests that go through
    the dashboard. The supervisor's own port (`:8372` by default) must not be

--- a/specs/architecture/security.md
+++ b/specs/architecture/security.md
@@ -35,6 +35,41 @@ curl -sH 'Host: evil.com' http://127.0.0.1:8081/api/health    # → 421
 curl -sX POST -H 'Origin: http://evil.com' http://127.0.0.1:8081/api/client-errors  # → 403
 ```
 
+## Read-only transport-proxy mode
+
+Opt-in via `DASHBOARD_READONLY=1` (default off). Hardens the `/gc-supervisor`
+transport proxy for an instance fronted by an external auth proxy, so a request
+that reaches the dashboard cannot mutate the city. Enforced server-side in
+`backend/src/routes/supervisor-transport-proxy.ts` against the explicit
+allowlist in `backend/src/routes/supervisor-read-allowlist.ts`. When enabled the
+proxy:
+
+- **Rejects any non-`GET`/`HEAD`** with `405` — the method gate is checked
+  _before_ the path gate, so a write like `POST .../sling` is `405`, never
+  forwarded.
+- **Default-denies reads** to the explicit read allowlist (the minimal set of
+  supervisor reads the SPA performs, plus both SSE streams). Anything else —
+  including the side-effecting agent `prime` GET flagged by the exposure
+  premortem — is `404`. A new read view fails closed until it is added to the
+  allowlist.
+- **Strips the write-authorizing `x-gc-request` header** (and `content-type`)
+  unconditionally before forwarding — it never depends on the header's absence.
+
+This is the single load-bearing exposure control: it sits upstream of the
+unauth supervisor and survives a blown-open network layer. The default
+(read/write) mode is unchanged, preserving the zero-friction local operator
+experience. The deployment side of this — when and how to expose at all — is
+the operator runbook in [`exposure.md`](./exposure.md).
+
+### Invariants
+
+```
+DASHBOARD_READONLY=1
+curl -sX POST -H 'x-gc-request: dashboard' http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/sling   # → 405, never forwarded
+curl -s  http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/agent/$AGENT/prime                        # → 404 (side-effecting GET, not allowlisted)
+curl -s  http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/beads                                     # → 200, x-gc-request stripped before forwarding
+```
+
 ## Frame / content type
 
 - `X-Frame-Options: DENY`

--- a/specs/architecture/security.md
+++ b/specs/architecture/security.md
@@ -31,8 +31,8 @@ rename supervisor payloads.
 ### Invariants
 
 ```
-curl -sH 'Host: evil.com' http://127.0.0.1:8081/api/health    # → 421
-curl -sX POST -H 'Origin: http://evil.com' http://127.0.0.1:8081/api/client-errors  # → 403
+curl -sH 'Host: evil.com' http://127.0.0.1:8082/api/health    # → 421
+curl -sX POST -H 'Origin: http://evil.com' http://127.0.0.1:8082/api/client-errors  # → 403
 ```
 
 ## Read-only transport-proxy mode
@@ -54,6 +54,15 @@ proxy:
   allowlist.
 - **Strips the write-authorizing `x-gc-request` header** (and `content-type`)
   unconditionally before forwarding — it never depends on the header's absence.
+- **Gates the resolved upstream path, not the raw `req.path`.** The allowlist
+  runs on `new URL(req.url, base).pathname` — the exact string forwarded — so a
+  traversal that would resolve to a different (e.g. cross-city GLOBAL) upstream
+  cannot pass the per-city `[^/]+` template, whether spelled literally (`..`),
+  percent-encoded (`%2e%2e`, `%2E%2E`, mixed), or via a backslash. An authority
+  in the request target (`//host/…`) is pinned to the supervisor origin.
+- **Logs every gate rejection** (`logWarn` with method + path) so an
+  externally-fronted instance leaves an audit trail of refused method/traversal
+  probes.
 
 This is the single load-bearing exposure control: it sits upstream of the
 unauth supervisor and survives a blown-open network layer. The default
@@ -65,9 +74,10 @@ the operator runbook in [`exposure.md`](./exposure.md).
 
 ```
 DASHBOARD_READONLY=1
-curl -sX POST -H 'x-gc-request: dashboard' http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/sling   # → 405, never forwarded
-curl -s  http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/agent/$AGENT/prime                        # → 404 (side-effecting GET, not allowlisted)
-curl -s  http://127.0.0.1:8081/gc-supervisor/v0/city/$CITY/beads                                     # → 200, x-gc-request stripped before forwarding
+curl -sX POST -H 'x-gc-request: dashboard' http://127.0.0.1:8082/gc-supervisor/v0/city/$CITY/sling   # → 405, never forwarded
+curl -s  http://127.0.0.1:8082/gc-supervisor/v0/city/$CITY/agent/$AGENT/prime                        # → 404 (side-effecting GET, not allowlisted)
+curl -s  http://127.0.0.1:8082/gc-supervisor/v0/city/$CITY/beads                                     # → 200, x-gc-request stripped before forwarding
+curl -s --path-as-is http://127.0.0.1:8082/gc-supervisor/v0/city/%2e%2e/events/stream                # → 404 (encoded `..` resolves to GLOBAL stream, gated on the resolved path)
 ```
 
 ## Frame / content type
@@ -95,7 +105,7 @@ Why not `csurf`: the canonical package is deprecated; rolling a minimal double-s
 ### Invariant
 
 ```
-curl -sX POST http://127.0.0.1:8081/api/client-errors -H 'Host: 127.0.0.1' -H 'Origin: http://127.0.0.1:8081'
+curl -sX POST http://127.0.0.1:8082/api/client-errors -H 'Host: 127.0.0.1' -H 'Origin: http://127.0.0.1:8082'
 # → 403 {"error":"Missing CSRF token","kind":"csrf"}
 ```
 
@@ -128,7 +138,7 @@ Every privileged invocation routes through `backend/src/exec.ts`. **No general-p
 ### Invariant
 
 ```
-curl -s http://127.0.0.1:8081/gc-supervisor/v0/city/test-city/session/$(printf "'; rm -rf /")/stream …
+curl -s http://127.0.0.1:8082/gc-supervisor/v0/city/test-city/session/$(printf "'; rm -rf /")/stream …
 # → 400 {"error":"invalid session id","kind":"validation"}
 ```
 


### PR DESCRIPTION
## Summary

Server-enforced **opt-in read-only gate** on the `/gc-supervisor/*` transport proxy, hardened against traversal-class bypasses and origin-pin spoofing.

When the read-only posture is enabled, the dashboard backend enforces an allow-list of safe supervisor reads at the proxy layer — mutating methods and out-of-allowlist paths are rejected with an RFC-compliant `405`, independent of any frontend gating.

### Security fixes (class-kills, not point-patches)
- **Path-traversal class-kill** — allow-list matching normalizes the request path and compares against the canonical allowed set, closing encoded-traversal (`%2e%2e`), matrix-notation (`;`), and raw `..` bypasses as a class rather than blacklisting individual encodings.
- **Absolute-URL origin pin lock** — the proxy locks the upstream origin, rejecting absolute-URL request targets that would otherwise repoint the proxy.
- **Raw-socket regression coverage** — tests drive malformed/raw requests directly to confirm the gate holds below the framework router, not just through normal route dispatch.

## Scope (bundled — 3 beads)

The z8n7 proxy-gate code and the snnz/vaah docs are **entangled** (the z8n7 commits edit `specs/architecture/exposure.md` / `security.md`, files introduced by snnz), so they ship as one reviewable bundle rather than a risky interactive-rebase split of a security-sensitive change:

- **z8n7** — server-enforced read-only proxy gate + traversal/origin hardening (`backend/src/routes/supervisor-*`, `config.ts`, `app.ts`, tests).
- **snnz** — operator-owned exposure contract + read-only posture docs (`specs/architecture/exposure.md`, `security.md`, `README.md`).
- **vaah** — concrete proxy recipes + 8081/8082 deploy-port drift reconciliation (`deploy/`, `frontend/vite.config.ts`, exposure docs).

## Test plan / CI parity (green, rebased onto current `main`)
- `npm run typecheck` (src + test) — clean
- `npm run lint` — clean
- `npm --workspace backend test` — 532 pass
- `npm --workspace shared test` — 62 pass

## Review status
Reviewed **3rd-pass APPROVE**. Mayor merge-gates — **do not merge** from here.
