### PR TITLE
fix: decision deeplink 404 (sg9o)

### DIFF
--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -5,9 +5,10 @@ import {
   GC_MUTATION_HEADERS,
   resetSupervisorApiForTests,
   setSupervisorApiForTests,
+  SupervisorApiError,
   type SupervisorApi,
 } from './client';
-import { listSupervisorBeads } from './beadReads';
+import { fetchSupervisorBead, listSupervisorBeads } from './beadReads';
 
 const baseApi: SupervisorApi = {
   baseUrl: '/gc-supervisor',
@@ -72,6 +73,51 @@ describe('supervisor bead reads', () => {
     expect(result.items.map((item) => item.id)).toEqual(['rc-decision', 'td-task']);
     expect(result.total).toBe(2);
     expect(result.upstream_total).toBe(4);
+  });
+
+  // gascity-dashboard-sg9o: a "needs you" decision alert can deep-link to a
+  // bead the supervisor has since pruned (e.g. gc-316879). fetchSupervisorBead
+  // is the data edge the deep-link modal sits on: it must surface a true 404 as
+  // a SupervisorApiError(404) so useBeadDetail can render the calm "resolved or
+  // removed" state instead of a hard error.
+  it('re-raises a 404 when a deep-linked bead is gone and absent from the fallback list', async () => {
+    const getBead = vi.fn(async () => {
+      throw new SupervisorApiError(404, 'bead missing', undefined);
+    });
+    const listBeads = vi.fn(async () => ({ items: [bead({ id: 'td-other' })], total: 1 }));
+    setSupervisorApiForTests({ ...baseApi, getBead, listBeads });
+
+    await expect(fetchSupervisorBead('gc-316879')).rejects.toMatchObject({
+      name: 'SupervisorApiError',
+      status: 404,
+    });
+    expect(getBead).toHaveBeenCalledWith('test-city', 'gc-316879');
+  });
+
+  it('recovers a deep-linked bead from the fallback list when getBead 404s but it still lists', async () => {
+    const getBead = vi.fn(async () => {
+      throw new SupervisorApiError(404, 'bead missing', undefined);
+    });
+    const listBeads = vi.fn(async () => ({
+      items: [bead({ id: 'rc-decision', issue_type: 'decision' })],
+      total: 1,
+    }));
+    setSupervisorApiForTests({ ...baseApi, getBead, listBeads });
+
+    const hit = await fetchSupervisorBead('rc-decision');
+
+    expect(hit.id).toBe('rc-decision');
+  });
+
+  it('propagates non-404 read failures without consulting the fallback list', async () => {
+    const getBead = vi.fn(async () => {
+      throw new SupervisorApiError(503, 'supervisor unavailable', undefined);
+    });
+    const listBeads = vi.fn();
+    setSupervisorApiForTests({ ...baseApi, getBead, listBeads });
+
+    await expect(fetchSupervisorBead('rc-decision')).rejects.toMatchObject({ status: 503 });
+    expect(listBeads).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Scope
Lock the `fetchSupervisorBead` 404 deep-link contract with regression tests. **Test-only — no source change.**

## What / Why
A "needs you" decision alert can deep-link to a supervisor bead the supervisor has since pruned (e.g. `gc-316879`, removed by the 2026-06-03 reaper). The calm "resolved or removed" modal state (`useBeadDetail` notFound + `BeadDetailModal`) depends on `fetchSupervisorBead` surfacing a true 404 as a `SupervisorApiError(404)` rather than a hard failure. That data-edge contract already ships (#53 filters `status:'open'`; #59/#61 added the graceful 404 path) but was untested.

Adds coverage for the three branches of `fetchSupervisorBead`:
- **404 + id absent from fallback list** → re-raises 404 (the `gc-316879` case that drives the calm "resolved or removed" state)
- **404 + id still present in the list** → recovers the bead from the fallback list
- **non-404 failure** → propagates without consulting the fallback, so `useBeadDetail` renders a hard error, not the notFound state

## CI parity (all green locally)
- `npm run typecheck` (src + test) ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- shared / backend / frontend tests ✅ (66 / 556 / 761)
- frontend build ✅
- openapi gc-supervisor drift check ✅

Rebased cleanly onto current `origin/main`.

mayor merge-gates — do not merge.