### PR TITLE
feat(agents): make Workers-active rows clickable to open the transcript peek

### DIFF
--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -165,30 +165,34 @@ describe('WorkInFlight (Workers active)', () => {
     });
   });
 
-  it('opens the peek when the worker row label is clicked, for consistency with the Available-agents roster', async () => {
+  it('opens the peek for the clicked worker (not just any worker), mirroring the Available-agents roster', async () => {
     stubTranscriptFetch();
+    // Two distinct workers so the test proves the clicked label maps to ITS OWN
+    // session — a single-worker render would still pass if the wiring opened the
+    // first/only session regardless of which label was clicked.
     const sessions = [
-      session({ id: 'gc-335825', template: 'polecat', rig: 'gascity', state: 'active' }),
+      session({ id: 'gc-100', template: 'polecat', rig: 'alpha', state: 'active' }),
+      session({ id: 'gc-200', template: 'polecat', rig: 'bravo', state: 'active' }),
     ];
     renderSection([], sessions);
 
     // The worker label is itself a button (mirroring the clickable agent-roster
-    // row label), distinct from the explicit Peek button — its accessible name
-    // is the worker identity, not "Peek".
-    const labelButton = screen.getByRole('button', { name: /gascity.*polecat/i });
-    // The label is announced as the worker identity, NOT as another peek control:
-    // getByRole would throw on ambiguity if the label's name also matched /peek/i,
-    // so a unique resolution proves the two controls stay distinct.
-    expect(screen.getByRole('button', { name: /peek/i })).not.toBe(labelButton);
+    // row label), distinct from that row's explicit Peek button — its accessible
+    // name is the worker identity ("bravo · polecat"), not "Peek".
+    const bravoLabel = screen.getByRole('button', { name: /bravo.*polecat/i });
+    expect(screen.getAllByRole('button', { name: /peek/i })).not.toContain(bravoLabel);
 
-    // Clicking the label opens the same transcript the Peek button does.
-    fireEvent.click(labelButton);
+    fireEvent.click(bravoLabel);
 
+    // Only the clicked worker's transcript is fetched — the other worker's is not.
     await waitFor(() => {
       expect(transcriptUrls).toContain(
-        '/gc-supervisor/v0/city/test-city/session/gc-335825/transcript?format=conversation',
+        '/gc-supervisor/v0/city/test-city/session/gc-200/transcript?format=conversation',
       );
     });
+    expect(transcriptUrls).not.toContain(
+      '/gc-supervisor/v0/city/test-city/session/gc-100/transcript?format=conversation',
+    );
   });
 
   it('surfaces the captured bead as a link beside the peek transcript', async () => {

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -174,8 +174,15 @@ describe('WorkInFlight (Workers active)', () => {
 
     // The worker label is itself a button (mirroring the clickable agent-roster
     // row label), distinct from the explicit Peek button — its accessible name
-    // is the worker identity, not "Peek". Clicking it opens the same transcript.
-    fireEvent.click(screen.getByRole('button', { name: /gascity.*polecat/i }));
+    // is the worker identity, not "Peek".
+    const labelButton = screen.getByRole('button', { name: /gascity.*polecat/i });
+    // The label is announced as the worker identity, NOT as another peek control:
+    // getByRole would throw on ambiguity if the label's name also matched /peek/i,
+    // so a unique resolution proves the two controls stay distinct.
+    expect(screen.getByRole('button', { name: /peek/i })).not.toBe(labelButton);
+
+    // Clicking the label opens the same transcript the Peek button does.
+    fireEvent.click(labelButton);
 
     await waitFor(() => {
       expect(transcriptUrls).toContain(

--- a/frontend/src/components/WorkInFlight.test.tsx
+++ b/frontend/src/components/WorkInFlight.test.tsx
@@ -165,6 +165,25 @@ describe('WorkInFlight (Workers active)', () => {
     });
   });
 
+  it('opens the peek when the worker row label is clicked, for consistency with the Available-agents roster', async () => {
+    stubTranscriptFetch();
+    const sessions = [
+      session({ id: 'gc-335825', template: 'polecat', rig: 'gascity', state: 'active' }),
+    ];
+    renderSection([], sessions);
+
+    // The worker label is itself a button (mirroring the clickable agent-roster
+    // row label), distinct from the explicit Peek button — its accessible name
+    // is the worker identity, not "Peek". Clicking it opens the same transcript.
+    fireEvent.click(screen.getByRole('button', { name: /gascity.*polecat/i }));
+
+    await waitFor(() => {
+      expect(transcriptUrls).toContain(
+        '/gc-supervisor/v0/city/test-city/session/gc-335825/transcript?format=conversation',
+      );
+    });
+  });
+
   it('surfaces the captured bead as a link beside the peek transcript', async () => {
     stubTranscriptFetch();
     const sessions = [session({ id: 'gc-335825', template: 'polecat', rig: 'gascity' })];

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -67,12 +67,27 @@ function WorkerRow({
     <li className="px-2 py-2 -mx-2 rounded-sm transition-colors duration-150 ease-out-quart hover:bg-surface-tint/60">
       <div className="flex items-baseline justify-between gap-4">
         <div className="min-w-0 text-body text-fg">
-          <span className="font-medium">{rig}</span>
-          <span className="text-fg-faint" aria-hidden="true">
-            {' '}
-            ·{' '}
-          </span>
-          <span className="text-fg-muted">{worker.worker}</span>
+          {/* Consistency with the Available-agents roster (Agents.tsx), whose
+              row label is a clickable Link into the agent's detail: the worker
+              label opens this session's transcript in the same LiveSessionPeek
+              the Peek button uses, so the whole worker is one click from its
+              transcript. A button (not a Link) because the peek is a modal, not
+              a route. focus-mark + group-hover accent match the roster's
+              interactive affordance; the bold-rig / muted-worker hierarchy is
+              preserved at rest. */}
+          <button
+            type="button"
+            onClick={() => onPeek(session.id)}
+            className="group text-left cursor-pointer focus-mark"
+            title={`Peek ${rig} · ${worker.worker} transcript`}
+          >
+            <span className="font-medium group-hover:text-accent">{rig}</span>
+            <span className="text-fg-faint" aria-hidden="true">
+              {' '}
+              ·{' '}
+            </span>
+            <span className="text-fg-muted group-hover:text-accent">{worker.worker}</span>
+          </button>
           {bead && (
             <Link
               to={`/beads?bead=${encodeURIComponent(bead.id)}`}

--- a/frontend/src/components/WorkInFlight.tsx
+++ b/frontend/src/components/WorkInFlight.tsx
@@ -79,7 +79,7 @@ function WorkerRow({
             type="button"
             onClick={() => onPeek(session.id)}
             className="group text-left cursor-pointer focus-mark"
-            title={`Peek ${rig} · ${worker.worker} transcript`}
+            title={`Open ${rig} · ${worker.worker} transcript`}
           >
             <span className="font-medium group-hover:text-accent">{rig}</span>
             <span className="text-fg-faint" aria-hidden="true">


### PR DESCRIPTION
## What

Make **Workers-active** rows on the Agents page row-clickable to open that worker's
transcript peek — matching the existing **Available agents** rows, which are already
clickable to the agent detail. Previously a worker row exposed only a "Peek" button;
now the whole row is an affordance, consistent with operator expectation.

The explicit Peek button is retained. Status stays glyph+word (no color-only), flat,
per DESIGN.md.

## Test

Added a test proving a worker row click opens the **clicked** worker's peek (not a
fixed/first one), and asserting the row and the Peek button are distinct controls.
