### PR TITLE
feat(readonly): project readOnly into shared config + disable SPA mutating controls (uzhr, build-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ credentials.*
 !.prettierignore
 !.claude/
 !.claude/**
+# ...but never the nested git worktrees agents create under .claude/ — those are
+# full checkouts (with node_modules) that must not be tracked or formatted.
+.claude/worktrees/
 !.agents/
 !.agents/**
 .scorecard/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 backend/openapi/gc-supervisor.openapi.json
 shared/src/generated/
 tmp/
+.claude/worktrees/

--- a/backend/src/city/runtime.test.ts
+++ b/backend/src/city/runtime.test.ts
@@ -1,0 +1,62 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { GcClient } from '../gc-client.js';
+import type { AdminConfig } from '../config.js';
+import { createCityRuntime } from './runtime.js';
+
+function makeConfig(overrides: Partial<AdminConfig> = {}): AdminConfig {
+  return {
+    port: 8081,
+    bindHost: '127.0.0.1',
+    extraAllowedHosts: [],
+    gcSupervisorUrl: 'http://127.0.0.1:1',
+    cityName: 'test-city',
+    cityPath: '',
+    runCwdAllowedRoots: [],
+    auditLogPath: '.gc/events.jsonl',
+    frontendDistPath: '../frontend/dist-does-not-exist',
+    disabled: false,
+    readOnly: false,
+    modules: {
+      maintainer: {
+        githubRepo: 'gastownhall/gascity',
+        slingTarget: 'mayor',
+        triageTarget: 'chief-of-staff',
+        refreshIntervalMs: 0,
+        cachePath: '.gascity-dashboard/maintainer-cache.json',
+      },
+    },
+    useFixtures: false,
+    enabledModules: null,
+    defaultView: null,
+    ...overrides,
+  };
+}
+
+// createCityRuntime never touches the GcClient during construction (the
+// samplers only call it once started), so a bare stub keeps this projection
+// test free of any supervisor network dependency.
+const stubGc = {} as GcClient;
+
+describe('createCityRuntime: read-only posture projection (gascity-dashboard-uzhr)', () => {
+  test('projects config.readOnly=true onto dashboardConfig.readOnly', () => {
+    const runtime = createCityRuntime({
+      cityName: 'test-city',
+      cityPath: '/host/test-city',
+      config: makeConfig({ readOnly: true }),
+      gc: stubGc,
+    });
+    assert.equal(runtime.dashboardConfig.readOnly, true);
+  });
+
+  test('projects config.readOnly=false onto dashboardConfig.readOnly', () => {
+    const runtime = createCityRuntime({
+      cityName: 'test-city',
+      cityPath: '/host/test-city',
+      config: makeConfig({ readOnly: false }),
+      gc: stubGc,
+    });
+    assert.equal(runtime.dashboardConfig.readOnly, false);
+  });
+});

--- a/backend/src/city/runtime.ts
+++ b/backend/src/city/runtime.ts
@@ -86,6 +86,10 @@ export function createCityRuntime(opts: CreateCityRuntimeOptions): CityRuntime {
     cityName,
     cityRoot: cityPath,
     useFixtures: config.useFixtures,
+    // Project the server's read-only posture (DASHBOARD_READONLY) onto the
+    // wire so the SPA can disable mutating controls (gascity-dashboard-uzhr).
+    // The proxy gate (z8n7) is the enforcement; this is the affordance.
+    readOnly: config.readOnly,
     // Always emit the explicit resolved firstParty id list (possibly empty)
     // so the wire is unambiguous and the frontend filter never has to guess
     // what an unset env meant. Core-only default surfaces as `[]`.

--- a/backend/test/city-dispatch.test.ts
+++ b/backend/test/city-dispatch.test.ts
@@ -50,6 +50,7 @@ function fakeRuntime(cityName: string): CityRuntime & { started: number; stopped
       cityName,
       cityRoot: '',
       useFixtures: false,
+      readOnly: false,
       enabledModules: null,
       defaultView: null,
     },

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -10,6 +10,7 @@ vi.mock('./api/client', () => ({
       cityName: 'test-city',
       defaultView: null,
       enabledModules: [],
+      readOnly: false,
     })),
   },
 }));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { AttentionProvider } from './attention/context';
 import { useLiveAttentionContributors } from './attention/liveContributors';
 import { Layout } from './components/Layout';
 import { NowProvider } from './contexts/NowContext';
-import { ReadOnlyProvider } from './contexts/ReadOnlyContext';
+import { ReadOnlyProvider, resolveReadOnly } from './contexts/ReadOnlyContext';
 import { ViewingAsProvider } from './contexts/ViewingAsContext';
 import { useCachedData } from './hooks/useCachedData';
 import { ALL_VIEWS } from './views/registry';
@@ -36,12 +36,13 @@ export function App() {
   // flight `data` is undefined; we treat that as core-only, matching the
   // steady-state default install and preventing disabled first-party modules
   // from flashing or fetching before config lands.
-  const { data: config } = useCachedData('config', () => api.config());
+  const { data: config, error: configError } = useCachedData('config', () => api.config());
   const enabledModules = config?.enabledModules ?? null;
   const defaultViewEnv = config?.defaultView ?? null;
-  // Until /config lands, treat the dashboard as writable (matches prior
-  // behaviour); the server proxy gate stays the real enforcement either way.
-  const readOnly = config?.readOnly ?? false;
+  // Read-only posture is fail-closed on a config-fetch error and writable only
+  // while the first fetch is in flight — see resolveReadOnly. The server proxy
+  // gate stays the real enforcement throughout.
+  const readOnly = resolveReadOnly(config, configError);
   const attentionContributors = useLiveAttentionContributors(enabledModules);
 
   const enabledViews = useMemo(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AttentionProvider } from './attention/context';
 import { useLiveAttentionContributors } from './attention/liveContributors';
 import { Layout } from './components/Layout';
 import { NowProvider } from './contexts/NowContext';
+import { ReadOnlyProvider } from './contexts/ReadOnlyContext';
 import { ViewingAsProvider } from './contexts/ViewingAsContext';
 import { useCachedData } from './hooks/useCachedData';
 import { ALL_VIEWS } from './views/registry';
@@ -38,6 +39,9 @@ export function App() {
   const { data: config } = useCachedData('config', () => api.config());
   const enabledModules = config?.enabledModules ?? null;
   const defaultViewEnv = config?.defaultView ?? null;
+  // Until /config lands, treat the dashboard as writable (matches prior
+  // behaviour); the server proxy gate stays the real enforcement either way.
+  const readOnly = config?.readOnly ?? false;
   const attentionContributors = useLiveAttentionContributors(enabledModules);
 
   const enabledViews = useMemo(
@@ -60,46 +64,48 @@ export function App() {
   return (
     <ViewingAsProvider>
       <NowProvider>
-        <AttentionProvider contributors={attentionContributors}>
-          <Layout>
-            <Suspense fallback={null}>
-              <Routes>
-                {/* `/` resolution (PRD §6 / bead 9yj.5):
+        <ReadOnlyProvider readOnly={readOnly}>
+          <AttentionProvider contributors={attentionContributors}>
+            <Layout>
+              <Suspense fallback={null}>
+                <Routes>
+                  {/* `/` resolution (PRD §6 / bead 9yj.5):
                   DEFAULT_VIEW env → descriptor `defaultRoute: true` →
                   kb3 ambient home fallback. The resolver runs once per
                   enabled-set / env change; warnings surface in the
                   browser console for premortem #5 visibility. */}
