### PR TITLE
feat(attention): add 'unavailable' tier so degraded runs reads don't inflate 'Runs N' (dash-ygj)

### DIFF
--- a/frontend/src/api/cache.test.ts
+++ b/frontend/src/api/cache.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getCached, getCachedFetchedAt, invalidate, invalidateKey, setCached } from './cache';
+
+afterEach(() => invalidate(''));
+
+describe('api cache fetch timestamp', () => {
+  it('stamps an ISO fetch timestamp on write and exposes it alongside the value', () => {
+    expect(getCachedFetchedAt('k')).toBeUndefined();
+
+    setCached('k', { n: 1 });
+
+    expect(getCached('k')).toEqual({ n: 1 });
+    const fetchedAt = getCachedFetchedAt('k');
+    expect(fetchedAt).toEqual(expect.any(String));
+    // A round-trippable ISO instant.
+    expect(new Date(fetchedAt!).toISOString()).toBe(fetchedAt);
+  });
+
+  it('advances the timestamp on each successive write', () => {
+    setCached('k', 'first');
+    const firstAt = getCachedFetchedAt('k');
+    setCached('k', 'second');
+    const secondAt = getCachedFetchedAt('k');
+
+    expect(getCached('k')).toBe('second');
+    expect(secondAt).toEqual(expect.any(String));
+    expect(Date.parse(secondAt!)).toBeGreaterThanOrEqual(Date.parse(firstAt!));
+  });
+
+  it('drops the timestamp when the entry is invalidated', () => {
+    setCached('k', 'v');
+    invalidateKey('k');
+
+    expect(getCached('k')).toBeUndefined();
+    expect(getCachedFetchedAt('k')).toBeUndefined();
+  });
+});

--- a/frontend/src/api/cache.ts
+++ b/frontend/src/api/cache.ts
@@ -9,14 +9,29 @@
 // Refresh-button presses go through useCachedData.refresh(), which
 // overwrites the cache slot in the same pass.
 
-const cache = new Map<string, unknown>();
+interface CacheEntry {
+  value: unknown;
+  /** ISO timestamp of the write that produced `value`. */
+  fetchedAt: string;
+}
+
+const cache = new Map<string, CacheEntry>();
 
 export function getCached<T>(key: string): T | undefined {
-  return cache.get(key) as T | undefined;
+  return cache.get(key)?.value as T | undefined;
+}
+
+/**
+ * ISO timestamp of the most recent setCached for `key`, or undefined if the key
+ * has never been written. Lets stale-while-revalidate consumers age a cached
+ * read — e.g. mark a degradation signal stale instead of rendering it as live.
+ */
+export function getCachedFetchedAt(key: string): string | undefined {
+  return cache.get(key)?.fetchedAt;
 }
 
 export function setCached<T>(key: string, value: T): void {
-  cache.set(key, value);
+  cache.set(key, { value, fetchedAt: new Date().toISOString() });
 }
 
 /** Drop every cache entry whose key starts with the given prefix. */

--- a/frontend/src/attention/AttentionSummaryPanel.test.tsx
+++ b/frontend/src/attention/AttentionSummaryPanel.test.tsx
@@ -46,6 +46,35 @@ describe('AttentionSummaryPanel', () => {
     expect(screen.queryByText('Mayor unread')).toBeNull();
   });
 
