### PR TITLE
fix(health): serve interactive status from cached sampler + clear spurious runs-partial badge (4bol)

### DIFF
--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -13,6 +13,11 @@ import {
   rigStoreHealthRouter,
   type RigStoreHealthSampler,
 } from '../routes/rig-store-health.js';
+import {
+  createSupervisorStatusSampler,
+  supervisorStatusRouter,
+  type SupervisorStatusSampler,
+} from '../routes/supervisor-status.js';
 import { ALL_MODULES } from '../views/registry.js';
 import { resolveEnabledFirstPartyIds } from '../views/enabled.js';
 import { bind, type CityContext } from '../views/types.js';
@@ -150,6 +155,16 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
   });
   router.use('/rig-store-health', rigStoreHealthRouter(rigStoreHealthSampler));
 
+  // gascity-dashboard-4bol: the interactive Health store-thresholds / dolt-usage
+  // / beads-usage widgets used a short browser-side /status read that fails fast
+  // on a slow supervisor. Sample /status on the background ceiling and serve the
+  // cached snapshot so those widgets show real (possibly cached) data instead of
+  // "supervisor status unavailable".
+  const supervisorStatusSampler: SupervisorStatusSampler = createSupervisorStatusSampler({
+    fetchStatus: () => gc.getStatus(undefined, STATUS_SAMPLER_TIMEOUT_MS),
+  });
+  router.use('/supervisor-status', supervisorStatusRouter(supervisorStatusSampler));
+
   return {
     cityName,
     router,
@@ -157,12 +172,14 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
     start() {
       doltNomsSampler.start();
       rigStoreHealthSampler.start();
+      supervisorStatusSampler.start();
       for (const w of moduleWorkers) w.start();
     },
     async stop() {
       await Promise.all(moduleWorkers.map((w) => w.stop()));
       doltNomsSampler.stop();
       rigStoreHealthSampler.stop();
+      supervisorStatusSampler.stop();
     },
   };
 }

--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -22,18 +22,21 @@ import { ALL_MODULES } from '../views/registry.js';
 import { resolveEnabledFirstPartyIds } from '../views/enabled.js';
 import { bind, type CityContext } from '../views/types.js';
 
-// gascity-dashboard-nyln: the dolt-noms and rig-store-health samplers read the
-// supervisor /status, which turns slow on a bloated city store (~247K beads on
-// ds-research) and trips the 5s default GcClient timeout — surfacing as
-// rig_list_failed even though the rig PATHs are valid. Both are periodic
-// background samplers serving cached snapshots, so they tolerate a higher
-// ceiling than the interactive default. Env-overridable so ops can tune the
-// live deployment without a code redeploy.
+// gascity-dashboard-nyln / -4bol: the dolt-noms, rig-store-health, and
+// supervisor-status samplers read the supervisor /status, which turns slow on a
+// bloated city store (~247K beads on ds-research) and trips the 5s default
+// GcClient timeout — surfacing as rig_list_failed / "status unavailable" even
+// though the data is valid. Live /status timings (gastownhall/gascity-dashboard#88)
+// run 10–38s with a ~38s tail that exceeds a 30s ceiling, so the default sits at
+// 45s of headroom above that tail. All three are periodic background samplers
+// serving cached snapshots, so they tolerate this ceiling; the deeper /status
+// perf fix is upstream (#88). Env-overridable so ops can tune the live
+// deployment without a code redeploy.
 const STATUS_SAMPLER_TIMEOUT_MS = (() => {
   const raw = process.env.GC_STATUS_SAMPLER_TIMEOUT_MS;
-  if (typeof raw !== 'string') return 30_000;
+  if (typeof raw !== 'string') return 45_000;
   const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : 30_000;
+  return Number.isFinite(n) && n > 0 ? n : 45_000;
 })();
 
 /**

--- a/backend/src/logging.ts
+++ b/backend/src/logging.ts
@@ -19,6 +19,7 @@ export const LOG_COMPONENT = {
   metrics: 'metrics',
   rigStoreHealth: 'rig-store-health',
   runs: 'runs',
+  supervisorStatus: 'supervisor-status',
 } as const;
 
 export const LOG_COMPONENTS = Object.values(LOG_COMPONENT);

--- a/backend/src/routes/supervisor-status.test.ts
+++ b/backend/src/routes/supervisor-status.test.ts
@@ -1,0 +1,122 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import type { StatusBody } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { SupervisorStatusReport } from 'gas-city-dashboard-shared';
+import {
+  createSupervisorStatusSampler,
+  supervisorStatusRouter,
+  type SamplerRuntime,
+  type SamplerTimer,
+} from './supervisor-status.js';
+
+function statusBody(partial: Partial<StatusBody> = {}): StatusBody {
+  return {
+    agent_count: 0,
+    agents: { quarantined: 0, running: 0, suspended: 0, total: 0 },
+    mail: { total: 0, unread: 0 },
+    name: 'test-city',
+    path: '/tmp/test-city',
+    rig_count: 0,
+    rigs: { suspended: 0, total: 0 },
+    running: 0,
+    suspended: false,
+    uptime_sec: 1,
+    work: { in_progress: 0, open: 0, ready: 0 },
+    ...partial,
+  };
+}
+
+// A SamplerRuntime that never fires the timer, so tests drive sampleOnce()
+// explicitly and assert the cached report — no wall-clock dependence.
+const inertRuntime: SamplerRuntime = {
+  setInterval: (): SamplerTimer => ({ unref: () => {} }),
+  clearInterval: () => {},
+};
+
+describe('createSupervisorStatusSampler', () => {
+  test('reports not_sampled_yet before the first sample', () => {
+    const sampler = createSupervisorStatusSampler({
+      fetchStatus: () => Promise.resolve(statusBody()),
+      runtime: inertRuntime,
+    });
+    assert.deepEqual(sampler.report(), {
+      available: false,
+      reason: 'not_sampled_yet',
+      status: null,
+    });
+  });
+
+  test('caches the supervisor status and serves it after a successful sample', async () => {
+    const status = statusBody({ work: { in_progress: 3, open: 7, ready: 5 } });
+    const sampler = createSupervisorStatusSampler({
+      fetchStatus: () => Promise.resolve(status),
+      runtime: inertRuntime,
+      now: () => '2026-06-07T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+    assert.deepEqual(sampler.report(), {
+      available: true,
+      sampledAt: '2026-06-07T00:00:00.000Z',
+      status,
+    });
+  });
+
+  test('retains the last good status across a later failed read (degraded, not blank)', async () => {
+    const good = statusBody({ work: { in_progress: 1, open: 2, ready: 3 } });
+    let fail = false;
+    const sampler = createSupervisorStatusSampler({
+      fetchStatus: () => (fail ? Promise.reject(new Error('slow /status')) : Promise.resolve(good)),
+      runtime: inertRuntime,
+      now: () => '2026-06-07T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+    fail = true;
+    await sampler.sampleOnce();
+    assert.deepEqual(sampler.report(), {
+      available: false,
+      reason: 'status_read_failed',
+      status: good,
+    });
+  });
+});
+
+async function startApp(
+  app: express.Express,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('supervisorStatusRouter', () => {
+  test('GET / serves the sampler report as JSON', async () => {
+    const status = statusBody({ work: { in_progress: 9, open: 1, ready: 0 } });
+    const sampler = createSupervisorStatusSampler({
+      fetchStatus: () => Promise.resolve(status),
+      runtime: inertRuntime,
+      now: () => '2026-06-07T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+
+    const app = express();
+    app.use('/api/city/test-city/supervisor-status', supervisorStatusRouter(sampler));
+    const { url, close } = await startApp(app);
+    try {
+      const res = await fetch(`${url}/api/city/test-city/supervisor-status`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as SupervisorStatusReport;
+      assert.equal(body.available, true);
+      assert.deepEqual(body.status, status);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/backend/src/routes/supervisor-status.ts
+++ b/backend/src/routes/supervisor-status.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import type { StatusBody } from 'gas-city-dashboard-shared/gc-supervisor';
+import type {
+  SupervisorStatusReport,
+  SupervisorStatusUnavailableReason,
+} from 'gas-city-dashboard-shared';
+import { recordAudit } from '../audit.js';
+import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
+
+// gascity-dashboard-4bol: the interactive Health store-thresholds / dolt-usage /
+// beads-usage widgets read the supervisor /status, which turns slow on a bloated
+// city store and trips a short interactive timeout — surfacing "supervisor
+// status unavailable" even while the 30s background samplers succeed. This
+// periodic sampler reads /status on the same higher background ceiling and the
+// route serves the cached snapshot, so a Health page load hits a fast local
+// route instead of racing the slow supervisor. The route is the dolt-noms /
+// rig-store-health sampler pattern; it serves the raw supervisor status wire
+// shape (not a dashboard DTO mirror) wrapped in availability/freshness metadata.
+
+const SAMPLE_INTERVAL_MS = 60 * 1_000;
+
+/** Fetches the supervisor city status (the cached snapshot's source). */
+export type FetchStatus = () => Promise<StatusBody>;
+
+export interface SamplerTimer {
+  unref(): void;
+}
+
+export interface SamplerRuntime {
+  setInterval(callback: () => void, delayMs: number): SamplerTimer;
+  clearInterval(timer: SamplerTimer): void;
+}
+
+const nodeRuntime: SamplerRuntime = {
+  setInterval: (callback, delayMs) => setInterval(callback, delayMs),
+  clearInterval: (timer) => clearInterval(timer as NodeJS.Timeout),
+};
+
+export interface SupervisorStatusSampler {
+  readonly running: boolean;
+  start(): void;
+  stop(): void;
+  sampleOnce(): Promise<void>;
+  report(): SupervisorStatusReport;
+}
+
+export interface SupervisorStatusSamplerOptions {
+  fetchStatus: FetchStatus;
+  runtime?: SamplerRuntime;
+  intervalMs?: number;
+  now?: () => string;
+}
+
+type SamplerTimerState = { status: 'idle' } | { status: 'scheduled'; timer: SamplerTimer };
+
+export function createSupervisorStatusSampler(
+  opts: SupervisorStatusSamplerOptions,
+): SupervisorStatusSampler {
+  const runtime = opts.runtime ?? nodeRuntime;
+  const intervalMs = opts.intervalMs ?? SAMPLE_INTERVAL_MS;
+  const now = opts.now ?? (() => new Date().toISOString());
+
+  // Last successful snapshot, retained across a later failed read so the report
+  // can still carry prior data (degraded, not blank) — mirrors rig-store-health.
+  let lastStatus: StatusBody | null = null;
+  let sampledAt: string | null = null;
+  let available = false;
+  let lastReason: SupervisorStatusUnavailableReason = 'not_sampled_yet';
+  let timerState: SamplerTimerState = { status: 'idle' };
+
+  const sampleOnce = async (): Promise<void> => {
+    try {
+      lastStatus = await opts.fetchStatus();
+      sampledAt = now();
+      available = true;
+    } catch (err) {
+      available = false;
+      lastReason = 'status_read_failed';
+      logWarn(LOG_COMPONENT.supervisorStatus, `sample failed: ${errorMessage(err)}`);
+    }
+  };
+
+  return {
+    get running() {
+      return timerState.status === 'scheduled';
+    },
+    start() {
+      if (timerState.status === 'scheduled') return;
+      void sampleOnce();
+      timerState = {
+        status: 'scheduled',
+        timer: runtime.setInterval(() => {
+          void sampleOnce();
+        }, intervalMs),
+      };
+      timerState.timer.unref();
+    },
+    stop() {
+      if (timerState.status === 'idle') return;
+      runtime.clearInterval(timerState.timer);
+      timerState = { status: 'idle' };
+    },
+    sampleOnce,
+    report(): SupervisorStatusReport {
+      if (available && sampledAt !== null && lastStatus !== null) {
+        return { available: true, sampledAt, status: lastStatus };
+      }
+      return { available: false, reason: lastReason, status: lastStatus };
+    },
+  };
+}
+
+export function supervisorStatusRouter(sampler: SupervisorStatusSampler): Router {
+  const router = Router();
+  router.get('/', (_req, res) => {
+    const payload = sampler.report();
+    void recordAudit({
+      type: 'dashboard.fetch',
+      endpoint: 'GET /api/city/:cityName/supervisor-status',
+      parsed_args: { available: String(payload.available) },
+      duration_ms: 0,
+    });
+    res.json(payload);
+  });
+  return router;
+}

