### PR TITLE
feat(dashboard): pre-exposure perf + UX polish (q89b)

### DIFF
--- a/frontend/src/components/AgentPanel.tsx
+++ b/frontend/src/components/AgentPanel.tsx
@@ -2,6 +2,12 @@ import { useMemo, useState } from 'react';
 import { OPERATOR_ALIAS, OPERATOR_WIRE_ALIAS } from '../contexts/ViewingAsContext';
 import { displayLabel, tierLabel, type AliasBucket } from '../hooks/aliasPriority';
 
+// Shared rail shell for both panel states: full-width with a bottom rule on
+// mobile, fixed-width with a right-edge rule from sm up; only the sm width
+// varies per state.
+const ASIDE_BASE_CLASS =
+  'border-rule pb-6 border-b sm:shrink-0 sm:pr-6 sm:pb-0 sm:border-b-0 sm:border-r';
+
 export function AgentPanel({
   buckets,
   loading,
@@ -55,7 +61,7 @@ export function AgentPanel({
 
   if (!expanded) {
     return (
-      <aside className="shrink-0 w-44 pr-6 border-r border-rule">
+      <aside className={`${ASIDE_BASE_CLASS} sm:w-44`}>
         <button
           type="button"
           onClick={() => setExpanded(true)}
@@ -92,7 +98,7 @@ export function AgentPanel({
   }
 
   return (
-    <aside className="shrink-0 w-64 pr-6 border-r border-rule">
+    <aside className={`${ASIDE_BASE_CLASS} sm:w-64`}>
       <button
         type="button"
         onClick={() => setExpanded(false)}

--- a/frontend/src/components/ambient/FirstRunNote.test.tsx
+++ b/frontend/src/components/ambient/FirstRunNote.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FirstRunNote } from './FirstRunNote';
+
+// gascity-dashboard-q89b — first-visit orientation for the ambient home.
+// The note must show until dismissed, persist the dismissal per browser,
+// and stay inside the editorial register (no maroon, greyscale-readable).
+
+const STORAGE_KEY = 'gascity:home-intro-dismissed';
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.removeItem(STORAGE_KEY);
+});
+
+describe('FirstRunNote', () => {
+  it('shows the orientation note on a first visit', () => {
+    render(<FirstRunNote />);
+    expect(screen.getByTestId('first-run-note')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
+  });
+
+  it('hides after dismiss and stays hidden on the next mount', () => {
+    const first = render(<FirstRunNote />);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByTestId('first-run-note')).toBeNull();
+    first.unmount();
+
+    render(<FirstRunNote />);
+    expect(screen.queryByTestId('first-run-note')).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1');
+  });
+
+  it('carries no maroon mark (One Mark Rule budget stays with the status sentence)', () => {
+    const { container } = render(<FirstRunNote />);
+    expect(container.querySelectorAll('.text-accent').length).toBe(0);
+  });
+});

--- a/frontend/src/components/ambient/FirstRunNote.tsx
+++ b/frontend/src/components/ambient/FirstRunNote.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { readBrowserStorage, writeBrowserStorage } from '../../lib/browserStorage';
+
+const STORAGE_KEY = 'gascity:home-intro-dismissed';
+const COMPONENT = 'FirstRunNote';
+
+// First-visit orientation for the ambient home (gascity-dashboard-q89b).
+// The home deliberately withholds healthy in-flight work (PRD R10), which
+// reads as an empty page to a zero-context newcomer. This note explains the
+// register once, then gets out of the way: Dismiss persists per browser.
+// If storage is unavailable the note simply shows again next visit; the
+// helper already reports the storage error.
+//
+// Editorial register per DESIGN.md: prose, not a card; no maroon (the One
+// Mark budget stays with the status sentence); textual dismiss affordance.
+export function FirstRunNote() {
+  const [dismissed, setDismissed] = useState(
+    () => readBrowserStorage('localStorage', STORAGE_KEY, COMPONENT).status === 'found',
+  );
+  if (dismissed) return null;
+
+  const onDismiss = (): void => {
+    setDismissed(true);
+    writeBrowserStorage('localStorage', STORAGE_KEY, '1', COMPONENT);
+  };
+
+  return (
+    <aside className="mt-6 max-w-[70ch]" data-testid="first-run-note">
+      <p className="text-body text-fg-muted">
+        New here? This page is the ambient home for a Gas City workspace: a calm census of the
+        formula runs in flight. Healthy work stays quiet by design; the page speaks up only when a
+        run needs an operator decision. The full record lives in Agents, Beads, Runs, and Mail
+        above.
+      </p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="mt-2 text-label uppercase tracking-wider text-fg-muted hover:text-fg transition-colors duration-150 ease-out-quart focus-mark"
+      >
+        Dismiss
+      </button>
+    </aside>
+  );
+}

--- a/frontend/src/routes/Activity.test.tsx
+++ b/frontend/src/routes/Activity.test.tsx
@@ -14,7 +14,7 @@ interface FetchCall {
 }
 
 const fetchCalls: FetchCall[] = [];
-let eventFetchMode: 'ok' | 'partial' | 'fail' = 'ok';
+let eventFetchMode: 'ok' | 'partial' | 'fail' | 'duplicate-audit' = 'ok';
 
 beforeEach(() => {
   setActiveCity('test-city');
@@ -35,6 +35,31 @@ beforeEach(() => {
           return new Response(JSON.stringify({ error: 'event store offline' }), {
             status: 503,
             headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (eventFetchMode === 'duplicate-audit') {
+          // Dashboard audit records forwarded into the supervisor event log
+          // carry no sequence number, so several arrive with seq 0
+          // (gascity-dashboard-q89b).
+          return jsonResponse({
+            items: [
+              supervisorEvent({
+                actor: 'dashboard',
+                message: 'audit fetch one',
+                seq: 0,
+                subject: 'GET /api/health/system',
+                type: 'dashboard.fetch',
+              }),
+              supervisorEvent({
+                actor: 'dashboard',
+                message: 'audit fetch two',
+                seq: 0,
+                subject: 'GET /api/health/local-tools',
+                type: 'dashboard.fetch',
+              }),
+            ],
+            partial: false,
+            total: 2,
           });
         }
         return jsonResponse({
@@ -121,6 +146,21 @@ describe('ActivityPage', () => {
     expect(eventFetch?.query.get('type')).toBe('session.crashed');
     expect(eventFetch?.query.get('since')).toBe('24h');
     expect(fetchCalls.some((call) => call.path === '/api/city/test-city/events')).toBe(false);
+  });
+
+  it('renders seq-less dashboard audit events without React key collisions (gascity-dashboard-q89b)', async () => {
+    eventFetchMode = 'duplicate-audit';
+    const consoleError = vi.spyOn(console, 'error');
+
+    renderPage('/activity?mode=events');
+
+    const table = await screen.findByRole('table', { name: /supervisor events/i });
+    expect(await within(table).findByText('audit fetch one')).toBeTruthy();
+    expect(within(table).getByText('audit fetch two')).toBeTruthy();
+    const keyWarnings = consoleError.mock.calls.filter((call) =>
+      String(call[0]).includes('same key'),
+    );
+    expect(keyWarnings).toHaveLength(0);
   });
 
   it('renders deploy and commit activity without using supervisor mirrors', async () => {

--- a/frontend/src/routes/Activity.tsx
+++ b/frontend/src/routes/Activity.tsx
@@ -415,9 +415,10 @@ function EventsSection({
                     : 'No supervisor events in this window.'}
             </EmptyRow>
           ) : (
-            items.map((event) => (
+            items.map((event, index) => (
               <tr
-                key={`${event.seq}:${event.type}`}
+                // Audit-forwarded events all arrive at seq 0; index breaks ties.
+                key={`${event.seq}:${event.type}:${index}`}
                 {...attentionRowProps(attentionSeverity(event))}
                 className={`border-b border-rule ${
                   attentionRowProps(attentionSeverity(event)).className ?? ''

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -54,6 +54,8 @@ afterEach(() => {
   cleanup();
   invalidateKey('runs:summary:racoon-city');
   invalidateKey('home:work:racoon-city');
+  // Keep the first-run note's dismissal from leaking across tests.
+  window.localStorage.removeItem('gascity:home-intro-dismissed');
   vi.useRealTimers();
 });
 
@@ -233,6 +235,12 @@ beforeEach(() => {
 });
 
 describe('AmbientHomePage', () => {
+  it('renders the first-run orientation note until dismissed (gascity-dashboard-q89b)', async () => {
+    mount();
+    await waitFor(() => expect(screen.getByTestId('phase-census')).toBeTruthy());
+    expect(screen.getByTestId('first-run-note')).toBeTruthy();
+  });
+
   it('renders the calm-city case with no concern rows and NO maroon (R10 + One Mark)', async () => {
     // Three known lanes, all fresh sessions, no thrashing, no
     // needsOperator. R10: no rows. R6: no fallback prose.

--- a/frontend/src/routes/AmbientHome.tsx
+++ b/frontend/src/routes/AmbientHome.tsx
@@ -4,6 +4,7 @@ import { getActiveCity } from '../api/cityBase';
 import { AttentionSummaryPanel } from '../attention/AttentionSummaryPanel';
 import { PageHeader } from '../components/PageHeader';
 import { ConcernRegion, type ConcernRow } from '../components/ambient/ConcernRegion';
+import { FirstRunNote } from '../components/ambient/FirstRunNote';
 import { PhaseCensus } from '../components/ambient/PhaseCensus';
 import { StatusSentence } from '../components/ambient/StatusSentence';
 import { useCachedData } from '../hooks/useCachedData';
@@ -152,10 +153,11 @@ function AmbientBody({ fresh, cityName, cycleKey, workInProgress }: BodyProps) {
   const synopsis =
     cityName !== null ? `${cityName}, ${summary.totalActive} active${inProgressClause}` : null;
 
-  if (summary.census.status !== 'available') {
-    return (
-      <section>
-        <PageHeader title="Home" synopsis={synopsis} />
+  return (
+    <section>
+      <PageHeader title="Home" synopsis={synopsis} />
+      <FirstRunNote />
+      {summary.census.status !== 'available' ? (
         <p
           className="mt-6 text-body text-fg-muted max-w-[70ch]"
           role="alert"
@@ -163,25 +165,20 @@ function AmbientBody({ fresh, cityName, cycleKey, workInProgress }: BodyProps) {
         >
           Census unavailable: {summary.census.error}.
         </p>
-      </section>
-    );
-  }
-
-  return (
-    <section>
-      <PageHeader title="Home" synopsis={synopsis} />
-      <div className="mt-6 space-y-6">
-        <AttentionSummaryPanel />
-        <div className="space-y-4">
-          <PhaseCensus
-            census={summary.census.data}
-            waitingCount={countWaiting(inFlightLanes)}
-            failingCount={failing}
-          />
-          {top !== undefined && <StatusSentence topConcern={top} />}
-          <ConcernRegion rows={rows} />
+      ) : (
+        <div className="mt-6 space-y-6">
+          <AttentionSummaryPanel />
+          <div className="space-y-4">
+            <PhaseCensus
+              census={summary.census.data}
+              waitingCount={countWaiting(inFlightLanes)}
+              failingCount={failing}
+            />
+            {top !== undefined && <StatusSentence topConcern={top} />}
+            <ConcernRegion rows={rows} />
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -50,7 +50,7 @@ describe('BeadsPage supervisor reads', () => {
       items: [bead({ id: 'legacy-city-bead', title: 'legacy city bead' })],
       total: 1,
       upstream_fetched: 1,
-      fetch_limit: 2000,
+      fetch_limit: 1000,
     });
 
     renderPage();

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -155,7 +155,7 @@ describe('BeadsPage', () => {
 
     expect(beadQueries.length).toBe(1);
     const [query] = beadQueries;
-    expect(query?.get('limit')).toBe('2000');
+    expect(query?.get('limit')).toBe('1000');
     expect(query?.has('all')).toBe(false);
     expect(query?.has('type')).toBe(false);
     expect(query?.has('showAll')).toBe(false);

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -306,7 +306,9 @@ export function MailPage() {
         }
       />
 
-      <div className="flex gap-8 items-start">
+      {/* Below sm the reading-as rail stacks above the list; its divider
+          rotates from right-edge rule to bottom rule in AgentPanel. */}
+      <div className="flex flex-col gap-8 sm:flex-row sm:items-start">
         <AgentPanel
           buckets={aliasBuckets}
           loading={aliasesLoading}

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -69,7 +69,7 @@ describe('supervisor bead reads', () => {
 
     const result = await listSupervisorBeads();
 
-    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 2000 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1000 });
     expect(result.items.map((item) => item.id)).toEqual(['rc-decision', 'td-task']);
     expect(result.total).toBe(2);
     expect(result.upstream_total).toBe(4);

--- a/frontend/src/supervisor/beadReads.ts
+++ b/frontend/src/supervisor/beadReads.ts
@@ -23,9 +23,12 @@ export interface ListSupervisorBeadsOptions {
   limit?: number;
 }
 
-const BEADS_FETCH_LIMIT = 2000;
+// Pre-exposure load bounds (gascity-dashboard-q89b): board and detail-fallback
+// list fetches run per client, so keep them modest. Truncation degrades
+// visibly: upstream_total vs fetch_limit feeds the board's truncation notice.
+const BEADS_FETCH_LIMIT = 1000;
 const ASSIGNED_BEADS_FETCH_LIMIT = 200;
-const DETAIL_FALLBACK_FETCH_LIMIT = 2000;
+const DETAIL_FALLBACK_FETCH_LIMIT = 1000;
 // The "real work" bead types the board fans out (one typed query each),
 // then keeps via defaultBeadFilter — the bookkeeping types
 // (message/session/molecule/…) are dropped. Every entry MUST be a type the

--- a/frontend/src/supervisor/entityLinks.test.ts
+++ b/frontend/src/supervisor/entityLinks.test.ts
@@ -105,7 +105,7 @@ describe('loadSupervisorEntityLinks', () => {
         resolved: true,
       },
     ]);
-    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 5_000 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1_000 });
     expect(listSessions).toHaveBeenCalledWith('test-city');
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/frontend/src/supervisor/entityLinks.ts
+++ b/frontend/src/supervisor/entityLinks.ts
@@ -1,11 +1,16 @@
 import type { EntityLinkView, DashboardBead, DashboardSession } from 'gas-city-dashboard-shared';
 import { buildLinkView, buildRelationIndex, parseRef } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
-import type { Bead, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
 import { supervisorApi } from './client';
+import { listIsIncomplete } from './listPartial';
 import { normalizeSessions, type SupervisorSessionList } from './sessionReads';
 
-const LINKS_FETCH_LIMIT = 5_000;
+// Pre-exposure load bound (gascity-dashboard-q89b): this fetch runs once per
+// focus ref per client, so the limit multiplies across viewers. Truncation is
+// safe: the partial flag below trips when upstream total exceeds what was
+// fetched, and RelatedEntities renders the partial notice.
+const LINKS_FETCH_LIMIT = 1_000;
 
 export async function loadSupervisorEntityLinks(ref: string): Promise<EntityLinkView> {
   const parsed = parseRef(ref);
@@ -15,10 +20,7 @@ export async function loadSupervisorEntityLinks(ref: string): Promise<EntityLink
   const supervisorFetchedAt = new Date().toISOString();
   const beadList = await supervisorApi().listBeads(cityName, { limit: LINKS_FETCH_LIMIT });
   const beads = normalizeBeads(beadList.items ?? []);
-  let partial = listIsPartial(beadList);
-  if (typeof beadList.total === 'number' && beadList.total > beads.length) {
-    partial = true;
-  }
+  let partial = listIsIncomplete(beadList, beads.length);
 
   let sessions: DashboardSession[] = [];
   try {
@@ -62,10 +64,6 @@ function normalizeBead(bead: Bead): DashboardBead {
   if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
   if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
   return normalized;
-}
-
-function listIsPartial(list: ListBodyBead): boolean {
-  return list.partial === true || (list.partial_errors?.length ?? 0) > 0;
 }
 
 function sessionListIsPartial(list: SupervisorSessionList): boolean {

--- a/frontend/src/supervisor/listPartial.ts
+++ b/frontend/src/supervisor/listPartial.ts
@@ -1,0 +1,23 @@
+import type { ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
+
+// Shared partial/truncation predicates for supervisor bead list reads
+// (gascity-dashboard-q89b). Bounded fetches must degrade visibly: a page is
+// incomplete when the supervisor flags it partial OR when the upstream total
+// exceeds what one bounded page returned.
+
+export function listIsPartial(list: ListBodyBead): boolean {
+  // `partial`/`partial_errors` signal a backend-side failure, but the supervisor
+  // also truncates at the fetch limit and reports more via `next_cursor` without
+  // setting `partial` (gascity-dashboard-4xcv). Treat a present cursor as partial
+  // so saturation surfaces through the same partial-notice + retry paths instead
+  // of silently dropping lanes.
+  return (
+    list.partial === true ||
+    (list.partial_errors?.length ?? 0) > 0 ||
+    (list.next_cursor?.length ?? 0) > 0
+  );
+}
+
+export function listIsIncomplete(list: ListBodyBead, fetchedCount: number): boolean {
+  return listIsPartial(list) || (typeof list.total === 'number' && list.total > fetchedCount);
+}

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -85,7 +85,7 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     expect(source.data.lanes[0]?.id).toBe('run-1');
     expect(source.data.lanes[0]?.health.status).toBe('unavailable');
     expect(listBeads).toHaveBeenCalledTimes(3);
-    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1_000 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
       limit: 500,
       type: 'molecule',
@@ -172,7 +172,7 @@ describe('loadSupervisorRunSummarySource', () => {
       statusCounts: { open: 1, in_progress: 1 },
     });
     expect(source.data.census.status).toBe('available');
-    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1_000 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
     expect(listBeads).toHaveBeenCalledWith('test-city', {
       limit: 500,
       type: 'molecule',
@@ -275,6 +275,29 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
+  it('marks the summary partial when the active bead list is truncated at the fetch limit', async () => {
+    // gascity-dashboard-q89b: the primary fetch is bounded; when the upstream
+    // total exceeds what one page returned, active runs may be missing and the
+    // lanes must read as partial rather than complete.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      return { ...beadList([runRoot()]), total: 501 };
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
     expect(source.data.lanesPartial).toBe(true);
   });
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -19,11 +19,15 @@ import {
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
-import type { Bead, FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { Bead, FormulaFeedBody } from 'gas-city-dashboard-shared/gc-supervisor';
 import { supervisorApiForRequestBudget } from './client';
+import { listIsIncomplete, listIsPartial } from './listPartial';
 import { normalizeSessions } from './sessionReads';
 
-const RUNS_FETCH_LIMIT = 1_000;
+// Pre-exposure load bound (gascity-dashboard-q89b): the primary in-flight
+// bead fetch refreshes on SSE bursts (10s debounce floor in Runs.tsx) per
+// client. listIsIncomplete keeps truncation visible in the lanes-partial signal.
+const RUNS_FETCH_LIMIT = 500;
 // gascity-dashboard-4xcv: the supervisor's bead list has no sort/recency
 // guarantee, so a small `all=true` window can drop run roots and step beads
 // arbitrarily — observed live as an empty first paint and a history list
@@ -152,7 +156,9 @@ async function loadRunBeads(cityName: string, limit: number): Promise<LoadedRunB
 
   const settled = await Promise.all([moleculeFetch, ...rigFetches]);
   const recentItems: DashboardBead[] = [];
-  let partial = feedDiscovery.partial || listIsPartial(activeList);
+  // Truncation at the bounded fetch reads as partial lanes, not complete
+  // (gascity-dashboard-q89b).
+  let partial = feedDiscovery.partial || listIsIncomplete(activeList, active.length);
 
   for (const outcome of settled) {
     if (outcome.ok) {
@@ -347,18 +353,6 @@ function normalizeBead(bead: Bead): DashboardBead {
   if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
   if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
   return normalized;
-}
-
-function listIsPartial(list: ListBodyBead): boolean {
-  // `partial`/`partial_errors` signal a backend-side failure, but the supervisor
-  // also truncates at the fetch limit and reports more via `next_cursor` without
-  // setting `partial`. Treat a present cursor as partial so saturation surfaces
-  // through the same partial-notice + retry paths instead of silently dropping lanes.
-  return (
-    list.partial === true ||
-    (list.partial_errors?.length ?? 0) > 0 ||
-    (list.next_cursor?.length ?? 0) > 0
-  );
 }
 
 function feedIsPartial(feed: FormulaFeedBody): boolean {

--- a/scripts/dashboard-tester.mjs
+++ b/scripts/dashboard-tester.mjs
@@ -46,7 +46,14 @@ const VIEWPORT = { width: 1440, height: 900 };
 const SSE_TIMEOUT_MS = 12_000;
 const SETTLE_MS = 2_500;
 
-const isDataCall = (url) => url.includes('/api/') || url.includes('/gc-supervisor/');
+// Match on the URL path PREFIX, not a substring: against a Vite dev server
+// the app's own source modules live at /src/api/*, and a substring match
+// 503s the bundle itself during fail-safe injection, blanking every route
+// (gascity-dashboard-q89b). Production assets never collide either way.
+const isDataCall = (url) => {
+  const pathname = new URL(url).pathname;
+  return pathname.startsWith('/api/') || pathname.startsWith('/gc-supervisor/');
+};
 const short = (s, n = 110) => (s ?? '').toString().replace(/\s+/g, ' ').trim().slice(0, n);
 
 // An explicit "data is not live" signal in the route's own content: the

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -387,7 +387,10 @@ async function installApiFixtureRoutes(context) {
     const limit = url.searchParams.get('limit');
     const type = url.searchParams.get('type');
     const items =
-      limit === '5000' && type === null
+      // The entity-links loader is the one type-less list read at the
+      // LINKS_FETCH_LIMIT bound (1000 since gascity-dashboard-q89b); the run
+      // summary's primary read arrives at its own lower bound.
+      limit === '1000' && type === null
         ? highVolumeLinkBeads()
         : type === null
           ? [runRootBeadFixture()]


### PR DESCRIPTION
## Scope
Pre-exposure perf + UX polish (gascity-dashboard-q89b), rebased onto current `main`.

- **Bounded run-bead fetches with visible truncation.** Extracts `listIsPartial`/`listIsIncomplete` into `frontend/src/supervisor/listPartial.ts`; the active in-flight fetch is bounded (`RUNS_FETCH_LIMIT=500`) and any truncation surfaces through the lanes-partial signal (`total > fetchedCount`) rather than silently dropping lanes.
- **First-run note** (`components/ambient/FirstRunNote`) rendered on Home under the page header in both census-available and census-unavailable states.
- Minor polish across `AgentPanel`, `Activity`, `Mail`, `entityLinks`, `beadReads`, and the `dashboard-tester` / `snap-formula-run-detail` scripts.

## Rebase conflict resolution (vs the 4xcv fix on main)
The 4xcv fix (raised fetch limits + `next_cursor`-as-partial) landed on `main` after this branch was authored. Resolved to **preserve both correctness mechanisms**:
- `RECENT_RUN_FETCH_LIMIT` kept at **500** (4xcv's history floor — 80 would drop most history on a busy store).
- `RUNS_FETCH_LIMIT` set to **500** for the active list (q89b's load bound; safe because `listIsIncomplete` keeps truncation visible).
- `next_cursor`-as-partial (4xcv) folded into the extracted `listPartial.ts` so that safety net survives alongside q89b's `total`-based `listIsIncomplete`.
- **Both** truncation regression tests retained (cursor-truncated + fetch-limit-truncated).

## CI parity (all green locally)
typecheck (src+test), lint, **format:check**, openapi drift, shared (66) + backend (572) + frontend (771) tests, frontend build.

mayor merge-gates — **do not merge** from here.