### PR TITLE
test: test-city supervisor fixture for proxy-backed tabs (a38k)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default tseslint.config(
       '**/node_modules/**',
       '**/coverage/**',
       '**/.claude/**',
+      '**/.gc/**',
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write . --ignore-path .gitignore --ignore-path .prettierignore",
     "format:check": "prettier --check . --ignore-path .gitignore --ignore-path .prettierignore",
     "lint": "eslint . --max-warnings=0",
-    "browser:test": "node scripts/snap.mjs --test && node scripts/snap-formula-run-detail.mjs --test",
+    "browser:test": "node scripts/snap.mjs --test && node scripts/snap-formula-run-detail.mjs --test && node scripts/snap-test-city.mjs --test",
     "dashboard:test": "node scripts/dashboard-tester.mjs --test",
     "openapi:gc-supervisor:update": "node scripts/update-gc-supervisor-openapi.mjs",
     "openapi:gc-supervisor:generate": "node scripts/generate-gc-supervisor-client.mjs",

--- a/scripts/fixtures/install-supervisor-fixtures.mjs
+++ b/scripts/fixtures/install-supervisor-fixtures.mjs
@@ -1,0 +1,97 @@
+// Playwright route installer for the static "test-city" supervisor fixture.
+//
+// Intercepts every `/gc-supervisor/*` proxy call a page makes and fulfills it
+// from the seeded snapshot in `gas-city-dashboard-shared/fixtures/test-city`,
+// so the dashboard's supervisor-backed tabs (Agents/Runs/Beads/Mail/Sessions/
+// Health) render deterministic, known state WITHOUT a live `gc` supervisor or a
+// live city. Dashboard-owned `/api/*` calls are left untouched — they pass
+// through to whatever backend is serving the page.
+//
+// Usage (from a Playwright script):
+//   import { installSupervisorFixtures } from './fixtures/install-supervisor-fixtures.mjs';
+//   await installSupervisorFixtures(page);
+//   await page.goto(`${cityBase}/beads`, ...);
+//
+// Requires the shared workspace to be built (`npm run build:shared`).
+
+import {
+  buildTestCitySupervisorData,
+  matchTestCitySupervisorRequest,
+  renderTestCityEventStream,
+} from 'gas-city-dashboard-shared/fixtures/test-city';
+
+const SUPERVISOR_GLOB = '**/gc-supervisor/**';
+
+/**
+ * Register the fixture route handler on a Playwright Page (or BrowserContext).
+ * Returns the seeded snapshot so callers can assert against the exact data.
+ *
+ * The supervisor data is city-agnostic (the matcher ignores the `/city/<name>/`
+ * segment), so the fixture serves whatever city the host dashboard is scoped
+ * to. Pass `activeCity` to make the seeded `/v0/cities` list advertise that
+ * same city, keeping the header's city switcher consistent with the active
+ * city — leave it unset to advertise the default `test-city`.
+ *
+ * @param {import('playwright').Page | import('playwright').BrowserContext} target
+ * @param {{ nowMs?: number, activeCity?: string }} [opts]
+ */
+export async function installSupervisorFixtures(target, opts = {}) {
+  const built = buildTestCitySupervisorData(opts.nowMs);
+  const data =
+    typeof opts.activeCity === 'string' && opts.activeCity.length > 0
+      ? {
+          ...built,
+          cities: [
+            { name: opts.activeCity, path: `/tmp/${opts.activeCity}`, running: true, status: 'ok' },
+          ],
+        }
+      : built;
+  const streamBody = renderTestCityEventStream(data);
+
+  await target.route(SUPERVISOR_GLOB, (route) => {
+    const request = route.request();
+    const method = request.method();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    // SSE streams: serve a finite event-stream body. EventSource opens (the
+    // dashboard's stream badge goes live), reads the seeded events, then the
+    // long `retry` directive keeps it from reconnect-storming during a test.
+    if (pathname.endsWith('/stream')) {
+      return route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        },
+        body: streamBody,
+      });
+    }
+
+    const matched = matchTestCitySupervisorRequest(data, method, pathname, url.searchParams);
+    if (matched !== null) {
+      return route.fulfill({
+        status: matched.status,
+        contentType: matched.contentType,
+        body: matched.body,
+      });
+    }
+
+    // Unseeded supervisor endpoint: answer with an explicit 501 rather than
+    // passing silently, so a view that depends on data the fixture doesn't
+    // cover surfaces as a visible gap (e.g. run-detail drill-in) instead of a
+    // false all-clear.
+    return route.fulfill({
+      status: 501,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'test-city fixture: no seed for this supervisor endpoint',
+        method,
+        path: pathname,
+      }),
+    });
+  });
+
+  return data;
+}

