### PR TITLE
fix(health): raise status-read timeout for background samplers (nyln)

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -17,6 +17,20 @@ import { ALL_MODULES } from '../views/registry.js';
 import { resolveEnabledFirstPartyIds } from '../views/enabled.js';
 import { bind, type CityContext } from '../views/types.js';
 
+// gascity-dashboard-nyln: the dolt-noms and rig-store-health samplers read the
+// supervisor /status, which turns slow on a bloated city store (~247K beads on
+// ds-research) and trips the 5s default GcClient timeout — surfacing as
+// rig_list_failed even though the rig PATHs are valid. Both are periodic
+// background samplers serving cached snapshots, so they tolerate a higher
+// ceiling than the interactive default. Env-overridable so ops can tune the
+// live deployment without a code redeploy.
+const STATUS_SAMPLER_TIMEOUT_MS = (() => {
+  const raw = process.env.GC_STATUS_SAMPLER_TIMEOUT_MS;
+  if (typeof raw !== 'string') return 30_000;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 30_000;
+})();
+
 /**
  * One city's worth of dashboard runtime (gascity-dashboard-ucc). Each
  * CityRuntime owns its OWN GcClient + CityContext + module
@@ -118,7 +132,7 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
   // gascity-dashboard-x82: dolt-noms trend sources the supervisor's
   // store_health.size_bytes (per-city GcClient.getStatus), not host-FS access.
   const doltNomsSampler: DoltNomsSampler = createDoltNomsSampler({
-    fetchStatus: () => gc.getStatus(),
+    fetchStatus: () => gc.getStatus(undefined, STATUS_SAMPLER_TIMEOUT_MS),
   });
   router.use('/dolt-noms', doltRouter(doltNomsSampler));
 
@@ -130,7 +144,7 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
   // `bd doctor` per rig.
   const rigStoreHealthSampler: RigStoreHealthSampler = createRigStoreHealthSampler({
     listRigs: async () => {
-      const status = await gc.getStatus();
+      const status = await gc.getStatus(undefined, STATUS_SAMPLER_TIMEOUT_MS);
       return (status.rig_details ?? []).map((rig) => ({ name: rig.name, path: rig.path }));
     },
   });

--- a/backend/src/gc-client.ts
+++ b/backend/src/gc-client.ts
@@ -79,7 +79,7 @@ export class GcClient {
     return err instanceof Error && err.name === 'TimeoutError';
   }
 
-  async getStatus(signal?: AbortSignal): Promise<StatusBody> {
+  async getStatus(signal?: AbortSignal, timeoutMs?: number): Promise<StatusBody> {
     return this.getOperation(
       this.operationKey('getV0CityByCityNameStatus'),
       'getStatus',
@@ -92,6 +92,7 @@ export class GcClient {
         }),
       signal,
       zGetV0CityByCityNameStatusResponse,
+      timeoutMs,
     );
   }
 
@@ -121,6 +122,7 @@ export class GcClient {
     fetcher: (signal: AbortSignal) => Promise<SupervisorFetchResult<RawValue>>,
     signal?: AbortSignal,
     responseSchema?: SupervisorResponseSchema,
+    timeoutMs?: number,
   ): Promise<RawValue> {
     if (signal?.aborted) {
       throw abortError();
@@ -129,7 +131,7 @@ export class GcClient {
     if (existing !== undefined) {
       return await this.withCallerAbort(existing as Promise<RawValue>, signal);
     }
-    const promise = this.fetchOnce(payloadName, fetcher, responseSchema);
+    const promise = this.fetchOnce(payloadName, fetcher, responseSchema, timeoutMs);
     this.inflight.set(key, promise);
     try {
       return await this.withCallerAbort(promise, signal);
@@ -144,10 +146,14 @@ export class GcClient {
     payloadName: string,
     fetcher: (signal: AbortSignal) => Promise<SupervisorFetchResult<RawValue>>,
     responseSchema?: SupervisorResponseSchema,
+    timeoutMs?: number,
   ): Promise<RawValue> {
     const startedAt = Date.now();
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(timeoutError()), this.defaultTimeoutMs);
+    const timeout = setTimeout(
+      () => controller.abort(timeoutError()),
+      timeoutMs ?? this.defaultTimeoutMs,
+    );
     recordCounter('supervisor.request', { operation: payloadName });
     try {
       const result = await fetcher(controller.signal).catch((err: unknown) => {

--- a/backend/test/gc-client.test.ts
+++ b/backend/test/gc-client.test.ts
@@ -238,6 +238,24 @@ describe('GcClient timeout and single-flight behavior', () => {
     assert.equal(GcClient.isTimeoutError(err), true);
   });
 
+  test('honors a per-call timeout override longer than the default', async () => {
+    // gascity-dashboard-nyln: the rig-store-health / dolt-noms samplers read a
+    // /status that turns slow on a bloated store. A latency-tolerant caller can
+    // raise its own ceiling above the default without abandoning the read.
+    fake.setHandler((_req, res) => {
+      setTimeout(() => json(res, validStatusBody('test')), 250);
+    });
+    const gc = new GcClient({
+      baseUrl: fake.baseUrl,
+      cityName: 'test',
+      defaultTimeoutMs: 100,
+    });
+
+    const out = await gc.getStatus(undefined, 1_000);
+
+    assert.equal(out.name, 'test');
+  });
+
   test('distinguishes caller aborts from upstream timeouts', async () => {
     fake.setHandler(() => {
       /* leave the request open */


