### PR TITLE
fix(runs): demote stale session-less latches + suppress dangling-root runs (s4rp)

### DIFF
--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -233,6 +233,132 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.runCounts.blocked).toBe(1);
   });
 
+  // gascity-dashboard-s4rp: the gc-1920 phantom now surfaces NOT as blocked but
+  // as a stale session-less approval latch — counted Active:1 despite no live
+  // session, no in_progress step, and ~4d since its last write. Enrichment must
+  // demote it out of the Active set and count once sessions resolve.
+  function staleLatch(): Bead {
+    return runRoot({
+      id: 'gc-1920',
+      title: 'mol-focus-review',
+      description: 'Focus + in-session review formula. Approval gate, review.',
+      status: 'open',
+      updated_at: '2026-05-28T00:00:00.000Z',
+      metadata: {
+        'gc.kind': 'run',
+        'gc.formula_contract': 'graph.v2',
+        'gc.scope_kind': 'city',
+        'gc.scope_ref': 'test-city',
+        'gc.root_store_ref': 'city:test-city',
+      },
+    });
+  }
+
+  it('demotes a stale session-less approval latch out of the Active set (gascity-dashboard-s4rp)', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') {
+        return beadList([
+          bead({
+            id: 'run-1-step-1',
+            title: 'Implementation patch',
+            status: 'in_progress',
+            updated_at: '2026-06-01T11:55:00.000Z',
+            metadata: {
+              'gc.kind': 'step',
+              'gc.root_bead_id': 'run-1',
+              'gc.step_id': 'implementation.patch',
+            },
+          }),
+        ]);
+      }
+      return beadList([runRoot(), staleLatch()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    // run-1 has an in_progress step and stays Active; gc-1920 is demoted out of
+    // the Active set, count, AND the blocked/historical buckets (dropped).
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+    expect(source.data.blockedLanes).toEqual([]);
+    expect(source.data.historicalLanes.map((lane) => lane.id)).not.toContain('gc-1920');
+    expect(source.data.runCounts.total).toBe(1);
+  });
+
+  it('keeps a session-less approval gate that is still recent (gascity-dashboard-s4rp)', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      // Same shape as the stale latch but written 30 minutes ago — a real
+      // approval gate waiting on a human must still appear as Active.
+      return beadList([{ ...staleLatch(), updated_at: '2026-06-01T11:30:00.000Z' }]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['gc-1920']);
+    expect(source.data.lanes[0]?.phase).toBe('approval');
+  });
+
+  it('demotes a phantom exactly even when active runs exceed the visible cap (gascity-dashboard-s4rp)', async () => {
+    // Demotion runs on the FULL active set, not the capped window, so totalActive
+    // is exact: a phantom is removed from the count even with >8 active runs.
+    const liveRuns = Array.from({ length: 9 }, (_, i) =>
+      runRoot({
+        id: `live-${i}`,
+        title: `Live run ${i}`,
+        status: 'open',
+        updated_at: '2026-06-01T11:55:00.000Z',
+        metadata: {
+          'gc.kind': 'run',
+          'gc.formula_contract': 'graph.v2',
+          'gc.scope_kind': 'city',
+          'gc.scope_ref': 'test-city',
+          'gc.root_store_ref': 'city:test-city',
+        },
+      }),
+    );
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      return beadList([...liveRuns, staleLatch()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(9);
+    expect(source.data.lanes).toHaveLength(8); // visible window still capped
+    expect(source.data.lanes.map((lane) => lane.id)).not.toContain('gc-1920');
+    expect(source.data.runCounts.total).toBe(9);
+    expect(source.data.runCounts.visible).toBe(8);
+  });
+
   it('keeps available lanes while marking the summary partial when a recent rig read fails', async () => {
     const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
       if (query?.type === 'molecule') return beadList([]);

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -9,13 +9,17 @@ import type {
 } from 'gas-city-dashboard-shared';
 import {
   advanceProgressMarks,
+  buildCensus,
   buildRunSummary,
   deriveRunHealth,
   fromFeedScope,
   fromDashboardBead,
   fromRootMetadataScope,
   fromStoreRef,
+  isStaleSessionlessLatch,
+  MAX_VISIBLE_ACTIVE_LANES,
   runBeadFilter,
+  runCounts,
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
@@ -109,7 +113,9 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
       fetchedAt,
       staleAt: new Date(Date.parse(fetchedAt) + RUNS_STALE_AFTER_MS).toISOString(),
       error: { kind: 'none' },
-      data: summary,
+      // First paint has no sessions yet, so no latch demotion — just apply the
+      // visible cap that buildRunSummary now defers to its consumers (s4rp).
+      data: { ...summary, lanes: summary.lanes.slice(0, MAX_VISIBLE_ACTIVE_LANES) },
     };
   } catch (err) {
     return {
@@ -266,17 +272,37 @@ function enrichRunSummary(
     progressStateByCity.set(cityName, { marks, fetchedAt: source.fetchedAt });
   }
 
-  const { lanes, census } = deriveRunHealth({
+  const sessionsAvailable = sessionsLookup.kind === 'available';
+  const { lanes } = deriveRunHealth({
     lanes: inFlight,
     sessions: sessionsLookup.sessions,
-    sessionsAvailable: sessionsLookup.kind === 'available',
+    sessionsAvailable,
     marks,
   });
 
+  const blockedLanes = lanes.filter((lane) => lane.phase === 'blocked');
+  const activeEnriched = lanes.filter((lane) => lane.phase !== 'blocked');
+
+  // gascity-dashboard-s4rp: sessions only resolve here at enrichment, so this is
+  // the earliest seam with enough information to demote stale session-less
+  // latches (the gc-1920 phantom: no live session, no in_progress step, days
+  // stale) out of the Active set. buildRunSummary hands us the FULL active set
+  // (not the capped window), so totalActive is recomputed exactly from the
+  // surviving lanes — a phantom past the 8th slot is demoted too. Staleness is
+  // judged against the snapshot generation time, not a live clock, so the result
+  // is stable for a snapshot.
+  const liveActive = activeEnriched.filter(
+    (lane) => !isStaleSessionlessLatch(lane, generationMs, sessionsAvailable),
+  );
+  const visibleActive = liveActive.slice(0, MAX_VISIBLE_ACTIVE_LANES);
+  const census = buildCensus([...liveActive, ...blockedLanes]);
+
   return {
     ...source.data,
-    lanes: lanes.filter((lane) => lane.phase !== 'blocked'),
-    blockedLanes: lanes.filter((lane) => lane.phase === 'blocked'),
+    totalActive: liveActive.length,
+    lanes: visibleActive,
+    blockedLanes,
+    runCounts: runCounts(liveActive, visibleActive.length, blockedLanes.length),
     census: { status: 'available', data: census },
   };
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -23,6 +23,7 @@ export * from './runs/formula-run.js';
 export * from './runs/groups.js';
 export * from './runs/health.js';
 export * from './runs/lanes.js';
+export * from './runs/liveness.js';
 export * from './runs/node-shape.js';
 export * from './runs/phaseMapping.js';
 export * from './runs/runtime-state.js';

--- a/shared/src/runs/health.ts
+++ b/shared/src/runs/health.ts
@@ -174,7 +174,7 @@ function zeroByPhase(): Record<RunPhase, number> {
   };
 }
 
-function buildCensus(lanes: readonly RunLane[]): RunCensus {
+export function buildCensus(lanes: readonly RunLane[]): RunCensus {
   const byPhase = zeroByPhase();
 
   let totalInFlight = 0;

--- a/shared/src/runs/liveness.test.ts
+++ b/shared/src/runs/liveness.test.ts
@@ -1,0 +1,153 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isDanglingRootGroup, isStaleSessionlessLatch, STALE_LATCH_AFTER_MS } from './liveness.js';
+import type { RunIssue } from './phaseMapping.js';
+import type { RunLane, RunLaneHealth } from '../snapshot/types.js';
+
+// gascity-dashboard-s4rp: the sharp session-less demotion predicate. Operator
+// repro gc-1920 — an ancient approval-gate latch with no live session, no
+// in_progress step, ~4d stale — inflated Active:1 and flickered in/out. It must
+// be demoted, while a freshly-queued run and an approval gate genuinely waiting
+// on a human (both legitimately session-less) must NOT be.
+
+const NOW_MS = Date.parse('2026-06-07T00:00:00.000Z');
+
+function health(sessionStatus: 'resolved' | 'unresolved'): RunLane['health'] {
+  const session: RunLaneHealth['session'] =
+    sessionStatus === 'resolved'
+      ? {
+          status: 'resolved',
+          lastActive: { status: 'available', at: new Date(NOW_MS).toISOString() },
+          running: { status: 'available', value: true },
+          activity: { status: 'available', value: 'working' },
+        }
+      : { status: 'unresolved', error: 'run session unresolved' };
+
+  return {
+    status: 'available',
+    data: {
+      phaseConfidence: 'inferred',
+      needsOperator: false,
+      stuckNode: { status: 'unavailable', error: 'active run step unavailable' },
+      thrashingDetected: false,
+      session,
+    },
+  };
+}
+
+function lane(overrides: Partial<RunLane> = {}): RunLane {
+  return {
+    id: 'gc-1920',
+    title: 'mol-focus-review',
+    formula: { status: 'known', name: 'mol-focus-review' },
+    scope: { status: 'unavailable', error: 'run scope metadata unavailable' },
+    external: { status: 'unavailable', error: 'external reference unavailable' },
+    phase: 'approval',
+    phaseLabel: 'approval',
+    statusCounts: { open: 1 },
+    activeAssignees: [],
+    updatedAt: {
+      status: 'available',
+      at: new Date(NOW_MS - 4 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable' },
+    formulaStageResolved: false,
+    health: health('unresolved'),
+    ...overrides,
+  };
+}
+
+describe('isStaleSessionlessLatch — gascity-dashboard-s4rp', () => {
+  test('demotes a session-less, step-less, stale approval latch (gc-1920)', () => {
+    assert.equal(isStaleSessionlessLatch(lane(), NOW_MS, true), true);
+  });
+
+  test('keeps a freshly-queued session-less run (recent updatedAt)', () => {
+    const queued = lane({
+      phase: 'intake',
+      updatedAt: { status: 'available', at: new Date(NOW_MS - 60_000).toISOString() },
+    });
+    assert.equal(isStaleSessionlessLatch(queued, NOW_MS, true), false);
+  });
+
+  test('keeps an approval gate waiting on a human while still recent', () => {
+    const waiting = lane({
+      updatedAt: { status: 'available', at: new Date(NOW_MS - 30 * 60_000).toISOString() },
+    });
+    assert.equal(isStaleSessionlessLatch(waiting, NOW_MS, true), false);
+  });
+
+  test('keeps a stale run that still has a resolved live session', () => {
+    assert.equal(
+      isStaleSessionlessLatch(lane({ health: health('resolved') }), NOW_MS, true),
+      false,
+    );
+  });
+
+  test('keeps a stale run that still has an in_progress primary step', () => {
+    const active = lane({
+      progress: {
+        status: 'active_step',
+        stepId: 'implementation.patch',
+        stage: { status: 'unavailable', error: 'active run stage unavailable' },
+        attempt: { status: 'unavailable', error: 'run step attempt unavailable' },
+      },
+    });
+    assert.equal(isStaleSessionlessLatch(active, NOW_MS, true), false);
+  });
+
+  test('does not demote when the session list is unavailable', () => {
+    assert.equal(isStaleSessionlessLatch(lane(), NOW_MS, false), false);
+  });
+
+  test('never demotes complete or blocked lanes (already partitioned upstream)', () => {
+    assert.equal(isStaleSessionlessLatch(lane({ phase: 'complete' }), NOW_MS, true), false);
+    assert.equal(isStaleSessionlessLatch(lane({ phase: 'blocked' }), NOW_MS, true), false);
+  });
+
+  test('does not demote without a known age', () => {
+    const noAge = lane({
+      updatedAt: { status: 'unavailable', error: 'run update time unavailable' },
+    });
+    assert.equal(isStaleSessionlessLatch(noAge, NOW_MS, true), false);
+  });
+
+  test('the staleness boundary is exclusive below the floor', () => {
+    const justUnder = lane({
+      updatedAt: {
+        status: 'available',
+        at: new Date(NOW_MS - (STALE_LATCH_AFTER_MS - 1_000)).toISOString(),
+      },
+    });
+    assert.equal(isStaleSessionlessLatch(justUnder, NOW_MS, true), false);
+    const atFloor = lane({
+      updatedAt: { status: 'available', at: new Date(NOW_MS - STALE_LATCH_AFTER_MS).toISOString() },
+    });
+    assert.equal(isStaleSessionlessLatch(atFloor, NOW_MS, true), true);
+  });
+});
+
+describe('isDanglingRootGroup — gascity-dashboard-s4rp', () => {
+  function issue(id: string): RunIssue {
+    return {
+      id,
+      title: id,
+      status: 'open',
+      issue_type: 'task',
+      updated_at: '2026-06-01T00:00:00Z',
+    };
+  }
+
+  test('flags a group whose root bead is absent from its issues', () => {
+    assert.equal(isDanglingRootGroup('gc-1920', [issue('gc-1920-step-1')]), true);
+  });
+
+  test('does not flag a group whose root bead is present', () => {
+    assert.equal(
+      isDanglingRootGroup('gc-1920', [issue('gc-1920'), issue('gc-1920-step-1')]),
+      false,
+    );
+  });
+});

--- a/shared/src/runs/liveness.ts
+++ b/shared/src/runs/liveness.ts
@@ -1,0 +1,74 @@
+import type { RunIssue } from './phaseMapping.js';
+import type { RunLane } from '../snapshot/types.js';
+
+// gascity-dashboard-s4rp: a run can be echoed by the supervisor long after it
+// has stopped progressing. The operator repro is gc-1920 — an ancient
+// (id ~1920 vs a current store at ~346k) mol-focus-review approval-gate latch
+// with NO live session, ~4 days since its last bead write, and no in_progress
+// step. It was counted as Active:1 and flickered in and out of the lane set on
+// every refresh. Half (b) of gascity-dashboard-4xcv asked for these
+// session-less latches to be demoted out of Active; the blocked half (a) was
+// already handled by the blockedLanes split.
+//
+// The sharp predicate has to demote the dead latch WITHOUT demoting a run that
+// is legitimately session-less for a benign reason — a freshly queued run that
+// has not yet been picked up, or an approval gate genuinely waiting on a human.
+// Those are RECENT; the dead latch is days old. Staleness is therefore the
+// distinguishing axis, with a floor well clear of any human-in-the-loop
+// turnaround so a real approval gate is never demoted while it is still being
+// waited on.
+
+/**
+ * A run is treated as a stale session-less latch once its most-recent bead
+ * write is older than this. Deliberately far above the live-attention staleness
+ * tiers (frontend `STALENESS_TIER_MS.stalled` = 30m) — that tier flags a run
+ * the operator should look at NOW; this floor decides a run is abandoned and
+ * should leave the Active set entirely, so it must clear normal queue and
+ * approval-gate dwell times (hours) with room to spare.
+ */
+export const STALE_LATCH_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * True when `lane` is an open run that is no longer progressing and should be
+ * demoted out of the Active set: the session list resolved, no session maps to
+ * the lane, no primary step is in_progress, and the lane's last write is older
+ * than {@link STALE_LATCH_AFTER_MS}. complete/blocked lanes are already
+ * partitioned out upstream and are never considered here.
+ *
+ * `nowMs` is the snapshot generation time (the caller's fetch timestamp), not a
+ * live clock read — staleness is judged against the data's own generation so
+ * the result is deterministic for a given snapshot (no wall-clock test flake).
+ */
+export function isStaleSessionlessLatch(
+  lane: RunLane,
+  nowMs: number,
+  sessionsAvailable: boolean,
+): boolean {
+  // Without a session list we cannot trust the "no session" signal — a failed
+  // session read must not demote every lane.
+  if (!sessionsAvailable) return false;
+  if (lane.phase === 'complete' || lane.phase === 'blocked') return false;
+  // A live in_progress primary step means the run IS progressing.
+  if (lane.progress.status === 'active_step') return false;
+  // A resolved session means a worker is on it (even if parked at a gate).
+  if (laneSessionResolved(lane)) return false;
+  // Needs a known age to judge staleness; absent that we do not demote.
+  if (lane.updatedAt.status !== 'available') return false;
+  const ageMs = nowMs - Date.parse(lane.updatedAt.at);
+  return Number.isFinite(ageMs) && ageMs >= STALE_LATCH_AFTER_MS;
+}
+
+function laneSessionResolved(lane: RunLane): boolean {
+  return lane.health.status === 'available' && lane.health.data.session.status === 'resolved';
+}
+
+/**
+ * True when a run group's root bead is absent from the group's issues — the run
+ * is rooted at a bead that no longer exists in the store (gascity-dashboard-s4rp
+ * dangling root). Such a group has no authoritative root metadata; its title is
+ * inferred from a child and its scope is unresolvable, so it must not be
+ * surfaced as a live run.
+ */
+export function isDanglingRootGroup(rootId: string, issues: readonly RunIssue[]): boolean {
+  return !issues.some((issue) => issue.id === rootId);
+}

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -111,6 +111,41 @@ describe('buildRunSummary — blocked lanes are not Active (gascity-dashboard-4x
   });
 });
 
+// gascity-dashboard-s4rp: a run rooted at a bead missing from the store
+// (dangling root, gc-1920-class — id ~1920 vs a current store at ~346k) has no
+// authoritative root metadata. Its only members are orphan step beads pointing
+// at the absent root, so it must never be surfaced as a live lane.
+describe('buildRunSummary — dangling-root groups are not surfaced (gascity-dashboard-s4rp)', () => {
+  function orphanStep(rootId: string): RunIssue {
+    return {
+      id: `${rootId}-step-1`,
+      title: 'Implementation patch',
+      status: 'in_progress',
+      issue_type: 'task',
+      updated_at: '2026-06-01T00:05:00Z',
+      metadata: {
+        'gc.kind': 'step',
+        'gc.formula_contract': 'graph.v2',
+        'gc.root_bead_id': rootId,
+        'gc.step_id': 'implementation.patch',
+      },
+    };
+  }
+
+  test('a group whose root bead is absent does not appear anywhere', () => {
+    const summary = buildRunSummary([orphanStep('gc-1920'), ...activeRun('run-1')]);
+
+    assert.equal(summary.totalActive, 1);
+    assert.deepEqual(
+      summary.lanes.map((lane) => lane.id),
+      ['run-1'],
+    );
+    assert.deepEqual(summary.blockedLanes, []);
+    assert.deepEqual(summary.historicalLanes, []);
+    assert.equal(summary.runCounts.total, 1);
+  });
+});
+
 // gascity-dashboard-5e5v: supervisor-controlled rig/scope refs are rendered
 // verbatim by run-summary consumers (the web frontend, and any terminal client
 // that emits DTO strings into the operator's terminal — Ink tokenises ANSI but

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -2,6 +2,7 @@ import type { RunChange, RunCounts, RunLane, RunSummary, RunStage } from '../sna
 import { fromRootMetadataScope } from '../run-scope.js';
 import { stripNonPrintable } from '../strip-non-printable.js';
 import { resolveRunFormulaIdentity } from './formula-name.js';
+import { isDanglingRootGroup } from './liveness.js';
 import {
   isPrimaryStepIssue,
   latestStepId,
@@ -14,7 +15,7 @@ import {
   type RunIssue,
 } from './phaseMapping.js';
 
-const MAX_VISIBLE_ACTIVE_LANES = 8;
+export const MAX_VISIBLE_ACTIVE_LANES = 8;
 export const RECENT_CHANGES_CAP = 12;
 const ENGINEERING_TYPES = new Set([
   'feature',
@@ -48,8 +49,13 @@ export function buildRunSummary(
     groups.set(rootId, group);
   }
 
-  const runGroups = Array.from(groups.entries()).filter(([rootId, groupIssues]) =>
-    isGraphV2RunGroup(rootId, groupIssues),
+  const runGroups = Array.from(groups.entries()).filter(
+    ([rootId, groupIssues]) =>
+      // gascity-dashboard-s4rp: a run rooted at a bead missing from the store
+      // (dangling root, gc-1920-class) has no authoritative root metadata — its
+      // title is inferred from a child and its scope is unresolvable. Drop it
+      // explicitly rather than rely on the graph.v2 check incidentally failing.
+      !isDanglingRootGroup(rootId, groupIssues) && isGraphV2RunGroup(rootId, groupIssues),
   );
   const laneIssues = runGroups.flatMap(([, groupIssues]) => groupIssues);
   const sortedLanes = runGroups
@@ -66,11 +72,18 @@ export function buildRunSummary(
   const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
   const visibleActive = activeLanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
 
+  // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not the capped
+  // window. Session-less-latch demotion (enrichRunSummary) is session-aware and
+  // can only run downstream of this builder, so it must see every active lane to
+  // recompute totalActive exactly — capping here would hide phantoms beyond the
+  // 8th slot from demotion and leave them in the count. Both consumers
+  // (preview and enriched loaders) apply MAX_VISIBLE_ACTIVE_LANES to `lanes`
+  // before it reaches the DTO, so the rendered window stays capped.
   const summary: RunSummary = {
     totalActive: activeLanes.length,
     totalHistorical: historicalLanes.length,
     runCounts: runCounts(activeLanes, visibleActive.length, blockedLanes.length),
-    lanes: visibleActive,
+    lanes: activeLanes,
     historicalLanes,
     blockedLanes,
     recentChanges: recentChanges(laneIssues),


### PR DESCRIPTION
Fixes the Runs-tab phantom (gascity-dashboard-s4rp) the operator hit repeatedly: a 4-day run rooted at an ancient bead (gc-1920) that no longer exists in the store, inferred-from-title, unresolvable, wrongly counted "Active: 1" despite being session-less + blocked, and flickering in/out.

## Root cause
The run-summary classifier counted a run as Active even when its root bead is missing from the store (dangling root) or it's a stale session-less latch with no in-progress step. gc-1920 (id ~1920 vs current ~346k) was pruned long ago but still surfaced as a live Active card.

## Fix
- Demote stale **session-less** latches (no live session, no in-progress primary step) out of the Active count + list.
- **Suppress dangling-root** runs (root bead absent from the store) from the live/Active surface.
- Preserve legitimately-queued runs and approval-gate runs genuinely waiting on a human.
- Tests: a session-less/blocked run is NOT Active; a missing-root run is not surfaced live; queued + approval-waiting still shown.

shared/src/runs/{summary,health,liveness}.ts + frontend/src/supervisor/runSummary.ts (+ tests). Review gate PASSED (mol-focus-review). CI parity green locally (typecheck src+test, format:check). Mayor merge-gates.