--- a/scripts/snap-test-city.mjs
+++ b/scripts/snap-test-city.mjs
@@ -1,0 +1,286 @@
+// Deterministic regression gate for the dashboard's supervisor-backed tabs.
+//
+// Unlike dashboard-tester.mjs (which drives a LIVE node against whatever the
+// live supervisor currently holds, so it can only assert "renders something or
+// an explicit empty state"), this script installs the static "test-city"
+// supervisor fixture via Playwright route interception and asserts SPECIFIC,
+// KNOWN seeded state on every supervisor-backed tab — with no live supervisor
+// or live city. This fills the gap the dashboard-owned SNAPSHOT_USE_FIXTURES
+// path leaves: it only covers `/api/*`, never the `/gc-supervisor/*` proxy.
+//
+// It does NOT start its own server: it drives whatever Vite/dashboard is
+// serving the base URL, mirroring the snap-harness contract in AGENTS.md.
+//
+//   node scripts/snap-test-city.mjs          # run + report, always exit 0
+//   node scripts/snap-test-city.mjs --test   # run + assert; non-zero on regression
+//
+// Base URL override (default http://127.0.0.1:5174, the Vite dev server):
+//   TEST_CITY_BASE=http://127.0.0.1:8082 node scripts/snap-test-city.mjs --test
+//
+// Requires the shared workspace to be built (`npm run build:shared`) so the
+// fixture import resolves.
+
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import { argv, env, exit } from 'node:process';
+import { installSupervisorFixtures } from './fixtures/install-supervisor-fixtures.mjs';
+
+const BASE = env.TEST_CITY_BASE || 'http://127.0.0.1:5174';
+const OUT = '/tmp/cp-snaps';
+const TEST_MODE = argv.includes('--test');
+const VIEWPORT = { width: 1440, height: 900 };
+const SETTLE_MS = 2_000;
+
+// The host dashboard's own `/api/*` data is real and scoped to its configured
+// city; only the `/gc-supervisor/*` proxy is faked. So we drive the host's real
+// city (discovered from the shell) and let the city-agnostic fixture serve its
+// supervisor calls — that keeps `/api/city/<city>/*` pointed at a city the
+// backend actually knows.
+let activeCity = null;
+
+const short = (s, n = 110) => (s ?? '').toString().replace(/\s+/g, ' ').trim().slice(0, n);
+const makeResult = (name) => ({ name, errors: [], info: {} });
+
+/**
+ * Open a context with the supervisor fixture installed (scoped to the
+ * discovered active city) and run `fn`. Pass `{ fixtures: false }` to open a
+ * plain context — used for city discovery before the city is known.
+ */
+async function withPage(browser, fn, { fixtures = true } = {}) {
+  const ctx = await browser.newContext({ viewport: VIEWPORT });
+  const page = await ctx.newPage();
+  try {
+    if (fixtures) await installSupervisorFixtures(ctx, { activeCity: activeCity ?? undefined });
+    return await fn(page);
+  } finally {
+    await ctx.close();
+  }
+}
+
+/** Collect any broken `/gc-supervisor/*` responses (>=400, incl. unseeded 501s). */
+function collectSupervisorErrors(page, result) {
+  const errs = [];
+  page.on('response', (r) => {
+    const url = r.url();
+    if (url.includes('/gc-supervisor/') && r.status() >= 400) {
+      errs.push(`${r.status()} ${r.request().method()} ${short(url, 90)}`);
+    }
+  });
+  return () => {
+    for (const e of errs) result.errors.push(`broken supervisor call: ${e}`);
+  };
+}
+
+async function readMain(page) {
+  return page
+    .locator('main')
+    .first()
+    .innerText()
+    .catch(() => '');
+}
+
+/** Assert each expected substring is present in the route's main content. */
+function assertContains(result, label, text, expected) {
+  for (const needle of expected) {
+    if (!text.includes(needle)) {
+      result.errors.push(`${label}: expected seeded text "${needle}" not found`);
+    }
+  }
+}
+
+async function snap(page, name) {
+  await page.screenshot({ path: `${OUT}/test-city-${name}.png` }).catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Discover the host's real city from the shell (no fixtures — the city comes
+// from the backend config, not supervisor data). Skip (exit 0) when nothing is
+// serving the base URL — the snap-harness contract; a real regression is the
+// only non-zero exit.
+// ---------------------------------------------------------------------------
+
+async function discoverCity(browser) {
+  return withPage(
+    browser,
+    async (page) => {
+      try {
+        await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+      } catch (err) {
+        const s = String(err);
+        if (/ERR_CONNECTION_REFUSED|net::ERR|NS_ERROR|Timeout/.test(s)) {
+          return { skip: `base URL not reachable at ${BASE}` };
+        }
+        throw err;
+      }
+      await page
+        .locator('nav a, header a')
+        .first()
+        .waitFor({ timeout: 8_000 })
+        .catch(() => {});
+      const href = await page
+        .locator('nav a, header a')
+        .first()
+        .getAttribute('href')
+        .catch(() => null);
+      const match = href?.match(/\/city\/([^/]+)/);
+      if (!match) {
+        return {
+          fail: `reachable at ${BASE} but no /city/<name> nav link rendered (broken shell?)`,
+        };
+      }
+      const city = match[1];
+      return { cityBase: `${BASE}/city/${city}`, city };
+    },
+    { fixtures: false },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-tab checks: assert KNOWN seeded content (text-based, greyscale-safe).
+// ---------------------------------------------------------------------------
+
+async function checkBeads(browser, cityBase) {
+  const result = makeResult('beads');
+  await withPage(browser, async (page) => {
+    const drain = collectSupervisorErrors(page, result);
+    await page.goto(`${cityBase}/beads`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+    const text = await readMain(page);
+    // A seeded epic title + a seeded p0 bug — both render verbatim in the board.
+    assertContains(result, 'beads', text, ['Guest checkout overhaul', 'SSO login redirect loop']);
+    drain();
+    await snap(page, 'beads');
+  });
+  return result;
+}
+
+async function checkAgents(browser, cityBase) {
+  const result = makeResult('agents');
+  await withPage(browser, async (page) => {
+    const drain = collectSupervisorErrors(page, result);
+    await page.goto(`${cityBase}/agents`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+    const labels = await page
+      .locator('table tbody a[href*="/agents/"]')
+      .allInnerTexts()
+      .catch(() => []);
+    result.info.rows = labels.length;
+    if (labels.length === 0) {
+      result.errors.push('agents: roster rendered zero rows against the seeded fixture');
+    } else if (!labels.some((l) => l.includes(' · '))) {
+      result.errors.push('agents: no `rig · agent` label rendered (rig column regression?)');
+    }
+    drain();
+    await snap(page, 'agents');
+  });
+  return result;
+}
+
+async function checkRuns(browser, cityBase) {
+  const result = makeResult('runs');
+  await withPage(browser, async (page) => {
+    const drain = collectSupervisorErrors(page, result);
+    await page.goto(`${cityBase}/runs`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+    const laneLinks = await page
+      .locator('a[href*="/runs/"]')
+      .count()
+      .catch(() => 0);
+    result.info.runLanes = laneLinks;
+    const text = await readMain(page);
+    // The Runs view derives lanes from graph.v2 workflow bead groups; a seeded
+    // in-flight run title should render.
+    assertContains(result, 'runs', text, ['guest-checkout address autocomplete']);
+    drain();
+    await snap(page, 'runs');
+  });
+  return result;
+}
+
+async function checkMail(browser, cityBase) {
+  const result = makeResult('mail');
+  await withPage(browser, async (page) => {
+    const drain = collectSupervisorErrors(page, result);
+    await page.goto(`${cityBase}/mail`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+    const text = await readMain(page);
+    assertContains(result, 'mail', text, ['Warehouse still not provisioned']);
+    drain();
+    await snap(page, 'mail');
+  });
+  return result;
+}
+
+async function checkHealth(browser, cityBase) {
+  const result = makeResult('health');
+  await withPage(browser, async (page) => {
+    const drain = collectSupervisorErrors(page, result);
+    await page.goto(`${cityBase}/health`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+    const text = await readMain(page);
+    // Health renders the seeded city/supervisor status; the fixture build id is
+    // a stable, distinctive marker.
+    if (!/test-fixture/i.test(text) && !/\bok\b/i.test(text)) {
+      result.errors.push('health: neither seeded version nor an "ok" status rendered');
+    }
+    drain();
+    await snap(page, 'health');
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+await mkdir(OUT, { recursive: true });
+const browser = await chromium.launch();
+const results = [];
+let skipReason = null;
+
+try {
+  const discovery = await discoverCity(browser);
+  if (discovery.skip) {
+    skipReason = discovery.skip;
+  } else if (discovery.fail) {
+    results.push({ name: 'preflight', errors: [discovery.fail], info: {} });
+  } else {
+    const { cityBase, city } = discovery;
+    activeCity = city;
+    console.log(`snap-test-city: driving ${cityBase} with the test-city supervisor fixture`);
+    results.push(await checkBeads(browser, cityBase));
+    results.push(await checkAgents(browser, cityBase));
+    results.push(await checkRuns(browser, cityBase));
+    results.push(await checkMail(browser, cityBase));
+    results.push(await checkHealth(browser, cityBase));
+  }
+} finally {
+  await browser.close();
+}
+
+if (skipReason) {
+  console.log(`snap-test-city: SKIPPED — ${skipReason}`);
+  exit(0);
+}
+
+let hadErrors = false;
+for (const r of results) {
+  const info = Object.entries(r.info)
+    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+    .join(' ');
+  if (r.errors.length) {
+    hadErrors = true;
+    console.error(`[${r.name}] FAIL${info ? ` (${info})` : ''}`);
+    for (const e of r.errors) console.error(`  - ${e}`);
+  } else {
+    console.log(`[${r.name}] PASS${info ? ` — ${info}` : ''}`);
+  }
+}
+
+if (TEST_MODE) {
+  if (hadErrors) {
+    console.error('snap-test-city: FAILED');
+    exit(1);
+  }
+  console.log('snap-test-city: PASSED');
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -13,6 +13,10 @@
     "./gc-supervisor": {
       "types": "./dist/generated/gc-supervisor-client/index.d.ts",
       "default": "./dist/generated/gc-supervisor-client/index.js"
+    },
+    "./fixtures/test-city": {
+      "types": "./dist/fixtures/test-city/index.d.ts",
+      "default": "./dist/fixtures/test-city/index.js"
     }
   },
   "scripts": {

--- a/shared/src/fixtures/test-city/data.ts
+++ b/shared/src/fixtures/test-city/data.ts
@@ -1,0 +1,376 @@
+// Static "test-city" supervisor fixture — a deterministic, seeded snapshot of
+// GC-supervisor state (rigs/agents/sessions/beads/runs/mail/events/health)
+// across many lifecycle states. It exists to drive the dashboard's
+// supervisor-backed tabs (Agents/Runs/Beads/Mail/Sessions/Health) WITHOUT a
+// live `gc` supervisor or a live city — filling the gap the dashboard-owned
+// `SNAPSHOT_USE_FIXTURES` path leaves untouched (it only covers `/api/*`, not
+// the `/gc-supervisor/*` proxy).
+//
+// Everything is typed against the GENERATED supervisor client types, so a wire
+// shape change at OpenAPI-regeneration time surfaces here as a compile error,
+// and `test-city.test.ts` re-validates every payload against the generated zod
+// schemas as a runtime regression gate.
+//
+// Timestamps are derived from an injected `nowMs` so seeded mail/events land
+// inside the views' relative time windows (24h/7d). Pass a fixed `nowMs` for
+// deterministic assertions; omit it (defaults to `Date.now()`) when serving a
+// live dashboard.
+
+import type {
+  AgentResponse,
+  Bead,
+  CityInfo,
+  Dep,
+  HealthOutputBody,
+  Message,
+  MonitorFeedItemResponse,
+  SessionPendingResponse,
+  SessionResponse,
+  StatusBody,
+  SupervisorHealthOutputBody,
+  TypedEventStreamEnvelope,
+} from '../../generated/gc-supervisor-client/index.js';
+import {
+  AGENT_SPECS,
+  type AgentSpec,
+  BEAD_SPECS,
+  type BeadSpec,
+  type BeadStatus,
+  MAIL_SPECS,
+  type MailSpec,
+  RUN_SPECS,
+  type RunSpec,
+  WORKFLOW_GROUPS,
+} from './seeds.js';
+
+export const TEST_CITY_NAME = 'test-city';
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+/** The five seeded rigs the fixture spreads work across. */
+export const TEST_CITY_RIGS = ['web', 'api', 'data', 'ops', 'docs'] as const;
+
+function specToBead(spec: BeadSpec, iso: (offsetMs: number) => string): Bead {
+  const dependencies: Dep[] = (spec.dependsOn ?? []).map((depId) => ({
+    depends_on_id: depId,
+    issue_id: spec.id,
+    type: 'blocks',
+  }));
+  const bead: Bead = {
+    id: spec.id,
+    title: spec.title,
+    status: spec.status,
+    issue_type: spec.issue_type,
+    created_at: iso(spec.agedH * HOUR),
+  };
+  if (spec.updatedH !== undefined) bead.updated_at = iso(spec.updatedH * HOUR);
+  if (spec.assignee !== undefined) bead.assignee = spec.assignee;
+  if (spec.priority !== undefined) bead.priority = spec.priority;
+  if (spec.labels !== undefined) bead.labels = spec.labels;
+  if (spec.parent !== undefined) bead.parent = spec.parent;
+  if (spec.description !== undefined) bead.description = spec.description;
+  if (spec.ephemeral !== undefined) bead.ephemeral = spec.ephemeral;
+  if (spec.metadata !== undefined) bead.metadata = spec.metadata;
+  if (dependencies.length > 0) bead.dependencies = dependencies;
+  return bead;
+}
+
+function specToAgent(spec: AgentSpec, iso: (offsetMs: number) => string): AgentResponse {
+  const agent: AgentResponse = {
+    name: spec.name,
+    state: spec.state,
+    available: spec.available,
+    running: spec.running,
+    suspended: spec.suspended,
+    provider: spec.provider,
+    model: spec.model,
+    rig: spec.rig,
+  };
+  if (spec.activeBead !== undefined) agent.active_bead = spec.activeBead;
+  if (spec.contextPct !== undefined) agent.context_pct = spec.contextPct;
+  if (spec.activity !== undefined) agent.activity = spec.activity;
+  if (spec.unavailableReason !== undefined) agent.unavailable_reason = spec.unavailableReason;
+  if (spec.sessionName !== undefined) {
+    agent.session = {
+      name: spec.sessionName,
+      attached: spec.sessionAttached ?? false,
+      ...(spec.lastActivityMin !== undefined
+        ? { last_activity: iso(spec.lastActivityMin * MIN) }
+        : {}),
+    };
+  }
+  return agent;
+}
+
+/** Sessions are derived from the agents that carry a `sessionName`. */
+function buildSessions(
+  agents: readonly AgentSpec[],
+  iso: (offsetMs: number) => string,
+): SessionResponse[] {
+  return agents
+    .filter((a) => a.sessionName !== undefined)
+    .map((a) => {
+      const session: SessionResponse = {
+        id: a.sessionName as string,
+        session_name: a.sessionName as string,
+        title: `${a.rig} · ${a.name.split('/')[1] ?? a.name}`,
+        template: 'pool-worker',
+        state: a.state,
+        provider: a.provider,
+        attached: a.sessionAttached ?? false,
+        running: a.running,
+        created_at: iso(6 * HOUR),
+        rig: a.rig,
+        model: a.model,
+      };
+      if (a.activeBead !== undefined) session.active_bead = a.activeBead;
+      if (a.contextPct !== undefined) session.context_pct = a.contextPct;
+      if (a.activity !== undefined) session.activity = a.activity;
+      if (a.lastActivityMin !== undefined) session.last_active = iso(a.lastActivityMin * MIN);
+      return session;
+    });
+}
+
+function specToMessage(spec: MailSpec, iso: (offsetMs: number) => string): Message {
+  const msg: Message = {
+    id: spec.id,
+    from: spec.from,
+    to: spec.to,
+    subject: spec.subject,
+    body: spec.body,
+    read: spec.read,
+    created_at: iso(spec.agedMin * MIN),
+  };
+  if (spec.threadId !== undefined) msg.thread_id = spec.threadId;
+  if (spec.rig !== undefined) msg.rig = spec.rig;
+  if (spec.priority !== undefined) msg.priority = spec.priority;
+  return msg;
+}
+
+function specToRun(spec: RunSpec, iso: (offsetMs: number) => string): MonitorFeedItemResponse {
+  return {
+    id: spec.id,
+    workflow_id: spec.workflowId,
+    root_bead_id: spec.rootBeadId,
+    root_store_ref: `rig:${spec.rig}`,
+    store_ref: `rig:${spec.rig}`,
+    scope_kind: 'city',
+    scope_ref: TEST_CITY_NAME,
+    title: spec.title,
+    target: spec.target,
+    type: spec.type,
+    status: spec.status,
+    started_at: iso(spec.startedH * HOUR),
+    updated_at: iso(spec.updatedH * HOUR),
+    detail_available: true,
+    run_detail_available: true,
+  };
+}
+
+function buildEvents(
+  beadById: Map<string, Bead>,
+  iso: (offsetMs: number) => string,
+): TypedEventStreamEnvelope[] {
+  const bead = (id: string): Bead => {
+    const b = beadById.get(id);
+    if (b === undefined)
+      throw new Error(`test-city fixture: unknown bead id "${id}" in event seed`);
+    return b;
+  };
+  // seq descending in recency; the Events read sorts by seq desc.
+  return [
+    {
+      type: 'session.crashed',
+      seq: 108,
+      ts: iso(40 * MIN),
+      actor: 'docs/writer',
+      subject: 'gc-docs-1',
+      message: 'session crashed (exit 1) during tc-docs-api-ref',
+      payload: { session_id: 'gc-docs-1', reason: 'exit 1' },
+    },
+    {
+      type: 'order.failed',
+      seq: 107,
+      ts: iso(38 * MIN),
+      actor: 'supervisor',
+      subject: 'order-4821',
+      message: 'order dispatch failed: no available agent in rig docs',
+      payload: {},
+    },
+    {
+      type: 'bead.updated',
+      seq: 106,
+      ts: iso(6 * HOUR),
+      actor: 'api/worker',
+      subject: 'tc-tax-service',
+      message: 'tc-tax-service moved to in_progress',
+      payload: { bead: bead('tc-tax-service') },
+    },
+    {
+      type: 'mail.sent',
+      seq: 105,
+      ts: iso(6 * MIN),
+      actor: 'api/worker',
+      subject: 'tc-mail-1',
+      message: 'BLOCKED: tax-rating service missing credentials',
+      payload: { rig: 'api' },
+    },
+    {
+      type: 'session.suspended',
+      seq: 104,
+      ts: iso(95 * MIN),
+      actor: 'data/etl',
+      subject: 'data/etl',
+      message: 'suspended pending tc-data-warehouse',
+      payload: {},
+    },
+    {
+      type: 'bead.created',
+      seq: 103,
+      ts: iso(6 * HOUR),
+      actor: 'web/builder',
+      subject: 'tc-convoy-input-1',
+      message: 'input convoy created for tc-feat-search',
+      payload: { bead: bead('tc-convoy-input-1') },
+    },
+    {
+      type: 'bead.closed',
+      seq: 102,
+      ts: iso(9 * 24 * HOUR),
+      actor: 'web/builder',
+      subject: 'tc-checkout-cart',
+      message: 'tc-checkout-cart closed',
+      payload: { bead: bead('tc-checkout-cart') },
+    },
+    {
+      type: 'session.woke',
+      seq: 101,
+      ts: iso(2 * HOUR),
+      actor: 'web/builder',
+      subject: 'gc-web-1',
+      message: 'session resumed work on tc-bug-login-loop',
+      payload: {},
+    },
+  ];
+}
+
+function countByStatus(beads: readonly Bead[], status: BeadStatus): number {
+  return beads.filter((b) => b.status === status).length;
+}
+
+/** The fully-built, typed snapshot the matcher and stream renderer consume. */
+export interface TestCitySupervisorData {
+  cities: CityInfo[];
+  beads: Bead[];
+  agents: AgentResponse[];
+  sessions: SessionResponse[];
+  mail: Message[];
+  formulaFeed: MonitorFeedItemResponse[];
+  events: TypedEventStreamEnvelope[];
+  /**
+   * Pending-interaction poll responses keyed by session id. The shell polls
+   * `/session/<id>/pending` for every session; the stuck agent's session has a
+   * real pending approval, everything else is "supported, nothing pending".
+   */
+  pendingBySession: Record<string, SessionPendingResponse>;
+  cityHealth: HealthOutputBody;
+  supervisorHealth: SupervisorHealthOutputBody;
+  status: StatusBody;
+}
+
+/** Session id of the stuck agent that has a pending operator approval. */
+const PENDING_SESSION_ID = 'gc-api-1';
+
+function buildPendingBySession(
+  sessions: readonly SessionResponse[],
+): Record<string, SessionPendingResponse> {
+  const out: Record<string, SessionPendingResponse> = {};
+  for (const session of sessions) {
+    out[session.id] =
+      session.id === PENDING_SESSION_ID
+        ? {
+            supported: true,
+            pending: {
+              kind: 'approval',
+              request_id: 'tc-req-tax-key',
+              prompt: 'Approve using the staging tax key until the prod key lands?',
+              options: ['approve', 'deny'],
+            },
+          }
+        : { supported: true };
+  }
+  return out;
+}
+
+/**
+ * Build the seeded snapshot. Timestamps are offsets from `nowMs` so seeded
+ * mail/events stay inside the views' relative windows. Pass a fixed `nowMs`
+ * for deterministic test assertions.
+ */
+export function buildTestCitySupervisorData(nowMs: number = Date.now()): TestCitySupervisorData {
+  const iso = (offsetMs: number): string => new Date(nowMs - offsetMs).toISOString();
+
+  const beads = [...BEAD_SPECS, ...WORKFLOW_GROUPS].map((s) => specToBead(s, iso));
+  const beadById = new Map(beads.map((b) => [b.id, b]));
+  const agents = AGENT_SPECS.map((s) => specToAgent(s, iso));
+  const sessions = buildSessions(AGENT_SPECS, iso);
+  const mail = MAIL_SPECS.map((s) => specToMessage(s, iso));
+  const formulaFeed = RUN_SPECS.map((s) => specToRun(s, iso));
+  const events = buildEvents(beadById, iso);
+
+  const cities: CityInfo[] = [
+    { name: TEST_CITY_NAME, path: `/tmp/${TEST_CITY_NAME}`, running: true, status: 'ok' },
+  ];
+  const cityHealth: HealthOutputBody = {
+    city: TEST_CITY_NAME,
+    status: 'ok',
+    uptime_sec: 4 * 3600,
+    version: 'test-fixture',
+  };
+  const supervisorHealth: SupervisorHealthOutputBody = {
+    status: 'ok',
+    uptime_sec: 6 * 3600,
+    cities_running: 1,
+    cities_total: 1,
+    build_id: 'test-fixture',
+    version: 'test-fixture',
+  };
+  const status: StatusBody = {
+    name: TEST_CITY_NAME,
+    path: `/tmp/${TEST_CITY_NAME}`,
+    suspended: false,
+    uptime_sec: 4 * 3600,
+    version: 'test-fixture',
+    agent_count: agents.length,
+    running: agents.filter((a) => a.running).length,
+    rig_count: TEST_CITY_RIGS.length,
+    agents: {
+      total: agents.length,
+      running: agents.filter((a) => a.running).length,
+      suspended: agents.filter((a) => a.suspended).length,
+      quarantined: 0,
+    },
+    rigs: { suspended: 0, total: TEST_CITY_RIGS.length },
+    mail: { total: mail.length, unread: mail.filter((m) => !m.read).length },
+    work: {
+      open: countByStatus(beads, 'open'),
+      ready: countByStatus(beads, 'open'),
+      in_progress: countByStatus(beads, 'in_progress'),
+    },
+  };
+
+  return {
+    cities,
+    beads,
+    agents,
+    sessions,
+    mail,
+    formulaFeed,
+    events,
+    pendingBySession: buildPendingBySession(sessions),
+    cityHealth,
+    supervisorHealth,
+    status,
+  };
+}

--- a/shared/src/fixtures/test-city/index.ts
+++ b/shared/src/fixtures/test-city/index.ts
@@ -1,0 +1,16 @@
+// Public surface of the static "test-city" supervisor fixture. Consumed by the
+// Playwright route installer (scripts/fixtures/install-supervisor-fixtures.mjs)
+// and by any test that needs a deterministic, seeded supervisor snapshot for
+// the dashboard's `/gc-supervisor/*`-backed tabs.
+
+export {
+  buildTestCitySupervisorData,
+  TEST_CITY_NAME,
+  TEST_CITY_RIGS,
+  type TestCitySupervisorData,
+} from './data.js';
+export {
+  matchTestCitySupervisorRequest,
+  renderTestCityEventStream,
+  type FixtureResponse,
+} from './match.js';

--- a/shared/src/fixtures/test-city/match.ts
+++ b/shared/src/fixtures/test-city/match.ts
@@ -1,0 +1,166 @@
+// Pure request → response matcher for the test-city supervisor fixture. Given a
+// prebuilt snapshot and an inbound `/gc-supervisor/v0/city/<city>/...` request,
+// it returns the JSON the dashboard's supervisor reads expect, or `null` when
+// the path isn't part of the fixture (the caller decides how to surface that —
+// the Playwright installer answers `null` with an explicit 501 so an unseeded
+// endpoint is visible rather than silently passing).
+//
+// The SSE event stream (`/events/stream`) and per-session stream are handled by
+// the caller, not here — they need a streaming content-type, not a JSON body.
+
+import type {
+  ListBodyAgentResponse,
+  ListBodyBead,
+  ListBodySessionResponse,
+  ListBodyWireEvent,
+  MailListBody,
+  FormulaFeedBody,
+  SupervisorCitiesOutputBody,
+  Bead,
+} from '../../generated/gc-supervisor-client/index.js';
+import type { TestCitySupervisorData } from './data.js';
+
+export interface FixtureResponse {
+  status: number;
+  contentType: string;
+  body: string;
+}
+
+const JSON_CONTENT_TYPE = 'application/json';
+
+function json(value: unknown, status = 200): FixtureResponse {
+  return { status, contentType: JSON_CONTENT_TYPE, body: JSON.stringify(value) };
+}
+
+function applyLimit<T>(items: readonly T[], search: URLSearchParams): T[] {
+  const raw = search.get('limit');
+  if (raw === null) return [...items];
+  const limit = Number.parseInt(raw, 10);
+  if (!Number.isFinite(limit) || limit <= 0) return [...items];
+  return items.slice(0, limit);
+}
+
+function beadMatchesRig(bead: Bead, rig: string): boolean {
+  if (bead.labels?.includes(`rig:${rig}`)) return true;
+  return bead.assignee?.startsWith(`${rig}/`) ?? false;
+}
+
+function filterBeads(data: TestCitySupervisorData, search: URLSearchParams): Bead[] {
+  let beads: readonly Bead[] = data.beads;
+  const rig = search.get('rig');
+  if (rig !== null && rig.length > 0) beads = beads.filter((b) => beadMatchesRig(b, rig));
+  const type = search.get('type');
+  if (type !== null && type.length > 0) beads = beads.filter((b) => b.issue_type === type);
+  const status = search.get('status');
+  if (status !== null && status.length > 0) beads = beads.filter((b) => b.status === status);
+  return applyLimit(beads, search);
+}
+
+function beadIdFrom(pathname: string): string | null {
+  // .../bead/<id> — return the id segment (the caller only routes bead detail).
+  const match = pathname.match(/\/bead\/([^/]+)\/?$/);
+  return match?.[1] ?? null;
+}
+
+function threadIdFrom(pathname: string): string | null {
+  const match = pathname.match(/\/mail\/thread\/([^/]+)\/?$/);
+  return match?.[1] ?? null;
+}
+
+const isCityScoped = (pathname: string): boolean => pathname.includes('/v0/city/');
+
+/**
+ * Resolve a GET request against the fixture. Returns `null` for unknown paths,
+ * non-GET methods, and the streaming endpoints (handled by the caller).
+ */
+export function matchTestCitySupervisorRequest(
+  data: TestCitySupervisorData,
+  method: string,
+  pathname: string,
+  search: URLSearchParams = new URLSearchParams(),
+): FixtureResponse | null {
+  if (method.toUpperCase() !== 'GET') return null;
+  // Streaming endpoints are the caller's responsibility.
+  if (pathname.endsWith('/stream')) return null;
+
+  // Non-city-scoped supervisor resource: the city list the shell uses to
+  // resolve the active city (redirecting `/` → `/city/test-city/`).
+  if (pathname.endsWith('/v0/cities')) {
+    const body: SupervisorCitiesOutputBody = {
+      items: data.cities,
+      total: data.cities.length,
+    };
+    return json(body);
+  }
+  if (pathname.endsWith('/health')) {
+    return isCityScoped(pathname) ? json(data.cityHealth) : json(data.supervisorHealth);
+  }
+  if (pathname.endsWith('/status')) {
+    return json(data.status);
+  }
+  // Per-session pending-interaction poll (the shell polls this for every
+  // session). Unknown sessions get a benign "supported, nothing pending".
+  const pendingMatch = pathname.match(/\/session\/([^/]+)\/pending\/?$/);
+  if (pendingMatch !== null) {
+    const sessionId = pendingMatch[1] ?? '';
+    return json(data.pendingBySession[sessionId] ?? { supported: true });
+  }
+  if (pathname.endsWith('/agents')) {
+    const items = applyLimit(data.agents, search);
+    const body: ListBodyAgentResponse = { items, total: items.length };
+    return json(body);
+  }
+  if (pathname.endsWith('/sessions')) {
+    const items = applyLimit(data.sessions, search);
+    const body: ListBodySessionResponse = { items, total: items.length };
+    return json(body);
+  }
+  if (pathname.endsWith('/formulas/feed')) {
+    const body: FormulaFeedBody = { items: data.formulaFeed, partial: false };
+    return json(body);
+  }
+  if (pathname.endsWith('/events')) {
+    const items = applyLimit(data.events, search);
+    const body: ListBodyWireEvent = { items, total: items.length };
+    return json(body);
+  }
+  // Mail thread detail must be checked before the bare `/mail` collection.
+  const threadId = threadIdFrom(pathname);
+  if (threadId !== null) {
+    const items = data.mail.filter((m) => m.thread_id === threadId);
+    const body: MailListBody = { items, total: items.length };
+    return json(body);
+  }
+  if (pathname.endsWith('/mail')) {
+    const items = applyLimit(data.mail, search);
+    const body: MailListBody = { items, total: items.length };
+    return json(body);
+  }
+  // Bead detail (`.../bead/<id>`) — checked last so collection routes win.
+  if (/\/bead\/[^/]+\/?$/.test(pathname)) {
+    const id = beadIdFrom(pathname);
+    const bead = id === null ? undefined : data.beads.find((b) => b.id === id);
+    if (bead === undefined) return json({ error: `bead ${id ?? '?'} not found` }, 404);
+    return json(bead);
+  }
+  if (pathname.endsWith('/beads')) {
+    const items = filterBeads(data, search);
+    const body: ListBodyBead = { items, total: items.length };
+    return json(body);
+  }
+  return null;
+}
+
+/**
+ * Render the seeded events as a finite Server-Sent-Events body. The supervisor
+ * names its events `event` (not the default `message`); `useGcEvents` listens
+ * for both. A long `retry` keeps EventSource from reconnect-storming during a
+ * short test once this finite body closes.
+ */
+export function renderTestCityEventStream(data: TestCitySupervisorData, maxEvents = 4): string {
+  const lines: string[] = ['retry: 30000', '', ': test-city fixture stream', ''];
+  for (const event of data.events.slice(0, maxEvents)) {
+    lines.push('event: event', `data: ${JSON.stringify(event)}`, '');
+  }
+  return lines.join('\n');
+}

--- a/shared/src/fixtures/test-city/seeds.ts
+++ b/shared/src/fixtures/test-city/seeds.ts
@@ -1,0 +1,892 @@
+// Declarative seed data for the static test-city supervisor fixture: the rigs,
+// beads (incl. graph.v2 formula-run groups), agents, sessions, mail, and run
+// records, expressed as plain spec records. `data.ts` converts these into wire
+// shapes. Kept separate so the data table and the assembly logic each stay
+// focused and small.
+
+import { OPERATOR_WIRE_ALIAS } from '../../operator.js';
+
+// The dashboard's operator mailbox filters on the operator WIRE alias, so mail
+// to/from the operator must use it (not a display name like "mayor") to land in
+// the default Inbox/Sent views.
+const OP = OPERATOR_WIRE_ALIAS;
+
+export type BeadStatus = 'open' | 'in_progress' | 'blocked' | 'closed';
+export type IssueType = 'feature' | 'bug' | 'task' | 'epic' | 'chore' | 'decision';
+
+/**
+ * Declarative bead seed. `agedH`/`updatedH` are hours-ago offsets resolved
+ * against `nowMs` at build time; `dependsOn` becomes typed `Dep[]`.
+ */
+export interface BeadSpec {
+  id: string;
+  title: string;
+  status: BeadStatus;
+  issue_type: IssueType;
+  agedH: number;
+  updatedH?: number;
+  assignee?: string;
+  priority?: number;
+  labels?: string[];
+  parent?: string;
+  description?: string;
+  dependsOn?: string[];
+  ephemeral?: boolean;
+  metadata?: Record<string, string>;
+}
+
+// ~38 beads: two epics with children, a blocked cluster wired by deps, a spread
+// of bug/task/feature/chore/decision work across open/in_progress/blocked/
+// closed, plus a pair of ephemeral convoy beads.
+export const BEAD_SPECS: readonly BeadSpec[] = [
+  // --- Epic: checkout (open) + children -----------------------------------
+  {
+    id: 'tc-epic-checkout',
+    title: 'EPIC: Guest checkout overhaul',
+    status: 'in_progress',
+    issue_type: 'epic',
+    agedH: 30 * 24,
+    updatedH: 3,
+    assignee: 'web/builder',
+    priority: 1,
+    labels: ['rig:web', 'epic'],
+    description: 'Umbrella for the guest-checkout rework across web + api.',
+  },
+  {
+    id: 'tc-checkout-cart',
+    title: 'Cart state survives refresh',
+    status: 'closed',
+    issue_type: 'feature',
+    agedH: 20 * 24,
+    updatedH: 9 * 24,
+    assignee: 'web/builder',
+    priority: 2,
+    labels: ['rig:web'],
+    parent: 'tc-epic-checkout',
+  },
+  {
+    id: 'tc-checkout-address',
+    title: 'Address autocomplete on shipping step',
+    status: 'in_progress',
+    issue_type: 'feature',
+    agedH: 12 * 24,
+    updatedH: 2,
+    assignee: 'web/builder',
+    priority: 2,
+    labels: ['rig:web'],
+    parent: 'tc-epic-checkout',
+  },
+  {
+    id: 'tc-checkout-tax',
+    title: 'Tax calc wrong for split shipments',
+    status: 'blocked',
+    issue_type: 'bug',
+    agedH: 8 * 24,
+    updatedH: 5,
+    assignee: 'api/worker',
+    priority: 0,
+    labels: ['rig:api', 'regression'],
+    parent: 'tc-epic-checkout',
+    dependsOn: ['tc-tax-service'],
+  },
+  {
+    id: 'tc-checkout-guest',
+    title: 'Allow checkout without an account',
+    status: 'open',
+    issue_type: 'feature',
+    agedH: 6 * 24,
+    assignee: 'web/reviewer',
+    priority: 1,
+    labels: ['rig:web'],
+    parent: 'tc-epic-checkout',
+  },
+  {
+    id: 'tc-checkout-analytics',
+    title: 'Funnel analytics for the new flow',
+    status: 'open',
+    issue_type: 'chore',
+    agedH: 5 * 24,
+    assignee: 'data/etl',
+    priority: 3,
+    labels: ['rig:data'],
+    parent: 'tc-epic-checkout',
+  },
+
+  // --- Epic: billing (in_progress) + children -----------------------------
+  {
+    id: 'tc-epic-billing',
+    title: 'EPIC: Usage-based billing',
+    status: 'in_progress',
+    issue_type: 'epic',
+    agedH: 25 * 24,
+    updatedH: 6,
+    assignee: 'api/worker',
+    priority: 1,
+    labels: ['rig:api', 'epic'],
+    description: 'Metered billing: meter ingestion, rating, invoices.',
+  },
+  {
+    id: 'tc-tax-service',
+    title: 'Stand up tax-rating service',
+    status: 'in_progress',
+    issue_type: 'task',
+    agedH: 10 * 24,
+    updatedH: 4,
+    assignee: 'api/worker',
+    priority: 0,
+    labels: ['rig:api'],
+    parent: 'tc-epic-billing',
+  },
+  {
+    id: 'tc-billing-meter',
+    title: 'Meter ingestion pipeline',
+    status: 'blocked',
+    issue_type: 'task',
+    agedH: 9 * 24,
+    updatedH: 7,
+    assignee: 'data/etl',
+    priority: 1,
+    labels: ['rig:data'],
+    parent: 'tc-epic-billing',
+    dependsOn: ['tc-tax-service', 'tc-data-warehouse'],
+  },
+  {
+    id: 'tc-billing-invoice',
+    title: 'Generate monthly invoices',
+    status: 'open',
+    issue_type: 'feature',
+    agedH: 7 * 24,
+    assignee: 'api/tester',
+    priority: 2,
+    labels: ['rig:api'],
+    parent: 'tc-epic-billing',
+  },
+  {
+    id: 'tc-billing-decision',
+    title: 'Decision: proration policy for mid-cycle plan changes',
+    status: 'open',
+    issue_type: 'decision',
+    agedH: 4 * 24,
+    assignee: 'mayor',
+    priority: 1,
+    labels: ['rig:api', 'needs-decision'],
+    parent: 'tc-epic-billing',
+  },
+
+  // --- Blocked cluster (data warehouse) -----------------------------------
+  {
+    id: 'tc-data-warehouse',
+    title: 'Provision analytics warehouse',
+    status: 'in_progress',
+    issue_type: 'task',
+    agedH: 14 * 24,
+    updatedH: 11,
+    assignee: 'ops/deployer',
+    priority: 1,
+    labels: ['rig:ops'],
+  },
+  {
+    id: 'tc-data-dbt',
+    title: 'dbt models for revenue rollups',
+    status: 'blocked',
+    issue_type: 'task',
+    agedH: 11 * 24,
+    updatedH: 8,
+    assignee: 'data/etl',
+    priority: 2,
+    labels: ['rig:data'],
+    dependsOn: ['tc-data-warehouse'],
+  },
+  {
+    id: 'tc-data-backfill',
+    title: 'Backfill 18 months of events',
+    status: 'blocked',
+    issue_type: 'chore',
+    agedH: 11 * 24,
+    updatedH: 8,
+    assignee: 'data/etl',
+    priority: 3,
+    labels: ['rig:data'],
+    dependsOn: ['tc-data-dbt'],
+  },
+
+  // --- Standalone bugs ----------------------------------------------------
+  {
+    id: 'tc-bug-login-loop',
+    title: 'SSO login redirect loop on Safari',
+    status: 'in_progress',
+    issue_type: 'bug',
+    agedH: 3 * 24,
+    updatedH: 1,
+    assignee: 'web/builder',
+    priority: 0,
+    labels: ['rig:web', 'regression', 'p0'],
+  },
+  {
+    id: 'tc-bug-rate-limit',
+    title: 'API rate-limiter off-by-one at window edge',
+    status: 'open',
+    issue_type: 'bug',
+    agedH: 2 * 24,
+    assignee: 'api/tester',
+    priority: 1,
+    labels: ['rig:api'],
+  },
+  {
+    id: 'tc-bug-mail-dupe',
+    title: 'Duplicate notification emails on retry',
+    status: 'closed',
+    issue_type: 'bug',
+    agedH: 16 * 24,
+    updatedH: 12 * 24,
+    assignee: 'ops/oncall',
+    priority: 2,
+    labels: ['rig:ops'],
+  },
+  {
+    id: 'tc-bug-stale-cache',
+    title: 'Stale price cache after catalog publish',
+    status: 'blocked',
+    issue_type: 'bug',
+    agedH: 4 * 24,
+    updatedH: 6,
+    assignee: 'web/reviewer',
+    priority: 1,
+    labels: ['rig:web'],
+    dependsOn: ['tc-checkout-tax'],
+  },
+
+  // --- Tasks / chores -----------------------------------------------------
+  {
+    id: 'tc-task-upgrade-node',
+    title: 'Upgrade backend to Node 22',
+    status: 'open',
+    issue_type: 'chore',
+    agedH: 5 * 24,
+    assignee: 'ops/deployer',
+    priority: 3,
+    labels: ['rig:ops', 'maintenance'],
+  },
+  {
+    id: 'tc-task-flaky-e2e',
+    title: 'Quarantine flaky checkout E2E',
+    status: 'in_progress',
+    issue_type: 'chore',
+    agedH: 2 * 24,
+    updatedH: 5,
+    assignee: 'api/tester',
+    priority: 2,
+    labels: ['rig:api', 'tests'],
+  },
+  {
+    id: 'tc-task-rotate-keys',
+    title: 'Rotate provider API keys',
+    status: 'closed',
+    issue_type: 'chore',
+    agedH: 30 * 24,
+    updatedH: 22 * 24,
+    assignee: 'ops/oncall',
+    priority: 1,
+    labels: ['rig:ops', 'security'],
+  },
+  {
+    id: 'tc-task-design-tokens',
+    title: 'Extract design tokens from DESIGN.md',
+    status: 'open',
+    issue_type: 'task',
+    agedH: 6 * 24,
+    assignee: 'web/reviewer',
+    priority: 3,
+    labels: ['rig:web', 'design'],
+  },
+
+  // --- Docs ----------------------------------------------------------------
+  {
+    id: 'tc-docs-api-ref',
+    title: 'Publish billing API reference',
+    status: 'in_progress',
+    issue_type: 'task',
+    agedH: 4 * 24,
+    updatedH: 10,
+    assignee: 'docs/writer',
+    priority: 2,
+    labels: ['rig:docs'],
+  },
+  {
+    id: 'tc-docs-runbook',
+    title: 'On-call runbook for billing incidents',
+    status: 'open',
+    issue_type: 'task',
+    agedH: 3 * 24,
+    assignee: 'docs/writer',
+    priority: 3,
+    labels: ['rig:docs'],
+  },
+  {
+    id: 'tc-docs-changelog',
+    title: 'Backfill changelog for Q1 releases',
+    status: 'closed',
+    issue_type: 'chore',
+    agedH: 40 * 24,
+    updatedH: 28 * 24,
+    assignee: 'docs/writer',
+    priority: 3,
+    labels: ['rig:docs'],
+  },
+
+  // --- Features in flight --------------------------------------------------
+  {
+    id: 'tc-feat-search',
+    title: 'Typeahead product search',
+    status: 'in_progress',
+    issue_type: 'feature',
+    agedH: 8 * 24,
+    updatedH: 3,
+    assignee: 'web/builder',
+    priority: 1,
+    labels: ['rig:web'],
+  },
+  {
+    id: 'tc-feat-webhooks',
+    title: 'Outbound webhooks for order events',
+    status: 'open',
+    issue_type: 'feature',
+    agedH: 6 * 24,
+    assignee: 'api/worker',
+    priority: 2,
+    labels: ['rig:api'],
+  },
+  {
+    id: 'tc-feat-darkmode',
+    title: 'Dark mode for the storefront',
+    status: 'open',
+    issue_type: 'feature',
+    agedH: 9 * 24,
+    assignee: 'web/reviewer',
+    priority: 3,
+    labels: ['rig:web', 'design'],
+  },
+  {
+    id: 'tc-feat-export',
+    title: 'CSV export of invoices',
+    status: 'closed',
+    issue_type: 'feature',
+    agedH: 18 * 24,
+    updatedH: 14 * 24,
+    assignee: 'api/tester',
+    priority: 2,
+    labels: ['rig:api'],
+  },
+
+  // --- Decisions -----------------------------------------------------------
+  {
+    id: 'tc-decision-cdn',
+    title: 'Decision: CDN vendor for static assets',
+    status: 'closed',
+    issue_type: 'decision',
+    agedH: 26 * 24,
+    updatedH: 20 * 24,
+    assignee: 'mayor',
+    priority: 2,
+    labels: ['rig:ops'],
+  },
+  {
+    id: 'tc-decision-auth',
+    title: 'Decision: roll our own sessions vs hosted auth',
+    status: 'open',
+    issue_type: 'decision',
+    agedH: 5 * 24,
+    assignee: 'mayor',
+    priority: 1,
+    labels: ['rig:web', 'needs-decision'],
+  },
+
+  // --- Ops / infra ---------------------------------------------------------
+  {
+    id: 'tc-ops-alerts',
+    title: 'Wire Prometheus alerts for billing latency',
+    status: 'in_progress',
+    issue_type: 'task',
+    agedH: 3 * 24,
+    updatedH: 4,
+    assignee: 'ops/oncall',
+    priority: 1,
+    labels: ['rig:ops', 'observability'],
+  },
+  {
+    id: 'tc-ops-incident',
+    title: 'Postmortem: 04-12 checkout outage',
+    status: 'closed',
+    issue_type: 'task',
+    agedH: 50 * 24,
+    updatedH: 44 * 24,
+    assignee: 'ops/oncall',
+    priority: 0,
+    labels: ['rig:ops', 'incident'],
+  },
+
+  // --- Ephemeral convoy beads ---------------------------------------------
+  {
+    id: 'tc-convoy-input-1',
+    title: 'input convoy for tc-feat-search',
+    status: 'open',
+    issue_type: 'task',
+    agedH: 6,
+    assignee: 'web/builder',
+    priority: 1,
+    labels: ['convoy'],
+    ephemeral: true,
+  },
+  {
+    id: 'tc-convoy-input-2',
+    title: 'input convoy for tc-billing-invoice',
+    status: 'closed',
+    issue_type: 'task',
+    agedH: 12,
+    updatedH: 2,
+    assignee: 'api/tester',
+    priority: 1,
+    labels: ['convoy'],
+    ephemeral: true,
+  },
+];
+
+/**
+ * A formula run is a `graph.v2` workflow-root bead plus its step beads (linked
+ * by `gc.root_bead_id`). The Runs tab only renders a bead group as a lane when
+ * the group root carries `gc.formula_contract: graph.v2`, so a plain bead seed
+ * yields zero run lanes — these groups are what make the Runs view light up.
+ */
+function workflowGroup(opts: {
+  rootId: string;
+  rig: string;
+  title: string;
+  assignee: string;
+  startedH: number;
+  updatedH: number;
+  rootStatus: BeadStatus;
+  steps: { suffix: string; title: string; status: BeadStatus; agedH: number; kind?: string }[];
+}): BeadSpec[] {
+  const rootMeta: Record<string, string> = {
+    'gc.formula_contract': 'graph.v2',
+    'gc.kind': 'run',
+    'gc.root_store_ref': `rig:${opts.rig}`,
+  };
+  const root: BeadSpec = {
+    id: opts.rootId,
+    title: opts.title,
+    status: opts.rootStatus,
+    issue_type: 'task',
+    agedH: opts.startedH,
+    updatedH: opts.updatedH,
+    assignee: opts.assignee,
+    priority: 1,
+    labels: [`rig:${opts.rig}`, 'run'],
+    metadata: rootMeta,
+  };
+  const steps: BeadSpec[] = opts.steps.map((step) => {
+    const meta: Record<string, string> = { 'gc.root_bead_id': opts.rootId };
+    if (step.kind !== undefined) meta['gc.kind'] = step.kind;
+    return {
+      id: `${opts.rootId}-${step.suffix}`,
+      title: step.title,
+      status: step.status,
+      issue_type: 'task',
+      agedH: step.agedH,
+      updatedH: Math.max(0, step.agedH - 1),
+      assignee: opts.assignee,
+      labels: [`rig:${opts.rig}`],
+      parent: opts.rootId,
+      metadata: meta,
+    };
+  });
+  return [root, ...steps];
+}
+
+// Three formula runs: one in-flight, one blocked, one finished (historical).
+export const WORKFLOW_GROUPS: readonly BeadSpec[] = [
+  ...workflowGroup({
+    rootId: 'tc-wf-checkout',
+    rig: 'web',
+    title: 'Formula run: guest-checkout address autocomplete',
+    assignee: 'web/builder',
+    startedH: 5,
+    updatedH: 1,
+    rootStatus: 'in_progress',
+    steps: [
+      { suffix: 'spec', title: 'draft spec', status: 'closed', agedH: 5, kind: 'spec' },
+      { suffix: 'impl', title: 'implement step', status: 'in_progress', agedH: 4 },
+    ],
+  }),
+  ...workflowGroup({
+    rootId: 'tc-wf-tax',
+    rig: 'api',
+    title: 'Formula run: tax-rating service',
+    assignee: 'api/worker',
+    startedH: 6,
+    updatedH: 5,
+    rootStatus: 'in_progress',
+    steps: [
+      { suffix: 'spec', title: 'draft spec', status: 'closed', agedH: 6, kind: 'spec' },
+      { suffix: 'impl', title: 'implement step', status: 'blocked', agedH: 5 },
+    ],
+  }),
+  ...workflowGroup({
+    rootId: 'tc-wf-cart',
+    rig: 'web',
+    title: 'Formula run: cart survives refresh',
+    assignee: 'web/builder',
+    startedH: 9 * 24,
+    updatedH: 9 * 24,
+    rootStatus: 'closed',
+    steps: [
+      { suffix: 'spec', title: 'draft spec', status: 'closed', agedH: 9 * 24 + 2, kind: 'spec' },
+      { suffix: 'impl', title: 'implement step', status: 'closed', agedH: 9 * 24 + 1 },
+    ],
+  }),
+];
+
+/** Declarative agent seed; resolved against `nowMs` at build time. */
+export interface AgentSpec {
+  name: string;
+  rig: string;
+  state: string;
+  available: boolean;
+  running: boolean;
+  suspended: boolean;
+  provider: string;
+  model: string;
+  activeBead?: string;
+  contextPct?: number;
+  activity?: string;
+  unavailableReason?: string;
+  sessionName?: string;
+  sessionAttached?: boolean;
+  lastActivityMin?: number;
+}
+
+export const AGENT_SPECS: readonly AgentSpec[] = [
+  {
+    name: 'web/builder',
+    rig: 'web',
+    state: 'running',
+    available: true,
+    running: true,
+    suspended: false,
+    provider: 'claude',
+    model: 'claude-opus-4-8',
+    activeBead: 'tc-bug-login-loop',
+    contextPct: 42,
+    activity: 'editing frontend/src/routes/Checkout.tsx',
+    sessionName: 'gc-web-1',
+    sessionAttached: true,
+    lastActivityMin: 1,
+  },
+  {
+    name: 'web/reviewer',
+    rig: 'web',
+    state: 'waiting',
+    available: true,
+    running: false,
+    suspended: false,
+    provider: 'claude',
+    model: 'claude-sonnet-4-6',
+    activity: 'idle — awaiting review work',
+    sessionName: 'gc-web-2',
+    sessionAttached: false,
+    lastActivityMin: 18,
+  },
+  {
+    name: 'api/worker',
+    rig: 'api',
+    state: 'stuck',
+    available: false,
+    running: false,
+    suspended: false,
+    provider: 'claude',
+    model: 'claude-opus-4-8',
+    activeBead: 'tc-tax-service',
+    contextPct: 88,
+    activity: 'blocked on missing tax-rating credentials',
+    unavailableReason: 'needs you: missing TAX_API_KEY',
+    sessionName: 'gc-api-1',
+    sessionAttached: true,
+    lastActivityMin: 6,
+  },
+  {
+    name: 'api/tester',
+    rig: 'api',
+    state: 'running',
+    available: true,
+    running: true,
+    suspended: false,
+    provider: 'codex',
+    model: 'gpt-5',
+    activeBead: 'tc-task-flaky-e2e',
+    contextPct: 55,
+    activity: 'running billing integration suite',
+    sessionName: 'gc-api-2',
+    sessionAttached: true,
+    lastActivityMin: 2,
+  },
+  {
+    name: 'data/etl',
+    rig: 'data',
+    state: 'suspended',
+    available: false,
+    running: false,
+    suspended: true,
+    provider: 'claude',
+    model: 'claude-sonnet-4-6',
+    activeBead: 'tc-billing-meter',
+    activity: 'suspended — upstream warehouse not ready',
+    unavailableReason: 'suspended pending tc-data-warehouse',
+    lastActivityMin: 95,
+  },
+  {
+    name: 'ops/deployer',
+    rig: 'ops',
+    state: 'detached',
+    available: true,
+    running: true,
+    suspended: false,
+    provider: 'claude',
+    model: 'claude-opus-4-8',
+    activeBead: 'tc-data-warehouse',
+    contextPct: 33,
+    activity: 'provisioning warehouse cluster',
+    sessionName: 'gc-ops-1',
+    sessionAttached: false,
+    lastActivityMin: 9,
+  },
+  {
+    name: 'ops/oncall',
+    rig: 'ops',
+    state: 'rate-limited',
+    available: false,
+    running: false,
+    suspended: false,
+    provider: 'claude',
+    model: 'claude-opus-4-8',
+    activity: 'paused — provider rate limit',
+    unavailableReason: 'rate-limited until window resets',
+    sessionName: 'gc-ops-2',
+    sessionAttached: false,
+    lastActivityMin: 14,
+  },
+  {
+    name: 'docs/writer',
+    rig: 'docs',
+    state: 'failed',
+    available: false,
+    running: false,
+    suspended: false,
+    provider: 'gemini',
+    model: 'gemini-2.5-pro',
+    activeBead: 'tc-docs-api-ref',
+    activity: 'crashed mid-generation',
+    unavailableReason: 'session crashed (exit 1)',
+    sessionName: 'gc-docs-1',
+    sessionAttached: false,
+    lastActivityMin: 40,
+  },
+];
+
+/** Declarative mail seed; `agedMin` resolved against `nowMs`. */
+export interface MailSpec {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  read: boolean;
+  agedMin: number;
+  threadId?: string;
+  rig?: string;
+  priority?: number;
+}
+
+export const MAIL_SPECS: readonly MailSpec[] = [
+  {
+    id: 'tc-mail-1',
+    from: 'api/worker',
+    to: OP,
+    subject: 'BLOCKED: tax-rating service missing credentials',
+    body: 'tc-tax-service is blocked — TAX_API_KEY is not set in the api rig env.',
+    read: false,
+    agedMin: 6,
+    threadId: 'tc-thread-tax',
+    rig: 'api',
+    priority: 0,
+  },
+  {
+    id: 'tc-mail-2',
+    from: OP,
+    to: 'api/worker',
+    subject: 'Re: BLOCKED: tax-rating service missing credentials',
+    body: 'Acknowledged — rotating a key now, will land in the rig env within the hour.',
+    read: true,
+    agedMin: 4,
+    threadId: 'tc-thread-tax',
+    rig: 'api',
+    priority: 0,
+  },
+  {
+    id: 'tc-mail-3',
+    from: 'web/builder',
+    to: OP,
+    subject: 'Checkout cart-refresh fix landed',
+    body: 'tc-checkout-cart closed and merged. Moving to address autocomplete next.',
+    read: true,
+    agedMin: 3 * 60,
+    rig: 'web',
+    priority: 2,
+  },
+  {
+    id: 'tc-mail-4',
+    from: 'data/etl',
+    to: OP,
+    subject: 'Warehouse still not provisioned',
+    body: 'tc-billing-meter and the dbt models are blocked until tc-data-warehouse is up.',
+    read: false,
+    agedMin: 95,
+    threadId: 'tc-thread-warehouse',
+    rig: 'data',
+    priority: 1,
+  },
+  {
+    id: 'tc-mail-5',
+    from: 'ops/deployer',
+    to: 'data/etl',
+    subject: 'Re: Warehouse still not provisioned',
+    body: 'Cluster is spinning up — ETA ~30 min. Will ping when ready.',
+    read: false,
+    agedMin: 60,
+    threadId: 'tc-thread-warehouse',
+    rig: 'ops',
+    priority: 1,
+  },
+  {
+    id: 'tc-mail-6',
+    from: 'docs/writer',
+    to: OP,
+    subject: 'Session crashed during API-ref generation',
+    body: 'gc-docs-1 exited 1 partway through tc-docs-api-ref. Restarting.',
+    read: false,
+    agedMin: 40,
+    rig: 'docs',
+    priority: 1,
+  },
+  {
+    id: 'tc-mail-7',
+    from: OP,
+    to: 'all',
+    subject: 'Proration policy decision needed',
+    body: 'tc-billing-decision is open — need a call on mid-cycle proration before invoicing ships.',
+    read: true,
+    agedMin: 5 * 60,
+    rig: 'api',
+    priority: 1,
+  },
+  {
+    id: 'tc-mail-8',
+    from: 'api/tester',
+    to: OP,
+    subject: 'Flaky checkout E2E quarantined',
+    body: 'Pulled the flaky spec into quarantine; tracking the real fix under tc-task-flaky-e2e.',
+    read: true,
+    agedMin: 5 * 60,
+    rig: 'api',
+    priority: 3,
+  },
+  {
+    id: 'tc-mail-9',
+    from: 'ops/oncall',
+    to: OP,
+    subject: 'Rate-limited on provider',
+    body: 'Hitting provider rate limits — backing off until the window resets.',
+    read: false,
+    agedMin: 14,
+    rig: 'ops',
+    priority: 2,
+  },
+  {
+    id: 'tc-mail-10',
+    from: 'web/reviewer',
+    to: 'web/builder',
+    subject: 'Review queue is empty',
+    body: 'No open review work — grabbing the design-tokens task in the meantime.',
+    read: true,
+    agedMin: 18,
+    rig: 'web',
+    priority: 3,
+  },
+];
+
+/** Declarative formula-run seed (the Runs tab's monitor feed). */
+export interface RunSpec {
+  id: string;
+  workflowId: string;
+  rootBeadId: string;
+  rig: string;
+  title: string;
+  target: string;
+  type: string;
+  status: string;
+  startedH: number;
+  updatedH: number;
+}
+
+// The monitor feed enriches run lanes with rig scope. Items must be `type:
+// 'formula'` or the Runs view's feed discovery skips them. `rootBeadId` points
+// at the graph.v2 workflow roots in WORKFLOW_GROUPS so the scopes line up.
+export const RUN_SPECS: readonly RunSpec[] = [
+  {
+    id: 'tc-run-checkout',
+    workflowId: 'tc-wf-checkout',
+    rootBeadId: 'tc-wf-checkout',
+    rig: 'web',
+    title: 'Formula run: guest-checkout address autocomplete',
+    target: 'tc-wf-checkout',
+    type: 'formula',
+    status: 'running',
+    startedH: 5,
+    updatedH: 1,
+  },
+  {
+    id: 'tc-run-tax',
+    workflowId: 'tc-wf-tax',
+    rootBeadId: 'tc-wf-tax',
+    rig: 'api',
+    title: 'Formula run: tax-rating service',
+    target: 'tc-wf-tax',
+    type: 'formula',
+    status: 'blocked',
+    startedH: 6,
+    updatedH: 5,
+  },
+  {
+    id: 'tc-run-cart',
+    workflowId: 'tc-wf-cart',
+    rootBeadId: 'tc-wf-cart',
+    rig: 'web',
+    title: 'Formula run: cart survives refresh',
+    target: 'tc-wf-cart',
+    type: 'formula',
+    status: 'done',
+    startedH: 9 * 24,
+    updatedH: 9 * 24,
+  },
+  {
+    id: 'tc-run-docs',
+    workflowId: 'tc-docs-api-ref',
+    rootBeadId: 'tc-docs-api-ref',
+    rig: 'docs',
+    title: 'Formula run: publish billing API reference',
+    target: 'tc-docs-api-ref',
+    type: 'formula',
+    status: 'failed',
+    startedH: 10,
+    updatedH: 9,
+  },
+];

--- a/shared/src/fixtures/test-city/test-city.test.ts
+++ b/shared/src/fixtures/test-city/test-city.test.ts
@@ -1,0 +1,212 @@
+// Regression gate for the static test-city supervisor fixture.
+//
+// Two jobs:
+//   1. Wire-shape conformance — every seeded payload and every matched response
+//      envelope is validated against the GENERATED zod schemas. When the
+//      supervisor OpenAPI is regenerated and a shape drifts, this fails in CI,
+//      forcing the fixture to be brought back into line (the whole point of
+//      keeping the seed typed against the generated client).
+//   2. Coverage invariants — the seed must actually exercise the lifecycle
+//      states the dashboard tabs render (blocked beads, a stuck agent, unread
+//      mail, an epic with children, runs across statuses, an attention event),
+//      so a future edit can't quietly hollow the fixture out.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildTestCitySupervisorData,
+  matchTestCitySupervisorRequest,
+  renderTestCityEventStream,
+  TEST_CITY_NAME,
+} from './index.js';
+import {
+  zAgentResponse,
+  zBead,
+  zFormulaFeedBody,
+  zHealthOutputBody,
+  zListBodyAgentResponse,
+  zListBodyBead,
+  zListBodySessionResponse,
+  zListBodyWireEvent,
+  zMailListBody,
+  zMessage,
+  zMonitorFeedItemResponse,
+  zSessionResponse,
+  zStatusBody,
+  zSupervisorCitiesOutputBody,
+  zSupervisorHealthOutputBody,
+  zTypedEventStreamEnvelope,
+} from '../../generated/gc-supervisor-client/zod.gen.js';
+
+// Fixed clock so assertions are deterministic. Date.parse (not Date.now) keeps
+// this reproducible across runs.
+const NOW = Date.parse('2026-06-06T12:00:00.000Z');
+const data = buildTestCitySupervisorData(NOW);
+
+const cityPath = (suffix: string): string => `/gc-supervisor/v0/city/${TEST_CITY_NAME}${suffix}`;
+
+void test('every seeded item conforms to the generated supervisor zod schemas', () => {
+  for (const bead of data.beads) zBead.parse(bead);
+  for (const agent of data.agents) zAgentResponse.parse(agent);
+  for (const session of data.sessions) zSessionResponse.parse(session);
+  for (const message of data.mail) zMessage.parse(message);
+  for (const run of data.formulaFeed) zMonitorFeedItemResponse.parse(run);
+  for (const event of data.events) zTypedEventStreamEnvelope.parse(event);
+  zHealthOutputBody.parse(data.cityHealth);
+  zSupervisorHealthOutputBody.parse(data.supervisorHealth);
+  zStatusBody.parse(data.status);
+});
+
+void test('matched list envelopes conform to their generated zod schemas', () => {
+  const parseMatched = (suffix: string, schema: { parse: (v: unknown) => unknown }): void => {
+    const res = matchTestCitySupervisorRequest(data, 'GET', cityPath(suffix));
+    assert.ok(res !== null, `expected a fixture response for ${suffix}`);
+    schema.parse(JSON.parse(res.body));
+  };
+  parseMatched('/beads', zListBodyBead);
+  parseMatched('/agents', zListBodyAgentResponse);
+  parseMatched('/sessions', zListBodySessionResponse);
+  parseMatched('/mail', zMailListBody);
+  parseMatched('/events', zListBodyWireEvent);
+  parseMatched('/formulas/feed', zFormulaFeedBody);
+  parseMatched('/status', zStatusBody);
+  parseMatched('/health', zHealthOutputBody);
+
+  const cities = matchTestCitySupervisorRequest(data, 'GET', '/gc-supervisor/v0/cities');
+  assert.ok(cities !== null, 'expected a fixture response for /v0/cities');
+  const citiesBody = zSupervisorCitiesOutputBody.parse(JSON.parse(cities.body));
+  assert.ok(
+    citiesBody.items?.some((c) => c.name === TEST_CITY_NAME),
+    'cities list must advertise the test city so the shell can resolve it',
+  );
+});
+
+void test('bead seed exercises every status and the key issue types', () => {
+  const statuses = new Set(data.beads.map((b) => b.status));
+  for (const s of ['open', 'in_progress', 'blocked', 'closed']) {
+    assert.ok(statuses.has(s), `bead seed is missing status "${s}"`);
+  }
+  const types = new Set(data.beads.map((b) => b.issue_type));
+  for (const t of ['epic', 'feature', 'bug', 'task', 'chore', 'decision']) {
+    assert.ok(types.has(t), `bead seed is missing issue_type "${t}"`);
+  }
+  // ~30-50 beads per the bead's scope.
+  assert.ok(data.beads.length >= 30, `expected >=30 beads, got ${data.beads.length}`);
+
+  // An epic with children wired by `parent`.
+  const epic = data.beads.find((b) => b.issue_type === 'epic');
+  assert.ok(epic, 'expected at least one epic');
+  const children = data.beads.filter((b) => b.parent === epic?.id);
+  assert.ok(children.length >= 2, 'expected the epic to have >=2 children');
+
+  // A blocked bead wired by real dependencies.
+  const blockedWithDeps = data.beads.find(
+    (b) => b.status === 'blocked' && (b.dependencies?.length ?? 0) > 0,
+  );
+  assert.ok(blockedWithDeps, 'expected a blocked bead with dependencies');
+});
+
+void test('agent seed surfaces a stuck "needs you" agent and varied states', () => {
+  const stuck = data.agents.find(
+    (a) => a.state === 'stuck' || (a.unavailable_reason?.includes('needs you') ?? false),
+  );
+  assert.ok(stuck, 'expected a stuck / needs-you agent');
+  const states = new Set(data.agents.map((a) => a.state));
+  assert.ok(states.size >= 4, `expected varied agent states, got ${[...states].join(',')}`);
+  assert.ok(
+    data.agents.some((a) => a.suspended),
+    'expected at least one suspended agent',
+  );
+});
+
+void test('mail seed has unread and threaded messages', () => {
+  assert.ok(
+    data.mail.some((m) => !m.read),
+    'expected at least one unread message',
+  );
+  const threaded = data.mail.filter((m) => m.thread_id !== undefined);
+  assert.ok(threaded.length >= 2, 'expected a threaded conversation');
+  const threadId = threaded[0]?.thread_id;
+  assert.ok(threadId);
+  const res = matchTestCitySupervisorRequest(data, 'GET', cityPath(`/mail/thread/${threadId}`));
+  assert.ok(res !== null);
+  const body = JSON.parse(res.body) as { items: unknown[] };
+  assert.ok(body.items.length >= 2, 'thread detail should return the threaded messages');
+});
+
+void test('run feed spans running, blocked, failed and done', () => {
+  const statuses = new Set(data.formulaFeed.map((r) => r.status));
+  for (const s of ['running', 'blocked', 'failed', 'done']) {
+    assert.ok(statuses.has(s), `run feed is missing status "${s}"`);
+  }
+});
+
+void test('every run feed item resolves to a real seeded bead', () => {
+  // Guards against dangling root_bead_id/workflow_id references as the feed
+  // grows — a feed item that points at a bead the seed never created.
+  const beadIds = new Set(data.beads.map((b) => b.id));
+  for (const run of data.formulaFeed) {
+    assert.ok(
+      run.root_bead_id !== undefined && beadIds.has(run.root_bead_id),
+      `run ${run.id} has root_bead_id "${run.root_bead_id ?? '(none)'}" with no matching bead`,
+    );
+  }
+});
+
+void test('per-session pending poll is seeded with one real pending approval', () => {
+  // The stuck agent's session carries a pending approval; others are benign.
+  const stuckSession = data.sessions.find(
+    (s) => data.pendingBySession[s.id]?.pending !== undefined,
+  );
+  assert.ok(stuckSession, 'expected one session with a pending interaction');
+  const res = matchTestCitySupervisorRequest(
+    data,
+    'GET',
+    cityPath(`/session/${stuckSession?.id ?? ''}/pending`),
+  );
+  assert.ok(res !== null);
+  const body = JSON.parse(res.body) as { supported: boolean; pending?: { request_id: string } };
+  assert.equal(body.supported, true);
+  assert.ok(body.pending?.request_id, 'pending interaction must carry a request_id');
+
+  // An unknown session still resolves to a benign supported/no-pending body.
+  const other = matchTestCitySupervisorRequest(data, 'GET', cityPath('/session/unknown/pending'));
+  assert.ok(other !== null);
+  assert.equal((JSON.parse(other.body) as { pending?: unknown }).pending, undefined);
+});
+
+void test('event seed includes an attention-class event', () => {
+  assert.ok(
+    data.events.some((e) => e.type === 'session.crashed' || e.type === 'order.failed'),
+    'expected an attention-class event (session.crashed / order.failed)',
+  );
+  // The rendered SSE body is non-empty and frames events as named `event`s.
+  const stream = renderTestCityEventStream(data);
+  assert.match(stream, /event: event/);
+  assert.match(stream, /retry: 30000/);
+});
+
+void test('matcher distinguishes city vs supervisor health and 404s unknown beads', () => {
+  const supervisor = matchTestCitySupervisorRequest(data, 'GET', '/gc-supervisor/health');
+  assert.ok(supervisor !== null);
+  zSupervisorHealthOutputBody.parse(JSON.parse(supervisor.body));
+
+  const city = matchTestCitySupervisorRequest(data, 'GET', cityPath('/health'));
+  assert.ok(city !== null);
+  zHealthOutputBody.parse(JSON.parse(city.body));
+
+  const missing = matchTestCitySupervisorRequest(data, 'GET', cityPath('/bead/does-not-exist'));
+  assert.ok(missing !== null);
+  assert.equal(missing.status, 404);
+
+  // Non-GET and unknown paths fall through to null.
+  assert.equal(matchTestCitySupervisorRequest(data, 'POST', cityPath('/beads')), null);
+  assert.equal(matchTestCitySupervisorRequest(data, 'GET', cityPath('/unknown')), null);
+});
+
+void test('builds are deterministic for a fixed clock', () => {
+  const a = buildTestCitySupervisorData(NOW);
+  const b = buildTestCitySupervisorData(NOW);
+  assert.deepEqual(a, b);
+});

--- a/specs/architecture/supervisor-test-fixture.md
+++ b/specs/architecture/supervisor-test-fixture.md
@@ -1,0 +1,91 @@
+# Static `test-city` supervisor fixture
+
+A deterministic, seeded snapshot of GC-supervisor state used to drive the
+dashboard's **supervisor-backed tabs** — Agents, Runs, Beads, Mail, Sessions,
+Health — without a live `gc` supervisor or a live city.
+
+## Why it exists
+
+The dashboard has two data planes:
+
+- **Dashboard-owned `/api/*`** — served by the dashboard's own backend. This
+  plane already has a fixture path: `SNAPSHOT_USE_FIXTURES=1` makes each
+  `SourceCache` fall back to canned data so the home/maintainer views stay
+  renderable when upstream fails.
+- **Supervisor-owned `/gc-supervisor/*`** — a transport-only proxy to the `gc`
+  supervisor. The supervisor-backed tabs read this plane **directly** via the
+  generated client. `SNAPSHOT_USE_FIXTURES` does **not** cover it, so before
+  this fixture those tabs could only be exercised against whatever a live
+  supervisor happened to hold — non-deterministic, and impossible in CI.
+
+This fixture fills that gap. It seeds ~44 beads across every status and issue
+type (two epics with children, a dependency-blocked cluster, three `graph.v2`
+formula-run groups), 8 agents across states (incl. a stuck "needs you" agent),
+their sessions (one with a pending operator approval), threaded mail across
+read/unread, a monitor feed spanning running/blocked/failed/done, an event
+stream including attention-class events, and health/status bodies.
+
+## Where it lives
+
+| Path                                               | Role                                                                                                                                                                                                                                                                    |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/src/fixtures/test-city/data.ts`            | The typed seed — built against the **generated** supervisor types, so a wire-shape drift is a compile error. `buildTestCitySupervisorData(nowMs?)` returns the snapshot; timestamps are offsets from `nowMs` so seeded mail/events land in the views' relative windows. |
+| `shared/src/fixtures/test-city/match.ts`           | Pure `(method, pathname, search) → response` matcher + the SSE stream renderer.                                                                                                                                                                                         |
+| `shared/src/fixtures/test-city/test-city.test.ts`  | The **regression gate**: validates every payload against the generated **zod** schemas and asserts coverage invariants. Runs under `npm --workspace shared test` (CI).                                                                                                  |
+| `scripts/fixtures/install-supervisor-fixtures.mjs` | Playwright route installer — intercepts `**/gc-supervisor/**` and fulfils from the snapshot.                                                                                                                                                                            |
+| `scripts/snap-test-city.mjs`                       | Browser regression script that drives every supervisor-backed tab against the fixture and asserts known seeded content.                                                                                                                                                 |
+
+Exported from shared as `gas-city-dashboard-shared/fixtures/test-city`.
+
+## How the two regression gates relate
+
+- **`shared` zod test** — always-on, deterministic, no browser. This is the CI
+  gate: when the supervisor OpenAPI is regenerated and a shape changes, the
+  fixture stops conforming and the test fails, forcing it back into line.
+- **`scripts/snap-test-city.mjs`** — the browser gate. Like the other snap
+  scripts it does **not** start its own server and **skips (exit 0)** when
+  nothing is serving the base URL. It is wired into `npm run browser:test`.
+
+## Pointing a dashboard at the fixture
+
+The fixture is **city-agnostic** (the matcher ignores the `/city/<name>/`
+segment) and only fakes the `/gc-supervisor/*` plane. The dashboard's own
+`/api/*` plane stays real, so you drive the host's **real** configured city and
+let the fixture serve its supervisor calls:
+
+```bash
+npm run build:shared          # the fixture import resolves from shared/dist
+npm run dev:backend           # real /api plane (its configured GC_CITY_NAME)
+npm run dev:frontend          # Vite on :5174
+
+# In another shell, with the dev server up:
+node scripts/snap-test-city.mjs --test
+# or against the production node:
+TEST_CITY_BASE=http://127.0.0.1:8082 node scripts/snap-test-city.mjs --test
+```
+
+`snap-test-city` discovers the host's real city from the shell, then installs
+the fixture (scoped to that city so the header's city switcher stays
+consistent) and asserts each tab. To reuse the installer in another Playwright
+script:
+
+```js
+import { installSupervisorFixtures } from './fixtures/install-supervisor-fixtures.mjs';
+const data = await installSupervisorFixtures(context, { activeCity });
+// every /gc-supervisor/* call the page makes is now served from `data`.
+```
+
+## Scope boundary and where live data still helps
+
+- **`gc city init` + registration is mayor-owned.** This fixture deliberately
+  does **not** stand up a real city; it serves supervisor responses by route
+  interception, which is enough for the list/board views and needs no live
+  supervisor. The same seed could later back a real seeded city if one is
+  provisioned (that step is the mayor's).
+- **Live runs would extend drill-in coverage.** The fixture seeds the Runs
+  _list_ (lane summaries from `graph.v2` bead groups) but not the per-run
+  _detail_ drill-in (`/workflow/<id>`, `/formulas/<name>`) or session
+  transcripts/streams — the installer answers those unseeded endpoints with an
+  explicit `501` so a view that needs them surfaces the gap rather than a false
+  all-clear. Exercising run-detail and transcript views against known state is
+  the natural next increment.


### PR DESCRIPTION
## Scope

Seeds a deterministic GC-supervisor snapshot (rigs/agents/sessions/beads/runs/mail/events/health across lifecycle states) and serves it to the dashboard's supervisor-backed tabs (Agents/Runs/Beads/Mail/Sessions/Health) via Playwright route interception — filling the gap `SNAPSHOT_USE_FIXTURES` leaves (it only covers dashboard-owned `/api/*`, never the `/gc-supervisor/*` proxy). No live supervisor or live city required.

- `shared/src/fixtures/test-city`: typed seed (against the generated client) + pure request matcher + SSE renderer, exported as `gas-city-dashboard-shared/fixtures/test-city`.
- `test-city.test.ts`: regression gate — validates every payload against the generated zod schemas (fails on OpenAPI drift) and asserts coverage invariants. Runs under `npm --workspace shared test`.
- `scripts/fixtures/install-supervisor-fixtures.mjs`: reusable Playwright installer (intercepts only `/gc-supervisor/**`; leaves `/api/*` real).
- `scripts/snap-test-city.mjs`: browser regression script asserting known seeded state on each tab; wired into `npm run browser:test`; skips when no server (snap-harness contract).
- ~44 beads across all statuses + epics/convoys/blocked-deps, 8 agents incl. a stuck needs-you agent, 3 graph.v2 formula-run groups, threaded mail.
- docs: `specs/architecture/supervisor-test-fixture.md`.

Originally branched off #62 (now merged as 541f4f7); rebased cleanly onto current `main`.

## CI parity (all green locally)

- typecheck (src + test) ✅
- lint (eslint, max-warnings=0) ✅
- format:check (prettier) ✅
- openapi gc-supervisor drift check ✅
- shared tests (77) ✅
- backend tests (572) ✅
- frontend tests (762) ✅
- frontend build ✅

Closes gascity-dashboard-a38k

mayor merge-gates — do NOT merge.