+  it('renders unavailable items with a muted tone, never the warn/accent badge colors', () => {
+    render(
+      <MemoryRouter
+        basename="/city/test-city"
+        initialEntries={['/city/test-city/']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <AttentionProvider
+          contributors={[
+            contributor('runs', [
+              item('runs:feed-partial', 'runs', 'unavailable', {
+                title: 'Formula run feed incomplete',
+                provenance: 'stale',
+              }),
+            ]),
+          ]}
+        >
+          <AttentionSummaryPanel />
+        </AttentionProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Formula run feed incomplete')).toBeTruthy();
+    const tag = screen.getByText('Runs');
+    expect(tag.className).toContain('text-fg-muted');
+    expect(tag.className).not.toContain('text-warn');
+    expect(tag.className).not.toContain('text-accent');
+  });
+
   it('renders nothing when there are no attention facts', () => {
     const { container } = render(
       <AttentionProvider contributors={[]}>

--- a/frontend/src/attention/AttentionSummaryPanel.tsx
+++ b/frontend/src/attention/AttentionSummaryPanel.tsx
@@ -54,5 +54,12 @@ function AttentionTitle({ item }: { item: AttentionItem }) {
 }
 
 function severityClass(severity: AttentionSeverity): string {
-  return severity === 'attention' ? 'text-accent' : 'text-warn';
+  switch (severity) {
+    case 'attention':
+      return 'text-accent';
+    case 'watch':
+      return 'text-warn';
+    case 'unavailable':
+      return 'text-fg-muted';
+  }
 }

--- a/frontend/src/attention/NavAttentionIndicator.tsx
+++ b/frontend/src/attention/NavAttentionIndicator.tsx
@@ -1,4 +1,4 @@
-import type { AttentionDomainSummary, AttentionSeverity } from './compose';
+import type { AttentionDomainSummary, BadgeSeverity } from './compose';
 
 export function NavAttentionIndicator({
   label,
@@ -21,6 +21,6 @@ export function NavAttentionIndicator({
   );
 }
 
-function severityClass(severity: AttentionSeverity): string {
+function severityClass(severity: BadgeSeverity): string {
   return severity === 'attention' ? 'text-accent' : 'text-warn';
 }

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -56,7 +56,64 @@ describe('composeAttention', () => {
     );
 
     expect(model.topItems.map((attention) => attention.id)).toEqual(['run-1', 'run-2']);
-    expect(model.overflowByDomain).toEqual([{ domain: 'mail', attention: 0, watch: 2, total: 2 }]);
+    expect(model.overflowByDomain).toEqual([
+      { domain: 'mail', attention: 0, watch: 2, unavailable: 0, total: 2 },
+    ]);
+  });
+
+  it('counts unavailable items in their own tier without inflating the badge or recoloring it', () => {
+    const model = composeAttention([
+      contributor('runs', [
+        item('run-watch', 'runs', 'watch'),
+        item('run-degraded', 'runs', 'unavailable', { provenance: 'stale' }),
+        item('run-down', 'runs', 'unavailable', { provenance: 'error' }),
+      ]),
+    ]);
+
+    // Badge count is attention + watch only — the two unavailable items are excluded.
+    expect(model.byDomain.runs.attention).toBe(0);
+    expect(model.byDomain.runs.watch).toBe(1);
+    expect(model.byDomain.runs.unavailable).toBe(2);
+    // The badge tier stays at watch; degraded reads never escalate the color.
+    expect(model.byDomain.runs.severity).toBe('watch');
+  });
+
+  it('never sets the badge severity from unavailable items alone', () => {
+    const model = composeAttention([
+      contributor('runs', [
+        item('feed-partial', 'runs', 'unavailable', { provenance: 'fresh' }),
+        item('detail-down', 'runs', 'unavailable', { provenance: 'error' }),
+      ]),
+    ]);
+
+    expect(model.byDomain.runs.attention).toBe(0);
+    expect(model.byDomain.runs.watch).toBe(0);
+    expect(model.byDomain.runs.unavailable).toBe(2);
+    // No attention/watch items ⇒ no badge, even though the domain has items.
+    expect(model.byDomain.runs.severity).toBeNull();
+  });
+
+  it('ranks unavailable items last and groups them as their own overflow count', () => {
+    const model = composeAttention(
+      [
+        contributor('runs', [
+          item('run-attention', 'runs', 'attention', { actionable: true }),
+          item('run-unavailable', 'runs', 'unavailable'),
+          item('run-watch', 'runs', 'watch'),
+        ]),
+      ],
+      { topLimit: 1 },
+    );
+
+    // attention < watch < unavailable in rank order.
+    expect(model.items.map((entry) => entry.id)).toEqual([
+      'run-attention',
+      'run-watch',
+      'run-unavailable',
+    ]);
+    expect(model.overflowByDomain).toEqual([
+      { domain: 'runs', attention: 0, watch: 1, unavailable: 1, total: 2 },
+    ]);
   });
 
   it('keeps the domain set explicit so nav consumers cannot drift', () => {

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -1,3 +1,5 @@
+import type { SourceStatus } from 'gas-city-dashboard-shared';
+
 export const ATTENTION_DOMAINS = [
   'agents',
   'beads',
@@ -8,7 +10,17 @@ export const ATTENTION_DOMAINS = [
   'maintainer',
 ] as const;
 
-export type AttentionSeverity = 'attention' | 'watch';
+/**
+ * Severity tiers. `attention` and `watch` are operator-actionable signals that
+ * count toward a domain's nav badge. `unavailable` is the data-degradation tier
+ * (gascity-dashboard issue-88 follow-up): a slice of a source could not be read,
+ * so the item must surface the degradation WITHOUT inflating the badge count or
+ * recoloring it. Only attention/watch drive `AttentionDomainSummary.severity`.
+ */
+export type AttentionSeverity = 'attention' | 'watch' | 'unavailable';
+
+/** The badge-driving tiers — the subset of severities that color/count a badge. */
+export type BadgeSeverity = Exclude<AttentionSeverity, 'unavailable'>;
 export type AttentionDomain = (typeof ATTENTION_DOMAINS)[number];
 
 export interface AttentionItem {
@@ -21,6 +33,19 @@ export interface AttentionItem {
   current?: boolean;
   actionable?: boolean;
   updatedAt?: string;
+  /**
+   * Freshness of the source this item was derived from, mirroring
+   * AlertItem.provenance. Carried on `unavailable` items so a badge fed from a
+   * stale cache read can be marked stale rather than rendered as live truth.
+   */
+  provenance?: SourceStatus;
+  /**
+   * ISO timestamp of the cache read this item was derived from (the
+   * useCachedData/cache fetch primitive). Pairs with `provenance` so a consumer
+   * can age a degradation signal — "as of <fetchedAt>, this slice was
+   * unavailable" — instead of treating a long-stale read as current.
+   */
+  fetchedAt?: string;
 }
 
 export interface AttentionContributor {
@@ -33,7 +58,10 @@ export interface AttentionDomainSummary {
   domain: AttentionDomain;
   attention: number;
   watch: number;
-  severity: AttentionSeverity | null;
+  /** Count of `unavailable`-tier items; never folded into the badge count. */
+  unavailable: number;
+  /** Badge tier — only ever attention/watch/null; `unavailable` never sets it. */
+  severity: BadgeSeverity | null;
   items: readonly AttentionItem[];
 }
 
@@ -41,6 +69,7 @@ export interface AttentionOverflowGroup {
   domain: AttentionDomain;
   attention: number;
   watch: number;
+  unavailable: number;
   total: number;
 }
 
@@ -78,7 +107,12 @@ export function composeAttention(
         domain: item.domain,
         attention: summary.attention + (item.severity === 'attention' ? 1 : 0),
         watch: summary.watch + (item.severity === 'watch' ? 1 : 0),
-        severity: highestSeverity(summary.severity, item.severity),
+        unavailable: summary.unavailable + (item.severity === 'unavailable' ? 1 : 0),
+        // Unavailable items report degradation; they must never color the badge.
+        severity:
+          item.severity === 'unavailable'
+            ? summary.severity
+            : highestSeverity(summary.severity, item.severity),
         items: nextItems,
       };
       index += 1;
@@ -102,6 +136,7 @@ function emptyDomainSummaries(): Record<AttentionDomain, AttentionDomainSummary>
       domain,
       attention: 0,
       watch: 0,
+      unavailable: 0,
       severity: null,
       items: [],
     };
@@ -110,9 +145,9 @@ function emptyDomainSummaries(): Record<AttentionDomain, AttentionDomainSummary>
 }
 
 function highestSeverity(
-  current: AttentionSeverity | null,
-  next: AttentionSeverity,
-): AttentionSeverity {
+  current: BadgeSeverity | null,
+  next: BadgeSeverity,
+): BadgeSeverity {
   if (current === 'attention' || next === 'attention') return 'attention';
   return 'watch';
 }
@@ -128,7 +163,14 @@ function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {
 }
 
 function severityRank(severity: AttentionSeverity): number {
-  return severity === 'attention' ? 0 : 1;
+  switch (severity) {
+    case 'attention':
+      return 0;
+    case 'watch':
+      return 1;
+    case 'unavailable':
+      return 2;
+  }
 }
 
 function booleanRank(value: boolean): number {
@@ -150,13 +192,15 @@ function groupOverflow(items: readonly AttentionItem[]): AttentionOverflowGroup[
   for (const domain of ATTENTION_DOMAINS) {
     let attention = 0;
     let watch = 0;
+    let unavailable = 0;
     for (const item of items) {
       if (item.domain !== domain) continue;
       if (item.severity === 'attention') attention += 1;
-      else watch += 1;
+      else if (item.severity === 'watch') watch += 1;
+      else unavailable += 1;
     }
-    const total = attention + watch;
-    if (total > 0) groups.push({ domain, attention, watch, total });
+    const total = attention + watch + unavailable;
+    if (total > 0) groups.push({ domain, attention, watch, unavailable, total });
   }
   return groups;
 }

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -144,10 +144,7 @@ function emptyDomainSummaries(): Record<AttentionDomain, AttentionDomainSummary>
   return summaries;
 }
 
-function highestSeverity(
-  current: BadgeSeverity | null,
-  next: BadgeSeverity,
-): BadgeSeverity {
+function highestSeverity(current: BadgeSeverity | null, next: BadgeSeverity): BadgeSeverity {
   if (current === 'attention' || next === 'attention') return 'attention';
   return 'watch';
 }

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -1,5 +1,9 @@
 import { useMemo } from 'react';
-import { OPERATOR_DISPLAY_ALIAS, OPERATOR_WIRE_ALIAS } from 'gas-city-dashboard-shared';
+import {
+  OPERATOR_DISPLAY_ALIAS,
+  OPERATOR_WIRE_ALIAS,
+  type SourceStatus,
+} from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { useCachedData } from '../hooks/useCachedData';
@@ -66,11 +70,40 @@ export function useLiveAttentionContributors(
           health: health.data,
           mail: mail.data,
           maintainer: maintainer.data,
-          runs: runs.data,
+          runs: withRunsFreshness(runs.data, runs.error, runs.fetchedAt),
         }),
       ),
-    [activity.data, agents.data, beads.data, health.data, mail.data, maintainer.data, runs.data],
+    [
+      activity.data,
+      agents.data,
+      beads.data,
+      health.data,
+      mail.data,
+      maintainer.data,
+      runs.data,
+      runs.error,
+      runs.fetchedAt,
+    ],
   );
+}
+
+/**
+ * Stamp the runs read's provenance + fetch timestamp onto its facts so the
+ * registry can carry them onto `unavailable`-tier items. A degraded read can
+ * then be aged (gascity-dashboard issue-88 follow-up) rather than rendered as
+ * current truth. The cache is event-refreshed (no TTL), so provenance is the
+ * coarse read status — `error` on failure, otherwise `fresh`; `fetchedAt`
+ * carries the exact read time for any age comparison.
+ */
+function withRunsFreshness(
+  facts: RunsAttentionFacts | undefined,
+  error: string | null,
+  fetchedAt: string | undefined,
+): RunsAttentionFacts | undefined {
+  if (facts === undefined) return undefined;
+  const provenance: SourceStatus =
+    error !== null || (facts.error !== undefined && facts.error.length > 0) ? 'error' : 'fresh';
+  return { ...facts, provenance, ...(fetchedAt === undefined ? {} : { fetchedAt }) };
 }
 
 async function fetchRunsAttention(cityName: string | null): Promise<RunsAttentionFacts> {

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -215,6 +215,77 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.runs.items[0]?.href).toBe('/runs/run-1');
   });
 
+  it('reclassifies runs data-unavailability emitters into the unavailable tier, carrying read freshness', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        runs: {
+          provenance: 'stale',
+          fetchedAt: '2026-06-06T12:00:00.000Z',
+          feed: formulaFeed({
+            partial: true,
+            partial_errors: ['feed degraded'],
+            items: [
+              {
+                id: 'run-detail',
+                root_bead_id: 'B-root',
+                root_store_ref: 'city:B-root',
+                scope_kind: 'city',
+                scope_ref: 'test-city',
+                started_at: '2026-05-29T20:00:00.000Z',
+                status: 'running',
+                target: 'mayor',
+                title: 'Detail run',
+                type: 'formula',
+                updated_at: '2026-05-29T20:05:00.000Z',
+                run_detail_available: false,
+              },
+            ],
+          }),
+          summary: {
+            ...runSummary([]),
+            lanesPartial: true,
+            lanes: [healthUnavailableLane('run-health', 'Health run')],
+          },
+        },
+      }),
+    );
+
+    // The four data-unavailability emitters (feed-partial, detail-unavailable,
+    // list-partial, health-unavailable) must never inflate the badge counts…
+    expect(model.byDomain.runs.attention).toBe(0);
+    expect(model.byDomain.runs.watch).toBe(0);
+    // …they land in the dedicated unavailable tier…
+    expect(model.byDomain.runs.unavailable).toBe(4);
+    // …and never color the nav badge.
+    expect(model.byDomain.runs.severity).toBeNull();
+
+    const ids = model.byDomain.runs.items.map((item) => item.id);
+    expect(ids).toContain('runs:feed-partial');
+    expect(ids).toContain('runs:run-detail:detail-unavailable');
+    expect(ids).toContain('runs:partial');
+    expect(ids).toContain('runs:run-health:health-unavailable');
+
+    for (const item of model.byDomain.runs.items) {
+      expect(item.severity).toBe('unavailable');
+      // Provenance + fetch timestamp ride along so a stale read can be aged.
+      expect(item.provenance).toBe('stale');
+      expect(item.fetchedAt).toBe('2026-06-06T12:00:00.000Z');
+    }
+  });
+
+  it('keeps a total runs read failure as a loud attention signal, not the quiet unavailable tier', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        runs: { error: 'formula run feed unavailable', provenance: 'error' },
+      }),
+    );
+
+    // A complete outage stays attention so the operator is not left blind.
+    expect(model.byDomain.runs.attention).toBe(1);
+    expect(model.byDomain.runs.unavailable).toBe(0);
+    expect(model.byDomain.runs.items[0]?.id).toBe('runs:unavailable');
+  });
+
   it('derives agent attention from pending supervisor interactions', () => {
     const model = composeAttention(
       createAttentionContributors({
@@ -706,6 +777,16 @@ function runLane({
         },
       },
     },
+  } as RunLane;
+}
+
+function healthUnavailableLane(id: string, title: string): RunLane {
+  return {
+    id,
+    title,
+    phase: 'active',
+    phaseLabel: 'active',
+    health: { status: 'unavailable', error: 'health probe failed' },
   } as RunLane;
 }
 

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -1156,7 +1156,10 @@ function domainWatch(
  */
 function domainUnavailable(
   domain: AttentionDomain,
-  item: Omit<AttentionItem, 'domain' | 'severity' | 'current' | 'actionable' | 'provenance' | 'fetchedAt'>,
+  item: Omit<
+    AttentionItem,
+    'domain' | 'severity' | 'current' | 'actionable' | 'provenance' | 'fetchedAt'
+  >,
   freshness?: ReadFreshness,
 ): AttentionItem {
   return {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -4,6 +4,7 @@ import type {
   MaintainerTriage,
   RunLane,
   RunSummary,
+  SourceStatus,
   SystemHealth,
   TriageItem,
 } from 'gas-city-dashboard-shared';
@@ -42,6 +43,14 @@ export interface RunsAttentionFacts {
   feed?: FormulaFeedBody;
   summary?: RunSummary;
   error?: string;
+  /**
+   * Freshness of the runs read these facts were assembled from, threaded by the
+   * live contributor layer. Carried onto `unavailable`-tier items so a degraded
+   * read can be aged rather than rendered as current truth.
+   */
+  provenance?: SourceStatus;
+  /** ISO timestamp of the cache read these facts came from (fetch primitive). */
+  fetchedAt?: string;
 }
 
 export interface AgentsAttentionFacts {
@@ -215,9 +224,13 @@ function maintainerContributor(facts: MaintainerAttentionFacts | undefined): Att
   };
 }
 
+/** The provenance + fetch timestamp carried onto runs `unavailable` items. */
+type ReadFreshness = { provenance: SourceStatus | undefined; fetchedAt: string | undefined };
+
 function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly AttentionItem[] {
   const items: AttentionItem[] = [];
   if (facts === undefined) return items;
+  const freshness: ReadFreshness = { provenance: facts.provenance, fetchedAt: facts.fetchedAt };
   if (facts.error !== undefined && facts.error.length > 0) {
     items.push(
       domainAttention('runs', {
@@ -232,47 +245,62 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
   const summary = facts.summary;
   const feed = facts.feed;
   if (feed !== undefined) {
-    appendFormulaFeedAttention(items, feed);
+    appendFormulaFeedAttention(items, feed, freshness);
   }
   if (summary === undefined) return items;
   if (summary.lanesPartial === true) {
     items.push(
-      domainWatch('runs', {
-        id: 'runs:partial',
-        title: 'Run list incomplete',
-        href: '/runs',
-      }),
+      domainUnavailable(
+        'runs',
+        {
+          id: 'runs:partial',
+          title: 'Run list incomplete',
+          href: '/runs',
+        },
+        freshness,
+      ),
     );
   }
 
   // gascity-dashboard-4xcv: blocked lanes moved out of summary.lanes into
   // their own bucket; they still need the operator, so both sets contribute.
   for (const lane of [...summary.lanes, ...summary.blockedLanes]) {
-    const item = attentionForRunLane(lane);
+    const item = attentionForRunLane(lane, freshness);
     if (item !== null) items.push(item);
   }
   return items;
 }
 
-function appendFormulaFeedAttention(items: AttentionItem[], feed: FormulaFeedBody): void {
+function appendFormulaFeedAttention(
+  items: AttentionItem[],
+  feed: FormulaFeedBody,
+  freshness: ReadFreshness,
+): void {
   if (feed.partial) {
     const summary = feed.partial_errors?.join('; ');
     items.push(
-      domainWatch('runs', {
-        id: 'runs:feed-partial',
-        title: 'Formula run feed incomplete',
-        href: '/runs',
-        ...(summary === undefined ? {} : { summary }),
-      }),
+      domainUnavailable(
+        'runs',
+        {
+          id: 'runs:feed-partial',
+          title: 'Formula run feed incomplete',
+          href: '/runs',
+          ...(summary === undefined ? {} : { summary }),
+        },
+        freshness,
+      ),
     );
   }
   for (const item of feed.items ?? []) {
-    const attention = attentionForFormulaFeedItem(item);
+    const attention = attentionForFormulaFeedItem(item, freshness);
     if (attention !== null) items.push(attention);
   }
 }
 
-function attentionForFormulaFeedItem(item: MonitorFeedItemResponse): AttentionItem | null {
+function attentionForFormulaFeedItem(
+  item: MonitorFeedItemResponse,
+  freshness: ReadFreshness,
+): AttentionItem | null {
   const status = item.status.toLowerCase();
   const href = runHref(item.id, item.scope_kind, item.scope_ref);
   if (isRunAttentionStatus(status)) {
@@ -285,12 +313,16 @@ function attentionForFormulaFeedItem(item: MonitorFeedItemResponse): AttentionIt
     });
   }
   if (item.run_detail_available === false || item.detail_available === false) {
-    return domainWatch('runs', {
-      id: `runs:${item.id}:detail-unavailable`,
-      title: `${item.title} detail unavailable`,
-      href,
-      updatedAt: item.started_at,
-    });
+    return domainUnavailable(
+      'runs',
+      {
+        id: `runs:${item.id}:detail-unavailable`,
+        title: `${item.title} detail unavailable`,
+        href,
+        updatedAt: item.started_at,
+      },
+      freshness,
+    );
   }
   if (isRunWatchStatus(status)) {
     return domainWatch('runs', {
@@ -304,18 +336,22 @@ function attentionForFormulaFeedItem(item: MonitorFeedItemResponse): AttentionIt
   return null;
 }
 
-function attentionForRunLane(lane: RunLane): AttentionItem | null {
+function attentionForRunLane(lane: RunLane, freshness: ReadFreshness): AttentionItem | null {
   const href =
     lane.scope?.status === 'available'
       ? runHref(lane.id, lane.scope.kind, lane.scope.ref)
       : runHref(lane.id);
   if (lane.health.status !== 'available') {
-    return domainWatch('runs', {
-      id: `runs:${lane.id}:health-unavailable`,
-      title: `${lane.title} health unavailable`,
-      summary: lane.health.error,
-      href,
-    });
+    return domainUnavailable(
+      'runs',
+      {
+        id: `runs:${lane.id}:health-unavailable`,
+        title: `${lane.title} health unavailable`,
+        summary: lane.health.error,
+        href,
+      },
+      freshness,
+    );
   }
 
   const health = lane.health.data;
@@ -1109,6 +1145,28 @@ function domainWatch(
     current: true,
     actionable: false,
     ...item,
+  };
+}
+
+/**
+ * A data-unavailability item: a slice of a source could not be read. It reports
+ * the degradation WITHOUT inflating or recoloring the domain's nav badge (see
+ * AttentionSeverity). `freshness` carries the read's provenance + fetch
+ * timestamp so the signal can be aged rather than rendered as current truth.
+ */
+function domainUnavailable(
+  domain: AttentionDomain,
+  item: Omit<AttentionItem, 'domain' | 'severity' | 'current' | 'actionable' | 'provenance' | 'fetchedAt'>,
+  freshness?: ReadFreshness,
+): AttentionItem {
+  return {
+    domain,
+    severity: 'unavailable',
+    current: true,
+    actionable: false,
+    ...item,
+    ...(freshness?.provenance === undefined ? {} : { provenance: freshness.provenance }),
+    ...(freshness?.fetchedAt === undefined ? {} : { fetchedAt: freshness.fetchedAt }),
   };
 }
 

--- a/frontend/src/attention/routeHighlight.test.ts
+++ b/frontend/src/attention/routeHighlight.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { composeAttention } from './compose';
+import type { AttentionDomain, AttentionItem, AttentionModel, AttentionSeverity } from './compose';
+import { prefixedAttentionSeverity, resourceAttentionSeverity } from './routeHighlight';
+
+function item(id: string, severity: AttentionSeverity, domain: AttentionDomain): AttentionItem {
+  return { id, domain, severity, title: id };
+}
+
+function modelWith(items: readonly AttentionItem[]): AttentionModel {
+  // composeAttention groups by item.domain, so a single contributor carries
+  // items across whatever domains the test seeds.
+  return composeAttention([{ id: 'test', domain: 'runs', getItems: () => items }]);
+}
+
+describe('resourceAttentionSeverity', () => {
+  it('returns null when only unavailable items match the resource', () => {
+    const model = modelWith([item('runs:lane1', 'unavailable', 'runs')]);
+    expect(resourceAttentionSeverity(model, 'runs', 'lane1')).toBeNull();
+  });
+
+  it('returns watch (not null) when a watch item is mixed with unavailable', () => {
+    const model = modelWith([
+      item('runs:lane1', 'watch', 'runs'),
+      item('runs:lane1:sub', 'unavailable', 'runs'),
+    ]);
+    expect(resourceAttentionSeverity(model, 'runs', 'lane1')).toBe('watch');
+  });
+
+  it('returns attention when an attention item is mixed with unavailable', () => {
+    const model = modelWith([
+      item('runs:lane1:sub', 'attention', 'runs'),
+      item('runs:lane1', 'unavailable', 'runs'),
+    ]);
+    expect(resourceAttentionSeverity(model, 'runs', 'lane1')).toBe('attention');
+  });
+});
+
+describe('prefixedAttentionSeverity', () => {
+  const prefixes = ['health:tool:'] as const;
+
+  it('returns null when only unavailable items match the prefix', () => {
+    const model = modelWith([item('health:tool:dolt', 'unavailable', 'health')]);
+    expect(prefixedAttentionSeverity(model, 'health', prefixes)).toBeNull();
+  });
+
+  it('returns watch (not null) when a watch item is mixed with unavailable', () => {
+    const model = modelWith([
+      item('health:tool:dolt', 'watch', 'health'),
+      item('health:tool:gc', 'unavailable', 'health'),
+    ]);
+    expect(prefixedAttentionSeverity(model, 'health', prefixes)).toBe('watch');
+  });
+
+  it('returns attention when an attention item is mixed with unavailable', () => {
+    const model = modelWith([
+      item('health:tool:dolt', 'attention', 'health'),
+      item('health:tool:gc', 'unavailable', 'health'),
+    ]);
+    expect(prefixedAttentionSeverity(model, 'health', prefixes)).toBe('attention');
+  });
+});

--- a/frontend/src/attention/routeHighlight.ts
+++ b/frontend/src/attention/routeHighlight.ts
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import type { AttentionDomain, AttentionModel, AttentionSeverity } from './compose';
+import type { AttentionDomain, AttentionModel, AttentionSeverity, BadgeSeverity } from './compose';
 
 type AttentionAttributes<T extends HTMLElement> = HTMLAttributes<T> & {
   'data-attention-severity'?: AttentionSeverity;
@@ -9,14 +9,16 @@ export function resourceAttentionSeverity(
   model: AttentionModel,
   domain: AttentionDomain,
   resourceId: string,
-): AttentionSeverity | null {
+): BadgeSeverity | null {
   const prefix = `${domain}:${resourceId}:`;
   const exact = `${domain}:${resourceId}`;
-  let severity: AttentionSeverity | null = null;
+  let severity: BadgeSeverity | null = null;
   for (const item of model.byDomain[domain].items) {
     if (item.id !== exact && !item.id.startsWith(prefix)) continue;
     if (item.severity === 'attention') return 'attention';
-    severity = 'watch';
+    // `unavailable` reports a degraded read, not a watch-worthy state — it must
+    // not tint a row as if the resource itself needs the operator.
+    if (item.severity === 'watch') severity = 'watch';
   }
   return severity;
 }
@@ -25,12 +27,13 @@ export function prefixedAttentionSeverity(
   model: AttentionModel,
   domain: AttentionDomain,
   itemIdPrefixes: readonly string[],
-): AttentionSeverity | null {
-  let severity: AttentionSeverity | null = null;
+): BadgeSeverity | null {
+  let severity: BadgeSeverity | null = null;
   for (const item of model.byDomain[domain].items) {
     if (!itemIdPrefixes.some((prefix) => item.id.startsWith(prefix))) continue;
     if (item.severity === 'attention') return 'attention';
-    severity = 'watch';
+    // `unavailable` reports a degraded read, not a watch-worthy state.
+    if (item.severity === 'watch') severity = 'watch';
   }
   return severity;
 }

--- a/frontend/src/attention/routeHighlight.ts
+++ b/frontend/src/attention/routeHighlight.ts
@@ -39,7 +39,7 @@ export function prefixedAttentionSeverity(
 }
 
 export function attentionRowProps(
-  severity: AttentionSeverity | null,
+  severity: BadgeSeverity | null,
 ): AttentionAttributes<HTMLTableRowElement> {
   if (severity === null) return {};
   return {
@@ -60,7 +60,7 @@ export function attentionDataProps(
 }
 
 export function attentionListItemProps(
-  severity: AttentionSeverity | null,
+  severity: BadgeSeverity | null,
 ): AttentionAttributes<HTMLLIElement> {
   if (severity === null) return {};
   return {
@@ -70,7 +70,7 @@ export function attentionListItemProps(
 }
 
 export function attentionBlockProps(
-  severity: AttentionSeverity | null,
+  severity: BadgeSeverity | null,
 ): AttentionAttributes<HTMLDivElement> {
   if (severity === null) return {};
   return {
@@ -80,7 +80,7 @@ export function attentionBlockProps(
 }
 
 export function attentionSectionProps(
-  severity: AttentionSeverity | null,
+  severity: BadgeSeverity | null,
 ): AttentionAttributes<HTMLElement> {
   if (severity === null) return {};
   const toneClass =
@@ -91,7 +91,7 @@ export function attentionSectionProps(
   };
 }
 
-function attentionHighlightClass(severity: AttentionSeverity): string {
+function attentionHighlightClass(severity: BadgeSeverity): string {
   return severity === 'attention'
     ? 'bg-accent/10 hover:bg-accent/15'
     : 'bg-warn/10 hover:bg-warn/15';

--- a/frontend/src/components/beads/BeadBoard.tsx
+++ b/frontend/src/components/beads/BeadBoard.tsx
@@ -1,6 +1,6 @@
 import { BOARD_COLUMNS, type BeadNode, type BoardColumnId } from '../../lib/beadGraph';
 import { BeadBoardRow } from './BeadBoardRow';
-import type { AttentionSeverity } from '../../attention/compose';
+import type { BadgeSeverity } from '../../attention/compose';
 
 // The Beads board: status columns (kanban) whose rows carry the dependency
 // graph (gascity-dashboard-6frc). Editorial register — columns are
@@ -17,7 +17,7 @@ import type { AttentionSeverity } from '../../attention/compose';
 interface BeadBoardProps {
   columns: Record<BoardColumnId, BeadNode[]>;
   selectedId: string | null;
-  attentionSeverity?: (beadId: string) => AttentionSeverity | null;
+  attentionSeverity?: (beadId: string) => BadgeSeverity | null;
   onSelect: (beadId: string) => void;
 }
 

--- a/frontend/src/components/beads/BeadBoardRow.tsx
+++ b/frontend/src/components/beads/BeadBoardRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { BeadNode } from '../../lib/beadGraph';
-import type { AttentionSeverity } from '../../attention/compose';
+import type { BadgeSeverity } from '../../attention/compose';
 import { attentionListItemProps } from '../../attention/routeHighlight';
 
 // One bead on the board, in the editorial register: a typeset row, no card,
@@ -13,7 +13,7 @@ import { attentionListItemProps } from '../../attention/routeHighlight';
 interface BeadBoardRowProps {
   node: BeadNode;
   selected: boolean;
-  attentionSeverity?: AttentionSeverity | null;
+  attentionSeverity?: BadgeSeverity | null;
   onSelect: (beadId: string) => void;
 }
 

--- a/frontend/src/components/beads/BeadBoardSection.tsx
+++ b/frontend/src/components/beads/BeadBoardSection.tsx
@@ -1,7 +1,7 @@
 import type { BeadGraph } from '../../lib/beadGraph';
 import { selectColumns } from '../../lib/beadGraph';
 import { BeadBoard } from './BeadBoard';
-import type { AttentionSeverity } from '../../attention/compose';
+import type { BadgeSeverity } from '../../attention/compose';
 
 // One rig's slice of the board (gascity-dashboard-6frc). The board groups
 // by rig so a city with hundreds of beads stays parseable — each rig gets a
@@ -18,7 +18,7 @@ interface BeadBoardSectionProps {
   graph: BeadGraph;
   ids: ReadonlySet<string>;
   selectedId: string | null;
-  attentionSeverity?: (beadId: string) => AttentionSeverity | null;
+  attentionSeverity?: (beadId: string) => BadgeSeverity | null;
   onSelect: (beadId: string) => void;
 }
 

--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -1,6 +1,6 @@
 import type { RunLane } from 'gas-city-dashboard-shared';
 import { Link } from 'react-router-dom';
-import type { AttentionSeverity } from '../../attention/compose';
+import type { BadgeSeverity } from '../../attention/compose';
 import { attentionListItemProps } from '../../attention/routeHighlight';
 import { formatRelative } from '../../hooks/time';
 import { StageLadder } from './StageLadder';
@@ -15,7 +15,7 @@ import { StageLadder } from './StageLadder';
 interface LaneCardProps {
   lane: RunLane;
   now: number;
-  attentionSeverity?: AttentionSeverity | null;
+  attentionSeverity?: BadgeSeverity | null;
 }
 
 /**

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
-import type { AttentionSeverity } from '../../attention/compose';
+import type { BadgeSeverity } from '../../attention/compose';
 import { LaneCard } from './LaneCard';
 
 // Run phase-lane map (gascity-dashboard-0t6). Renders the snapshot's
@@ -19,7 +19,7 @@ interface RunMapProps {
   source: SourceState<RunSummary>;
   now: number;
   showHistory: boolean;
-  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }
 
 const COUNT_LABELS: Array<[keyof RunSummary['runCounts'], string]> = [
@@ -81,7 +81,7 @@ function ActiveSection({
 }: {
   summary: RunSummary;
   now: number;
-  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
   if (summary.lanes.length === 0) {
     // gascity-dashboard-4xcv: a partial fetch with zero lanes is "we could
@@ -137,7 +137,7 @@ function LaneList({
 }: {
   lanes: readonly RunLane[];
   now: number;
-  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
   listId?: string;
 }) {
   return (
@@ -197,7 +197,7 @@ function BlockedSection({
 }: {
   summary: RunSummary;
   now: number;
-  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
   if (summary.blockedLanes.length === 0) return null;
   return (
@@ -219,7 +219,7 @@ function HistoricalSection({
 }: {
   summary: RunSummary;
   now: number;
-  attentionSeverity?: (lane: RunLane) => AttentionSeverity | null;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
   const [expanded, setExpanded] = useState(false);
   const lanes = summary.historicalLanes;

--- a/frontend/src/hooks/useCachedData.test.tsx
+++ b/frontend/src/hooks/useCachedData.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getCached, invalidate } from '../api/cache';
+import { getCached, getCachedFetchedAt, invalidate } from '../api/cache';
 import { useCachedData } from './useCachedData';
 
 afterEach(() => {
@@ -129,6 +129,42 @@ describe('useCachedData', () => {
     });
 
     expect(getCached<string>(cacheKey)).toBeUndefined();
+  });
+
+  it('exposes the cache fetch timestamp once data lands', async () => {
+    const value = deferred<string>();
+    const cacheKey = 'fetched-at-key';
+
+    const { result } = renderHook(() => useCachedData(cacheKey, () => value.promise));
+
+    // No write has happened yet, so there is no fetch timestamp.
+    expect(result.current.fetchedAt).toBeUndefined();
+
+    await act(async () => {
+      value.resolve('landed');
+      await value.promise;
+    });
+    await waitFor(() => expect(result.current.data).toBe('landed'));
+
+    // The exposed timestamp mirrors the cache primitive the write stamped.
+    expect(result.current.fetchedAt).toBe(getCachedFetchedAt(cacheKey));
+    expect(result.current.fetchedAt).toEqual(expect.any(String));
+  });
+
+  it('seeds the fetch timestamp from the cache on mount', async () => {
+    const cacheKey = 'preseeded-key';
+    const { result } = renderHook(() => useCachedData(cacheKey, () => Promise.resolve('fresh')));
+    await waitFor(() => expect(result.current.data).toBe('fresh'));
+    const landedAt = result.current.fetchedAt;
+    expect(landedAt).toEqual(expect.any(String));
+
+    // A second mount on the warm cache seeds both data and timestamp
+    // synchronously from cache; the never-settling refetch leaves them intact.
+    const second = renderHook(() =>
+      useCachedData(cacheKey, () => new Promise<string>(() => {})),
+    );
+    expect(second.result.current.data).toBe('fresh');
+    expect(second.result.current.fetchedAt).toBe(landedAt);
   });
 
   it('reports the latest fetch failure through onError', async () => {

--- a/frontend/src/hooks/useCachedData.test.tsx
+++ b/frontend/src/hooks/useCachedData.test.tsx
@@ -106,6 +106,12 @@ describe('useCachedData', () => {
     });
     await waitFor(() => expect(result.current.data).toBe('first result'));
 
+    // The rescued first-paint result carries a provenance timestamp even
+    // though the rescue path never wrote the cache — without it, fetchedAt
+    // would stay undefined for the whole storm, defeating provenance exactly
+    // when the source is busiest.
+    expect(result.current.fetchedAt).toEqual(expect.any(String));
+
     // Once the latest run lands it wins, replacing the rescued value.
     await act(async () => {
       second.resolve('second result');
@@ -160,9 +166,7 @@ describe('useCachedData', () => {
 
     // A second mount on the warm cache seeds both data and timestamp
     // synchronously from cache; the never-settling refetch leaves them intact.
-    const second = renderHook(() =>
-      useCachedData(cacheKey, () => new Promise<string>(() => {})),
-    );
+    const second = renderHook(() => useCachedData(cacheKey, () => new Promise<string>(() => {})));
     expect(second.result.current.data).toBe('fresh');
     expect(second.result.current.fetchedAt).toBe(landedAt);
   });

--- a/frontend/src/hooks/useCachedData.ts
+++ b/frontend/src/hooks/useCachedData.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { getCached, setCached } from '../api/cache';
+import { getCached, getCachedFetchedAt, setCached } from '../api/cache';
 
 interface UseCachedDataResult<T> {
   data: T | undefined;
   loading: boolean;
   error: string | null;
+  /** ISO timestamp of the cache read backing `data`, or undefined before any lands. */
+  fetchedAt: string | undefined;
   refresh: () => Promise<void>;
 }
 
@@ -49,6 +51,7 @@ export function useCachedData<T>(
   const [data, setData] = useState<T | undefined>(() => getCached<T>(key));
   const [loading, setLoading] = useState<boolean>(() => getCached<T>(key) === undefined);
   const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<string | undefined>(() => getCachedFetchedAt(key));
 
   const runFetcher = useCallback(
     async (fetch: () => Promise<T>) => {
@@ -64,6 +67,7 @@ export function useCachedData<T>(
         if (isLatestRun && isActiveKey) {
           setCached(cacheKey, fresh);
           setData(fresh);
+          setFetchedAt(getCachedFetchedAt(cacheKey));
         } else if (isActiveKey) {
           // First-paint rescue: a busy SSE stream can re-fire refresh()
           // faster than a slow fetch (e.g. the beads board's per-type
@@ -98,11 +102,12 @@ export function useCachedData<T>(
     const cached = getCached<T>(key);
     setData(cached);
     setLoading(cached === undefined);
+    setFetchedAt(getCachedFetchedAt(key));
     void runFetcher(fetcherRef.current);
     return () => {
       runIdRef.current += 1;
     };
   }, [key, runFetcher]);
 
-  return { data, loading, error, refresh };
+  return { data, loading, error, fetchedAt, refresh };
 }

--- a/frontend/src/hooks/useCachedData.ts
+++ b/frontend/src/hooks/useCachedData.ts
@@ -78,6 +78,14 @@ export function useCachedData<T>(
           // landed, latest-run-wins resumes and a stale slow fetch never
           // clobbers fresher data.
           setData((prev) => (prev === undefined ? fresh : prev));
+          // Mirror the data adoption for provenance. The rescue skips setCached
+          // (a superseded slow fetch must not become the authoritative cache
+          // value), so getCachedFetchedAt is undefined on a cold first paint —
+          // the exact SSE-storm case this rescue exists for. Stamp the rescued
+          // result as-of-now (same clock setCached uses) so fetchedAt never
+          // stays undefined while data is shown, while a kept prev or a real
+          // cache write keeps its own timestamp.
+          setFetchedAt((prev) => prev ?? getCachedFetchedAt(cacheKey) ?? new Date().toISOString());
         }
       } catch (err) {
         if (runIdRef.current === runId) {


### PR DESCRIPTION
Runs data-unavailability signals (feed-partial, detail-unavailable, list-partial, health-unavailable) were emitted as `watch` items, inflating the nav 'Runs N' badge and recoloring it under degradation (issue-88 follow-up after #89). Add a third `unavailable` severity tier that is counted on its own and never drives the badge count or color, reclassify the runs emitters into it, and expose a fetch timestamp from the cache so a stale-fed read can carry provenance and be aged.

- compose: `unavailable` tier + per-domain count; ranked last; separate overflow count; badge severity stays attention/watch/null.
- registry: `domainUnavailable` helper; reclassify runs:partial, runs:feed-partial, runs:{id}:detail-unavailable, runs:{lane}:health-unavailable; carry provenance + fetchedAt from the read. A total read failure (runs:unavailable) deliberately stays `attention` so a full outage stays loud.
- cache/useCachedData: expose getCachedFetchedAt / fetchedAt (the fetch primitive); liveContributors threads the runs read's provenance + fetchedAt onto the facts.
- routeHighlight/panel: handle the 3-valued union explicitly — unavailable items render muted and never tint a resource row.

Tests via existing fixtures; no new deps.

<!--
  PR template for gas-city-dashboard. Keep it terse. Bullets over prose.
  Delete this comment and any section that genuinely does not apply,
  but say so explicitly (e.g. "Test plan: N/A, docs only").
-->

## Summary

1 to 3 bullets. What this PR changes, and why.

-
-

## Scope

- Named Rule touched (if any): e.g. The Flat Page Rule, The One Mark Rule, The One Voice Rule, The Greyscale Test, The Tabular Figures Rule. None is a valid answer.
- Views or routes affected: Agents, Beads, Mail, Activity, Health, or N/A.
- Layer: backend, frontend, shared, docs, ci, deploy. Multiple allowed.

## Test plan

- Tests added or modified: list paths.
- Automated checks run: typecheck and tests in each touched workspace, `npm run build` if frontend changed.
- Manual checks run: `node scripts/snap.mjs <route>` for any visual change, peek modal exercise for any Agents change, write-route smoke test for any backend write path.

## Risk + rollback

- What could regress, and where the operator would notice first.
- How to back out: revert the merge commit, or list the specific commits to revert.

## Linked issue

Closes #<n>, or `bd` id, or N/A.

## Operator-affecting changes

Tick both, or explain in the section above.

- [ ] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [ ] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).
