### PR TITLE
test(run-detail): resolve Formula Detail for version-less supervisor payloads (3eo8)

### DIFF
--- a/frontend/src/supervisor/runDetail.test.ts
+++ b/frontend/src/supervisor/runDetail.test.ts
@@ -91,6 +91,19 @@ describe('loadSupervisorFormulaRunDetail', () => {
     });
   });
 
+  it('resolves formula detail when the supervisor omits the version field (3eo8, mol-focus-review)', async () => {
+    formulaDetail.mockResolvedValue(versionlessFormulaDetailResponse());
+
+    const detail = await loadSupervisorFormulaRunDetail('wf-1', 'city', 'test-city');
+
+    expect(detail.formulaDetail).toEqual({
+      kind: 'available',
+      name: 'mol-test',
+      target: 'test-city/codex',
+    });
+    expect(detail.completeness).toEqual({ kind: 'complete' });
+  });
+
   it('reports missing formula metadata without calling the formula endpoint', async () => {
     workflowRun.mockResolvedValue(
       workflowSnapshot({
@@ -249,4 +262,13 @@ function formulaDetailResponse() {
     deps: [],
     var_defs: [],
   };
+}
+
+// Inferred/title-based formulas (e.g. mol-focus-review) come back from the
+// supervisor with no `version` key — `{ name, description, var_defs, steps,
+// deps, preview }`. The dashboard must resolve these to `available`, not
+// degrade the Formula Detail panel (3eo8).
+function versionlessFormulaDetailResponse() {
+  const { version: _version, ...rest } = formulaDetailResponse();
+  return rest;
 }


### PR DESCRIPTION
## Scope

`mol-focus-review` and other inferred/title-based formulas come back from the supervisor with no `version` key. PR #71 was blocked because it branched from a pre-#62 base and patched generated-client paths that #62 deleted. On current `main` the `invalid_payload` symptom is already fixed: #62 set the shared SDK `validator.response = false` (r43k), so the frontend `formulaDetail` path never runs `zFormulaDetailResponse`, `toFormulaDetail` never reads `version`, and the failure is no longer produced.

This locks that in with a **regression test only** asserting a version-less `FormulaDetailResponse` resolves to `available` / `complete`. The durable upstream fix (OpenAPI marking `FormulaDetailResponse.version` optional) stays on `gastownhall/gascity`.

Test-only change — no source change.

Bead: gascity-dashboard-3eo8 / publish drive gascity-dashboard-c9k8

## Rebase

Rebased onto current `main` — clean, no conflicts.

## CI parity (local, all green)

- `build:shared` ✓
- `typecheck` (src + test) ✓
- `lint` + `format:check` (changed file) ✓
- frontend tests 766 (incl. the new 3eo8 case) ✓ / backend tests 572 ✓
- frontend build ✓
- openapi gc-supervisor drift check ✓

mayor merge-gates — do NOT merge.