### PR DESCRIPTION
## Root cause

`/api/city/ds-research/rig-store-health` returned `{available:false, reason:rig_list_failed}` on the bloated ds-research store (~247K beads). This was **not** a rig PATH problem (that was the earlier nfyw/HOME fix). The deploy log showed the real cause:

> `[rig-store-health] rig list failed: gc supervisor request timed out`

`listRigs` (in `backend/src/city/runtime.ts`, via the rig-store-health sampler) reads the supervisor `/status` through `gc.getStatus()`. On the bloated store that `/status` read (carrying `rig_details`) is genuinely slow, and the **5s default `GcClient` timeout** aborted it — surfacing as `rig_list_failed` even though the rig paths are valid. The dolt-noms sampler reads the same `/status` and is exposed to the same abort.

## Fix

Thread an optional per-call `timeoutMs` through `getStatus → getOperation → fetchOnce` (the interactive default is unchanged), and have the two **periodic background samplers** — dolt-noms and rig-store-health, which serve cached snapshots, so they tolerate a higher ceiling than an interactive request — pass a generous `GC_STATUS_SAMPLER_TIMEOUT_MS` (default **30s**, env-overridable for live tuning without a redeploy).

- `backend/src/gc-client.ts` — optional `timeoutMs` param plumbed through; default path untouched.
- `backend/src/city/runtime.ts` — `STATUS_SAMPLER_TIMEOUT_MS` (env `GC_STATUS_SAMPLER_TIMEOUT_MS`, 30s default, validated) passed by both samplers.
- `backend/test/gc-client.test.ts` — regression test: a per-call override longer than the default lets a slow `/status` read complete instead of aborting.

Scope: timeout ceiling for the background samplers only. The interactive `GcClient` default is unchanged, so no interactive-path latency regression.

Bead: gascity-dashboard-nyln (split from el4e; u6d0 rig-store-health)

## Rebase

Rebased onto current `main` (incl. #83) — clean, no conflicts.

## CI parity (local, all green)

- `build:shared` ✓
- `typecheck` (src + test) ✓
- `lint` + `format:check` (changed files) ✓
- shared 94 / backend 558 (incl. the new nyln timeout-override test) / frontend 771 tests ✓
- frontend build ✓
- openapi gc-supervisor drift check ✓

## Live verification note

The bead's live acceptance (`/api/city/ds-research/rig-store-health -> available:true with real rigs` on :8082) requires a redeploy of the running dashboard with this build; that is a deploy-side step the mayor gates. The code fix + regression test are complete here.

mayor merge-gates — do NOT merge.