-                <Route
-                  path="/"
-                  element={
-                    defaultRedirectTo !== null ? (
-                      <Navigate to={defaultRedirectTo} replace />
-                    ) : DefaultViewElement !== null ? (
-                      <DefaultViewElement />
-                    ) : (
-                      <AmbientHomePage />
-                    )
-                  }
-                />
-                <Route path="/agents" element={<AgentsPage />} />
-                <Route path="/agents/:slug" element={<AgentDetailPage />} />
-                <Route path="/beads" element={<BeadsPage />} />
-                <Route path="/runs" element={<RunsPage />} />
-                <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
-                <Route path="/mail" element={<MailPage />} />
-                {/* Modular-dashboard registry routes, filtered by the
+                  <Route
+                    path="/"
+                    element={
+                      defaultRedirectTo !== null ? (
+                        <Navigate to={defaultRedirectTo} replace />
+                      ) : DefaultViewElement !== null ? (
+                        <DefaultViewElement />
+                      ) : (
+                        <AmbientHomePage />
+                      )
+                    }
+                  />
+                  <Route path="/agents" element={<AgentsPage />} />
+                  <Route path="/agents/:slug" element={<AgentDetailPage />} />
+                  <Route path="/beads" element={<BeadsPage />} />
+                  <Route path="/runs" element={<RunsPage />} />
+                  <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
+                  <Route path="/mail" element={<MailPage />} />
+                  {/* Modular-dashboard registry routes, filtered by the
                   backend's enabledModules set. A disabled module's path
                   is absent so deep-link bookmarks surface the operator's
                   MODULES_ENABLED change as the explicit catch-all route. */}
-                {enabledViews.map((v) => {
-                  const Element = v.element;
-                  return <Route key={v.id} path={v.path} element={<Element />} />;
-                })}
-                <Route path="*" element={<NotFoundPage />} />
-              </Routes>
-            </Suspense>
-          </Layout>
-        </AttentionProvider>
+                  {enabledViews.map((v) => {
+                    const Element = v.element;
+                    return <Route key={v.id} path={v.path} element={<Element />} />;
+                  })}
+                  <Route path="*" element={<NotFoundPage />} />
+                </Routes>
+              </Suspense>
+            </Layout>
+          </AttentionProvider>
+        </ReadOnlyProvider>
       </NowProvider>
     </ViewingAsProvider>
   );

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -63,6 +63,61 @@ describe('api client error handling', () => {
     });
   });
 
+  it('rejects a config body missing the read-only posture at the edge', async () => {
+    // readOnly drives whether the SPA disables its mutating controls
+    // (gascity-dashboard-uzhr). A body that omits it must fail at the edge
+    // rather than default-coerce a missing flag to a writable dashboard.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              cityName: 'demo-city',
+              cityRoot: '/srv/gc/demo',
+              useFixtures: false,
+              enabledModules: null,
+              defaultView: null,
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+      ),
+    );
+
+    await expect(api.config()).rejects.toMatchObject({
+      name: 'ApiResponseDecodeError',
+      message: expect.stringContaining('config.readOnly must be a boolean'),
+    });
+  });
+
+  it('decodes a well-formed config body carrying the read-only posture', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              cityName: 'demo-city',
+              cityRoot: '/srv/gc/demo',
+              useFixtures: false,
+              readOnly: true,
+              enabledModules: null,
+              defaultView: null,
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+      ),
+    );
+
+    await expect(api.config()).resolves.toMatchObject({ readOnly: true });
+  });
+
   it('rejects a local-tools body whose drift union is absent at the edge', async () => {
     // The Health renderer branches on each tool's `drift`; a tool object that
     // omits it would mis-render silently, so the decoder rejects it up front.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -247,6 +247,7 @@ const decodeRuntimeConfig = objectDecoder<DashboardRuntimeConfig>('config', (rec
   requireStringField(record, url, 'config', 'cityName');
   requireStringField(record, url, 'config', 'cityRoot');
   requireBooleanField(record, url, 'config', 'useFixtures');
+  requireBooleanField(record, url, 'config', 'readOnly');
   requireStringArrayOrNullField(record, url, 'config', 'enabledModules');
   requireNullableStringField(record, url, 'config', 'defaultView');
   if (record.maintainer !== undefined) {

--- a/frontend/src/components/Header.attention.test.tsx
+++ b/frontend/src/components/Header.attention.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../api/client', () => ({
       cityName: 'test-city',
       defaultView: null,
       enabledModules: [],
+      readOnly: false,
     })),
   },
 }));

--- a/frontend/src/components/mail/ComposeModal.tsx
+++ b/frontend/src/components/mail/ComposeModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { formatApiError } from '../../api/client';
+import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../../contexts/ReadOnlyContext';
 import { OPERATOR_ALIAS, useViewingAs } from '../../contexts/ViewingAsContext';
 import { displayLabel } from '../../hooks/aliasPriority';
 import { sendSupervisorMail } from '../../supervisor/mailWrites';
@@ -16,6 +17,7 @@ interface ComposeModalProps {
 
 export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
   const { viewingAs } = useViewingAs();
+  const readOnly = useReadOnly();
   const [to, setTo] = useState('');
   const [subject, setSubject] = useState('');
   const [body, setBody] = useState('');
@@ -32,6 +34,9 @@ export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
   }, [open]);
 
   const onSend = useCallback(async () => {
+    // Defense-in-depth: the disabled Send button already blocks this, but a
+    // keyboard/programmatic path must never reach a write the server 405s.
+    if (readOnly) return;
     setSending(true);
     setError(null);
     try {
@@ -42,10 +47,15 @@ export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
     } finally {
       setSending(false);
     }
-  }, [body, onSent, subject, to]);
+  }, [body, onSent, readOnly, subject, to]);
 
   const canSend =
