### PR TITLE
fix(runs): runs-tab first-impression defects (4xcv)

### DIFF
--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -649,6 +649,7 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
   return {
     lanes: [...lanes],
     historicalLanes: [],
+    blockedLanes: [],
     totalActive: lanes.length,
     totalHistorical: 0,
     runCounts: {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -245,7 +245,9 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
     );
   }
 
-  for (const lane of summary.lanes) {
+  // gascity-dashboard-4xcv: blocked lanes moved out of summary.lanes into
+  // their own bucket; they still need the operator, so both sets contribute.
+  for (const lane of [...summary.lanes, ...summary.blockedLanes]) {
     const item = attentionForRunLane(lane);
     if (item !== null) items.push(item);
   }

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -272,7 +272,7 @@ function CountsHeader({ summary }: { summary: RunSummary | null }) {
         {COUNT_LABELS.map(([key, label]) => (
           <CountTile key={key} label={label} value={summary?.runCounts[key] ?? 0} tone="muted" />
         ))}
-        {blocked > 0 && <CountTile label="Blocked" value={blocked} tone="accent" />}
+        {blocked > 0 && <CountTile label="Blocked" value={blocked} tone="muted" />}
       </div>
     </header>
   );
@@ -285,12 +285,11 @@ function CountTile({
 }: {
   label: string;
   value: number;
-  tone: 'strong' | 'muted' | 'accent';
+  tone: 'strong' | 'muted';
 }) {
   // tnum + tracked-uppercase label per the column-head register elsewhere on
   // the page; value sits below in body weight. No box around either.
-  const valueTone =
-    tone === 'strong' ? 'text-fg' : tone === 'accent' ? 'text-accent' : 'text-fg-muted';
+  const valueTone = tone === 'strong' ? 'text-fg' : 'text-fg-muted';
   return (
     <div className="flex flex-col">
       <span className="text-label uppercase tracking-wider text-fg-faint">{label}</span>

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -58,6 +58,11 @@ export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapPr
         now={now}
         {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
       />
+      <BlockedSection
+        summary={summary}
+        now={now}
+        {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+      />
       {showHistory && (
         <HistoricalSection
           summary={summary}
@@ -79,6 +84,16 @@ function ActiveSection({
   attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
 }) {
   if (summary.lanes.length === 0) {
+    // gascity-dashboard-4xcv: a partial fetch with zero lanes is "we could
+    // not see the runs", not "there are no runs". Never present a degraded
+    // read as an empty store; say so in words instead.
+    if (summary.lanesPartial === true) {
+      return (
+        <p className="mt-8 text-body text-fg-muted italic">
+          Run sources were partially unavailable; the lane set may be incomplete.
+        </p>
+      );
+    }
     // Distinguish "nothing at all" from "nothing active but N completed".
     const trailer = summary.totalHistorical > 0 ? ` (${summary.totalHistorical} completed.)` : '';
     return (
@@ -96,18 +111,11 @@ function ActiveSection({
       {groups.map(({ rig, lanes }) => (
         <div key={rig} className="mt-6">
           <h3 className="text-label uppercase tracking-wider text-fg-faint">{rigLabel(rig)}</h3>
-          <ol className="mt-3 divide-y divide-rule">
-            {lanes.map((lane) => (
-              <LaneCard
-                key={lane.id}
-                lane={lane}
-                now={now}
-                {...(attentionSeverity === undefined
-                  ? {}
-                  : { attentionSeverity: attentionSeverity(lane) })}
-              />
-            ))}
-          </ol>
+          <LaneList
+            lanes={lanes}
+            now={now}
+            {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+          />
         </div>
       ))}
       {summary.totalActive > summary.lanes.length && (
@@ -119,13 +127,50 @@ function ActiveSection({
   );
 }
 
+/** The hairline-separated lane list shared by the active rig groups, the
+ *  Blocked section, and the Historical section. */
+function LaneList({
+  lanes,
+  now,
+  attentionSeverity,
+  listId,
+}: {
+  lanes: readonly RunLane[];
+  now: number;
+  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  listId?: string;
+}) {
+  return (
+    <ol {...(listId === undefined ? {} : { id: listId })} className="mt-3 divide-y divide-rule">
+      {lanes.map((lane) => (
+        <LaneCard
+          key={lane.id}
+          lane={lane}
+          now={now}
+          {...(attentionSeverity === undefined
+            ? {}
+            : { attentionSeverity: attentionSeverity(lane) })}
+        />
+      ))}
+    </ol>
+  );
+}
+
 /** Group lanes by their run-root rig, preserving first-seen (pre-sorted)
- *  order so the most-recently-active rig surfaces first. */
+ *  order so the most-recently-active rig surfaces first.
+ *
+ *  gascity-dashboard-4xcv: non-rig lanes group under 'city'. A city-scoped
+ *  run (control-dispatcher work) is not an "unknown rig" — and a lane whose
+ *  scope metadata is unavailable still came from the city's bead store, so
+ *  the city group is the honest default. */
 function groupLanesByRig(lanes: readonly RunLane[]): Array<{ rig: string; lanes: RunLane[] }> {
   const order: string[] = [];
   const byRig = new Map<string, RunLane[]>();
   for (const lane of lanes) {
-    const rig = lane.scope.status === 'available' ? lane.scope.rootStoreRef : 'unknown';
+    const rig =
+      lane.scope.status === 'available' && lane.scope.kind === 'rig'
+        ? lane.scope.rootStoreRef
+        : 'city';
     let bucket = byRig.get(rig);
     if (bucket === undefined) {
       bucket = [];
@@ -138,8 +183,33 @@ function groupLanesByRig(lanes: readonly RunLane[]): Array<{ rig: string; lanes:
 }
 
 function rigLabel(rig: string): string {
-  if (rig === 'unknown') return 'unknown rig';
   return rig.replace(/^rig:/, '');
+}
+
+/** Blocked runs (gascity-dashboard-4xcv). A blocked lane needs the operator,
+ *  so it stays on the page — but in its own labeled section, never mixed
+ *  into (or counted with) the Active set. Hidden entirely when nothing is
+ *  blocked: the calm room does not announce the absence of trouble. */
+function BlockedSection({
+  summary,
+  now,
+  attentionSeverity,
+}: {
+  summary: RunSummary;
+  now: number;
+  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+}) {
+  if (summary.blockedLanes.length === 0) return null;
+  return (
+    <section aria-label="Blocked runs" className="mt-12">
+      <h2 className="text-label uppercase tracking-wider text-fg-faint">Blocked</h2>
+      <LaneList
+        lanes={summary.blockedLanes}
+        now={now}
+        {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+      />
+    </section>
+  );
 }
 
 function HistoricalSection({
@@ -164,18 +234,12 @@ function HistoricalSection({
         </p>
       ) : (
         <>
-          <ol id={HISTORICAL_LIST_ID} className="mt-3 divide-y divide-rule">
-            {shown.map((lane) => (
-              <LaneCard
-                key={lane.id}
-                lane={lane}
-                now={now}
-                {...(attentionSeverity === undefined
-                  ? {}
-                  : { attentionSeverity: attentionSeverity(lane) })}
-              />
-            ))}
-          </ol>
+          <LaneList
+            lanes={shown}
+            now={now}
+            listId={HISTORICAL_LIST_ID}
+            {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+          />
           {lanes.length > HISTORICAL_PREVIEW && (
             <button
               type="button"

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -163,6 +163,7 @@ function runSource({
       totalActive: lanes.length,
       totalHistorical: 0,
       historicalLanes: [],
+      blockedLanes: [],
       runCounts: {
         total: lanes.length,
         visible: lanes.length,

--- a/frontend/src/routes/AmbientHome.tsx
+++ b/frontend/src/routes/AmbientHome.tsx
@@ -114,11 +114,18 @@ interface BodyProps {
 
 function AmbientBody({ fresh, cityName, cycleKey, workInProgress }: BodyProps) {
   const { summary } = fresh;
-  const staleness = useStaleness(summary.lanes);
-  const top = useMemo(() => pickTopConcern(summary.lanes, staleness), [summary.lanes, staleness]);
+  // gascity-dashboard-4xcv: blocked lanes moved out of summary.lanes into
+  // blockedLanes. They are no longer "Active", but a blocked run is still an
+  // operator concern, so the home attention math runs over both sets.
+  const inFlightLanes = useMemo(
+    () => [...summary.lanes, ...summary.blockedLanes],
+    [summary.lanes, summary.blockedLanes],
+  );
+  const staleness = useStaleness(inFlightLanes);
+  const top = useMemo(() => pickTopConcern(inFlightLanes, staleness), [inFlightLanes, staleness]);
   const rows = useMemo(
-    () => buildConcernRows(summary.lanes, staleness, top?.lane.id),
-    [summary.lanes, staleness, top],
+    () => buildConcernRows(inFlightLanes, staleness, top?.lane.id),
+    [inFlightLanes, staleness, top],
   );
 
   // The server's `thrashing` count already excludes inferred lanes;
@@ -168,7 +175,7 @@ function AmbientBody({ fresh, cityName, cycleKey, workInProgress }: BodyProps) {
         <div className="space-y-4">
           <PhaseCensus
             census={summary.census.data}
-            waitingCount={countWaiting(summary.lanes)}
+            waitingCount={countWaiting(inFlightLanes)}
             failingCount={failing}
           />
           {top !== undefined && <StatusSentence topConcern={top} />}

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -169,9 +169,7 @@ describe('FormulaRunDetailPage', () => {
 
     renderPage();
 
-    expect(
-      await screen.findByRole('list', { name: /pending adoption run stages/i }),
-    ).toBeTruthy();
+    expect(await screen.findByRole('list', { name: /pending adoption run stages/i })).toBeTruthy();
     expect(screen.queryByText(/^Loading formula run\.$/i)).toBeNull();
   });
 

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -148,6 +148,33 @@ describe('FormulaRunDetailPage', () => {
     expect(screen.queryByRole('heading', { name: /local changes/i })).toBeNull();
   });
 
+  it('renders the optimistic skeleton for a BLOCKED run lane (gascity-dashboard-4xcv)', async () => {
+    // Blocked lanes moved out of summary.lanes into blockedLanes; a blocked
+    // run is the most likely one the operator clicks into, so the skeleton
+    // lookup must search both buckets.
+    invalidate('runs:summary:test-city');
+    const source = runSummarySourceWithActiveLane();
+    if (source.status === 'error') throw new Error(source.error);
+    source.data.blockedLanes = source.data.lanes;
+    source.data.lanes = [];
+    source.data.totalActive = 0;
+    loadSupervisorRunSummarySource.mockResolvedValue(source);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    loadSupervisorFormulaRunDetail.mockImplementationOnce(
+      () => new Promise<FormulaRunDetail>(() => {}),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('list', { name: /pending adoption run stages/i }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/^Loading formula run\.$/i)).toBeNull();
+  });
+
   it('does not repeat missing formula metadata as formula detail and a partial banner', async () => {
     currentDetail = {
       ...detail,
@@ -706,6 +733,7 @@ function runSummarySource(lanes: RunLane[] = []): SourceState<RunSummary> {
       totalActive: lanes.length,
       totalHistorical: 0,
       historicalLanes: [],
+      blockedLanes: [],
       runCounts: {
         total: lanes.length,
         visible: lanes.length,

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -122,9 +122,7 @@ export function FormulaRunDetailPage() {
     if (runsData === null || runsData === undefined) return null;
     // gascity-dashboard-4xcv: blocked lanes live in their own bucket now, and
     // a blocked run is the most likely one the operator clicks into.
-    return (
-      [...runsData.lanes, ...runsData.blockedLanes].find((lane) => lane.id === runId) ?? null
-    );
+    return [...runsData.lanes, ...runsData.blockedLanes].find((lane) => lane.id === runId) ?? null;
   }, [runSummary.data, runId]);
 
   const synopsis = detail

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -119,7 +119,12 @@ export function FormulaRunDetailPage() {
     if (!runId) return null;
     const runs = runSummary.data;
     const runsData = runs && runs.status !== 'error' ? runs.data : null;
-    return runsData?.lanes.find((lane) => lane.id === runId) ?? null;
+    if (runsData === null || runsData === undefined) return null;
+    // gascity-dashboard-4xcv: blocked lanes live in their own bucket now, and
+    // a blocked run is the most likely one the operator clicks into.
+    return (
+      [...runsData.lanes, ...runsData.blockedLanes].find((lane) => lane.id === runId) ?? null
+    );
   }, [runSummary.data, runId]);
 
   const synopsis = detail

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -73,6 +73,7 @@ function buildRunSource(
       totalActive: 0,
       totalHistorical: 0,
       historicalLanes: [],
+      blockedLanes: [],
       runCounts: {
         total: 0,
         visible: 0,
@@ -564,6 +565,166 @@ describe('RunsPage — partial lane set (gascity-dashboard-n6f1)', () => {
     await waitForMount();
 
     expect(screen.queryByRole('status')).toBeNull();
+  });
+});
+
+describe('RunsPage — blocked lanes are not Active (gascity-dashboard-4xcv)', () => {
+  function blockedLane(): RunLane {
+    return activeLane({
+      id: 'gc-1920',
+      title: 'mol-focus-review latch',
+      phase: 'blocked',
+      phaseLabel: 'blocked',
+      statusCounts: { blocked: 1 },
+      health: {
+        status: 'available',
+        data: {
+          phaseConfidence: 'inferred',
+          needsOperator: true,
+          stuckNode: { status: 'unavailable', error: 'run stuck node unavailable' },
+          thrashingDetected: false,
+          session: { status: 'unresolved', error: 'run session unresolved' },
+        },
+      },
+    });
+  }
+
+  it('renders a blocked lane under the Blocked section, not among active rig groups', async () => {
+    const source = buildRunSource('fresh');
+    const runs = requireRunData(source);
+    runs.totalActive = 1;
+    runs.lanes = [
+      activeLane({
+        scope: { status: 'available', kind: 'rig', ref: 'gascity', rootStoreRef: 'rig:gascity' },
+      }),
+    ];
+    runs.blockedLanes = [blockedLane()];
+    runs.runCounts = { ...runs.runCounts, total: 1, visible: 1, blocked: 1 };
+    mockLoadRunSummary.mockResolvedValue(source);
+
+    mount();
+    await waitForMount();
+
+    const blockedSection = await screen.findByRole('region', { name: /blocked runs/i });
+    expect(blockedSection.textContent).toContain('mol-focus-review latch');
+    // The active rig group does not contain the blocked lane.
+    const activeGroupHeading = await screen.findByText('gascity');
+    expect(activeGroupHeading.parentElement?.textContent).not.toContain(
+      'mol-focus-review latch',
+    );
+  });
+
+  it('omits the Blocked section when nothing is blocked', async () => {
+    mount();
+    await waitForMount();
+    expect(screen.queryByRole('region', { name: /blocked runs/i })).toBeNull();
+  });
+});
+
+describe('RunsPage — run scope labels (gascity-dashboard-4xcv)', () => {
+  it('groups city-scoped and scope-unavailable lanes under a single "city" header, never "unknown rig"', async () => {
+    const source = buildRunSource('fresh');
+    const runs = requireRunData(source);
+    runs.totalActive = 2;
+    runs.lanes = [
+      activeLane({
+        id: 'gc-city-run',
+        scope: {
+          status: 'available',
+          kind: 'city',
+          ref: 'racoon-city',
+          rootStoreRef: 'city:racoon-city',
+        },
+      }),
+      activeLane({
+        id: 'gc-scopeless-run',
+        scope: { status: 'unavailable', error: 'run scope metadata unavailable' },
+      }),
+    ];
+    mockLoadRunSummary.mockResolvedValue(source);
+
+    mount();
+    await waitForMount();
+
+    expect(await screen.findByText('gc-city-run')).toBeTruthy();
+    expect(await screen.findByText('gc-scopeless-run')).toBeTruthy();
+    expect(screen.getAllByText('city')).toHaveLength(1);
+    expect(screen.queryByText(/unknown rig/i)).toBeNull();
+  });
+});
+
+describe('RunsPage — degraded first load recovery (gascity-dashboard-4xcv)', () => {
+  it('renders the partial notice, not the empty state, when a partial fetch yields zero lanes', async () => {
+    const source = buildRunSource('fresh');
+    requireRunData(source).lanesPartial = true;
+    mockLoadRunSummary.mockResolvedValue(source);
+
+    mount();
+    await waitForMount();
+
+    expect(
+      await screen.findByText(/Run sources were partially unavailable/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/No active formula runs/i)).toBeNull();
+  });
+
+  const errorSource = {
+    source: 'runs',
+    status: 'error',
+    error: 'supervisor warming up',
+  } satisfies SourceState<RunSummary>;
+
+  it('auto-retries a degraded load with backoff, bounded by the retry budget', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Both fetchers keep failing so the degraded state persists and the
+    // retry chain is observable in isolation (a successful retry would
+    // also trigger the one-time full refresh, which is covered elsewhere).
+    // Fresh object per call: the real loaders construct a new source every
+    // load, and React's setState bails out on identical references.
+    mockLoadRunSummaryPreview.mockImplementation(async () => ({ ...errorSource }));
+    mockLoadRunSummary.mockImplementation(async () => ({ ...errorSource }));
+
+    mount();
+    await waitForMount();
+    expect(mockLoadRunSummary).not.toHaveBeenCalled();
+
+    // Retries fire on the 2s / 5s / 10s backoff ladder...
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+    expect(mockLoadRunSummary).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(mockLoadRunSummary).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_100);
+    });
+    expect(mockLoadRunSummary).toHaveBeenCalledTimes(3);
+
+    // ...and stop once the budget is spent (SSE / manual take over).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(mockLoadRunSummary).toHaveBeenCalledTimes(3);
+  });
+
+  it('SSE callback refreshes when the runs source is in error state', async () => {
+    // The old guard skipped every non-fresh status, so an error first
+    // load latched the page dead until a manual refresh. A bead event is
+    // exactly the cue to try live data again.
+    mockLoadRunSummaryPreview.mockResolvedValue(errorSource);
+    mockLoadRunSummary.mockResolvedValue(errorSource);
+
+    mount();
+    await waitForMount();
+    mockLoadRunSummary.mockClear();
+
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    expect(mockLoadRunSummary).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -609,9 +609,7 @@ describe('RunsPage — blocked lanes are not Active (gascity-dashboard-4xcv)', (
     expect(blockedSection.textContent).toContain('mol-focus-review latch');
     // The active rig group does not contain the blocked lane.
     const activeGroupHeading = await screen.findByText('gascity');
-    expect(activeGroupHeading.parentElement?.textContent).not.toContain(
-      'mol-focus-review latch',
-    );
+    expect(activeGroupHeading.parentElement?.textContent).not.toContain('mol-focus-review latch');
   });
 
   it('omits the Blocked section when nothing is blocked', async () => {
@@ -662,9 +660,7 @@ describe('RunsPage — degraded first load recovery (gascity-dashboard-4xcv)', (
     mount();
     await waitForMount();
 
-    expect(
-      await screen.findByText(/Run sources were partially unavailable/i),
-    ).toBeTruthy();
+    expect(await screen.findByText(/Run sources were partially unavailable/i)).toBeTruthy();
     expect(screen.queryByText(/No active formula runs/i)).toBeNull();
   });
 

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -126,7 +126,9 @@ export function RunsPage() {
     const degraded =
       runs.status === 'error'
         ? true
-        : runs.data.lanesPartial === true && runs.data.lanes.length === 0;
+        : runs.data.lanesPartial === true &&
+          runs.data.lanes.length === 0 &&
+          runs.data.blockedLanes.length === 0;
     if (!degraded) {
       retryAttemptRef.current = 0;
       return;

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -47,6 +47,12 @@ import {
 // SSE is the path for actual data updates.
 
 const REFRESH_DEBOUNCE_MS = 10_000;
+// gascity-dashboard-4xcv: bounded retry backoff for a degraded first load
+// (error source, or a partial fetch that produced zero lanes). The operator
+// saw an empty tab that needed 2-3 manual refreshes; these retries recover
+// transient supervisor warm-up failures without her. After the budget is
+// spent, SSE events and the manual Refresh button take over.
+const RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 const RUN_PHASE_GRAMMAR = 'Phase grammar: intake, implementation, review, approval, finalization.';
 const HISTORY_QUERY_PARAM = 'history';
 const HISTORY_QUERY_VALUE = '1';
@@ -109,10 +115,36 @@ export function RunsPage() {
     });
   }, [cityName, refresh, runs]);
 
+  // gascity-dashboard-4xcv: bounded auto-retry on a degraded load. An error
+  // source (or a partial fetch with zero lanes) used to latch the page dead:
+  // the SSE callback skipped non-fresh sources and the one-time full refresh
+  // bailed on error, so only a manual Refresh recovered. Retry a few times
+  // with backoff, and reset the budget once a healthy load lands.
+  const retryAttemptRef = useRef(0);
+  useEffect(() => {
+    if (runs === null) return;
+    const degraded =
+      runs.status === 'error'
+        ? true
+        : runs.data.lanesPartial === true && runs.data.lanes.length === 0;
+    if (!degraded) {
+      retryAttemptRef.current = 0;
+      return;
+    }
+    const delay = RETRY_DELAYS_MS[retryAttemptRef.current];
+    if (delay === undefined) return;
+    retryAttemptRef.current += 1;
+    const timer = setTimeout(() => void refresh(), delay);
+    return () => clearTimeout(timer);
+  }, [runs, refresh]);
+
   const onSseMatch = useCallback(() => {
-    // Skip when supervisor is unreachable — every forced refresh under
-    // fixture-fallback re-runs loadFixture(), which is wasted file IO.
-    if (runsStatusRef.current !== 'fresh') return;
+    // Skip when fixtures are serving (supervisor down) — every forced
+    // refresh under fixture-fallback re-runs loadFixture(), which is wasted
+    // file IO. An 'error' or 'stale' source is the opposite case: a bead
+    // event is exactly the cue to try loading live data again
+    // (gascity-dashboard-4xcv).
+    if (runsStatusRef.current === null || runsStatusRef.current === 'fixture') return;
     // Skip when an explicit refresh is already in flight. Without this
     // guard, a fast SSE event firing while a slow upstream call is
     // still resolving lets two requests race; older-completion can

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -87,12 +87,12 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     expect(listBeads).toHaveBeenCalledTimes(3);
     expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1_000 });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 80,
+      limit: 500,
       type: 'molecule',
       all: true,
     });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 80,
+      limit: 500,
       type: 'task',
       rig: 'rig-a',
       all: true,
@@ -174,12 +174,12 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.census.status).toBe('available');
     expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1_000 });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 80,
+      limit: 500,
       type: 'molecule',
       all: true,
     });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 80,
+      limit: 500,
       type: 'task',
       rig: 'rig-a',
       all: true,
@@ -190,6 +190,47 @@ describe('loadSupervisorRunSummarySource', () => {
     });
     expect(listSessions).toHaveBeenCalledWith('test-city');
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('enriches blocked lanes with health and keeps them out of the active set (gascity-dashboard-4xcv)', async () => {
+    // gc-1920 repro: a stale blocked formula latch must land in
+    // blockedLanes (with derived health, so attention still sees it),
+    // never in lanes/totalActive.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      return beadList([
+        runRoot(),
+        runRoot({
+          id: 'gc-1920',
+          title: 'mol-focus-review',
+          status: 'blocked',
+          metadata: {
+            'gc.kind': 'workflow',
+            'gc.formula_contract': 'graph.v2',
+            'gc.scope_kind': 'city',
+            'gc.scope_ref': 'test-city',
+            'gc.root_store_ref': 'city:test-city',
+          },
+        }),
+      ]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+    expect(source.data.blockedLanes.map((lane) => lane.id)).toEqual(['gc-1920']);
+    expect(source.data.blockedLanes[0]?.health.status).toBe('available');
+    expect(source.data.runCounts.blocked).toBe(1);
   });
 
   it('keeps available lanes while marking the summary partial when a recent rig read fails', async () => {

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -254,6 +254,30 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.lanesPartial).toBe(true);
   });
 
+  it('marks the summary partial when the active bead list is cursor-truncated', async () => {
+    // gascity-dashboard-4xcv: the supervisor truncates at the fetch limit and
+    // reports the rest via next_cursor WITHOUT setting partial. Treat a present
+    // cursor as partial so saturation surfaces the notice + retry instead of
+    // silently dropping lanes at 501+ beads.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      return beadList([runRoot()], false, 'next-page-token');
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
   it('does not let optional enrichment reads hold the summary refresh indefinitely', async () => {
     const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
       if (query?.type === 'molecule') return new Promise<ListBodyBead>(() => {});
@@ -327,11 +351,12 @@ function bead(overrides: Partial<Bead> = {}): Bead {
   };
 }
 
-function beadList(items: Bead[], partial = false): ListBodyBead {
+function beadList(items: Bead[], partial = false, nextCursor?: string): ListBodyBead {
   return {
     items,
     partial,
     total: items.length,
+    ...(nextCursor !== undefined ? { next_cursor: nextCursor } : {}),
   };
 }
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -350,7 +350,15 @@ function normalizeBead(bead: Bead): DashboardBead {
 }
 
 function listIsPartial(list: ListBodyBead): boolean {
-  return list.partial === true || (list.partial_errors?.length ?? 0) > 0;
+  // `partial`/`partial_errors` signal a backend-side failure, but the supervisor
+  // also truncates at the fetch limit and reports more via `next_cursor` without
+  // setting `partial`. Treat a present cursor as partial so saturation surfaces
+  // through the same partial-notice + retry paths instead of silently dropping lanes.
+  return (
+    list.partial === true ||
+    (list.partial_errors?.length ?? 0) > 0 ||
+    (list.next_cursor?.length ?? 0) > 0
+  );
 }
 
 function feedIsPartial(feed: FormulaFeedBody): boolean {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -24,7 +24,14 @@ import { supervisorApiForRequestBudget } from './client';
 import { normalizeSessions } from './sessionReads';
 
 const RUNS_FETCH_LIMIT = 1_000;
-const RECENT_RUN_FETCH_LIMIT = 80;
+// gascity-dashboard-4xcv: the supervisor's bead list has no sort/recency
+// guarantee, so a small `all=true` window can drop run roots and step beads
+// arbitrarily — observed live as an empty first paint and a history list
+// missing most completed runs (a busy rig store holds hundreds of closed
+// task beads). 500 covers the largest observed store with headroom; if a
+// store outgrows it the symptom returns as silently missing lanes, so a
+// real fix beyond raising the cap means cursor pagination.
+const RECENT_RUN_FETCH_LIMIT = 500;
 const RUNS_STALE_AFTER_MS = 60 * 1000;
 const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 5_000;
 const OPTIONAL_ENRICHMENT_TIMEOUT_MS = 2_500;
@@ -241,16 +248,20 @@ function enrichRunSummary(
   source: SourceAvailableState<RunSummary>,
   sessionsLookup: RunSessionsLookup,
 ): RunSummary {
+  // gascity-dashboard-4xcv: blocked lanes are enriched alongside active
+  // ones so they carry derived health (needsOperator) for the attention
+  // layer, then split back out — they are not part of the Active set.
+  const inFlight = [...source.data.lanes, ...source.data.blockedLanes];
   const state = progressStateByCity.get(cityName);
   const generationMs = Date.parse(source.fetchedAt);
   let marks = state?.marks ?? new Map<string, LaneProgressMark>();
   if (state === undefined || generationMs > Date.parse(state.fetchedAt)) {
-    marks = advanceProgressMarks(marks, source.data.lanes);
+    marks = advanceProgressMarks(marks, inFlight);
     progressStateByCity.set(cityName, { marks, fetchedAt: source.fetchedAt });
   }
 
   const { lanes, census } = deriveRunHealth({
-    lanes: source.data.lanes,
+    lanes: inFlight,
     sessions: sessionsLookup.sessions,
     sessionsAvailable: sessionsLookup.kind === 'available',
     marks,
@@ -258,7 +269,8 @@ function enrichRunSummary(
 
   return {
     ...source.data,
-    lanes,
+    lanes: lanes.filter((lane) => lane.phase !== 'blocked'),
+    blockedLanes: lanes.filter((lane) => lane.phase === 'blocked'),
     census: { status: 'available', data: census },
   };
 }

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -1,0 +1,111 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildRunSummary, emptyRunSummary } from './summary.js';
+import type { RunIssue } from './phaseMapping.js';
+
+// Active-classification regression coverage (gascity-dashboard-4xcv §2).
+// Operator repro gc-1920: a long-stale formula latch with status=blocked
+// (city-level, no live session) was counted and shown in the ACTIVE lane.
+// A blocked run still needs operator attention, but it is not progressing:
+// it belongs in its own blocked bucket, never in the Active set or count.
+
+function latch(overrides: Partial<RunIssue> = {}): RunIssue {
+  // Shape mirrors a real mol-focus-review latch root (gc-1920-class bead):
+  // a single graph.v2 root task with no step children.
+  return {
+    id: 'gc-1920',
+    title: 'mol-focus-review',
+    description: 'Focus + in-session review formula. Approval gate, review.',
+    status: 'blocked',
+    issue_type: 'task',
+    updated_at: '2026-04-01T00:00:00Z',
+    metadata: {
+      'gc.formula_contract': 'graph.v2',
+      'gc.kind': 'workflow',
+    },
+    ...overrides,
+  };
+}
+
+function activeRun(id: string): RunIssue[] {
+  return [
+    latch({
+      id,
+      title: 'Adopt PR #42',
+      description: 'implementation work',
+      status: 'open',
+      updated_at: '2026-06-01T00:00:00Z',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+    }),
+    {
+      id: `${id}-step-1`,
+      title: 'Implementation patch',
+      status: 'in_progress',
+      issue_type: 'task',
+      updated_at: '2026-06-01T00:05:00Z',
+      metadata: {
+        'gc.kind': 'step',
+        'gc.root_bead_id': id,
+        'gc.step_id': 'implementation.patch',
+      },
+    },
+  ];
+}
+
+function completedRun(id: string): RunIssue[] {
+  return [
+    latch({
+      id,
+      title: 'Done run',
+      description: 'merge finalize',
+      status: 'closed',
+      updated_at: '2026-05-01T00:00:00Z',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+    }),
+  ];
+}
+
+describe('buildRunSummary — blocked lanes are not Active (gascity-dashboard-4xcv)', () => {
+  test('a blocked formula latch lands in blockedLanes, not lanes or totalActive', () => {
+    const summary = buildRunSummary([latch(), ...activeRun('run-1')]);
+
+    assert.equal(summary.totalActive, 1);
+    assert.deepEqual(
+      summary.lanes.map((lane) => lane.id),
+      ['run-1'],
+    );
+    assert.deepEqual(
+      summary.blockedLanes.map((lane) => lane.id),
+      ['gc-1920'],
+    );
+    assert.equal(summary.runCounts.total, 1);
+    assert.equal(summary.runCounts.blocked, 1);
+  });
+
+  test('blocked lanes are not historical either', () => {
+    const summary = buildRunSummary([latch(), ...completedRun('run-done')]);
+
+    assert.equal(summary.totalActive, 0);
+    assert.equal(summary.totalHistorical, 1);
+    assert.deepEqual(
+      summary.historicalLanes.map((lane) => lane.id),
+      ['run-done'],
+    );
+    assert.deepEqual(
+      summary.blockedLanes.map((lane) => lane.id),
+      ['gc-1920'],
+    );
+  });
+
+  test('with no blocked lanes, blockedLanes is empty and blocked count is zero', () => {
+    const summary = buildRunSummary(activeRun('run-1'));
+
+    assert.deepEqual(summary.blockedLanes, []);
+    assert.equal(summary.runCounts.blocked, 0);
+  });
+
+  test('emptyRunSummary carries an empty blockedLanes array', () => {
+    assert.deepEqual(emptyRunSummary().blockedLanes, []);
+  });
+});

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -55,16 +55,23 @@ export function buildRunSummary(
     .map(([rootId, groupIssues]) => runLane(rootId, groupIssues, feedScopes))
     .sort(compareLanes);
 
-  const activeLanes = sortedLanes.filter((lane) => lane.phase !== 'complete');
+  // gascity-dashboard-4xcv: blocked lanes are split out of Active. A stale
+  // blocked formula latch (gc-1920 repro) is not progressing; it surfaces in
+  // its own section instead of inflating the Active set.
+  const activeLanes = sortedLanes.filter(
+    (lane) => lane.phase !== 'complete' && lane.phase !== 'blocked',
+  );
   const historicalLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
+  const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
   const visibleActive = activeLanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
 
   const summary: RunSummary = {
     totalActive: activeLanes.length,
     totalHistorical: historicalLanes.length,
-    runCounts: runCounts(activeLanes, visibleActive.length),
+    runCounts: runCounts(activeLanes, visibleActive.length, blockedLanes.length),
     lanes: visibleActive,
     historicalLanes,
+    blockedLanes,
     recentChanges: recentChanges(laneIssues),
     census: runCensusUnavailable(),
   };
@@ -76,21 +83,18 @@ function isGraphV2RunGroup(rootId: string, issues: RunIssue[]): boolean {
   return stringValue(root?.metadata?.['gc.formula_contract']) === 'graph.v2';
 }
 
-export function runCounts(lanes: RunLane[], visible: number): RunCounts {
+export function runCounts(lanes: RunLane[], visible: number, blocked: number): RunCounts {
   const counts: RunCounts = {
     total: lanes.length,
     visible,
     prReview: 0,
     designReview: 0,
     bugfix: 0,
-    blocked: 0,
+    blocked,
     other: 0,
   };
 
   for (const lane of lanes) {
-    if (lane.phase === 'blocked' || (lane.statusCounts.blocked ?? 0) > 0) {
-      counts.blocked += 1;
-    }
     switch (runKind(lane.formula)) {
       case 'prReview':
         counts.prReview += 1;
@@ -362,6 +366,7 @@ export function emptyRunSummary(): RunSummary {
     },
     lanes: [],
     historicalLanes: [],
+    blockedLanes: [],
     recentChanges: [],
     census: runCensusUnavailable(),
   };

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -330,9 +330,11 @@ export type RunCensusState = Avail<{
  * adds the time-derived "failing / stalled" count on its 1s clock.
  */
 export interface RunCensus {
-  /** In-flight (non-complete, non-blocked) lane count per phase. */
+  /** Lane count per phase across the snapshot. Includes the `blocked` phase;
+   *  `complete` lanes are tallied here but excluded from `totalInFlight`. */
   byPhase: Record<RunPhase, number>;
-  /** Total in-flight lanes (the census denominator base). */
+  /** Total non-complete lanes (the census denominator base). Includes blocked
+   *  lanes — they are non-progressing but still in flight for census purposes. */
   totalInFlight: number;
   /**
    * In-flight lanes the engine cannot classify with confidence

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -268,11 +268,12 @@ export interface WorkSummary {
 // ── runs ─────────────────────────────────────────────────────────────
 
 export interface RunSummary {
-  /** Count of ACTIVE lanes (`phase !== 'complete'`). Blocked lanes ARE
-   *  included — a blocked lane still needs operator attention and is not
-   *  "done". Aligns with `RunCensus.totalInFlight`, which also
-   *  excludes only complete. The headline `activeRuns` metric
-   *  counts this set (via census when available, this field as fallback). */
+  /** Count of ACTIVE lanes (`phase` neither 'complete' nor 'blocked').
+   *  gascity-dashboard-4xcv: blocked lanes are EXCLUDED — a stale blocked
+   *  formula latch (gc-1920 repro) is not progressing and must not read as
+   *  Active. Blocked lanes live in `blockedLanes` and still surface for
+   *  operator attention; they are simply not part of the Active set or
+   *  the headline `activeRuns` metric. */
   totalActive: number;
   /** Count of HISTORICAL lanes (phase === 'complete'). gascity-dashboard-yh5i:
    *  /runs defaults to showing the active set; toggling `?history=1`
@@ -286,6 +287,13 @@ export interface RunSummary {
    *  MAX_VISIBLE_HISTORICAL_LANES. Frontend renders these only when the user
    *  toggles ?history=1; backend always returns the array. */
   historicalLanes: RunLane[];
+  /** Blocked (phase === 'blocked') lanes, sorted by compareLanes
+   *  (gascity-dashboard-4xcv). Rendered as their own section so a blocked
+   *  run stays visible for the operator without being misread as Active.
+   *  `runCounts.blocked` counts this array. Deliberately uncapped: every
+   *  blocked lane is an operator-attention item and must not be silently
+   *  truncated the way the active 8-cap window trims calm lanes. */
+  blockedLanes: RunLane[];
   recentChanges: RunChange[];
   /**
    * City-level health census (gascity-dashboard-3ax). Threshold-INDEPENDENT
@@ -407,6 +415,11 @@ export interface RunCounts {
   prReview: number;
   designReview: number;
   bugfix: number;
+  /** Count of blocked lanes (`phase === 'blocked'`, i.e. `blockedLanes.length`).
+   *  gascity-dashboard-4xcv: disjoint from `total`, which counts only the
+   *  Active set. A lane with a blocked member always classifies as
+   *  phase 'blocked' (mapRunPhase checks members first), so this is the
+   *  complete blocked count, not a subset. */
   blocked: number;
   other: number;
 }


### PR DESCRIPTION
Fixes the operator-visible defects that undercut the `/runs` tab's first impression, plus a silent-at-scale guard.

## Operator-visible defects fixed
- **First-load race** — a partial fetch with zero lanes was rendered as "no active runs". A degraded read is now stated in words ("Run sources were partially unavailable; the lane set may be incomplete"), never presented as an empty store.
- **Blocked shown as Active** — a stale blocked formula latch (gc-1920 repro) was inflating the Active set and count. Blocked lanes are now split into their own labeled section, never mixed into or counted with Active.
- **Unknown-rig mislabel** — city-scoped runs (control-dispatcher work) and lanes with unavailable scope metadata were surfaced as an "unknown rig". They now group honestly under `city`, since they still came from the city's bead store.
- **History cap dead-end** — the historical section's static "N more not shown" footnote is replaced by an expand-in-place preview (5 lanes + Show-more / Show-fewer toggle), reconciled with `main`'s restored toggle (#74).

## Silent-at-scale guard
- Surfaces `listIsPartial` + `next_cursor` truncation so a capped/cursored read is visible rather than silently dropping rows, with a regression test.

## Review-fix commit (6e12bd5)
listIsPartial+next_cursor regression test; prettier; Blocked tile accent→muted (One Mark Rule); retry guard; RunCensus JSDoc.

## Rebase note
Rebased onto current `main` (ff15d95). One semantic conflict in `RunMap.tsx`: `main` #74 ("restore expand-in-place history toggle") landed an expand toggle in the same region this branch had rewritten to a static footnote. Resolved by keeping #74's expand-in-place behavior and routing it through this branch's extracted `LaneList` component (whose docstring already lists the Historical section as a consumer), with an optional `listId` to preserve the toggle's `aria-controls`. The old "N more not shown" path was also dead code post-merge (`totalHistorical === historicalLanes.length`). The `RunMap.test.tsx` expand-in-place suite (l9q9) passes.

## CI parity (green)
typecheck (src+test), eslint, prettier, openapi drift, shared 66 / frontend 756 / backend 509, frontend build.

In-session review gate PASSED — reviewed APPROVE; mayor merge-gates (do not merge).