--- a/backend/test/logging.test.ts
+++ b/backend/test/logging.test.ts
@@ -27,6 +27,7 @@ describe('logging component vocabulary', () => {
         LOG_COMPONENT.metrics,
         LOG_COMPONENT.rigStoreHealth,
         LOG_COMPONENT.runs,
+        LOG_COMPONENT.supervisorStatus,
       ].sort(),
     );
   });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -155,4 +155,51 @@ describe('api client error handling', () => {
       message: expect.stringContaining('supervisor status.status must be an object'),
     });
   });
+
+  it('rejects an available supervisor-status report missing sampledAt', async () => {
+    // The available branch's contract requires sampledAt; absence must fail at
+    // the edge so the decoded value does not lie about its type.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              available: true,
+              status: { name: 'demo-city', work: { open: 1, ready: 2, in_progress: 3 } },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await expect(api.supervisorStatus()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('supervisor status.sampledAt must be a string'),
+    });
+  });
+
+  it('rejects a supervisor-status report whose status.work is missing', async () => {
+    // The Beads usage widget dereferences status.work.{open,ready,in_progress};
+    // a status object without work must fail at the edge, not crash at render.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              available: true,
+              sampledAt: '2026-06-07T00:00:00.000Z',
+              status: { name: 'demo-city' },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await expect(api.supervisorStatus()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('supervisor status.status.work must be an object'),
+    });
+  });
 });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -135,4 +135,24 @@ describe('api client error handling', () => {
       message: expect.stringContaining('supervisor status.available must be a boolean'),
     });
   });
+
+  it('rejects an available supervisor-status report whose status payload is missing', async () => {
+    // The Health widgets dereference status fields; an available report with no
+    // status object must fail at the edge rather than crash at render.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ available: true, sampledAt: '2026-06-07T00:00:00.000Z' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    );
+
+    await expect(api.supervisorStatus()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('supervisor status.status must be an object'),
+    });
+  });
 });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -91,4 +91,48 @@ describe('api client error handling', () => {
       message: expect.stringContaining('dolt.drift must be a string'),
     });
   });