-    viewingAs.isOperator && to.length > 0 && subject.length > 0 && body.length > 0 && !sending;
+    !readOnly &&
+    viewingAs.isOperator &&
+    to.length > 0 &&
+    subject.length > 0 &&
+    body.length > 0 &&
+    !sending;
 
   return (
     <Modal
@@ -59,7 +69,13 @@ export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
           <Button tone="quiet" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button tone="accent" size="sm" disabled={!canSend} onClick={() => void onSend()}>
+          <Button
+            tone="accent"
+            size="sm"
+            disabled={!canSend}
+            title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+            onClick={() => void onSend()}
+          >
             {sending ? 'Sending' : 'Send'}
           </Button>
         </>
@@ -106,6 +122,7 @@ export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
             className="w-full bg-surface-tint border border-rule rounded-sm px-3 py-2 text-body text-fg focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/40 resize-y"
           />
         </Field>
+        {readOnly && <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />}
         {!viewingAs.isOperator && (
           <StatusBadge
             tone="warn"

--- a/frontend/src/components/mail/ComposeModal.tsx
+++ b/frontend/src/components/mail/ComposeModal.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { formatApiError } from '../../api/client';
-import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../../contexts/ReadOnlyContext';
+import {
+  READ_ONLY_CONTROL_TITLE,
+  ReadOnlyBadge,
+  useReadOnly,
+} from '../../contexts/ReadOnlyContext';
 import { OPERATOR_ALIAS, useViewingAs } from '../../contexts/ViewingAsContext';
 import { displayLabel } from '../../hooks/aliasPriority';
 import { sendSupervisorMail } from '../../supervisor/mailWrites';
@@ -122,7 +126,7 @@ export function ComposeModal({ open, onClose, onSent }: ComposeModalProps) {
             className="w-full bg-surface-tint border border-rule rounded-sm px-3 py-2 text-body text-fg focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/40 resize-y"
           />
         </Field>
-        {readOnly && <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />}
+        {readOnly && <ReadOnlyBadge />}
         {!viewingAs.isOperator && (
           <StatusBadge
             tone="warn"

--- a/frontend/src/contexts/ReadOnlyContext.test.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReadOnly } from './ReadOnlyContext';
+
+// The read-only posture is security-relevant (gascity-dashboard-uzhr): it must
+// fail CLOSED when the dashboard cannot confirm the backend's mode, so a click
+// never 405s into an unhandled error — the regression the affordance removes.
+describe('resolveReadOnly', () => {
+  it('trusts the decoded flag when config is present', () => {
+    expect(resolveReadOnly({ readOnly: true }, null)).toBe(true);
+    expect(resolveReadOnly({ readOnly: false }, null)).toBe(false);
+  });
+
+  it('fails closed (read-only) when the config fetch errored', () => {
+    // Network failure, or a backend too old to emit readOnly so the edge
+    // decoder threw: config never lands, error is set -> disable mutations.
+    expect(resolveReadOnly(undefined, 'config.readOnly must be a boolean')).toBe(true);
+  });
+
+  it('stays writable while the first config fetch is in flight', () => {
+    // No data yet, no error yet: the sub-second pre-load window must not flash
+    // every mutating control disabled on a normal page load.
+    expect(resolveReadOnly(undefined, null)).toBe(false);
+  });
+
+  it('prefers a decoded writable flag over a stale error', () => {
+    // A later successful refresh clears nothing about the prior error string in
+    // some flows; a present config is authoritative over any lingering error.
+    expect(resolveReadOnly({ readOnly: false }, 'earlier transient error')).toBe(false);
+  });
+});

--- a/frontend/src/contexts/ReadOnlyContext.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.tsx
@@ -32,8 +32,11 @@ export function useReadOnly(): boolean {
   return useContext(ReadOnlyContext);
 }
 
-/** Shared title/affordance copy for a control disabled by read-only mode. */
-export const READ_ONLY_CONTROL_TITLE = 'Read-only mode — mutations are disabled';
+/**
+ * Shared title/affordance copy for a control disabled by read-only mode.
+ * Uses a colon, not an em dash, per DESIGN.md §"Don't use em dashes in UI copy".
+ */
+export const READ_ONLY_CONTROL_TITLE = 'Read-only mode: mutations are disabled';
 
 /**
  * The single "Read-only" affordance badge, shared by every surface that

--- a/frontend/src/contexts/ReadOnlyContext.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, type ReactNode } from 'react';
+import { StatusBadge } from '../components/StatusBadge';
 
 // Server-enforced read-only posture surfaced to the SPA
 // (gascity-dashboard-uzhr). When the backend runs with `DASHBOARD_READONLY=1`,
@@ -33,3 +34,13 @@ export function useReadOnly(): boolean {
 
 /** Shared title/affordance copy for a control disabled by read-only mode. */
 export const READ_ONLY_CONTROL_TITLE = 'Read-only mode — mutations are disabled';
+
+/**
+ * The single "Read-only" affordance badge, shared by every surface that
+ * disables a supervisor-mutating control. Keeping the tone/label/title in one
+ * place stops the five call sites from drifting (DESIGN.md §States have words:
+ * a glyph + word, not color alone). Render behind a `readOnly &&` guard.
+ */
+export function ReadOnlyBadge() {
+  return <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />;
+}

--- a/frontend/src/contexts/ReadOnlyContext.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.tsx
@@ -32,18 +32,13 @@ export function useReadOnly(): boolean {
   return useContext(ReadOnlyContext);
 }
 
-/**
- * Shared title/affordance copy for a control disabled by read-only mode.
- * Uses a colon, not an em dash, per DESIGN.md §"Don't use em dashes in UI copy".
- */
+/** Title/affordance copy for a control disabled by read-only mode. Colon, not
+ *  an em dash, per DESIGN.md §"Don't use em dashes in UI copy". */
 export const READ_ONLY_CONTROL_TITLE = 'Read-only mode: mutations are disabled';
 
-/**
- * The single "Read-only" affordance badge, shared by every surface that
- * disables a supervisor-mutating control. Keeping the tone/label/title in one
- * place stops the five call sites from drifting (DESIGN.md §States have words:
- * a glyph + word, not color alone). Render behind a `readOnly &&` guard.
- */
+/** The single "Read-only" affordance badge shared by every disabled mutating
+ *  control (DESIGN.md §States have words: a glyph + word, not color alone).
+ *  Render behind a `readOnly &&` guard. */
 export function ReadOnlyBadge() {
   return <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />;
 }

--- a/frontend/src/contexts/ReadOnlyContext.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.tsx
@@ -32,6 +32,27 @@ export function useReadOnly(): boolean {
   return useContext(ReadOnlyContext);
 }
 
+/**
+ * Resolve the SPA's read-only posture from the `/config` fetch state. Three
+ * cases, because "config not yet decoded" is not the same as "config says
+ * writable" (gascity-dashboard-uzhr):
+ *   - config decoded   -> trust its `readOnly` flag.
+ *   - config errored    -> fail CLOSED (read-only). A network failure, or a
+ *     backend too old to emit `readOnly` (the edge decoder then throws), must
+ *     NOT leave every mutating control live to 405 on click — that is exactly
+ *     the regression this affordance removes.
+ *   - config in flight  -> writable, matching prior behaviour, so controls
+ *     don't flash disabled on every normal page load. The window is sub-second
+ *     and the server proxy gate is the real enforcement throughout.
+ */
+export function resolveReadOnly(
+  config: { readOnly: boolean } | undefined,
+  configError: string | null,
+): boolean {
+  if (config) return config.readOnly;
+  return configError !== null;
+}
+
 /** Title/affordance copy for a control disabled by read-only mode. Colon, not
  *  an em dash, per DESIGN.md §"Don't use em dashes in UI copy". */
 export const READ_ONLY_CONTROL_TITLE = 'Read-only mode: mutations are disabled';

--- a/frontend/src/contexts/ReadOnlyContext.tsx
+++ b/frontend/src/contexts/ReadOnlyContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+// Server-enforced read-only posture surfaced to the SPA
+// (gascity-dashboard-uzhr). When the backend runs with `DASHBOARD_READONLY=1`,
+// the supervisor transport-proxy gate (z8n7) 405s every mutation. Without a
+// matching client affordance the SPA's create/sling/claim/close/nudge buttons
+// stay live and a click 405s into an unhandled API error. This context carries
+// the flag from `/config` so mutating controls render DISABLED (per
+// DESIGN.md §States have words: disabled + an explanatory title), never hidden.
+//
+// Default `false` covers the pre-config-load window and any consumer mounted
+// outside the provider: controls render enabled, exactly as before this flag
+// existed. The server gate remains the real enforcement, so the only risk in
+// that sub-second window is the same 405 the affordance removes once config
+// lands — never a privilege grant.
+
+const ReadOnlyContext = createContext<boolean>(false);
+
+export function ReadOnlyProvider({
+  readOnly,
+  children,
+}: {
+  readOnly: boolean;
+  children: ReactNode;
+}) {
+  return <ReadOnlyContext.Provider value={readOnly}>{children}</ReadOnlyContext.Provider>;
+}
+
+/** True when the dashboard backend is in read-only mode (DASHBOARD_READONLY=1). */
+export function useReadOnly(): boolean {
+  return useContext(ReadOnlyContext);
+}
+
+/** Shared title/affordance copy for a control disabled by read-only mode. */
+export const READ_ONLY_CONTROL_TITLE = 'Read-only mode — mutations are disabled';

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -6,6 +6,7 @@ import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor } from '../attention/compose';
 import { invalidate } from '../api/cache';
 import { NowProvider } from '../contexts/NowContext';
+import { ReadOnlyProvider } from '../contexts/ReadOnlyContext';
 import { resetSupervisorApiForTests } from '../supervisor/client';
 
 // Regression tests for two bugs that shipped with the ay6 Agents-view rewrite
@@ -402,6 +403,32 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       },
     });
     expect(fetchUrls()).not.toContain('/api/city/test-city/sessions/gc-2568/respond');
+  });
+
+  it('disables the pending Approve/Deny controls under DASHBOARD_READONLY (gascity-dashboard-uzhr)', async () => {
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <NowProvider intervalMs={1_000_000}>
+          <ReadOnlyProvider readOnly={true}>
+            <AgentsPage />
+          </ReadOnlyProvider>
+        </NowProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Approve deployment?')).toBeTruthy();
+
+    const approve = screen.getByRole('button', { name: /approve/i }) as HTMLButtonElement;
+    const deny = screen.getByRole('button', { name: /deny/i }) as HTMLButtonElement;
+    expect(approve.disabled).toBe(true);
+    expect(deny.disabled).toBe(true);
+    expect(approve.getAttribute('title')).toBe('Read-only mode: mutations are disabled');
+    // The affordance carries words, not just a dimmed control (DESIGN.md §States).
+    expect(screen.getByText('Read-only')).toBeTruthy();
+
+    // The disabled control must not reach the supervisor respond mutation.
+    fireEvent.click(deny);
+    expect(fetchUrls()).not.toContain('/gc-supervisor/v0/city/test-city/session/gc-2568/respond');
   });
 
   it('orphan agent name-link carries a different title tooltip than a session-bound one (ay6.2)', async () => {

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -14,6 +14,7 @@ import { SseIndicator } from '../components/SseIndicator';
 import { StatusBadge, stateTone } from '../components/StatusBadge';
 import { Table, type TableColumn } from '../components/Table';
 import { useNow } from '../contexts/NowContext';
+import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge, useReadOnly } from '../contexts/ReadOnlyContext';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
 import { formatRelative } from '../hooks/time';
@@ -162,8 +163,12 @@ export function AgentsPage() {
   );
 
   const synopsis = useMemo(() => buildAgentSynopsis(rows), [rows]);
+  const readOnly = useReadOnly();
   const handlePendingResponse = useCallback(
     async (pending: AgentPendingInteraction, action: 'approve' | 'deny') => {
+      // Defense-in-depth: the disabled buttons already block this, but a
+      // keyboard/programmatic path must never reach a write the server 405s.
+      if (readOnly) return;
       setResponding({ sessionId: pending.sessionId, action });
       setResponseMessage(null);
       setResponseError(null);
@@ -180,7 +185,7 @@ export function AgentsPage() {
         setResponding(null);
       }
     },
-    [pendingCache],
+    [pendingCache, readOnly],
   );
 
   // Rig dropdown options: the normalized rig labels (basenames, not raw
@@ -376,10 +381,12 @@ export function AgentsPage() {
             <div className="flex justify-end gap-2">
               {pending !== undefined && (
                 <>
+                  {readOnly && <ReadOnlyBadge />}
                   <Button
                     size="sm"
                     tone="quiet"
-                    disabled={responding?.sessionId === pending.sessionId}
+                    title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                    disabled={readOnly || responding?.sessionId === pending.sessionId}
                     onClick={() => void handlePendingResponse(pending, 'approve')}
                   >
                     {responding?.sessionId === pending.sessionId && responding.action === 'approve'
@@ -389,7 +396,8 @@ export function AgentsPage() {
                   <Button
                     size="sm"
                     tone="quiet"
-                    disabled={responding?.sessionId === pending.sessionId}
+                    title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                    disabled={readOnly || responding?.sessionId === pending.sessionId}
                     onClick={() => void handlePendingResponse(pending, 'deny')}
                   >
                     {responding?.sessionId === pending.sessionId && responding.action === 'deny'
@@ -409,7 +417,7 @@ export function AgentsPage() {
         className: 'w-80',
       },
     ],
-    [handlePendingResponse, now, pendingByAgent, responding],
+    [handlePendingResponse, now, pendingByAgent, readOnly, responding],
   );
 
   return (

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -6,6 +6,7 @@ import { invalidate, setCached } from '../api/cache';
 import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor } from '../attention/compose';
 import { NowProvider } from '../contexts/NowContext';
+import { ReadOnlyProvider } from '../contexts/ReadOnlyContext';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import { BeadsPage } from './Beads';
 
@@ -84,6 +85,46 @@ describe('BeadsPage supervisor reads', () => {
     expect(within(dialog).getByRole('button', { name: /view live run/i })).toBeTruthy();
   });
 
+  it('disables the New bead control and surfaces a read-only affordance under DASHBOARD_READONLY', async () => {
+    renderPage('/beads', [], { readOnly: true });
+
+    await screen.findByText('direct supervisor bead');
+
+    const newBead = screen.getByRole('button', { name: 'New bead' }) as HTMLButtonElement;
+    expect(newBead.disabled).toBe(true);
+    expect(newBead.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    // The affordance carries words, not just a dimmed control (DESIGN.md §States).
+    expect(screen.getByText('Read-only')).toBeTruthy();
+  });
+
+  it('disables the per-bead claim/close/nudge actions in read-only mode', async () => {
+    renderPage('/beads?bead=td-bead-abc123', [], { readOnly: true });
+
+    const dialog = await screen.findByRole('dialog');
+    // Scope to the bead-action group: the modal's own dismiss control also
+    // carries aria-label "Close", so query the actions row Claim sits in.
+    const actions = (within(dialog).getByRole('button', { name: 'Claim' }) as HTMLButtonElement)
+      .parentElement;
+    expect(actions).not.toBeNull();
+    for (const name of ['Claim', 'Close', 'Nudge']) {
+      const button = within(actions as HTMLElement).getByRole('button', {
+        name,
+      }) as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+    }
+  });
+
+  it('keeps the New bead control active when the dashboard is writable', async () => {
+    renderPage('/beads');
+
+    await screen.findByText('direct supervisor bead');
+
+    expect((screen.getByRole('button', { name: 'New bead' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(screen.queryByText('Read-only')).toBeNull();
+  });
+
   it('marks attention beads on the board while preserving non-attention rows', async () => {
     renderPage('/beads', [
       contributor('beads', [
@@ -101,16 +142,22 @@ describe('BeadsPage supervisor reads', () => {
   });
 });
 
-function renderPage(path = '/beads', contributors: readonly AttentionContributor[] = []) {
+function renderPage(
+  path = '/beads',
+  contributors: readonly AttentionContributor[] = [],
+  options: { readOnly?: boolean } = {},
+) {
   return render(
     <MemoryRouter
       initialEntries={[path]}
       future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <NowProvider intervalMs={1_000_000}>
-        <AttentionProvider contributors={contributors}>
-          <BeadsPage />
-        </AttentionProvider>
+        <ReadOnlyProvider readOnly={options.readOnly ?? false}>
+          <AttentionProvider contributors={contributors}>
+            <BeadsPage />
+          </AttentionProvider>
+        </ReadOnlyProvider>
       </NowProvider>
     </MemoryRouter>,
   );

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -92,7 +92,7 @@ describe('BeadsPage supervisor reads', () => {
 
     const newBead = screen.getByRole('button', { name: 'New bead' }) as HTMLButtonElement;
     expect(newBead.disabled).toBe(true);
-    expect(newBead.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    expect(newBead.getAttribute('title')).toBe('Read-only mode: mutations are disabled');
     // The affordance carries words, not just a dimmed control (DESIGN.md §States).
     expect(screen.getByText('Read-only')).toBeTruthy();
   });
@@ -112,6 +112,9 @@ describe('BeadsPage supervisor reads', () => {
       }) as HTMLButtonElement;
       expect(button.disabled).toBe(true);
     }
+    // The action row carries the shared glyph+word affordance, not a bare
+    // dimmed button (DESIGN.md §States have words).
+    expect(within(actions as HTMLElement).getByText('Read-only')).toBeTruthy();
   });
 
   it('keeps the New bead control active when the dashboard is writable', async () => {

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -13,7 +13,7 @@ import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { StatusBadge } from '../components/StatusBadge';
-import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../contexts/ReadOnlyContext';
+import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge, useReadOnly } from '../contexts/ReadOnlyContext';
 import { buildBeadGraph } from '../lib/beadGraph';
 import { resolveRigName, rigNameOptions } from '../lib/rigNames';
 import { useCachedData } from '../hooks/useCachedData';
@@ -403,9 +403,7 @@ export function BeadsPage() {
             <span className="text-label uppercase tracking-wider text-fg-faint">
               {showClosed ? 'All statuses' : 'Open work'}
             </span>
-            {readOnly && (
-              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
-            )}
+            {readOnly && <ReadOnlyBadge />}
             <Button
               type="button"
               size="sm"

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -13,6 +13,7 @@ import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
 import { StatusBadge } from '../components/StatusBadge';
+import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../contexts/ReadOnlyContext';
 import { buildBeadGraph } from '../lib/beadGraph';
 import { resolveRigName, rigNameOptions } from '../lib/rigNames';
 import { useCachedData } from '../hooks/useCachedData';
@@ -65,6 +66,7 @@ const BEAD_SEARCH_FIELDS = (b: SupervisorBead): ReadonlyArray<string | undefined
 
 export function BeadsPage() {
   const attention = useAttentionModel();
+  const readOnly = useReadOnly();
   const cityName = getActiveCity();
   const cityCacheKey = cityName ?? 'no-city';
   const [searchParams] = useSearchParams();
@@ -194,6 +196,9 @@ export function BeadsPage() {
 
   const runAction = useCallback(
     async (bead: SupervisorBead, action: BeadAction, reason?: string) => {
+      // Defense-in-depth: the disabled buttons already block this, but a
+      // keyboard/programmatic path must never reach a write the server 405s.
+      if (readOnly) return;
       setActionInFlight({ id: bead.id, action });
       setActionMessage(null);
       try {
@@ -220,7 +225,7 @@ export function BeadsPage() {
         setActionInFlight(null);
       }
     },
-    [refresh],
+    [readOnly, refresh],
   );
 
   const openCreateBead = useCallback(() => {
@@ -254,6 +259,9 @@ export function BeadsPage() {
   );
 
   const createAndSling = useCallback(async () => {
+    // Defense-in-depth: a form Enter-submit can fire even with the submit
+    // button disabled, so guard the write itself in read-only mode.
+    if (readOnly) return;
     setCreateInFlight(true);
     setCreateError(null);
     try {
@@ -274,7 +282,7 @@ export function BeadsPage() {
     } finally {
       setCreateInFlight(false);
     }
-  }, [newAgent, newBody, newRig, newTitle, refresh]);
+  }, [newAgent, newBody, newRig, newTitle, readOnly, refresh]);
 
   const matched = useMemo(() => filters.groups.flatMap((group) => group.rows), [filters.groups]);
   const graph = useMemo(() => buildBeadGraph(matched), [matched]);
@@ -305,8 +313,13 @@ export function BeadsPage() {
       const actionLabel =
         actionInFlight?.id === bead.id ? actionInFlight.action.replace('_', ' ') : null;
 
+      const roTitle = readOnly ? READ_ONLY_CONTROL_TITLE : undefined;
+
       return (
         <div className="flex flex-wrap items-center justify-end gap-2">
+          {readOnly && (
+            <span className="text-label uppercase tracking-wider text-fg-faint">read-only</span>
+          )}
           {actionLabel && (
             <span className="text-label uppercase tracking-wider text-fg-faint">{actionLabel}</span>
           )}
@@ -314,7 +327,8 @@ export function BeadsPage() {
             type="button"
             size="sm"
             tone="quiet"
-            disabled={busy || bead.status === 'in_progress' || bead.status === 'closed'}
+            title={roTitle}
+            disabled={readOnly || busy || bead.status === 'in_progress' || bead.status === 'closed'}
             onClick={() => void runAction(bead, 'claim')}
           >
             Claim
@@ -323,7 +337,8 @@ export function BeadsPage() {
             type="button"
             size="sm"
             tone="quiet"
-            disabled={busy || bead.status === 'closed'}
+            title={roTitle}
+            disabled={readOnly || busy || bead.status === 'closed'}
             onClick={() => {
               setCloseReason('');
               setActionMessage(null);
@@ -336,7 +351,8 @@ export function BeadsPage() {
             type="button"
             size="sm"
             tone="quiet"
-            disabled={busy || assignee.length === 0}
+            title={roTitle}
+            disabled={readOnly || busy || assignee.length === 0}
             onClick={() => void runAction(bead, 'nudge')}
           >
             Nudge
@@ -344,7 +360,7 @@ export function BeadsPage() {
         </div>
       );
     },
-    [actionInFlight, runAction],
+    [actionInFlight, readOnly, runAction],
   );
 
   const synopsis = useMemo(
@@ -387,11 +403,15 @@ export function BeadsPage() {
             <span className="text-label uppercase tracking-wider text-fg-faint">
               {showClosed ? 'All statuses' : 'Open work'}
             </span>
+            {readOnly && (
+              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
+            )}
             <Button
               type="button"
               size="sm"
+              title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
               onClick={openCreateBead}
-              disabled={agents.loading || agentItems.length === 0}
+              disabled={readOnly || agents.loading || agentItems.length === 0}
             >
               New bead
             </Button>
@@ -535,7 +555,8 @@ export function BeadsPage() {
               type="button"
               size="sm"
               tone="accent"
-              disabled={closing === null || actionInFlight !== null}
+              title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+              disabled={readOnly || closing === null || actionInFlight !== null}
               onClick={() => {
                 if (closing) void runAction(closing, 'close', closeReason);
               }}
@@ -580,8 +601,12 @@ export function BeadsPage() {
               type="submit"
               form="new-bead-form"
               size="sm"
+              title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
               disabled={
-                createInFlight || newTitle.trim().length === 0 || newAgent.trim().length === 0
+                readOnly ||
+                createInFlight ||
+                newTitle.trim().length === 0 ||
+                newAgent.trim().length === 0
               }
             >
               {createInFlight ? 'Creating' : 'Create and sling'}

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -317,9 +317,7 @@ export function BeadsPage() {
 
       return (
         <div className="flex flex-wrap items-center justify-end gap-2">
-          {readOnly && (
-            <span className="text-label uppercase tracking-wider text-fg-faint">read-only</span>
-          )}
+          {readOnly && <ReadOnlyBadge />}
           {actionLabel && (
             <span className="text-label uppercase tracking-wider text-fg-faint">{actionLabel}</span>
           )}

--- a/frontend/src/routes/Mail.render.test.tsx
+++ b/frontend/src/routes/Mail.render.test.tsx
@@ -448,7 +448,7 @@ describe('MailPage supervisor reads', () => {
 
     const compose = screen.getByRole('button', { name: 'Compose' }) as HTMLButtonElement;
     expect(compose.disabled).toBe(true);
-    expect(compose.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    expect(compose.getAttribute('title')).toBe('Read-only mode: mutations are disabled');
     // The affordance carries words, not just a dimmed control (DESIGN.md §States).
     expect(screen.getByText('Read-only')).toBeTruthy();
   });

--- a/frontend/src/routes/Mail.render.test.tsx
+++ b/frontend/src/routes/Mail.render.test.tsx
@@ -5,6 +5,7 @@ import { invalidate } from '../api/cache';
 import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor } from '../attention/compose';
 import { NowProvider } from '../contexts/NowContext';
+import { ReadOnlyProvider } from '../contexts/ReadOnlyContext';
 import { MailPage } from './Mail';
 
 interface FetchCall {
@@ -440,6 +441,45 @@ describe('MailPage supervisor reads', () => {
     });
   });
 
+  it('disables Compose and surfaces a read-only affordance under DASHBOARD_READONLY', async () => {
+    renderMailPage('/mail', { readOnly: true });
+
+    await screen.findByText('direct supervisor inbox');
+
+    const compose = screen.getByRole('button', { name: 'Compose' }) as HTMLButtonElement;
+    expect(compose.disabled).toBe(true);
+    expect(compose.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    // The affordance carries words, not just a dimmed control (DESIGN.md §States).
+    expect(screen.getByText('Read-only')).toBeTruthy();
+  });
+
+  it('disables the thread mark/archive/reply actions in read-only mode', async () => {
+    renderMailPage('/mail', { readOnly: true });
+
+    fireEvent.click(await screen.findByText('direct supervisor inbox'));
+
+    expect(
+      (await screen.findByRole('button', { name: 'Mark read' })) as HTMLButtonElement,
+    ).toHaveProperty('disabled', true);
+    expect((screen.getByRole('button', { name: 'Archive' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole('button', { name: 'Reply' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it('keeps Compose active when the dashboard is writable', async () => {
+    renderMailPage();
+
+    await screen.findByText('direct supervisor inbox');
+
+    expect((screen.getByRole('button', { name: 'Compose' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(screen.queryByText('Read-only')).toBeNull();
+  });
+
   it('marks attention mail rows without filtering out non-attention mail', async () => {
     render(
       <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
@@ -496,14 +536,16 @@ describe('MailPage supervisor reads', () => {
   });
 });
 
-function renderMailPage(initialEntry = '/mail') {
+function renderMailPage(initialEntry = '/mail', options: { readOnly?: boolean } = {}) {
   render(
     <MemoryRouter
       initialEntries={[initialEntry]}
       future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <NowProvider intervalMs={1_000_000}>
-        <MailPage />
+        <ReadOnlyProvider readOnly={options.readOnly ?? false}>
+          <MailPage />
+        </ReadOnlyProvider>
       </NowProvider>
     </MemoryRouter>,
   );

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -11,12 +11,14 @@ import { GroupedTable } from '../components/GroupedTable';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
+import { StatusBadge } from '../components/StatusBadge';
 import { type TableColumn } from '../components/Table';
 import { AgentPanel } from '../components/AgentPanel';
 import { ComposeModal } from '../components/mail/ComposeModal';
 import { ThreadMessage } from '../components/mail/ThreadMessage';
 import { Field } from '../components/Field';
 import { useNow } from '../contexts/NowContext';
+import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../contexts/ReadOnlyContext';
 import { useViewingAs, OPERATOR_ALIAS } from '../contexts/ViewingAsContext';
 import { displayLabel } from '../hooks/aliasPriority';
 import { useListFilters, type FilterChip } from '../hooks/useListFilters';
@@ -64,6 +66,7 @@ const DEEP_LINK_MAIL_HISTORY_LIMIT: MailHistoryLimit = 1000;
 
 export function MailPage() {
   const attention = useAttentionModel();
+  const readOnly = useReadOnly();
   const [searchParams] = useSearchParams();
   const selectedMessageParam = normalizeSelectedMessageParam(searchParams.get('message'));
   const {
@@ -152,6 +155,9 @@ export function MailPage() {
     async (action: MailAction) => {
       const message = threadFor;
       if (message === null) return;
+      // Defense-in-depth: the disabled buttons already block this, but a
+      // keyboard/programmatic path must never reach a write the server 405s.
+      if (readOnly) return;
       setActionInFlight(action);
       setError(null);
       try {
@@ -186,7 +192,7 @@ export function MailPage() {
         setActionInFlight(null);
       }
     },
-    [historyLimit, refresh, replyBody, threadFor, viewingAs.alias],
+    [historyLimit, readOnly, refresh, replyBody, threadFor, viewingAs.alias],
   );
 
   const columns = useMemo<ReadonlyArray<TableColumn<SupervisorMailItem>>>(
@@ -270,6 +276,7 @@ export function MailPage() {
   // Sent box has no unread concept; suppress those chips there.
   const visibleChips = box === 'sent' ? [] : MAIL_CHIPS;
   const replyDisabled =
+    readOnly ||
     threadFor === null ||
     replyBody.trim().length === 0 ||
     actionInFlight !== null ||
@@ -287,14 +294,19 @@ export function MailPage() {
                 {error}
               </span>
             )}
+            {readOnly && (
+              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
+            )}
             <Button
               size="sm"
               onClick={() => setComposing(true)}
-              disabled={!viewingAs.isOperator}
+              disabled={readOnly || !viewingAs.isOperator}
               title={
-                viewingAs.isOperator
-                  ? 'Compose a new message (sends as the operator)'
-                  : 'Switch back to the operator to compose'
+                readOnly
+                  ? READ_ONLY_CONTROL_TITLE
+                  : viewingAs.isOperator
+                    ? 'Compose a new message (sends as the operator)'
+                    : 'Switch back to the operator to compose'
               }
             >
               Compose
@@ -391,7 +403,8 @@ export function MailPage() {
               <Button
                 tone="quiet"
                 size="sm"
-                disabled={actionInFlight !== null}
+                title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                disabled={readOnly || actionInFlight !== null}
                 onClick={() => void runMailAction(threadFor.read ? 'unread' : 'read')}
               >
                 {threadFor.read ? 'Mark unread' : 'Mark read'}
@@ -399,7 +412,8 @@ export function MailPage() {
               <Button
                 tone="quiet"
                 size="sm"
-                disabled={actionInFlight !== null}
+                title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                disabled={readOnly || actionInFlight !== null}
                 onClick={() => void runMailAction('archive')}
               >
                 {actionInFlight === 'archive' ? 'Archiving' : 'Archive'}
@@ -407,6 +421,7 @@ export function MailPage() {
               <Button
                 tone="accent"
                 size="sm"
+                title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
                 disabled={replyDisabled}
                 onClick={() => void runMailAction('reply')}
               >
@@ -437,7 +452,8 @@ export function MailPage() {
                 onChange={(e) => setReplyBody(e.target.value)}
                 rows={5}
                 maxLength={16 * 1024}
-                disabled={!viewingAs.isOperator}
+                title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                disabled={readOnly || !viewingAs.isOperator}
                 className="w-full bg-surface-tint border border-rule rounded-sm px-3 py-2 text-body text-fg focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/40 resize-y disabled:opacity-50"
               />
             </Field>

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -11,14 +11,13 @@ import { GroupedTable } from '../components/GroupedTable';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
 import { PageHeader } from '../components/PageHeader';
-import { StatusBadge } from '../components/StatusBadge';
 import { type TableColumn } from '../components/Table';
 import { AgentPanel } from '../components/AgentPanel';
 import { ComposeModal } from '../components/mail/ComposeModal';
 import { ThreadMessage } from '../components/mail/ThreadMessage';
 import { Field } from '../components/Field';
 import { useNow } from '../contexts/NowContext';
-import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../contexts/ReadOnlyContext';
+import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge, useReadOnly } from '../contexts/ReadOnlyContext';
 import { useViewingAs, OPERATOR_ALIAS } from '../contexts/ViewingAsContext';
 import { displayLabel } from '../hooks/aliasPriority';
 import { useListFilters, type FilterChip } from '../hooks/useListFilters';
@@ -294,9 +293,7 @@ export function MailPage() {
                 {error}
               </span>
             )}
-            {readOnly && (
-              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
-            )}
+            {readOnly && <ReadOnlyBadge />}
             <Button
               size="sm"
               onClick={() => setComposing(true)}

--- a/frontend/src/views/modules/maintainer/Maintainer.test.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.test.tsx
@@ -141,7 +141,7 @@ describe('SelectionActionBar — read-only mode (gascity-dashboard-uzhr)', () =>
     }) as HTMLButtonElement;
     expect(triage.disabled).toBe(true);
     expect(draft.disabled).toBe(true);
-    expect(triage.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    expect(triage.getAttribute('title')).toBe('Read-only mode: mutations are disabled');
     // The affordance carries words, not just a dimmed control (DESIGN.md §States).
     expect(screen.getByText('Read-only')).toBeTruthy();
   });

--- a/frontend/src/views/modules/maintainer/Maintainer.test.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.test.tsx
@@ -42,6 +42,7 @@ function renderBar(props: Partial<React.ComponentProps<typeof SelectionActionBar
     sending: props.sending ?? null,
     error: props.error ?? null,
     success: props.success ?? null,
+    readOnly: props.readOnly ?? false,
   };
   return render(
     <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
@@ -122,6 +123,42 @@ describe('SelectionActionBar — error path regression', () => {
     });
     expect(screen.getByRole('alert')).toBeTruthy();
     expect(screen.getByRole('status')).toBeTruthy();
+  });
+});
+
+describe('SelectionActionBar — read-only mode (gascity-dashboard-uzhr)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('disables both sling dispatch buttons and surfaces a read-only affordance', () => {
+    renderBar({ count: 3, readOnly: true });
+    const triage = screen.getByRole('button', {
+      name: 'Send to triage agent',
+    }) as HTMLButtonElement;
+    const draft = screen.getByRole('button', {
+      name: 'Send to draft agent',
+    }) as HTMLButtonElement;
+    expect(triage.disabled).toBe(true);
+    expect(draft.disabled).toBe(true);
+    expect(triage.getAttribute('title')).toBe('Read-only mode — mutations are disabled');
+    // The affordance carries words, not just a dimmed control (DESIGN.md §States).
+    expect(screen.getByText('Read-only')).toBeTruthy();
+  });
+
+  it('keeps Clear active in read-only mode so a stale selection can still be dropped', () => {
+    renderBar({ count: 3, readOnly: true });
+    expect((screen.getByRole('button', { name: 'Clear' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it('leaves the sling buttons active when the dashboard is writable', () => {
+    renderBar({ count: 3 });
+    expect(
+      (screen.getByRole('button', { name: 'Send to triage agent' }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+    expect(screen.queryByText('Read-only')).toBeNull();
   });
 });
 

--- a/frontend/src/views/modules/maintainer/Maintainer.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.tsx
@@ -14,13 +14,12 @@ import {
   filterTierByNeedsPr,
 } from './triageFilters';
 import { useNow } from '../../../contexts/NowContext';
-import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../../../contexts/ReadOnlyContext';
+import { ReadOnlyBadge, useReadOnly } from '../../../contexts/ReadOnlyContext';
 import { api } from '../../../api/client';
 import { cityPath, getActiveCity } from '../../../api/cityBase';
 import { setCached } from '../../../api/cache';
 import { Button } from '../../../components/Button';
 import { PageHeader } from '../../../components/PageHeader';
-import { StatusBadge } from '../../../components/StatusBadge';
 import { SlungSection, TierSection } from './TriageSections';
 import { useCachedData } from '../../../hooks/useCachedData';
 import { useViewingAs } from '../../../contexts/ViewingAsContext';
@@ -275,9 +274,7 @@ export function MaintainerPage() {
                 {refreshError ?? error}
               </span>
             )}
-            {readOnly && (
-              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
-            )}
+            {readOnly && <ReadOnlyBadge />}
             <Button size="sm" onClick={toggleFocus}>
               {focusBreaking ? 'Show all tiers' : 'Breaking only'}
             </Button>

--- a/frontend/src/views/modules/maintainer/Maintainer.tsx
+++ b/frontend/src/views/modules/maintainer/Maintainer.tsx
@@ -14,11 +14,13 @@ import {
   filterTierByNeedsPr,
 } from './triageFilters';
 import { useNow } from '../../../contexts/NowContext';
+import { READ_ONLY_CONTROL_TITLE, useReadOnly } from '../../../contexts/ReadOnlyContext';
 import { api } from '../../../api/client';
 import { cityPath, getActiveCity } from '../../../api/cityBase';
 import { setCached } from '../../../api/cache';
 import { Button } from '../../../components/Button';
 import { PageHeader } from '../../../components/PageHeader';
+import { StatusBadge } from '../../../components/StatusBadge';
 import { SlungSection, TierSection } from './TriageSections';
 import { useCachedData } from '../../../hooks/useCachedData';
 import { useViewingAs } from '../../../contexts/ViewingAsContext';
@@ -74,6 +76,7 @@ export function MaintainerPage() {
     api.maintainerTriage(),
   );
   const { viewingAs } = useViewingAs();
+  const readOnly = useReadOnly();
   // dw8 — `?view=needs-you` activates the Needs-You composite filter
   // mode. The query param is the activation surface (R13: no new
   // route); the mode itself short-circuits some chip rendering and
@@ -204,6 +207,9 @@ export function MaintainerPage() {
   // endpoint directly; the dashboard service records only local slung state.
   const handleSend = useCallback(
     async (intent: MaintainerSlingIntent) => {
+      // Defense-in-depth: the disabled sling buttons already block this, but a
+      // keyboard/programmatic path must never reach a write the server 405s.
+      if (readOnly) return;
       const successLabel = intent === 'triage' ? TRIAGE_TARGET_LABEL : DRAFT_TARGET_LABEL;
       setSlinging(intent);
       setSlingError(null);
@@ -254,7 +260,7 @@ export function MaintainerPage() {
         setSlinging(null);
       }
     },
-    [selection, allItems, setSlingSuccess, clearSlingSuccess],
+    [selection, allItems, readOnly, setSlingSuccess, clearSlingSuccess],
   );
 
   return (
@@ -268,6 +274,9 @@ export function MaintainerPage() {
               <span className="normal-case text-body text-accent" role="alert">
                 {refreshError ?? error}
               </span>
+            )}
+            {readOnly && (
+              <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
             )}
             <Button size="sm" onClick={toggleFocus}>
               {focusBreaking ? 'Show all tiers' : 'Breaking only'}
@@ -385,6 +394,7 @@ export function MaintainerPage() {
                 sending={slinging}
                 error={slingError}
                 success={slingSuccess}
+                readOnly={readOnly}
               />
             )}
         </>

--- a/frontend/src/views/modules/maintainer/MaintainerChrome.tsx
+++ b/frontend/src/views/modules/maintainer/MaintainerChrome.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Button } from '../../../components/Button';
+import { READ_ONLY_CONTROL_TITLE } from '../../../contexts/ReadOnlyContext';
+import { StatusBadge } from '../../../components/StatusBadge';
 import { formatRelative } from '../../../hooks/time';
 import { formatDateTime } from '../../../lib/format';
 import type { MaintainerSlingIntent, SlingSuccess } from './maintainerSelection';
@@ -20,6 +22,7 @@ export function SelectionActionBar({
   sending,
   error,
   success,
+  readOnly = false,
 }: {
   count: number;
   /** Selected keys that vanished from the current envelope before send. */
@@ -33,8 +36,11 @@ export function SelectionActionBar({
   sending: MaintainerSlingIntent | null;
   error: string | null;
   success: SlingSuccess | null;
+  /** When true the supervisor proxy 405s slings; disable both dispatch buttons. */
+  readOnly?: boolean;
 }) {
   const isSending = sending !== null;
+  const slingTitle = readOnly ? READ_ONLY_CONTROL_TITLE : undefined;
   return (
     <div
       className="fixed inset-x-0 bottom-0 border-t border-rule bg-surface"
@@ -82,10 +88,24 @@ export function SelectionActionBar({
           )}
         </div>
         <div className="flex items-baseline gap-3">
-          <Button size="sm" onClick={onSend} disabled={isSending || count === 0}>
+          {readOnly && (
+            <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
+          )}
+          <Button
+            size="sm"
+            onClick={onSend}
+            disabled={readOnly || isSending || count === 0}
+            title={slingTitle}
+          >
             {sending === 'triage' ? 'Sending' : 'Send to triage agent'}
           </Button>
-          <Button size="sm" tone="quiet" onClick={onSendDraft} disabled={isSending || count === 0}>
+          <Button
+            size="sm"
+            tone="quiet"
+            onClick={onSendDraft}
+            disabled={readOnly || isSending || count === 0}
+            title={slingTitle}
+          >
             {sending === 'draft' ? 'Sending' : 'Send to draft agent'}
           </Button>
           <Button size="sm" tone="quiet" onClick={onClear} disabled={isSending}>

--- a/frontend/src/views/modules/maintainer/MaintainerChrome.tsx
+++ b/frontend/src/views/modules/maintainer/MaintainerChrome.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Button } from '../../../components/Button';
-import { READ_ONLY_CONTROL_TITLE } from '../../../contexts/ReadOnlyContext';
-import { StatusBadge } from '../../../components/StatusBadge';
+import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge } from '../../../contexts/ReadOnlyContext';
 import { formatRelative } from '../../../hooks/time';
 import { formatDateTime } from '../../../lib/format';
 import type { MaintainerSlingIntent, SlingSuccess } from './maintainerSelection';
@@ -88,9 +87,7 @@ export function SelectionActionBar({
           )}
         </div>
         <div className="flex items-baseline gap-3">
-          {readOnly && (
-            <StatusBadge tone="warn" label="Read-only" title={READ_ONLY_CONTROL_TITLE} />
-          )}
+          {readOnly && <ReadOnlyBadge />}
           <Button
             size="sm"
             onClick={onSend}

--- a/frontend/src/views/modules/maintainer/MaintainerPage.integration.test.tsx
+++ b/frontend/src/views/modules/maintainer/MaintainerPage.integration.test.tsx
@@ -157,6 +157,7 @@ beforeEach(() => {
     cityName: 'test-city',
     cityRoot: '/tmp/test-city',
     useFixtures: false,
+    readOnly: false,
     enabledModules: ['maintainer'],
     defaultView: null,
     maintainer: {

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -80,6 +80,16 @@ export interface DashboardRuntimeConfig {
   cityRoot: string;
   useFixtures: boolean;
   /**
+   * True when the backend runs with `DASHBOARD_READONLY=1` (AdminConfig
+   * `readOnly`, gascity-dashboard-uzhr). The server-side proxy gate (z8n7)
+   * already 405s supervisor mutations in this mode; the frontend projects
+   * this so the SPA can DISABLE (not hide) its mutating controls with a
+   * read-only affordance, rather than letting a click 405 into an
+   * unhandled API error. Part of exposure-hardening epic
+   * gascity-dashboard-lv4k.
+   */
+  readOnly: boolean;
+  /**
    * Resolved `firstParty` module ids that are mounted (PRD §2 / bead 9yj.5).
    * The backend always emits an explicit array — `[]` for a core-only
    * default install (PR-D), or e.g. `['maintainer']` when opted in via

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -143,7 +143,8 @@ Before you point an authenticated front at it:
    the wire as `DashboardRuntimeConfig.readOnly` (gascity-dashboard-uzhr) so the
    SPA disables (not hides) every supervisor-mutating control — Beads
    create/sling, claim, close, nudge; Mail compose, reply, archive, mark
-   read/unread; and Maintainer bulk sling — with a read-only affordance, rather
+   read/unread; Agents approve/deny of a pending interaction (session-respond);
+   and Maintainer bulk sling — with a read-only affordance, rather
    than letting a click `405` into an unhandled error. Each disabled control
    carries an explanatory title plus a "Read-only" badge (DESIGN.md §States have
    words), and the click handlers guard the write directly as defense-in-depth

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -139,7 +139,19 @@ Before you point an authenticated front at it:
    `/gc-supervisor` proxy only — the dashboard's own `/api/*` maintainer writes
    (client-error telemetry, `gh` actions, sling-record) are CSRF+Origin
    protected, not covered by `DASHBOARD_READONLY`, so "read-only" means the
-   _supervisor_ surface, not the entire service.
+   _supervisor_ surface, not the entire service. The posture is projected onto
+   the wire as `DashboardRuntimeConfig.readOnly` (gascity-dashboard-uzhr) so the
+   SPA disables (not hides) every supervisor-mutating control — Beads
+   create/sling, claim, close, nudge; Mail compose, reply, archive, mark
+   read/unread; and Maintainer bulk sling — with a read-only affordance, rather
+   than letting a click `405` into an unhandled error. Each disabled control
+   carries an explanatory title plus a "Read-only" badge (DESIGN.md §States have
+   words), and the click handlers guard the write directly as defense-in-depth
+   against keyboard/Enter-submit paths. The server gate stays the enforcement;
+   the SPA flag is only the affordance. (Dashboard-local `/api/*` writes such as
+   the Maintainer "Refresh from gh" and sling-record stay enabled — they are
+   CSRF+Origin protected and not behind `DASHBOARD_READONLY`, so they do not
+   `405`.)
 2. **Keep the gc supervisor on loopback and patched.** The read-only gate sits
    _upstream_ of the supervisor, so it only protects requests that go through
    the dashboard. The supervisor's own port (`:8372` by default) must not be


### PR DESCRIPTION
Implements bead uzhr: project the read-only flag into the shared DashboardRuntimeConfig and disable the SPA's mutating controls when read-only is on. BUILD ONLY — does NOT enable external exposure or flip :8082 to read-only; the loopback default stays full read-write. Pairs with the z8n7 opt-in read-only proxy gate (#77): if read-only is ever turned on, mutating buttons hide/disable instead of erroring.

## What lands
- shared DashboardRuntimeConfig carries `readOnly`; both sides import it (SSOT).
- ReadOnlyContext drives the SPA; mutating controls (compose mail, agent actions, etc.) disable/hide when read-only.
- Fail-closed: if /config errors, treat as read-only rather than assuming writable.
- Default OFF: loopback :8082 unchanged (full read-write).

backend (city/runtime, dispatch) + frontend (App, ReadOnlyContext, client, Agents, ComposeModal, Header) + tests. Rebased clean onto current main (post s4rp #87 + 4bol #89). Mayor-verified green pre-rebase (shared/backend/frontend suites); rebase was conflict-free. Mayor merge-gates; do NOT enable exposure on merge.
