### PR TITLE
fix(agents): bucket builtin maintenance pools (dog) as Maintenance, not a rig (jj2z)

### DIFF
--- a/frontend/src/hooks/projectOf.test.ts
+++ b/frontend/src/hooks/projectOf.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { getActiveCity, setActiveCity } from '../api/cityBase';
 import {
+  MAINTENANCE_PROJECT,
   ORCHESTRATION_PROJECT,
   agentProject,
   beadProject,
@@ -169,6 +170,43 @@ describe('agentProject', () => {
       label: 'gascity',
     });
   });
+
+  // gascity-dashboard-jj2z: a gascity builtin MAINTENANCE pool (e.g. `dog`)
+  // runs cross-rig agents whose `rig` is empty. The pool name is NOT a rig, so
+  // it must bucket into the pinned Maintenance group, never fall through to
+  // pool-as-rig (which mislabelled `dog` as a rig in the Rig column/filter).
+  it('buckets a maintenance-builtin pool (dog) into Maintenance, NOT a rig named "dog"', () => {
+    const bucket = agentProject({ name: 'dog-1', pool: 'dog' } as never);
+    expect(bucket).toEqual({ key: MAINTENANCE_PROJECT, label: MAINTENANCE_PROJECT });
+    // The exact symptom from the bug report: no rig bucket named 'dog'.
+    expect(bucket.key).not.toBe('dog');
+    expect(bucket.label).not.toBe('dog');
+  });
+
+  it('buckets a maintenance pool into Maintenance even with empty-string rig (cross-rig dog agents)', () => {
+    expect(agentProject({ name: 'dog-2', rig: '', pool: 'dog' } as never)).toEqual({
+      key: MAINTENANCE_PROJECT,
+      label: MAINTENANCE_PROJECT,
+    });
+  });
+
+  it('does NOT bucket a rig-scoped agent into Maintenance even if its pool is a maintenance pool (rig wins)', () => {
+    // Mirrors the orchestration rig-guard: a real rig association always wins
+    // over the pool-derived bucket.
+    expect(agentProject({ name: 'x', rig: '/home/ds/gascity', pool: 'dog' } as never)).toEqual({
+      key: 'gascity',
+      label: 'gascity',
+    });
+  });
+
+  it('leaves a non-maintenance pool as a rig synonym (only the named builtin pools are special-cased)', () => {
+    // Guards against over-broad matching: `research` is a legitimate
+    // pool-as-rig and must be unaffected by the maintenance carve-out.
+    expect(agentProject({ name: 'a1', pool: 'research' } as never)).toEqual({
+      key: 'research',
+      label: 'research',
+    });
+  });
 });
 
 describe('isPerRigDispatcherAgent', () => {
@@ -235,6 +273,13 @@ describe('isAgentOutsideRig', () => {
 
   it('is false for a pool-scoped agent (a pool stands in as the rig label)', () => {
     expect(isAgentOutsideRig({ name: 'a1', pool: 'research' } as never)).toBe(false);
+  });
+
+  it('is true for a maintenance-builtin pool agent (dog) — a maintenance pool is not a rig', () => {
+    // gascity-dashboard-jj2z: the Maintenance bucket is outside-rig, so the Rig
+    // column shows the clean alias (no `dog ·` prefix) and the agent is excluded
+    // from the rig filter dropdown.
+    expect(isAgentOutsideRig({ name: 'dog-1', pool: 'dog' } as never)).toBe(true);
   });
 });
 

--- a/frontend/src/hooks/projectOf.ts
+++ b/frontend/src/hooks/projectOf.ts
@@ -53,6 +53,14 @@ export function orchestrationLabel(): string {
 // Residual bucket for a row with no rig association and no orchestration role.
 export const NO_RIG_PROJECT = '(no rig)';
 
+// Pinned bucket for gascity builtin MAINTENANCE pools (e.g. `dog`). These pools
+// run cross-rig housekeeping agents whose `rig` is empty, so without this
+// carve-out the pool name falls through to pool-as-rig and is mislabelled as a
+// rig in the Agents Rig column/filter. Distinct from Orchestration (mayor /
+// dispatchers, which direct work) and from (no rig) (agents with no rig AND no
+// pool).
+export const MAINTENANCE_PROJECT = 'Maintenance';
+
 // Templates whose sessions are cross-rig orchestration (no specific
 // rig). Per-rig dispatchers (alias '<rig>/control-dispatcher') are
 // NOT in this set — they belong to their rig and are styled inline.
@@ -178,6 +186,15 @@ const ORCHESTRATION_AGENT_NAMES: ReadonlySet<string> = new Set([
   'oversight-rig.chief-of-staff',
 ]);
 
+// gascity builtin maintenance pool templates (the `dog` housekeeping pool;
+// gascity internal/config defines these as cross-rig builtins). Their agents
+// carry an empty `rig`, so they must be lifted into the Maintenance bucket
+// rather than fall through to pool-as-rig. A small named constant set — not a
+// regex or substring match (ZFC / anti-slop): the maintenance pools are a
+// closed, enumerable set, and a loose match could wrongly capture a legitimate
+// pool-as-rig (e.g. `research`) whose name merely contains a maintenance token.
+const MAINTENANCE_POOLS: ReadonlySet<string> = new Set(['dog']);
+
 export function isOrchestrationAgent(a: AgentResponse): boolean {
   if (a.rig && a.rig.length > 0) return false;
   return ORCHESTRATION_AGENT_NAMES.has(a.name);
@@ -202,6 +219,13 @@ export function agentProject(agent: AgentResponse): ProjectBucket {
   // (the supervisor uses '' for cross-rig agents that aren't in the
   // orchestration set).
   const rig = agent.rig && agent.rig.length > 0 ? agent.rig : undefined;
+  // A maintenance-builtin pool (e.g. `dog`) is cross-rig and is NOT a rig. Lift
+  // it into the pinned Maintenance bucket before the pool-as-rig fallback, so
+  // the pool name is never mislabelled as a rig. A real rig association still
+  // wins (the rig-guard semantics), so this only fires for rig-less agents.
+  if (!rig && agent.pool && MAINTENANCE_POOLS.has(agent.pool)) {
+    return { key: MAINTENANCE_PROJECT, label: MAINTENANCE_PROJECT };
+  }
   const candidate = rig ?? agent.pool;
   if (!candidate) {
     return { key: NO_RIG_PROJECT, label: NO_RIG_PROJECT };
@@ -250,12 +274,13 @@ export function cleanWorkerName(name: string): string {
 }
 
 /**
- * True when an agent has no rig association — either the pinned cross-rig
- * Orchestration bucket (mayor, control-dispatcher, oversight chief-of-staff)
- * or the residual (no rig) bucket. The Agents Rig column renders a neutral
- * dot for these rather than a pseudo-rig label, since neither is a real rig.
+ * True when an agent has no rig association — the pinned cross-rig
+ * Orchestration bucket (mayor, control-dispatcher, oversight chief-of-staff),
+ * the pinned Maintenance bucket (builtin housekeeping pools like `dog`), or the
+ * residual (no rig) bucket. The Agents Rig column shows the bare alias for
+ * these rather than a pseudo-rig label, since none is a real rig.
  */
 export function isAgentOutsideRig(agent: AgentResponse): boolean {
   const { key } = agentProject(agent);
-  return key === ORCHESTRATION_PROJECT || key === NO_RIG_PROJECT;
+  return key === ORCHESTRATION_PROJECT || key === MAINTENANCE_PROJECT || key === NO_RIG_PROJECT;
 }

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -185,11 +185,14 @@ export function AgentsPage() {
 
   // Rig dropdown options: the normalized rig labels (basenames, not raw
   // paths) present in the current roster, sorted. Empty value = all rigs.
+  // Outside-rig agents (cross-rig Orchestration, builtin Maintenance pools like
+  // `dog`, and the residual no-rig bucket) are excluded — their bucket labels
+  // are not rigs and must not appear as rig filter options (gascity-dashboard-jj2z).
   const rigOptions = useMemo(
     () =>
-      Array.from(new Set(rows.map((a) => agentProject(a).label))).sort((x, y) =>
-        x.localeCompare(y),
-      ),
+      Array.from(
+        new Set(rows.filter((a) => !isAgentOutsideRig(a)).map((a) => agentProject(a).label)),
+      ).sort((x, y) => x.localeCompare(y)),
     [rows],
   );
   // If the selected rig leaves the roster, fall back to all rigs.


### PR DESCRIPTION
## Scope

The Agents view bucketed gascity builtin **maintenance pools** (e.g. the `dog` housekeeping pool) as if the pool name were a rig. Those pools run cross-rig agents whose supervisor `rig` is empty, so they fell through the pool-as-rig fallback in `agentProject` and surfaced as a bogus rig named `dog` in the Rig column and the rig filter dropdown.

- `frontend/src/hooks/projectOf.ts`: pin builtin maintenance pools into a new `MAINTENANCE_PROJECT` bucket **before** the pool-as-rig fallback. A real rig association still wins (rig-guard preserved). `isAgentOutsideRig` now includes the Maintenance bucket so the Rig column shows the bare alias and the agent is excluded from the rig filter.
- `frontend/src/routes/Agents.tsx`: exclude outside-rig agents (Orchestration, Maintenance, no-rig) from the rig filter options — their bucket labels are not rigs.
- `frontend/src/hooks/projectOf.test.ts`: coverage for `dog` → Maintenance (with empty-string rig), rig-wins-over-pool, the over-broad-match guard (`research` stays pool-as-rig), and `isAgentOutsideRig`.

## CI — full local parity, all green

- `typecheck` (src + test) ✓
- `lint` (eslint, max-warnings=0) ✓
- `format:check` (prettier) ✓
- `npm --workspace shared|backend|frontend test` ✓ (frontend 770/770)
- `npm --workspace frontend run build` ✓
- `openapi:gc-supervisor:check` — client up to date ✓

Rebased onto current `origin/main`; single commit.

## Design note for the merge gate

The bead flagged a preference to consume `resolveRigName` (`frontend/src/lib/rigNames.ts`) rather than the basename heuristic. Assessment: `resolveRigName(raw, rigs)` answers *"is this raw value a registered rig?"* by matching the authoritative rig list — it does **not** answer *"is this a maintenance pool?"*, which is the actual classification needed here (a non-rig pool is not necessarily a maintenance pool). Using it for this carve-out would also require threading the supervisor `rigItems` list through `agentProject` and every `projectOf` consumer (`useListFilters`, Agents/Mail/Beads), a blast radius beyond this fix. The chosen approach is an explicit, closed, ZFC-justified constant set (`MAINTENANCE_POOLS = {'dog'}`) — exact-match, not substring — matching how `dog` is defined as a gascity builtin. Flagging for the gate in case you want the broader `resolveRigName` refactor tracked as a separate bead.

**mayor merge-gates — do NOT merge.**