+
+  it('decodes a cached supervisor-status report at the edge', async () => {
+    // gascity-dashboard-4bol: the Health status widgets read the dashboard
+    // backend's cached /supervisor-status snapshot; the report envelope is
+    // validated at the API edge before the page consumes it.
+    const report = {
+      available: true,
+      sampledAt: '2026-06-07T00:00:00.000Z',
+      status: { name: 'demo-city', work: { open: 1, ready: 2, in_progress: 3 } },
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(report), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    );
+
+    await expect(api.supervisorStatus()).resolves.toMatchObject({
+      available: true,
+      sampledAt: '2026-06-07T00:00:00.000Z',
+    });
+  });
+
+  it('rejects a supervisor-status body missing the availability discriminant', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ status: null }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    );
+
+    await expect(api.supervisorStatus()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('supervisor status.available must be a boolean'),
+    });
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -299,6 +299,16 @@ const decodeSupervisorStatus = objectDecoder<SupervisorStatusReport>(
   'supervisor status',
   (record, url) => {
     requireBooleanField(record, url, 'supervisor status', 'available');
+    if (record['available'] === true) {
+      // The Health widgets dereference status.store_health / status.work, so a
+      // present-but-malformed status must fail at the edge, not at render.
+      requireObjectField(record, url, 'supervisor status', 'status');
+    } else {
+      requireStringField(record, url, 'supervisor status', 'reason');
+      if (record['status'] !== null) {
+        requireObjectField(record, url, 'supervisor status', 'status');
+      }
+    }
   },
 );
 const decodeRunDiff = objectDecoder<RunDiffResponse>('run diff', (record, url) => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   LocalToolVersions,
   DoltNomsTrend,
   RigStoreHealthReport,
+  SupervisorStatusReport,
   MaintainerTriage,
   MaintainerSlingRecordRequest,
   ContributorStat,
@@ -294,6 +295,12 @@ const decodeRigStoreHealth = objectDecoder<RigStoreHealthReport>(
     requireArrayField(record, url, 'rig store health', 'rigs');
   },
 );
