### PR TITLE
feat(health): recommended tool-version drift surface (nfyw)

### DIFF
--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -5,13 +5,16 @@ import { recordAudit } from '../audit.js';
 import {
   probeBeadsVersion,
   probeDoltVersion,
+  probeGcVersion,
   type VersionProbe,
   type VersionProbeResult,
 } from './version-probe.js';
+import { RECOMMENDED_TOOL_FLOORS, recommendedToolVersion } from './recommended-versions.js';
 
 export interface HealthRouterOptions {
   doltProbe?: VersionProbe;
   beadsProbe?: VersionProbe;
+  gcProbe?: VersionProbe;
 }
 
 /** Dashboard-local admin process and host health. GC supervisor health is
@@ -20,6 +23,7 @@ export function healthRouter(options: HealthRouterOptions = {}): Router {
   const router = Router();
   const doltProbe = options.doltProbe ?? probeDoltVersion;
   const beadsProbe = options.beadsProbe ?? probeBeadsVersion;
+  const gcProbe = options.gcProbe ?? probeGcVersion;
 
   router.get('/system', async (_req, res) => {
     const mem = process.memoryUsage();
@@ -51,10 +55,20 @@ export function healthRouter(options: HealthRouterOptions = {}): Router {
   });
 
   router.get('/local-tools', async (_req, res) => {
-    const [dolt, beads] = await Promise.all([doltProbe(), beadsProbe()]);
+    const [dolt, beads, gc] = await Promise.all([doltProbe(), beadsProbe(), gcProbe()]);
     const payload: LocalToolVersions = {
-      dolt: localToolVersion(dolt, 'local probe: dolt version'),
-      beads: localToolVersion(beads, 'local probe: bd version'),
+      dolt: recommendedToolVersion(
+        localToolVersion(dolt, 'local probe: dolt version'),
+        RECOMMENDED_TOOL_FLOORS.dolt,
+      ),
+      beads: recommendedToolVersion(
+        localToolVersion(beads, 'local probe: bd version'),
+        RECOMMENDED_TOOL_FLOORS.beads,
+      ),
+      gc: recommendedToolVersion(
+        localToolVersion(gc, 'local probe: gc version'),
+        RECOMMENDED_TOOL_FLOORS.gc,
+      ),
     };
     await recordAudit({
       type: 'dashboard.fetch',

--- a/backend/src/routes/recommended-versions.test.ts
+++ b/backend/src/routes/recommended-versions.test.ts
@@ -1,0 +1,89 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { LocalToolVersion } from 'gas-city-dashboard-shared';
+import {
+  compareVersions,
+  driftAgainstFloor,
+  parseVersionTuple,
+  recommendedToolVersion,
+} from './recommended-versions.js';
+
+const available = (version: string): LocalToolVersion => ({
+  status: 'available',
+  version,
+  source: 'test probe',
+});
+
+const unavailable: LocalToolVersion = { status: 'unavailable', reason: 'probe failed' };
+
+describe('parseVersionTuple', () => {
+  test('parses an X.Y.Z version', () => {
+    assert.deepEqual(parseVersionTuple('2.1.2'), [2, 1, 2]);
+  });
+
+  test('trims surrounding whitespace', () => {
+    assert.deepEqual(parseVersionTuple('  1.0.4 \n'), [1, 0, 4]);
+  });
+
+  test('returns null for a non-X.Y.Z string', () => {
+    assert.equal(parseVersionTuple('dev'), null);
+    assert.equal(parseVersionTuple('1.0'), null);
+    assert.equal(parseVersionTuple('1.0.4-rc1'), null);
+  });
+});
+
+describe('compareVersions', () => {
+  test('orders by major, then minor, then patch', () => {
+    assert.equal(compareVersions('2.1.2', '2.1.1'), 1);
+    assert.equal(compareVersions('2.0.9', '2.1.0'), -1);
+    assert.equal(compareVersions('1.0.0', '2.0.0'), -1);
+    assert.equal(compareVersions('2.1.2', '2.1.2'), 0);
+  });
+
+  test('returns null when either side is not comparable', () => {
+    assert.equal(compareVersions('dev', '2.1.2'), null);
+    assert.equal(compareVersions('2.1.2', 'dev'), null);
+  });
+});
+
+describe('driftAgainstFloor', () => {
+  test('satisfied when installed is at or above the floor', () => {
+    assert.equal(driftAgainstFloor(available('2.1.2'), '2.1.2'), 'satisfied');
+    assert.equal(driftAgainstFloor(available('2.2.0'), '2.1.2'), 'satisfied');
+  });
+
+  test('below_floor when installed is under the floor', () => {
+    assert.equal(driftAgainstFloor(available('2.0.7'), '2.1.2'), 'below_floor');
+  });
+
+  test('unknown when the floor is unpublished', () => {
+    assert.equal(driftAgainstFloor(available('dev'), null), 'unknown');
+    assert.equal(driftAgainstFloor(available('2.1.2'), null), 'unknown');
+  });
+
+  test('unknown when the probe failed', () => {
+    assert.equal(driftAgainstFloor(unavailable, '2.1.2'), 'unknown');
+  });
+
+  test('unknown when installed is not a comparable semver', () => {
+    assert.equal(driftAgainstFloor(available('dev'), '2.1.2'), 'unknown');
+  });
+});
+
+describe('recommendedToolVersion', () => {
+  test('assembles installed, floor, and computed drift', () => {
+    assert.deepEqual(recommendedToolVersion(available('2.0.7'), '2.1.2'), {
+      installed: available('2.0.7'),
+      recommendedFloor: '2.1.2',
+      drift: 'below_floor',
+    });
+  });
+
+  test('carries a null floor through as unknown drift', () => {
+    assert.deepEqual(recommendedToolVersion(available('dev'), null), {
+      installed: available('dev'),
+      recommendedFloor: null,
+      drift: 'unknown',
+    });
+  });
+});

--- a/backend/src/routes/recommended-versions.test.ts
+++ b/backend/src/routes/recommended-versions.test.ts
@@ -29,6 +29,7 @@ describe('parseVersionTuple', () => {
     assert.equal(parseVersionTuple('dev'), null);
     assert.equal(parseVersionTuple('1.0'), null);
     assert.equal(parseVersionTuple('1.0.4-rc1'), null);
+    assert.equal(parseVersionTuple('1.2.3.4'), null);
   });
 });
 

--- a/backend/src/routes/recommended-versions.ts
+++ b/backend/src/routes/recommended-versions.ts
@@ -1,0 +1,69 @@
+import type {
+  LocalToolVersion,
+  RecommendedToolVersion,
+  ToolVersionDrift,
+} from 'gas-city-dashboard-shared';
+
+// Recommended minimum ("floor") versions for the host tools the dashboard
+// depends on. The authoritative pins live in gc itself (`gc doctor` gates
+// dolt / bd compatibility), but gc exposes no machine-readable floor, so the
+// dashboard maintains this table. Bump it when gc raises its floor.
+//
+// gc carries no numeric floor: it ships as `dev` builds, so its drift is
+// reported `unknown` rather than compared against a fabricated version.
+export const RECOMMENDED_TOOL_FLOORS: {
+  readonly dolt: string;
+  readonly beads: string;
+  readonly gc: string | null;
+} = {
+  dolt: '2.1.2',
+  beads: '1.0.4',
+  gc: null,
+};
+
+/** Parse an `X.Y.Z` version into a numeric tuple, or null if it is not that
+ *  exact shape. Probe output is already reduced to `X.Y.Z` by parseVersion,
+ *  and floors are authored as `X.Y.Z`, so this is the full comparable set. */
+export function parseVersionTuple(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (match === null) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/** Compare two `X.Y.Z` versions: -1 if a < b, 0 if equal, 1 if a > b. Returns
+ *  null when either side is not a comparable `X.Y.Z`. */
+export function compareVersions(a: string, b: string): number | null {
+  const left = parseVersionTuple(a);
+  const right = parseVersionTuple(b);
+  if (left === null || right === null) return null;
+  // Destructuring a fixed 3-tuple yields plain numbers (no undefined under
+  // noUncheckedIndexedAccess), so the comparison stays cast- and fallback-free.
+  const [lMajor, lMinor, lPatch] = left;
+  const [rMajor, rMinor, rPatch] = right;
+  if (lMajor !== rMajor) return lMajor < rMajor ? -1 : 1;
+  if (lMinor !== rMinor) return lMinor < rMinor ? -1 : 1;
+  if (lPatch !== rPatch) return lPatch < rPatch ? -1 : 1;
+  return 0;
+}
+
+export function driftAgainstFloor(
+  installed: LocalToolVersion,
+  floor: string | null,
+): ToolVersionDrift {
+  if (floor === null) return 'unknown';
+  if (installed.status !== 'available') return 'unknown';
+  const cmp = compareVersions(installed.version, floor);
+  if (cmp === null) return 'unknown';
+  return cmp >= 0 ? 'satisfied' : 'below_floor';
+}
+
+export function recommendedToolVersion(
+  installed: LocalToolVersion,
+  floor: string | null,
+): RecommendedToolVersion {
+  return {
+    installed,
+    recommendedFloor: floor,
+    drift: driftAgainstFloor(installed, floor),
+  };
+}

--- a/backend/src/routes/version-probe.test.ts
+++ b/backend/src/routes/version-probe.test.ts
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseVersion } from './version-probe.js';
+import { parseGcVersionJson, parseVersion } from './version-probe.js';
 
 describe('parseVersion', () => {
   test('extracts the semver from `dolt version` output', () => {
@@ -13,5 +13,28 @@ describe('parseVersion', () => {
 
   test('returns null when no version token is present', () => {
     assert.equal(parseVersion('command not found'), null);
+  });
+});
+
+describe('parseGcVersionJson', () => {
+  test('reads the version field verbatim, including a bare `dev` build', () => {
+    assert.equal(
+      parseGcVersionJson('{"commit":"ee446af6b","ok":true,"version":"dev"}'),
+      'dev',
+    );
+  });
+
+  test('reads a release semver from the version field', () => {
+    assert.equal(parseGcVersionJson('{"version":"0.9.1"}'), '0.9.1');
+  });
+
+  test('returns null when the version field is absent or non-string', () => {
+    assert.equal(parseGcVersionJson('{"commit":"abc"}'), null);
+    assert.equal(parseGcVersionJson('{"version":123}'), null);
+    assert.equal(parseGcVersionJson('{"version":""}'), null);
+  });
+
+  test('returns null on malformed JSON', () => {
+    assert.equal(parseGcVersionJson('not json'), null);
   });
 });

--- a/backend/src/routes/version-probe.test.ts
+++ b/backend/src/routes/version-probe.test.ts
@@ -18,10 +18,7 @@ describe('parseVersion', () => {
 
 describe('parseGcVersionJson', () => {
   test('reads the version field verbatim, including a bare `dev` build', () => {
-    assert.equal(
-      parseGcVersionJson('{"commit":"ee446af6b","ok":true,"version":"dev"}'),
-      'dev',
-    );
+    assert.equal(parseGcVersionJson('{"commit":"ee446af6b","ok":true,"version":"dev"}'), 'dev');
   });
 
   test('reads a release semver from the version field', () => {

--- a/backend/src/routes/version-probe.ts
+++ b/backend/src/routes/version-probe.ts
@@ -19,6 +19,24 @@ export function parseVersion(stdout: string): string | null {
   return SEMVER_RE.exec(stdout)?.[1] ?? null;
 }
 
+// gc has no semver release line: `gc version` prints a bare token (`dev` for
+// local builds, a semver for releases). `gc version --json` carries it in a
+// `version` field, which we read verbatim so a `dev` build surfaces as `dev`
+// rather than collapsing to "no recognizable version".
+export function parseGcVersionJson(stdout: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
+    return null;
+  }
+  const version = (parsed as { version: unknown }).version;
+  return typeof version === 'string' && version.length > 0 ? version : null;
+}
+
 async function probeVersion(cmd: string): Promise<VersionProbeResult> {
   try {
     const result = await runExec(cmd, ['version'], VERSION_PROBE_TIMEOUT_MS);
@@ -36,6 +54,25 @@ async function probeVersion(cmd: string): Promise<VersionProbeResult> {
   }
 }
 
+async function probeGcVersionJson(): Promise<VersionProbeResult> {
+  try {
+    const result = await runExec('gc', ['version', '--json'], VERSION_PROBE_TIMEOUT_MS);
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || 'no output';
+      return { kind: 'error', reason: `gc version exited ${result.exitCode}: ${detail}` };
+    }
+    const version = parseGcVersionJson(result.stdout);
+    if (version === null) {
+      return { kind: 'error', reason: 'gc version --json output had no version field' };
+    }
+    return { kind: 'ok', version };
+  } catch (err) {
+    return { kind: 'error', reason: `gc version probe failed: ${errorMessage(err)}` };
+  }
+}
+
 export const probeDoltVersion: VersionProbe = () => probeVersion('dolt');
 
 export const probeBeadsVersion: VersionProbe = () => probeVersion('bd');
+
+export const probeGcVersion: VersionProbe = () => probeGcVersionJson();

--- a/backend/test/routes.test.ts
+++ b/backend/test/routes.test.ts
@@ -12,6 +12,7 @@ function buildApp(): { app: express.Express } {
     healthRouter({
       doltProbe: async () => ({ kind: 'ok', version: '2.0.7' }),
       beadsProbe: async () => ({ kind: 'error', reason: 'bd missing' }),
+      gcProbe: async () => ({ kind: 'ok', version: 'dev' }),
     }),
   );
   return { app };
@@ -60,14 +61,33 @@ describe('dashboard-local routes', () => {
       const res = await fetch(`${url}/api/system/local-tools`);
       assert.equal(res.status, 200);
       assert.deepEqual(await res.json(), {
+        // dolt 2.0.7 is below its 2.1.2 floor → drift; beads probe failed →
+        // unknown; gc is a `dev` build with no published floor → unknown.
         dolt: {
-          status: 'available',
-          version: '2.0.7',
-          source: 'local probe: dolt version',
+          installed: {
+            status: 'available',
+            version: '2.0.7',
+            source: 'local probe: dolt version',
+          },
+          recommendedFloor: '2.1.2',
+          drift: 'below_floor',
         },
         beads: {
-          status: 'unavailable',
-          reason: 'bd missing',
+          installed: {
+            status: 'unavailable',
+            reason: 'bd missing',
+          },
+          recommendedFloor: '1.0.4',
+          drift: 'unknown',
+        },
+        gc: {
+          installed: {
+            status: 'available',
+            version: 'dev',
+            source: 'local probe: gc version',
+          },
+          recommendedFloor: null,
+          drift: 'unknown',
         },
       });
     } finally {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -62,4 +62,33 @@ describe('api client error handling', () => {
       message: expect.stringContaining('config.cityRoot must be a string'),
     });
   });
+
+  it('rejects a local-tools body whose drift union is absent at the edge', async () => {
+    // The Health renderer branches on each tool's `drift`; a tool object that
+    // omits it would mis-render silently, so the decoder rejects it up front.
+    const tool = {
+      installed: { status: 'available' },
+      recommendedFloor: '2.1.2',
+      drift: 'below_floor',
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              gc: tool,
+              beads: tool,
+              dolt: { installed: { status: 'available' }, recommendedFloor: '2.1.2' },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await expect(api.localToolVersions()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('dolt.drift must be a string'),
+    });
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -263,6 +263,7 @@ const decodeLocalToolVersions = objectDecoder<LocalToolVersions>(
   (record, url) => {
     requireObjectField(record, url, 'local tool versions', 'dolt');
     requireObjectField(record, url, 'local tool versions', 'beads');
+    requireObjectField(record, url, 'local tool versions', 'gc');
   },
 );
 const decodeDoltTrend = objectDecoder<DoltNomsTrend>('dolt trend', (record, url) => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -258,12 +258,29 @@ const decodeSystemHealth = objectDecoder<SystemHealth>('system health', (record,
   requireObjectField(record, url, 'system health', 'admin');
   requireObjectField(record, url, 'system health', 'host');
 });
+function requireRecommendedToolVersionField(
+  record: JsonRecord,
+  url: string,
+  label: string,
+  field: string,
+): void {
+  requireObjectField(record, url, label, field);
+  // The Health renderer branches on `installed.status` and `drift`, so validate
+  // them here at the edge rather than letting a malformed wire value mis-render.
+  const tool = record[field] as JsonRecord;
+  const toolLabel = `${label}.${field}`;
+  requireObjectField(tool, url, toolLabel, 'installed');
+  requireStringField(tool.installed as JsonRecord, url, `${toolLabel}.installed`, 'status');
+  requireNullableStringField(tool, url, toolLabel, 'recommendedFloor');
+  requireStringField(tool, url, toolLabel, 'drift');
+}
+
 const decodeLocalToolVersions = objectDecoder<LocalToolVersions>(
   'local tool versions',
   (record, url) => {
-    requireObjectField(record, url, 'local tool versions', 'dolt');
-    requireObjectField(record, url, 'local tool versions', 'beads');
-    requireObjectField(record, url, 'local tool versions', 'gc');
+    requireRecommendedToolVersionField(record, url, 'local tool versions', 'dolt');
+    requireRecommendedToolVersionField(record, url, 'local tool versions', 'beads');
+    requireRecommendedToolVersionField(record, url, 'local tool versions', 'gc');
   },
 );
 const decodeDoltTrend = objectDecoder<DoltNomsTrend>('dolt trend', (record, url) => {

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -227,8 +227,6 @@ describe('HealthPage', () => {
 
     await screen.findByRole('heading', { name: /diagnostics/i });
 
-    expect(screen.getByText('2.0.7')).toBeTruthy();
-    expect(screen.getByText('1.0.4')).toBeTruthy();
     expect(screen.getByText('Dolt usage')).toBeTruthy();
     expect(screen.getByText('Beads usage')).toBeTruthy();
     expect(screen.getByText('5')).toBeTruthy();
@@ -264,6 +262,52 @@ describe('HealthPage', () => {
     await screen.findByRole('heading', { name: /supervisor/i });
     await screen.findByRole('heading', { name: /bead stores · per rig/i });
     expect(screen.getByText(/per-rig store health unavailable/i)).toBeTruthy();
+  });
+
+  it('shows installed vs recommended tool versions and warns on drift below the floor', async () => {
+    const { container } = renderPage();
+
+    await screen.findByRole('heading', { name: /tool versions/i });
+
+    // dolt is below its floor: installed + recommended both visible, and a
+    // visible cell carries the warning tone. (The row wrapper is
+    // `display:contents`, which can't carry color — the cells do.)
+    const dolt = toolRow(container, 'dolt');
+    expect(dolt?.textContent).toContain('2.0.7');
+    expect(dolt?.textContent).toContain('2.1.2');
+    expect(dolt?.textContent).toMatch(/below floor/i);
+    expect(dolt?.querySelector('.text-warn')).not.toBeNull();
+
+    // beads sits at its floor: no warning.
+    const beads = toolRow(container, 'bd');
+    expect(beads?.textContent).toContain('1.0.4');
+    expect(beads?.textContent).not.toMatch(/below floor/i);
+    expect(beads?.querySelector('.text-warn')).toBeNull();
+
+    // gc has no published floor: installed dev build, "not pinned" recommended.
+    const gc = toolRow(container, 'gc');
+    expect(gc?.textContent).toContain('dev');
+    expect(gc?.textContent).toContain('not pinned');
+    expect(gc?.textContent).not.toMatch(/below floor/i);
+  });
+
+  it('surfaces a probe failure reason in the tool versions table', async () => {
+    currentLocalTools = {
+      ...baseLocalTools(),
+      gc: {
+        installed: { status: 'unavailable', reason: 'gc version probe failed: ENOENT' },
+        recommendedFloor: null,
+        drift: 'unknown',
+      },
+    };
+
+    const { container } = renderPage();
+
+    await screen.findByRole('heading', { name: /tool versions/i });
+
+    const gc = toolRow(container, 'gc');
+    expect(gc?.textContent).toContain('unavailable');
+    expect(gc?.textContent).toContain('gc version probe failed: ENOENT');
   });
 
   it('highlights Health sections that match composed attention facts', async () => {
@@ -336,6 +380,10 @@ function valueFor(container: HTMLElement, label: string): HTMLElement | null {
   return terms[0]?.nextElementSibling as HTMLElement | null;
 }
 
+function toolRow(container: HTMLElement, label: string): HTMLElement | null {
+  return container.querySelector(`[data-tool-version-row="${label}"]`);
+}
+
 function synopsisFor(heading: HTMLElement): HTMLElement | null {
   // PageHeader renders the synopsis as a sibling of the heading inside
   // a shared header element. Walk up to the nearest <header>, then look
@@ -401,15 +449,22 @@ function baseHealth(): SystemHealth {
 
 function baseLocalTools(): LocalToolVersions {
   return {
+    // dolt below its floor (drift), beads at its floor (satisfied), gc a
+    // dev build with no published floor (unknown).
     dolt: {
-      status: 'available',
-      version: '2.0.7',
-      source: 'local probe: dolt version',
+      installed: { status: 'available', version: '2.0.7', source: 'local probe: dolt version' },
+      recommendedFloor: '2.1.2',
+      drift: 'below_floor',
     },
     beads: {
-      status: 'available',
-      version: '1.0.4',
-      source: 'local probe: bd version',
+      installed: { status: 'available', version: '1.0.4', source: 'local probe: bd version' },
+      recommendedFloor: '1.0.4',
+      drift: 'satisfied',
+    },
+    gc: {
+      installed: { status: 'available', version: 'dev', source: 'local probe: gc version' },
+      recommendedFloor: null,
+      drift: 'unknown',
     },
   };
 }

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -278,17 +278,47 @@ describe('HealthPage', () => {
     expect(dolt?.textContent).toMatch(/below floor/i);
     expect(dolt?.querySelector('.text-warn')).not.toBeNull();
 
-    // beads sits at its floor: no warning.
+    // beads sits at its floor: no warning, and its cells read in neutral tone.
     const beads = toolRow(container, 'bd');
     expect(beads?.textContent).toContain('1.0.4');
     expect(beads?.textContent).not.toMatch(/below floor/i);
     expect(beads?.querySelector('.text-warn')).toBeNull();
+    expect(beads?.querySelector('.text-fg')).not.toBeNull();
 
     // gc has no published floor: installed dev build, "not pinned" recommended.
     const gc = toolRow(container, 'gc');
     expect(gc?.textContent).toContain('dev');
     expect(gc?.textContent).toContain('not pinned');
     expect(gc?.textContent).not.toMatch(/below floor/i);
+  });
+
+  it('renders only the first below-floor tool in warn tone (One Mark Rule)', async () => {
+    // The bead's own example: bd and dolt both pinned below floor at once. Only
+    // the first drift may carry the maroon mark; every later drifted row keeps
+    // the "below floor" word but reads neutral, so the viewport holds one mark.
+    currentLocalTools = {
+      ...baseLocalTools(),
+      beads: {
+        installed: { status: 'available', version: '1.0.3', source: 'local probe: bd version' },
+        recommendedFloor: '1.0.4',
+        drift: 'below_floor',
+      },
+      // dolt stays below_floor from baseLocalTools().
+    };
+
+    const { container } = renderPage();
+
+    await screen.findByRole('heading', { name: /tool versions/i });
+
+    // bd is the first below-floor row (gc carries no floor): single warn mark.
+    const beads = toolRow(container, 'bd');
+    expect(beads?.textContent).toMatch(/below floor/i);
+    expect(beads?.querySelector('.text-warn')).not.toBeNull();
+
+    // dolt is below floor too but later — word kept, tone neutral, no 2nd mark.
+    const dolt = toolRow(container, 'dolt');
+    expect(dolt?.textContent).toMatch(/below floor/i);
+    expect(dolt?.querySelector('.text-warn')).toBeNull();
   });
 
   it('surfaces a probe failure reason in the tool versions table', async () => {

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -1,8 +1,8 @@
 import { useCallback, type ReactNode } from 'react';
 import type {
   DoltNomsTrend,
-  LocalToolVersion,
   LocalToolVersions,
+  RecommendedToolVersion,
   RigStoreHealth,
   RigStoreHealthReport,
   RigStoreHealthUnavailableReason,
@@ -228,28 +228,12 @@ export function HealthPage() {
             )}
           </Section>
 
+          <Section title="Tool versions">
+            <ToolVersionsTable state={localTools} />
+          </Section>
+
           <Section title="Diagnostics">
             <div className="space-y-8">
-              <KvList>
-                <LocalToolKv
-                  label="Dolt version"
-                  datum={localTools?.status === 'available' ? localTools.data.dolt : null}
-                  fallbackReason={
-                    localTools?.status === 'unavailable'
-                      ? localTools.error
-                      : 'local tool versions still loading'
-                  }
-                />
-                <LocalToolKv
-                  label="Beads version"
-                  datum={localTools?.status === 'available' ? localTools.data.beads : null}
-                  fallbackReason={
-                    localTools?.status === 'unavailable'
-                      ? localTools.error
-                      : 'local tool versions still loading'
-                  }
-                />
-              </KvList>
               <DoltUsageBlock usage={doltUsageOf(status)} />
               <BeadsUsageBlock usage={beadsUsageOf(status)} />
             </div>
@@ -263,7 +247,7 @@ export function HealthPage() {
             <RigStoreHealthBlock report={rigStores} />
           </Section>
 
-          <Section title="Recommended vs loaded">
+          <Section title="Store thresholds">
             <ConfigComparison comparison={configComparisonOf(status)} />
           </Section>
 
@@ -352,22 +336,63 @@ interface ConfigComparisonRow {
   withinRecommendation: boolean;
 }
 
-function LocalToolKv({
-  label,
-  datum,
-  fallbackReason,
-}: {
-  label: string;
-  datum: LocalToolVersion | null;
-  fallbackReason: string;
-}) {
-  if (datum === null) {
-    return <Kv label={label} value={`unavailable - ${fallbackReason}`} tone="warn" />;
+function ToolVersionsTable({ state }: { state: LocalToolVersionsState | null }) {
+  if (state === null) {
+    return <p className="text-body text-fg-muted italic">Loading tool versions.</p>;
   }
-  return datum.status === 'available' ? (
-    <Kv label={label} value={datum.version} />
-  ) : (
-    <Kv label={label} value={`unavailable - ${datum.reason}`} tone="warn" />
+  if (state.status === 'unavailable') {
+    return (
+      <p className="text-body text-fg-muted italic">Tool versions unavailable: {state.error}.</p>
+    );
+  }
+  // gc first (it carries no floor and frames the section), then the pinned
+  // tools the operator most often drifts on.
+  const rows: { label: string; tool: RecommendedToolVersion }[] = [
+    { label: 'gc', tool: state.data.gc },
+    { label: 'bd', tool: state.data.beads },
+    { label: 'dolt', tool: state.data.dolt },
+  ];
+  return (
+    <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
+      <div className="text-label uppercase tracking-wider text-fg-muted">Tool</div>
+      <div className="text-label uppercase tracking-wider text-fg-muted text-right">Installed</div>
+      <div className="text-label uppercase tracking-wider text-fg-muted text-right">
+        Recommended
+      </div>
+      {rows.map((row) => (
+        <ToolVersionRow key={row.label} label={row.label} tool={row.tool} />
+      ))}
+    </div>
+  );
+}
+
+function ToolVersionRow({ label, tool }: { label: string; tool: RecommendedToolVersion }) {
+  const belowFloor = tool.drift === 'below_floor';
+  const tone = belowFloor ? 'text-warn' : 'text-fg';
+  const recommended = tool.recommendedFloor ?? 'not pinned';
+  // `contents` makes the row's cells participate directly in the parent grid.
+  // Color can't inherit through a `display:contents` box, so each visible cell
+  // carries its own `tone` rather than relying on the wrapper.
+  return (
+    <div className="contents" data-tool-version-row={label}>
+      <div className={`text-body ${tone}`}>
+        {label}
+        {belowFloor && (
+          <span className="text-label uppercase tracking-wider text-warn"> · below floor</span>
+        )}
+      </div>
+      <div className="text-right">
+        {tool.installed.status === 'available' ? (
+          <span className={`text-body tnum font-medium ${tone}`}>{tool.installed.version}</span>
+        ) : (
+          <div className="space-y-1">
+            <div className="text-body tnum font-medium text-warn">unavailable</div>
+            <div className="text-label text-fg-muted normal-case">{tool.installed.reason}</div>
+          </div>
+        )}
+      </div>
+      <div className="text-body tnum text-fg-muted text-right">{recommended}</div>
+    </div>
   );
 }
 

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -352,6 +352,12 @@ function ToolVersionsTable({ state }: { state: LocalToolVersionsState | null }) 
     { label: 'bd', tool: state.data.beads },
     { label: 'dolt', tool: state.data.dolt },
   ];
+  // One Mark Rule (Workers-Active precedent): several tools can sit below floor
+  // at once (the bead's own example: bd + dolt both pinned), but the maroon warn
+  // tone renders only on the first drift. Every other below-floor row keeps the
+  // "· below floor" word in neutral tone so the signal survives without a second
+  // mark competing for the viewport's single accent.
+  const accentIndex = rows.findIndex((row) => row.tool.drift === 'below_floor');
   return (
     <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
       <div className="text-label uppercase tracking-wider text-fg-muted">Tool</div>
@@ -359,16 +365,31 @@ function ToolVersionsTable({ state }: { state: LocalToolVersionsState | null }) 
       <div className="text-label uppercase tracking-wider text-fg-muted text-right">
         Recommended
       </div>
-      {rows.map((row) => (
-        <ToolVersionRow key={row.label} label={row.label} tool={row.tool} />
+      {rows.map((row, i) => (
+        <ToolVersionRow
+          key={row.label}
+          label={row.label}
+          tool={row.tool}
+          accent={i === accentIndex}
+        />
       ))}
     </div>
   );
 }
 
-function ToolVersionRow({ label, tool }: { label: string; tool: RecommendedToolVersion }) {
+function ToolVersionRow({
+  label,
+  tool,
+  accent,
+}: {
+  label: string;
+  tool: RecommendedToolVersion;
+  accent: boolean;
+}) {
   const belowFloor = tool.drift === 'below_floor';
-  const tone = belowFloor ? 'text-warn' : 'text-fg';
+  // Only the first below-floor tool (accent) carries the maroon warn tone; later
+  // drifted rows keep the word but read neutral, per the One Mark Rule.
+  const tone = accent ? 'text-warn' : 'text-fg';
   const recommended = tool.recommendedFloor ?? 'not pinned';
   // `contents` makes the row's cells participate directly in the parent grid.
   // Color can't inherit through a `display:contents` box, so each visible cell
@@ -378,7 +399,7 @@ function ToolVersionRow({ label, tool }: { label: string; tool: RecommendedToolV
       <div className={`text-body ${tone}`}>
         {label}
         {belowFloor && (
-          <span className="text-label uppercase tracking-wider text-warn"> · below floor</span>
+          <span className={`text-label uppercase tracking-wider ${tone}`}> · below floor</span>
         )}
       </div>
       <div className="text-right">

--- a/shared/src/dashboard-health.ts
+++ b/shared/src/dashboard-health.ts
@@ -26,9 +26,27 @@ export type LocalToolVersion =
   | { status: 'available'; version: string; source: string }
   | { status: 'unavailable'; reason: string };
 
+/** How an installed tool compares to its recommended floor:
+ *  - `satisfied`   — installed is a comparable semver at or above the floor.
+ *  - `below_floor` — installed is a comparable semver below the floor (drift).
+ *  - `unknown`     — no floor is published, the probe failed, or the installed
+ *                    version is not a comparable `X.Y.Z` (e.g. gc `dev` builds). */
+export type ToolVersionDrift = 'satisfied' | 'below_floor' | 'unknown';
+
+export interface RecommendedToolVersion {
+  /** Locally probed installed version. */
+  installed: LocalToolVersion;
+  /** Recommended minimum ("floor") version, or null when the tool has no
+   *  published pin (gc ships as `dev` builds, so it carries no numeric floor). */
+  recommendedFloor: string | null;
+  /** Drift of `installed` against `recommendedFloor`. */
+  drift: ToolVersionDrift;
+}
+
 export interface LocalToolVersions {
-  dolt: LocalToolVersion;
-  beads: LocalToolVersion;
+  dolt: RecommendedToolVersion;
+  beads: RecommendedToolVersion;
+  gc: RecommendedToolVersion;
 }
 
 export interface DoltNomsSample {


### PR DESCRIPTION
## Scope

Adds a **Tool versions** panel to the Health tab surfacing installed-vs-recommended versions for `bd`, `dolt`, and `gc`, with below-floor drift warnings. Backend probes local tool versions (`version-probe.ts`) and resolves them against recommended floors (`recommended-versions.ts`); the frontend renders the comparison and decodes the wire shape at the edge.

## Cleared `request_changes` items (verdict 20260606T055251Z-nfyw)

- **(A) CI BLOCKER — prettier:** the multi-line `assert.equal` in `version-probe.test.ts` that fit one line is collapsed; `prettier --check` is now green repo-wide.
- **(B) DESIGN One Mark Rule:** `ToolVersionsTable` previously rendered every below-floor tool in maroon warn tone (the bead's own `bd` + `dolt` example produced 2–3 marks in one viewport). Applied the Workers-Active precedent — only the first drift carries the mark; later below-floor rows keep the "· below floor" word in neutral tone. Regression test added. Also hardened `decodeLocalToolVersions` to validate the nested `installed.status` / `drift` union at the edge.

## Rebase

Rebased onto current `origin/main`, resolving additive conflicts in `Health.tsx` / `Health.test.tsx` against #76 (per-rig bead-store health). Both features coexist: the new "Bead stores · per rig" section (#76) sits alongside this PR's "Tool versions" panel, and this PR's "Recommended vs loaded" → "Store thresholds" rename is preserved to disambiguate from the new tool-version recommendations. All four tests from both features retained.

## CI parity (all green locally)

- `npm run typecheck` (src + test) ✓
- `npm run lint` ✓
- `npm run format:check` ✓ (the (A) blocker)
- `npm --workspace shared test` — 66/66 ✓
- `npm --workspace backend test` — 549/549 ✓
- `npm --workspace frontend test` — 762/762 ✓
- `npm --workspace frontend run build` ✓
- openapi drift — up to date ✓

mayor merge-gates