+const decodeSupervisorStatus = objectDecoder<SupervisorStatusReport>(
+  'supervisor status',
+  (record, url) => {
+    requireBooleanField(record, url, 'supervisor status', 'available');
+  },
+);
 const decodeRunDiff = objectDecoder<RunDiffResponse>('run diff', (record, url) => {
   requireStringField(record, url, 'run diff', 'kind');
   requireObjectField(record, url, 'run diff', 'rootPath');
@@ -371,6 +378,9 @@ export const api = {
   },
   rigStoreHealth(): Promise<RigStoreHealthReport> {
     return request('GET', cityPath('/rig-store-health'), decodeRigStoreHealth);
+  },
+  supervisorStatus(): Promise<SupervisorStatusReport> {
+    return request('GET', cityPath('/supervisor-status'), decodeSupervisorStatus);
   },
   runDiff(
     runId: string,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -295,18 +295,26 @@ const decodeRigStoreHealth = objectDecoder<RigStoreHealthReport>(
     requireArrayField(record, url, 'rig store health', 'rigs');
   },
 );
+// The Health Dolt/Beads/threshold widgets dereference status.work.{open,ready,
+// in_progress} unconditionally (store_health is optional and the widget guards
+// its absence), so validate the nested shape the widgets actually read at the
+// edge, not at render. Both the fresh and the degraded-with-last-good paths
+// surface status to those widgets, so both validate it.
+function requireStatusBody(value: unknown, url: string): void {
+  const status = requireRecord(value, url, 'supervisor status.status');
+  requireObjectField(status, url, 'supervisor status.status', 'work');
+}
 const decodeSupervisorStatus = objectDecoder<SupervisorStatusReport>(
   'supervisor status',
   (record, url) => {
     requireBooleanField(record, url, 'supervisor status', 'available');
     if (record['available'] === true) {
-      // The Health widgets dereference status.store_health / status.work, so a
-      // present-but-malformed status must fail at the edge, not at render.
-      requireObjectField(record, url, 'supervisor status', 'status');
+      requireStringField(record, url, 'supervisor status', 'sampledAt');
+      requireStatusBody(record['status'], url);
     } else {
       requireStringField(record, url, 'supervisor status', 'reason');
       if (record['status'] !== null) {
-        requireObjectField(record, url, 'supervisor status', 'status');
+        requireStatusBody(record['status'], url);
       }
     }
   },

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -13,7 +13,7 @@ import { invalidateKey } from '../api/cache';
 import { NowProvider } from '../contexts/NowContext';
 import { assertAtMostOneMark } from '../test/assertions/oneMarkRule';
 import { supervisorApi } from '../supervisor/client';
-import { loadSupervisorRunSummarySource } from '../supervisor/runSummary';
+import { loadSupervisorRunSummaryMountSource } from '../supervisor/runSummary';
 import { AmbientHomePage } from './AmbientHome';
 
 // gascity-dashboard-kb3 — AmbientHome integration coverage.
@@ -32,7 +32,7 @@ import { AmbientHomePage } from './AmbientHome';
 //   • R6 no-negative-reassurance — calm sentence is absent, not "all clear".
 
 vi.mock('../supervisor/runSummary', () => ({
-  loadSupervisorRunSummarySource: vi.fn(),
+  loadSupervisorRunSummaryMountSource: vi.fn(),
 }));
 
 vi.mock('../supervisor/client', () => ({
@@ -59,7 +59,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const mockLoadRunSummary = loadSupervisorRunSummarySource as Mock;
+const mockLoadRunSummary = loadSupervisorRunSummaryMountSource as Mock;
 const mockSupervisorApi = supervisorApi as Mock;
 
 function knownHealth(overrides: Partial<RunLaneHealth> = {}): RunLaneHealth {

--- a/frontend/src/routes/AmbientHome.tsx
+++ b/frontend/src/routes/AmbientHome.tsx
@@ -11,7 +11,7 @@ import { useCachedData } from '../hooks/useCachedData';
 import { useFaviconSignal } from '../hooks/useFaviconSignal';
 import { useStaleness, type StalenessResult } from '../hooks/useStaleness';
 import { supervisorApi } from '../supervisor/client';
-import { loadSupervisorRunSummarySource } from '../supervisor/runSummary';
+import { loadSupervisorRunSummaryMountSource } from '../supervisor/runSummary';
 
 // gascity-dashboard-kb3 — the L0 ambient home at `/`. PRD §4 + §5.
 //
@@ -187,7 +187,7 @@ export function AmbientHomePage() {
   const cityName = getActiveCity();
   const { data, loading, error } = useCachedData(
     `runs:summary:${cityName ?? 'no-city'}`,
-    loadSupervisorRunSummarySource,
+    loadSupervisorRunSummaryMountSource,
   );
   const work = useCachedData(`home:work:${cityName ?? 'no-city'}`, fetchHomeWorkInProgress);
 

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -20,14 +20,14 @@ import {
 import rawFormulaRunDetailFixture from '../test/fixtures/formula-run-detail.json';
 
 const loadSupervisorFormulaRunDetail = vi.hoisted(() => vi.fn());
-const loadSupervisorRunSummarySource = vi.hoisted(() => vi.fn());
+const loadSupervisorRunSummaryMountSource = vi.hoisted(() => vi.fn());
 
 vi.mock('../supervisor/runDetail', () => ({
   loadSupervisorFormulaRunDetail,
 }));
 
 vi.mock('../supervisor/runSummary', () => ({
-  loadSupervisorRunSummarySource,
+  loadSupervisorRunSummaryMountSource,
 }));
 
 vi.mock('../hooks/useEntityLinks', () => ({
@@ -61,9 +61,9 @@ beforeEach(() => {
   invalidate('formula-run');
   invalidate('runs:summary:test-city');
   loadSupervisorFormulaRunDetail.mockReset();
-  loadSupervisorRunSummarySource.mockReset();
+  loadSupervisorRunSummaryMountSource.mockReset();
   loadSupervisorFormulaRunDetail.mockImplementation(async () => currentDetail);
-  loadSupervisorRunSummarySource.mockResolvedValue(runSummarySource());
+  loadSupervisorRunSummaryMountSource.mockResolvedValue(runSummarySource());
   currentDetail = detail;
   currentDiff = diff;
   vi.stubGlobal('EventSource', FakeEventSource);
@@ -125,7 +125,7 @@ describe('FormulaRunDetailPage', () => {
     // title + phase stages instantly instead of a blank spinner. Here the
     // detail (and diff) fetch hangs while the summary resolves with a lane.
     invalidate('runs:summary:test-city');
-    loadSupervisorRunSummarySource.mockResolvedValue(runSummarySourceWithActiveLane());
+    loadSupervisorRunSummaryMountSource.mockResolvedValue(runSummarySourceWithActiveLane());
     vi.stubGlobal(
       'fetch',
       vi.fn(() => new Promise<Response>(() => {})),
@@ -158,7 +158,7 @@ describe('FormulaRunDetailPage', () => {
     source.data.blockedLanes = source.data.lanes;
     source.data.lanes = [];
     source.data.totalActive = 0;
-    loadSupervisorRunSummarySource.mockResolvedValue(source);
+    loadSupervisorRunSummaryMountSource.mockResolvedValue(source);
     vi.stubGlobal(
       'fetch',
       vi.fn(() => new Promise<Response>(() => {})),

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -24,7 +24,7 @@ import { useRunDiff } from '../hooks/useRunDiff';
 import { useEntityLinks } from '../hooks/useEntityLinks';
 import { useCachedData } from '../hooks/useCachedData';
 import { getActiveCity } from '../api/cityBase';
-import { loadSupervisorRunSummarySource } from '../supervisor/runSummary';
+import { loadSupervisorRunSummaryMountSource } from '../supervisor/runSummary';
 import { NEEDS_YOU_VIEW_PARAM } from '../views/modules/maintainer/needsYou';
 
 const RUN_DETAIL_EVENT_PREFIXES = [GC_EVENT_PREFIX.bead, GC_EVENT_PREFIX.session] as const;
@@ -113,7 +113,7 @@ export function FormulaRunDetailPage() {
   // instead of a blank spinner while the full detail assembles.
   const runSummary = useCachedData(
     `runs:summary:${cityName ?? 'no-city'}`,
-    loadSupervisorRunSummarySource,
+    loadSupervisorRunSummaryMountSource,
   );
   const skeletonLane = useMemo(() => {
     if (!runId) return null;

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -267,12 +267,16 @@ describe('HealthPage', () => {
     expect(screen.getByText('5')).toBeTruthy();
     expect(screen.getByText('Dolt MB-per-row ratio')).toBeTruthy();
     expect(screen.getByText('<= 1')).toBeTruthy();
+    // Fresh data carries no stale marker — guards against the marker leaking
+    // onto a healthy read (the negative contrast for the degraded test below).
+    expect(screen.queryAllByText(/showing the last sample/i)).toHaveLength(0);
   });
 
-  it('shows cached status data (Dolt/Beads/thresholds) when the latest sample failed but a prior one exists', async () => {
+  it('shows cached status data plus a stale marker when the latest sample failed but a prior one exists', async () => {
     // gascity-dashboard-4bol: a degraded report (latest /status read failed on a
     // slow supervisor) still carries the last good snapshot, so the widgets must
-    // render real data, NOT "supervisor status unavailable".
+    // render real data with a "showing last sample" marker, NOT
+    // "supervisor status unavailable".
     statusMode = 'degraded';
 
     renderPage();
@@ -283,6 +287,11 @@ describe('HealthPage', () => {
     expect(screen.getByText('Beads usage')).toBeTruthy();
     expect(screen.getByText('Dolt MB-per-row ratio')).toBeTruthy();
     expect(screen.queryAllByText(/supervisor status unavailable/i)).toHaveLength(0);
+    // The stale marker renders on each cached widget (Dolt usage, Beads usage,
+    // Store thresholds), mirroring the rig-store-health "showing last sample".
+    expect(
+      screen.getAllByText(/showing the last sample — refresh failed/i).length,
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it('surfaces the warming-up copy when the backend has not sampled status yet', async () => {

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -15,13 +15,11 @@ import type {
 import { supervisorApiForRequestBudget } from '../supervisor/client';
 
 const mockCityHealth = vi.fn<(cityName: string) => Promise<HealthOutputBody>>();
-const mockCityStatus = vi.fn<(cityName: string) => Promise<StatusBody>>();
 const mockSupervisorApiForRequestBudget = supervisorApiForRequestBudget as unknown as Mock;
 
 vi.mock('../supervisor/client', () => ({
   supervisorApiForRequestBudget: vi.fn(() => ({
     cityHealth: mockCityHealth,
-    cityStatus: mockCityStatus,
   })),
 }));
 
@@ -36,24 +34,33 @@ let currentHealth: SystemHealth = baseHealth();
 let currentLocalTools: LocalToolVersions = baseLocalTools();
 let currentTrend: DoltNomsTrend = baseTrend();
 let currentRigStores: RigStoreHealthReport = baseRigStores();
+let currentStatus: StatusBody = baseStatus();
 let systemHealthMode: 'ok' | 'fail' = 'ok';
 let trendMode: 'ok' | 'fail' = 'ok';
 let rigStoreMode: 'ok' | 'fail' = 'ok';
+// gascity-dashboard-4bol: the Health status widgets read the dashboard
+// backend's cached /supervisor-status snapshot, not the supervisor directly.
+// 'available' = fresh sample, 'degraded' = last-good served while the latest
+// read failed (must still render data), 'blank' = never sampled (unavailable),
+// 'pending' = the local fetch has not resolved yet.
+let statusMode: 'available' | 'degraded' | 'blank' = 'available';
+let pendingStatusResponse: Promise<Response> | null = null;
 
 beforeEach(() => {
   invalidate('health');
   mockSupervisorApiForRequestBudget.mockClear();
   mockCityHealth.mockReset();
-  mockCityStatus.mockReset();
   mockCityHealth.mockResolvedValue(presentLocator());
-  mockCityStatus.mockResolvedValue(baseStatus());
   currentHealth = baseHealth();
   currentLocalTools = baseLocalTools();
   currentTrend = baseTrend();
   currentRigStores = baseRigStores();
+  currentStatus = baseStatus();
   systemHealthMode = 'ok';
   trendMode = 'ok';
   rigStoreMode = 'ok';
+  statusMode = 'available';
+  pendingStatusResponse = null;
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL) => {
@@ -78,6 +85,26 @@ beforeEach(() => {
           return errorResponse('rig store health offline');
         }
         return jsonResponse(currentRigStores);
+      }
+      if (url === '/api/city/test-city/supervisor-status') {
+        if (pendingStatusResponse !== null) {
+          return pendingStatusResponse;
+        }
+        if (statusMode === 'blank') {
+          return jsonResponse({ available: false, reason: 'status_read_failed', status: null });
+        }
+        if (statusMode === 'degraded') {
+          return jsonResponse({
+            available: false,
+            reason: 'status_read_failed',
+            status: currentStatus,
+          });
+        }
+        return jsonResponse({
+          available: true,
+          sampledAt: '2026-06-07T00:00:00.000Z',
+          status: currentStatus,
+        });
       }
       throw new Error(`unexpected fetch: ${url}`);
     }),
@@ -157,14 +184,18 @@ describe('HealthPage', () => {
     expect(synopsis?.textContent ?? '').toMatch(/Supervisor healthy on demo-city, uptime /);
   });
 
-  it('uses the generated supervisor client for city health/status and not dashboard city mirrors', async () => {
+  it('reads city health via the generated supervisor client and status via the dashboard cached-status route', async () => {
+    // gascity-dashboard-4bol: health stays on the direct (fast) supervisor
+    // client, but the slow /status read moves behind the dashboard backend's
+    // cached sampler at /supervisor-status. The page must NOT hit the supervisor
+    // /status directly, and must NOT reintroduce a dashboard city-health mirror.
     renderPage();
 
     await screen.findByRole('heading', { name: /supervisor/i });
 
     expect(mockCityHealth).toHaveBeenCalledWith('test-city');
-    expect(mockCityStatus).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApiForRequestBudget).toHaveBeenCalledWith(2500);
+    expect(fetch).toHaveBeenCalledWith('/api/city/test-city/supervisor-status', expect.any(Object));
     expect(fetch).toHaveBeenCalledWith('/api/health/system', expect.any(Object));
     expect(fetch).toHaveBeenCalledWith('/api/health/local-tools', expect.any(Object));
     expect(fetch).not.toHaveBeenCalledWith('/api/city/test-city/health/system', expect.any(Object));
@@ -172,8 +203,8 @@ describe('HealthPage', () => {
   });
 
   it('renders fast sections while supervisor status is still pending', async () => {
-    const pendingStatus = deferred<StatusBody>();
-    mockCityStatus.mockReturnValue(pendingStatus.promise);
+    const pendingStatus = deferred<Response>();
+    pendingStatusResponse = pendingStatus.promise;
 
     renderPage();
 
@@ -222,7 +253,7 @@ describe('HealthPage', () => {
     expect(screen.getByRole('heading', { name: /diagnostics/i })).toBeTruthy();
   });
 
-  it('restores diagnostics from local probes plus direct supervisor status', async () => {
+  it('restores diagnostics from local probes plus the cached supervisor status', async () => {
     renderPage();
 
     await screen.findByRole('heading', { name: /diagnostics/i });
@@ -232,6 +263,32 @@ describe('HealthPage', () => {
     expect(screen.getByText('5')).toBeTruthy();
     expect(screen.getByText('Dolt MB-per-row ratio')).toBeTruthy();
     expect(screen.getByText('<= 1')).toBeTruthy();
+  });
+
+  it('shows cached status data (Dolt/Beads/thresholds) when the latest sample failed but a prior one exists', async () => {
+    // gascity-dashboard-4bol: a degraded report (latest /status read failed on a
+    // slow supervisor) still carries the last good snapshot, so the widgets must
+    // render real data, NOT "supervisor status unavailable".
+    statusMode = 'degraded';
+
+    renderPage();
+
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    expect(screen.getByText('Dolt usage')).toBeTruthy();
+    expect(screen.getByText('Beads usage')).toBeTruthy();
+    expect(screen.getByText('Dolt MB-per-row ratio')).toBeTruthy();
+    expect(screen.queryAllByText(/supervisor status unavailable/i)).toHaveLength(0);
+  });
+
+  it('surfaces the unavailable copy only when the backend has never sampled status', async () => {
+    statusMode = 'blank';
+
+    renderPage();
+
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    expect(screen.getAllByText(/latest supervisor status read failed/i).length).toBeGreaterThan(0);
   });
 
   it('surfaces per-rig bead-store health with a down rig flagged', async () => {

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -290,7 +290,7 @@ describe('HealthPage', () => {
     // The stale marker renders on each cached widget (Dolt usage, Beads usage,
     // Store thresholds), mirroring the rig-store-health "showing last sample".
     expect(
-      screen.getAllByText(/showing the last sample — refresh failed/i).length,
+      screen.getAllByText(/showing the last sample; refresh failed/i).length,
     ).toBeGreaterThanOrEqual(3);
   });
 

--- a/frontend/src/routes/Health.test.tsx
+++ b/frontend/src/routes/Health.test.tsx
@@ -41,9 +41,10 @@ let rigStoreMode: 'ok' | 'fail' = 'ok';
 // gascity-dashboard-4bol: the Health status widgets read the dashboard
 // backend's cached /supervisor-status snapshot, not the supervisor directly.
 // 'available' = fresh sample, 'degraded' = last-good served while the latest
-// read failed (must still render data), 'blank' = never sampled (unavailable),
-// 'pending' = the local fetch has not resolved yet.
-let statusMode: 'available' | 'degraded' | 'blank' = 'available';
+// read failed (must still render data), 'warming' = never sampled yet,
+// 'blank' = a read failed with no prior sample. A null status under 'pending'
+// is modelled via pendingStatusResponse (the local fetch has not resolved yet).
+let statusMode: 'available' | 'degraded' | 'warming' | 'blank' = 'available';
 let pendingStatusResponse: Promise<Response> | null = null;
 
 beforeEach(() => {
@@ -89,6 +90,9 @@ beforeEach(() => {
       if (url === '/api/city/test-city/supervisor-status') {
         if (pendingStatusResponse !== null) {
           return pendingStatusResponse;
+        }
+        if (statusMode === 'warming') {
+          return jsonResponse({ available: false, reason: 'not_sampled_yet', status: null });
         }
         if (statusMode === 'blank') {
           return jsonResponse({ available: false, reason: 'status_read_failed', status: null });
@@ -281,7 +285,19 @@ describe('HealthPage', () => {
     expect(screen.queryAllByText(/supervisor status unavailable/i)).toHaveLength(0);
   });
 
-  it('surfaces the unavailable copy only when the backend has never sampled status', async () => {
+  it('surfaces the warming-up copy when the backend has not sampled status yet', async () => {
+    statusMode = 'warming';
+
+    renderPage();
+
+    await screen.findByRole('heading', { name: /diagnostics/i });
+
+    expect(screen.getAllByText(/supervisor status sample is warming up/i).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('surfaces the read-failed copy when a sample failed with no prior snapshot', async () => {
     statusMode = 'blank';
 
     renderPage();

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -482,7 +482,7 @@ function RigStoreHealthBlock({ report }: { report: RigStoreHealthReport | null }
     <div className="space-y-6 max-w-prose">
       {!report.available && (
         <p className="text-body text-warn italic">
-          Showing the last sample — refresh failed: {rigStoreUnavailableCopy(report.reason)}.
+          Showing the last sample; refresh failed: {rigStoreUnavailableCopy(report.reason)}.
         </p>
       )}
       {rigs.map((rig) => (
@@ -756,7 +756,7 @@ function supervisorStatusUnavailableCopy(
 function supervisorStatusStaleCopy(
   reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
 ): string {
-  return `Showing the last sample — refresh failed: ${supervisorStatusUnavailableCopy(reason)}.`;
+  return `Showing the last sample; refresh failed: ${supervisorStatusUnavailableCopy(reason)}.`;
 }
 
 // gascity-dashboard-4bol: read the dashboard backend's cached /status snapshot

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -7,6 +7,7 @@ import type {
   RigStoreHealthReport,
   RigStoreHealthUnavailableReason,
   RigStoreRollup,
+  SupervisorStatusReport,
   SystemHealth,
 } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
@@ -720,22 +721,39 @@ async function fetchSupervisorHealth(): Promise<SupervisorHealthState> {
   }
 }
 
-async function fetchSupervisorStatus(): Promise<SupervisorStatusState> {
-  const cityName = getActiveCity();
-  if (cityName === null) {
-    throw new Error('Health page loaded before an active city was resolved');
+function supervisorStatusUnavailableCopy(
+  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
+): string {
+  switch (reason) {
+    case 'not_sampled_yet':
+      return 'supervisor status sample is warming up; data appears after the next backend sample';
+    case 'status_read_failed':
+      return 'latest supervisor status read failed; check the backend log';
   }
+}
+
+// gascity-dashboard-4bol: read the dashboard backend's cached /status snapshot
+// (sampled on the background ceiling) instead of racing the slow supervisor on a
+// short interactive budget. A degraded report still carries the last good
+// status, so the store-thresholds / dolt-usage / beads-usage widgets show real
+// (possibly cached) data rather than "supervisor status unavailable".
+async function fetchSupervisorStatus(): Promise<SupervisorStatusState> {
   try {
-    return {
-      status: 'available',
-      data: await supervisorApiForRequestBudget(HEALTH_SUPERVISOR_REQUEST_TIMEOUT_MS).cityStatus(
-        cityName,
-      ),
-    };
-  } catch {
+    const report = await api.supervisorStatus();
+    if (report.available) {
+      return { status: 'available', data: report.status };
+    }
+    if (report.status !== null) {
+      return { status: 'available', data: report.status };
+    }
     return {
       status: 'unavailable',
-      error: 'supervisor status unavailable',
+      error: supervisorStatusUnavailableCopy(report.reason),
+    };
+  } catch (err) {
+    return {
+      status: 'unavailable',
+      error: formatApiError(err, 'supervisor status unavailable'),
     };
   }
 }

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -327,7 +327,7 @@ function Kv({ label, value, tone }: { label: string; value: string; tone?: 'warn
 }
 
 type DiagnosticDatum<T> =
-  | { status: 'available'; value: T; source: string }
+  | { status: 'available'; value: T; source: string; stale?: string }
   | { status: 'unavailable'; reason: string };
 
 interface ConfigComparisonRow {
@@ -426,6 +426,7 @@ function DoltUsageBlock({ usage }: { usage: DiagnosticDatum<StatusStoreHealth> }
   return (
     <div className="space-y-2">
       <h3 className="text-label uppercase tracking-wider text-fg-muted">Dolt usage</h3>
+      {usage.stale !== undefined && <StaleNote message={usage.stale} />}
       <KvList>
         <Kv label="On-disk size" value={formatHumanSize(statusNumber(u.size_bytes))} />
         <Kv label="Live rows" value={u.live_rows.toLocaleString()} />
@@ -454,6 +455,7 @@ function BeadsUsageBlock({ usage }: { usage: DiagnosticDatum<StatusWorkCounts> }
   return (
     <div className="space-y-2">
       <h3 className="text-label uppercase tracking-wider text-fg-muted">Beads usage</h3>
+      {usage.stale !== undefined && <StaleNote message={usage.stale} />}
       <KvList>
         <Kv label="Open" value={u.open.toString()} />
         <Kv label="Ready" value={u.ready.toString()} />
@@ -583,15 +585,18 @@ function ConfigComparison({ comparison }: { comparison: DiagnosticDatum<ConfigCo
     );
   }
   return (
-    <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
-      <div className="text-label uppercase tracking-wider text-fg-muted">Setting</div>
-      <div className="text-label uppercase tracking-wider text-fg-muted text-right">
-        Recommended
+    <div className="space-y-2">
+      {comparison.stale !== undefined && <StaleNote message={comparison.stale} />}
+      <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
+        <div className="text-label uppercase tracking-wider text-fg-muted">Setting</div>
+        <div className="text-label uppercase tracking-wider text-fg-muted text-right">
+          Recommended
+        </div>
+        <div className="text-label uppercase tracking-wider text-fg-muted text-right">Loaded</div>
+        {comparison.value.map((row) => (
+          <ComparisonRow key={row.label} row={row} />
+        ))}
       </div>
-      <div className="text-label uppercase tracking-wider text-fg-muted text-right">Loaded</div>
-      {comparison.value.map((row) => (
-        <ComparisonRow key={row.label} row={row} />
-      ))}
     </div>
   );
 }
@@ -619,6 +624,12 @@ function UnavailableNote({ heading, reason }: { heading: string; reason: string 
       <p className="text-body text-fg-muted italic">Unavailable: {reason}.</p>
     </div>
   );
+}
+
+// Warn-toned "showing last sample" line for cached diagnostics whose latest read
+// failed, matching the rig-store-health stale affordance.
+function StaleNote({ message }: { message: string }) {
+  return <p className="text-body text-warn italic">{message}</p>;
 }
 
 function Sparkline({ samples }: { samples: { ts: string; bytes: number }[] }) {
@@ -680,7 +691,14 @@ type SystemHealthState =
   | { status: 'unavailable'; error: string };
 
 type SupervisorStatusState =
-  | { status: 'available'; data: StatusBody }
+  // `staleReason` is set when the data is the last good snapshot served after a
+  // later sample failed (degraded, not blank) — drives the "showing last sample"
+  // marker on the diagnostics widgets. null means the data is fresh.
+  | {
+      status: 'available';
+      data: StatusBody;
+      staleReason: Extract<SupervisorStatusReport, { available: false }>['reason'] | null;
+    }
   | { status: 'unavailable'; error: string };
 
 type LocalToolVersionsState =
@@ -732,19 +750,29 @@ function supervisorStatusUnavailableCopy(
   }
 }
 
+// Stale marker shown above cached diagnostics, mirroring the rig-store-health
+// "Showing the last sample" affordance so a degraded snapshot is never mistaken
+// for a fresh read.
+function supervisorStatusStaleCopy(
+  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
+): string {
+  return `Showing the last sample — refresh failed: ${supervisorStatusUnavailableCopy(reason)}.`;
+}
+
 // gascity-dashboard-4bol: read the dashboard backend's cached /status snapshot
 // (sampled on the background ceiling) instead of racing the slow supervisor on a
-// short interactive budget. A degraded report still carries the last good
-// status, so the store-thresholds / dolt-usage / beads-usage widgets show real
-// (possibly cached) data rather than "supervisor status unavailable".
+// short interactive budget — live /status runs 10–38s (gastownhall/gascity-dashboard#88).
+// A degraded report still carries the last good status, so the store-thresholds /
+// dolt-usage / beads-usage widgets show real (cached) data with a "stale" marker
+// rather than "supervisor status unavailable".
 async function fetchSupervisorStatus(): Promise<SupervisorStatusState> {
   try {
     const report = await api.supervisorStatus();
     if (report.available) {
-      return { status: 'available', data: report.status };
+      return { status: 'available', data: report.status, staleReason: null };
     }
     if (report.status !== null) {
-      return { status: 'available', data: report.status };
+      return { status: 'available', data: report.status, staleReason: report.reason };
     }
     return {
       status: 'unavailable',
@@ -866,6 +894,9 @@ function doltUsageOf(
     status: 'available',
     value: storeHealth,
     source: 'supervisor status.store_health',
+    ...(statusState.staleReason !== null
+      ? { stale: supervisorStatusStaleCopy(statusState.staleReason) }
+      : {}),
   };
 }
 
@@ -882,6 +913,9 @@ function beadsUsageOf(
     status: 'available',
     value: statusState.data.work,
     source: 'supervisor status.work',
+    ...(statusState.staleReason !== null
+      ? { stale: supervisorStatusStaleCopy(statusState.staleReason) }
+      : {}),
   };
 }
 
@@ -896,6 +930,7 @@ function configComparisonOf(
   return {
     status: 'available',
     source: 'supervisor status.store_health (threshold vs actual)',
+    ...(usage.stale !== undefined ? { stale: usage.stale } : {}),
     value: [
       {
         label: 'Dolt MB-per-row ratio',

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -103,6 +103,36 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     });
     expect(listSessions).not.toHaveBeenCalled();
   });
+
+  it('marks the summary partial when a slow enrichment read exceeds the tight first-paint budget (gascity-dashboard-4bol)', async () => {
+    // First paint blocks on the preview load, so it keeps a tight 2.5s budget: a
+    // rig read that takes 10s on a slow supervisor degrades to partial rather
+    // than holding the tab blank. The wider refresh budget then clears it.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') {
+        return new Promise<ListBodyBead>((resolve) => {
+          setTimeout(() => resolve(beadList([])), 10_000);
+        });
+      }
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummaryPreviewSource();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanesPartial).toBe(true);
+  });
 });
 
 describe('loadSupervisorRunSummarySource', () => {
@@ -442,13 +472,45 @@ describe('loadSupervisorRunSummarySource', () => {
     });
 
     const pending = loadSupervisorRunSummarySource();
-    await vi.advanceTimersByTimeAsync(2_500);
+    // The full source is Runs.tsx's background refresh, so its enrichment runs on
+    // the wider REFRESH budget (gascity-dashboard-4bol); the cap still fires.
+    await vi.advanceTimersByTimeAsync(30_000);
     const source = await pending;
 
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanesPartial).toBe(true);
+  });
+
+  it('clears the spurious partial when a slow-but-available enrichment read lands within the wider refresh budget (gascity-dashboard-4bol)', async () => {
+    // The background refresh tolerates a slow supervisor: a rig read that takes
+    // 10s — past the 2.5s first-paint budget but inside the 30s refresh budget —
+    // lands, so the lanes are NOT latched partial (upstream gascity-dashboard#88).
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') {
+        return new Promise<ListBodyBead>((resolve) => {
+          setTimeout(() => resolve(beadList([])), 10_000);
+        });
+      }
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummarySource();
+    await vi.advanceTimersByTimeAsync(10_000);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanesPartial).toBeUndefined();
   });
 
   it('returns an error source when the active bead list fails', async () => {

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -9,6 +9,7 @@ import type {
 } from 'gas-city-dashboard-shared/gc-supervisor';
 import { resetSupervisorApiForTests, setSupervisorApiForTests, type SupervisorApi } from './client';
 import {
+  loadSupervisorRunSummaryMountSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
   resetSupervisorRunSummaryStateForTests,
@@ -511,6 +512,37 @@ describe('loadSupervisorRunSummarySource', () => {
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanesPartial).toBeUndefined();
+  });
+
+  it('keeps the tight first-paint budget on the mount source so Home/Formula Run Detail never block on a slow read (gascity-dashboard-4bol)', async () => {
+    // Same 10s rig read as the refresh test above, but the mount source (Home,
+    // Formula Run Detail first paint) runs on the 2.5s budget — the read does NOT
+    // land, so the lanes are latched partial rather than blocking ~30s on a cold
+    // navigation. This is the regression guard for the refresh-budget leak.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') {
+        return new Promise<ListBodyBead>((resolve) => {
+          setTimeout(() => resolve(beadList([])), 10_000);
+        });
+      }
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummaryMountSource();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanesPartial).toBe(true);
   });
 
   it('returns an error source when the active bead list fails', async () => {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -75,13 +75,30 @@ interface ProgressState {
 
 const progressStateByCity = new Map<string, ProgressState>();
 
+// Runs.tsx background refresh ONLY (gascity-dashboard-4bol): the wide enrichment
+// budget lets slow-but-available list/feed reads land and clear the spurious
+// "runs partial" badge (upstream gascity-dashboard#88). Do NOT use as a
+// mount/first-paint fetcher — it can block up to REFRESH_ENRICHMENT_TIMEOUT_MS;
+// mount consumers (Home, Formula Run Detail) use loadSupervisorRunSummaryMountSource.
 export async function loadSupervisorRunSummarySource(): Promise<SourceState<RunSummary>> {
+  return loadRunSummarySource(REFRESH_ENRICHMENT_TIMEOUT_MS);
+}
+
+// Mount / first-paint full source for Home and Formula Run Detail: the same data
+// as the refresh source (lanes + sessions) but on the tight first-paint budget,
+// so a cold navigation to those routes never blocks on slow optional enrichment
+// reads (gascity-dashboard-4bol).
+export async function loadSupervisorRunSummaryMountSource(): Promise<SourceState<RunSummary>> {
+  return loadRunSummarySource(PREVIEW_ENRICHMENT_TIMEOUT_MS);
+}
+
+async function loadRunSummarySource(enrichmentBudgetMs: number): Promise<SourceState<RunSummary>> {
   const cityName = activeCityOrThrow('load supervisor run summary');
   const fetchedAt = new Date().toISOString();
   try {
     const [loaded, sessions] = await Promise.all([
-      loadRunBeads(cityName, RUNS_FETCH_LIMIT, REFRESH_ENRICHMENT_TIMEOUT_MS),
-      loadRunSessions(cityName, REFRESH_ENRICHMENT_TIMEOUT_MS),
+      loadRunBeads(cityName, RUNS_FETCH_LIMIT, enrichmentBudgetMs),
+      loadRunSessions(cityName, enrichmentBudgetMs),
     ]);
     const summary = buildRunSummary(
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -42,7 +42,19 @@ const RUNS_FETCH_LIMIT = 500;
 const RECENT_RUN_FETCH_LIMIT = 500;
 const RUNS_STALE_AFTER_MS = 60 * 1000;
 const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 5_000;
-const OPTIONAL_ENRICHMENT_TIMEOUT_MS = 2_500;
+// Optional run-summary enrichment (recent-bead / formula-feed / session reads)
+// is best-effort: a miss degrades the lanes to "partial" rather than failing the
+// load. The budget is split by call site (gascity-dashboard-4bol). The preview
+// runs on first paint and blocks it, so it keeps a tight bound and the tab paints
+// fast even when the supervisor is slow. The full source runs only as Runs.tsx's
+// background refreshFetcher, so it can afford a far wider budget matching the 30s
+// background status samplers: on the bloated store the supervisor's list/feed
+// reads run ~10-38s (upstream gascity-dashboard#88), so a 2.5s interactive bound
+// always times out and latches a spurious "runs partial" badge. The wider refresh
+// budget lets those slow-but-available reads land and clear it, without the
+// first-paint spinner a single global raise would cause.
+const PREVIEW_ENRICHMENT_TIMEOUT_MS = 2_500;
+const REFRESH_ENRICHMENT_TIMEOUT_MS = 30_000;
 
 interface LoadedRunBeads {
   beads: DashboardBead[];
@@ -68,8 +80,8 @@ export async function loadSupervisorRunSummarySource(): Promise<SourceState<RunS
   const fetchedAt = new Date().toISOString();
   try {
     const [loaded, sessions] = await Promise.all([
-      loadRunBeads(cityName, RUNS_FETCH_LIMIT),
-      loadRunSessions(cityName),
+      loadRunBeads(cityName, RUNS_FETCH_LIMIT, REFRESH_ENRICHMENT_TIMEOUT_MS),
+      loadRunSessions(cityName, REFRESH_ENRICHMENT_TIMEOUT_MS),
     ]);
     const summary = buildRunSummary(
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
@@ -101,7 +113,7 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
   const cityName = activeCityOrThrow('load supervisor run summary preview');
   const fetchedAt = new Date().toISOString();
   try {
-    const loaded = await loadRunBeads(cityName, RUNS_FETCH_LIMIT);
+    const loaded = await loadRunBeads(cityName, RUNS_FETCH_LIMIT, PREVIEW_ENRICHMENT_TIMEOUT_MS);
     const summary = buildRunSummary(
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
       loaded.feedScopes,
@@ -134,30 +146,42 @@ function requiredRunSummaryApi() {
   return supervisorApiForRequestBudget(REQUIRED_RUN_SUMMARY_TIMEOUT_MS);
 }
 
-function optionalRunSummaryApi() {
-  return supervisorApiForRequestBudget(OPTIONAL_ENRICHMENT_TIMEOUT_MS);
+function optionalRunSummaryApi(budgetMs: number) {
+  return supervisorApiForRequestBudget(budgetMs);
 }
 
-async function loadRunBeads(cityName: string, limit: number): Promise<LoadedRunBeads> {
-  const moleculeFetch = settledRecentFetch(cityName, {
-    limit: RECENT_RUN_FETCH_LIMIT,
-    type: 'molecule',
-    all: true,
-  });
+async function loadRunBeads(
+  cityName: string,
+  limit: number,
+  enrichmentBudgetMs: number,
+): Promise<LoadedRunBeads> {
+  const moleculeFetch = settledRecentFetch(
+    cityName,
+    {
+      limit: RECENT_RUN_FETCH_LIMIT,
+      type: 'molecule',
+      all: true,
+    },
+    enrichmentBudgetMs,
+  );
   const [activeList, feedDiscovery] = await Promise.all([
     requiredRunSummaryApi().listBeads(cityName, { limit }),
-    discoverFromFeed(cityName),
+    discoverFromFeed(cityName, enrichmentBudgetMs),
   ]);
   const active = normalizeBeads(activeList.items ?? []);
   const rigNames = unionRigNames(runRigNames(active), feedDiscovery.rigNames);
 
   const rigFetches = rigNames.map((rig) =>
-    settledRecentFetch(cityName, {
-      limit: RECENT_RUN_FETCH_LIMIT,
-      type: 'task',
-      rig,
-      all: true,
-    }),
+    settledRecentFetch(
+      cityName,
+      {
+        limit: RECENT_RUN_FETCH_LIMIT,
+        type: 'task',
+        rig,
+        all: true,
+      },
+      enrichmentBudgetMs,
+    ),
   );
 
   const settled = await Promise.all([moleculeFetch, ...rigFetches]);
@@ -185,11 +209,13 @@ async function loadRunBeads(cityName: string, limit: number): Promise<LoadedRunB
 async function settledRecentFetch(
   cityName: string,
   query: { limit: number; type: string; all: true; rig?: string },
+  budgetMs: number,
 ): Promise<RecentFetchOutcome> {
   try {
     const list = await withOptionalReadBudget(
-      optionalRunSummaryApi().listBeads(cityName, query),
+      optionalRunSummaryApi(budgetMs).listBeads(cityName, query),
       `recent ${query.type} beads`,
+      budgetMs,
     );
     return {
       ok: true,
@@ -207,14 +233,15 @@ interface FeedDiscovery {
   partial: boolean;
 }
 
-async function discoverFromFeed(cityName: string): Promise<FeedDiscovery> {
+async function discoverFromFeed(cityName: string, budgetMs: number): Promise<FeedDiscovery> {
   try {
     const runs = await withOptionalReadBudget(
-      optionalRunSummaryApi().formulaFeed(cityName, {
+      optionalRunSummaryApi(budgetMs).formulaFeed(cityName, {
         scope_kind: 'city',
         scope_ref: cityName,
       }),
       'formula feed',
+      budgetMs,
     );
     const rigNames = new Set<string>();
     const scopes = new Map<string, RunFeedScope>();
@@ -240,11 +267,12 @@ async function discoverFromFeed(cityName: string): Promise<FeedDiscovery> {
   }
 }
 
-async function loadRunSessions(cityName: string): Promise<RunSessionsLookup> {
+async function loadRunSessions(cityName: string, budgetMs: number): Promise<RunSessionsLookup> {
   try {
     const list = await withOptionalReadBudget(
-      optionalRunSummaryApi().listSessions(cityName),
+      optionalRunSummaryApi(budgetMs).listSessions(cityName),
       'run sessions',
+      budgetMs,
     );
     return {
       kind: 'available',
@@ -331,12 +359,16 @@ function unionRigNames(a: readonly string[], b: readonly string[]): string[] {
   return [...all];
 }
 
-function withOptionalReadBudget<T>(promise: Promise<T>, label: string): Promise<T> {
+function withOptionalReadBudget<T>(
+  promise: Promise<T>,
+  label: string,
+  budgetMs: number,
+): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | null = null;
   const budget = new Promise<T>((_, reject) => {
     timeout = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${OPTIONAL_ENRICHMENT_TIMEOUT_MS}ms`));
-    }, OPTIONAL_ENRICHMENT_TIMEOUT_MS);
+      reject(new Error(`${label} timed out after ${budgetMs}ms`));
+    }, budgetMs);
   });
   return Promise.race([
     promise.finally(() => {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -49,6 +49,7 @@ export type * from './dashboard-beads.js';
 export type * from './activity.js';
 export type * from './dashboard-health.js';
 export type * from './rig-store-health.js';
+export type * from './supervisor-status.js';
 export type * from './api-error.js';
 export type * from './maintainer-triage.js';
 export type * from './views.js';

--- a/shared/src/supervisor-status.ts
+++ b/shared/src/supervisor-status.ts
@@ -1,0 +1,31 @@
+import type { IsoTimestamp } from './dashboard-sessions.js';
+import type { StatusBody } from './generated/gc-supervisor-client/index.js';
+
+// gascity-dashboard-4bol: the supervisor /status read turns slow on a bloated
+// city store (~247K beads / 21 rigs) and trips the interactive 2.5s budget the
+// Health page used for its store-thresholds / dolt-usage / beads-usage widgets,
+// surfacing "supervisor status unavailable" even while the 30s background
+// samplers succeed. The dashboard backend now samples /status on the same
+// higher ceiling and serves the cached snapshot, so the browser reads a fast
+// local route instead of racing the slow supervisor. The envelope is
+// dashboard-owned (availability + freshness metadata); `status` passes the raw
+// supervisor wire shape through unchanged rather than mirroring it.
+
+export type SupervisorStatusUnavailableReason =
+  /** The backend sampler has not completed a first read yet. */
+  | 'not_sampled_yet'
+  /** Backend sampled, but the supervisor /status read failed. */
+  | 'status_read_failed';
+
+export type SupervisorStatusReport =
+  | {
+      available: true;
+      sampledAt: IsoTimestamp;
+      status: StatusBody;
+    }
+  | {
+      available: false;
+      reason: SupervisorStatusUnavailableReason;
+      /** The last successfully sampled status, if any (degraded, not blank). */
+      status: StatusBody | null;
+    };


### PR DESCRIPTION
Fixes the noisy Health tab + spurious "Runs N" badge Stephanie hit (bead 4bol). Root cause: the live supervisor `/v0/city/.../status` read is 10–38s (median ~23s) on the bloated store, but the interactive Health reads (Dolt/Beads usage, Store thresholds) + the runs-partial path used a 2.5s budget → always timed out → "supervisor status unavailable" + a spurious "runs partial" badge, while the 30s background samplers succeeded. (Timing + profiling: gastownhall/gascity-dashboard#88.)

## Fix (3 commits)
- **c8efe08** serve the interactive status widgets (Dolt usage, Beads usage, Store thresholds) from the cached 30s-sampler `/status` snapshot instead of a fresh 2.5s interactive read — no user-facing 30s wait, no false "unavailable".
- **517a2bc** split the run-summary enrichment budget so the background refresh clears the spurious "runs partial" badge + harden the status edge decode.
- **c9eb349** sampler headroom + a "stale" marker for cached status (the 37.9s spike exceeds even the 30s sampler ceiling, so serve last-good with a stale marker rather than going fully unavailable on one miss).

shared/supervisor-status + backend (runtime, supervisor-status route) + frontend (Health, runSummary, client) + tests. CI parity green locally (typecheck src+test, format:check; mayor-verified shared 106/backend 562/frontend 797 + build). Backend change → needs a restart on redeploy. Refs #88. Mayor merge-gates.
