### PR TITLE
fix(runs): blocked-only badge + page parity, kill partial-count flap, suppress phantom roots

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -265,7 +265,13 @@ describe('useLiveAttentionContributors', () => {
 
     await waitFor(() => {
       const model = composeAttention(result.current);
-      expect(model.byDomain.runs.attention).toBe(1);
+      // gascity-dashboard-2j8e.2: the Runs badge now counts genuinely-blocked
+      // runs from the bead-derived run summary, not the formula feed. This
+      // fixture has no graph.v2 run beads (only a plain task bead + a city feed
+      // item), so there are no blocked runs to count. The blocked-counting
+      // logic is covered in registry.test.ts; here we assert the contributor is
+      // wired to the summary loader (listBeads({ limit: 500 }) below).
+      expect(model.byDomain.runs.attention).toBe(0);
       expect(model.byDomain.agents.attention).toBe(2);
       expect(model.byDomain.beads.attention).toBe(1);
       expect(model.byDomain.mail.attention).toBe(1);
@@ -276,11 +282,9 @@ describe('useLiveAttentionContributors', () => {
       expect(model.byDomain.maintainer.attention).toBe(1);
     });
 
-    expect(mockSupervisorApi.formulaFeed).toHaveBeenCalledWith('test-city', {
-      limit: 100,
-      scope_kind: 'city',
-      scope_ref: 'test-city',
-    });
+    // The Runs contributor drives the bead-derived run summary loader, whose
+    // required read is the active run-bead list (gascity-dashboard-2j8e.2).
+    expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
     expect(mockSupervisorApi.listAgents).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApi.listSessions).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApi.sessionPending).toHaveBeenCalledWith('test-city', 'gc-2568');

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -11,6 +11,7 @@ import { listAgentPendingInteractions } from '../supervisor/agentPending';
 import { listSupervisorBeads } from '../supervisor/beadReads';
 import { supervisorApi, supervisorApiForRequestBudget } from '../supervisor/client';
 import { DEFAULT_MAIL_HISTORY_LIMIT, listSupervisorMail } from '../supervisor/mailReads';
+import { loadSupervisorRunSummaryPreviewSource } from '../supervisor/runSummary';
 import type { AttentionContributor } from './compose';
 import {
   createAttentionContributors,
@@ -25,7 +26,6 @@ import {
   type RunsAttentionFacts,
 } from './registry';
 
-const FORMULA_FEED_LIMIT = 100;
 const ATTENTION_LIST_LIMIT = 1000;
 const ACTIVITY_EVENT_FETCH_LIMIT = 100;
 const ACTIVITY_EVENT_WINDOW = '24h';
@@ -108,17 +108,25 @@ function withRunsFreshness(
 
 async function fetchRunsAttention(cityName: string | null): Promise<RunsAttentionFacts> {
   if (cityName === null) return {};
-  try {
-    return {
-      feed: await supervisorApi().formulaFeed(cityName, {
-        limit: FORMULA_FEED_LIMIT,
-        scope_kind: 'city',
-        scope_ref: cityName,
-      }),
-    };
-  } catch (err) {
-    return { error: formatApiError(err, 'formula run feed unavailable') };
+  // gascity-dashboard-2j8e.2: the badge derives genuinely-blocked runs from the
+  // bead-derived run summary — the SAME source the /runs page reads — so the
+  // badge and the page count one selector and cannot disagree. The preview
+  // source is sufficient: `phase === 'blocked'` is decided from bead state in
+  // buildRunSummary and needs no session enrichment. The formula feed (the old
+  // source) is dropped: it counted phantom feed-only roots and flapped on
+  // partial fan-outs.
+  //
+  // This refetches the summary under the attention cache key rather than sharing
+  // the page's `runs:summary:*` entry, so when the operator is on /runs the
+  // fan-out runs twice. The attention fetch is mount-driven (no recurring poll),
+  // so the cost is bounded to cold load / city switch; unifying the two cache
+  // entries is a worthwhile follow-up but a cross-cutting cache change kept out
+  // of this focused fix.
+  const source = await loadSupervisorRunSummaryPreviewSource();
+  if (source.status === 'error') {
+    return { error: source.error };
   }
+  return { summary: source.data };
 }
 
 async function fetchAgentsAttention(cityName: string | null): Promise<AgentsAttentionFacts> {

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -11,7 +11,6 @@ import type {
 import type {
   AgentResponse,
   Bead,
-  FormulaFeedBody,
   HealthOutputBody,
   Message,
   TypedEventStreamEnvelope,
@@ -116,23 +115,21 @@ describe('createAttentionContributors', () => {
     const model = composeAttention(
       createAttentionContributors({
         runs: {
-          feed: formulaFeed({
-            items: [
-              {
-                id: 'run-1',
-                root_bead_id: 'B-root',
-                root_store_ref: 'city:B-root',
-                scope_kind: 'city',
-                scope_ref: 'test-city',
-                started_at: '2026-05-29T20:00:00.000Z',
-                status: 'failed',
-                target: 'mayor',
-                title: 'Review formula output',
-                type: 'formula',
-                updated_at: '2026-05-29T20:05:00.000Z',
+          summary: runSummary([
+            runLane({
+              id: 'run-1',
+              title: 'Review formula output',
+              phase: 'blocked',
+              scope: {
+                status: 'available',
+                kind: 'city',
+                ref: 'test-city',
+                rootStoreRef: 'city:test-city',
               },
-            ],
-          }),
+              statusCounts: { blocked: 1 },
+              health: { phaseConfidence: 'known', needsOperator: true, thrashingDetected: false },
+            }),
+          ]),
         },
         agents: {
           items: [
@@ -191,20 +188,23 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.health.attention).toBe(1);
   });
 
-  it('still derives run attention from the existing RunSummary health model', () => {
+  it('counts genuinely-blocked runs only — a needs-operator active lane does not count (gascity-dashboard-2j8e.2)', () => {
     const model = composeAttention(
       createAttentionContributors({
         runs: {
           summary: runSummary([
             runLane({
-              id: 'run-1',
-              title: 'Review formula output',
+              id: 'active-1',
+              title: 'Active needs operator',
               phase: 'approval',
-              health: {
-                phaseConfidence: 'known',
-                needsOperator: true,
-                thrashingDetected: false,
-              },
+              health: { phaseConfidence: 'known', needsOperator: true, thrashingDetected: false },
+            }),
+            runLane({
+              id: 'blocked-1',
+              title: 'Stuck run',
+              phase: 'blocked',
+              statusCounts: { blocked: 1 },
+              health: { phaseConfidence: 'known', needsOperator: true, thrashingDetected: false },
             }),
           ]),
         },
@@ -212,35 +212,51 @@ describe('createAttentionContributors', () => {
     );
 
     expect(model.byDomain.runs.attention).toBe(1);
-    expect(model.byDomain.runs.items[0]?.href).toBe('/runs/run-1');
+    expect(model.byDomain.runs.watch).toBe(0);
+    expect(model.byDomain.runs.items.map((item) => item.id)).toEqual(['runs:blocked-1:blocked']);
+    expect(model.byDomain.runs.items[0]?.href).toBe('/runs/blocked-1');
   });
 
-  it('reclassifies runs data-unavailability emitters into the unavailable tier, carrying read freshness', () => {
+  it('never counts a supervisor partial read as a run (gascity-dashboard-2j8e.2)', () => {
+    const summary = runSummary([
+      runLane({
+        id: 'blocked-1',
+        title: 'Stuck run',
+        phase: 'blocked',
+        statusCounts: { blocked: 1 },
+        health: { phaseConfidence: 'inferred', needsOperator: false, thrashingDetected: false },
+      }),
+    ]);
+    const model = composeAttention(
+      createAttentionContributors({ runs: { summary: { ...summary, lanesPartial: true } } }),
+    );
+
+    // The blocked run counts; the partial flag lands only in the non-counting
+    // unavailable tier (dash-ygj) — so the badge count is stable across partial
+    // fan-outs (no 6<->13 flap) while the degraded read still surfaces quietly.
+    expect(model.byDomain.runs.attention).toBe(1);
+    expect(model.byDomain.runs.watch).toBe(0);
+    expect(model.byDomain.runs.unavailable).toBe(1);
+    const ids = model.byDomain.runs.items.map((item) => item.id);
+    expect(ids).toContain('runs:blocked-1:blocked');
+    expect(ids).toContain('runs:partial');
+  });
+
+  it('surfaces a single unavailable item when run data errors (gascity-dashboard-2j8e.2)', () => {
+    const model = composeAttention(
+      createAttentionContributors({ runs: { error: 'supervisor unreachable' } }),
+    );
+
+    expect(model.byDomain.runs.items.map((item) => item.id)).toEqual(['runs:unavailable']);
+    expect(model.byDomain.runs.attention).toBe(1);
+  });
+
+  it('reclassifies summary-derived runs data-unavailability into the unavailable tier, carrying read freshness', () => {
     const model = composeAttention(
       createAttentionContributors({
         runs: {
           provenance: 'stale',
           fetchedAt: '2026-06-06T12:00:00.000Z',
-          feed: formulaFeed({
-            partial: true,
-            partial_errors: ['feed degraded'],
-            items: [
-              {
-                id: 'run-detail',
-                root_bead_id: 'B-root',
-                root_store_ref: 'city:B-root',
-                scope_kind: 'city',
-                scope_ref: 'test-city',
-                started_at: '2026-05-29T20:00:00.000Z',
-                status: 'running',
-                target: 'mayor',
-                title: 'Detail run',
-                type: 'formula',
-                updated_at: '2026-05-29T20:05:00.000Z',
-                run_detail_available: false,
-              },
-            ],
-          }),
           summary: {
             ...runSummary([]),
             lanesPartial: true,
@@ -250,18 +266,18 @@ describe('createAttentionContributors', () => {
       }),
     );
 
-    // The four data-unavailability emitters (feed-partial, detail-unavailable,
-    // list-partial, health-unavailable) must never inflate the badge counts…
+    // The summary-derived data-unavailability emitters (list-partial,
+    // health-unavailable) must never inflate the badge counts… (the formula feed
+    // is no longer a runs-attention source — gascity-dashboard-2j8e.2 — so its
+    // feed-partial / detail-unavailable emitters are gone with it.)
     expect(model.byDomain.runs.attention).toBe(0);
     expect(model.byDomain.runs.watch).toBe(0);
     // …they land in the dedicated unavailable tier…
-    expect(model.byDomain.runs.unavailable).toBe(4);
+    expect(model.byDomain.runs.unavailable).toBe(2);
     // …and never color the nav badge.
     expect(model.byDomain.runs.severity).toBeNull();
 
     const ids = model.byDomain.runs.items.map((item) => item.id);
-    expect(ids).toContain('runs:feed-partial');
-    expect(ids).toContain('runs:run-detail:detail-unavailable');
     expect(ids).toContain('runs:partial');
     expect(ids).toContain('runs:run-health:health-unavailable');
 
@@ -717,19 +733,21 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
   for (const lane of lanes) {
     byPhase[lane.phase] += 1;
   }
+  const blockedLanes = lanes.filter((lane) => lane.phase === 'blocked');
+  const activeLanes = lanes.filter((lane) => lane.phase !== 'blocked' && lane.phase !== 'complete');
   return {
-    lanes: [...lanes],
-    historicalLanes: [],
-    blockedLanes: [],
-    totalActive: lanes.length,
+    lanes: activeLanes,
+    historicalLanes: lanes.filter((lane) => lane.phase === 'complete'),
+    blockedLanes,
+    totalActive: activeLanes.length,
     totalHistorical: 0,
     runCounts: {
-      total: lanes.length,
-      visible: lanes.length,
+      total: activeLanes.length,
+      visible: activeLanes.length,
       prReview: 0,
       designReview: 0,
       bugfix: 0,
-      blocked: lanes.filter((lane) => lane.phase === 'blocked').length,
+      blocked: blockedLanes.length,
       other: 0,
     },
     recentChanges: [],
@@ -751,6 +769,9 @@ function runLane({
   title,
   phase,
   health,
+  scope,
+  statusCounts = {},
+  activeAssignees = [],
 }: {
   id: string;
   title: string;
@@ -760,12 +781,24 @@ function runLane({
     needsOperator: boolean;
     thrashingDetected: boolean;
   };
+  scope?: RunLane['scope'];
+  statusCounts?: Record<string, number>;
+  activeAssignees?: string[];
 }): RunLane {
   return {
     id,
     title,
     phase,
     phaseLabel: phase,
+    formula: { status: 'known', name: 'mol-test' },
+    scope: scope ?? { status: 'unavailable', error: 'run scope metadata unavailable' },
+    external: { status: 'unavailable', error: 'external reference unavailable' },
+    statusCounts,
+    activeAssignees,
+    updatedAt: { status: 'available', at: '2026-05-29T20:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable' },
+    formulaStageResolved: false,
     health: {
       status: 'available',
       data: {
@@ -777,7 +810,7 @@ function runLane({
         },
       },
     },
-  } as RunLane;
+  };
 }
 
 function healthUnavailableLane(id: string, title: string): RunLane {
@@ -786,6 +819,7 @@ function healthUnavailableLane(id: string, title: string): RunLane {
     title,
     phase: 'active',
     phaseLabel: 'active',
+    scope: { status: 'unavailable', error: 'run scope metadata unavailable' },
     health: { status: 'unavailable', error: 'health probe failed' },
   } as RunLane;
 }
@@ -830,14 +864,6 @@ function deploys(overrides: Partial<DeployList>): DeployList {
     failed_marker: false,
     items: [],
     source: null,
-    ...overrides,
-  };
-}
-
-function formulaFeed(overrides: Partial<FormulaFeedBody>): FormulaFeedBody {
-  return {
-    items: [],
-    partial: false,
     ...overrides,
   };
 }

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -2,19 +2,18 @@ import type {
   DeployList,
   DoltNomsTrend,
   MaintainerTriage,
-  RunLane,
   RunSummary,
   SourceStatus,
   SystemHealth,
   TriageItem,
 } from 'gas-city-dashboard-shared';
+import { selectBlockedRuns } from 'gas-city-dashboard-shared';
+import { runDetailHref } from '../supervisor/runHref';
 import type {
   AgentResponse,
   Bead,
-  FormulaFeedBody,
   HealthOutputBody,
   Message,
-  MonitorFeedItemResponse,
   TypedEventStreamEnvelope,
 } from 'gas-city-dashboard-shared/gc-supervisor';
 import type { AgentPendingInteraction } from '../supervisor/agentPending';
@@ -40,7 +39,14 @@ export interface HealthAttentionFacts {
 }
 
 export interface RunsAttentionFacts {
-  feed?: FormulaFeedBody;
+  /**
+   * The bead-derived run summary (gascity-dashboard-2j8e.2). The Runs badge
+   * counts genuinely-blocked runs from `summary.blockedLanes` — the same
+   * selectBlockedRuns the /runs page reads, so the badge and the page count
+   * cannot disagree. The formula feed is deliberately NOT a source here: it
+   * surfaced phantom feed-only roots (gc-1920 codeprobe upstream_error) and
+   * flapped 6<->13 on partial fan-outs.
+   */
   summary?: RunSummary;
   error?: string;
   /**
@@ -240,14 +246,19 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
         href: '/runs',
       }),
     );
+    return items;
   }
 
   const summary = facts.summary;
-  const feed = facts.feed;
-  if (feed !== undefined) {
-    appendFormulaFeedAttention(items, feed, freshness);
-  }
   if (summary === undefined) return items;
+
+  // dash-ygj + gascity-dashboard-2j8e.2: degraded runs reads land in the
+  // `unavailable` tier, which BadgeSeverity excludes — so a partial fan-out and
+  // any lane whose health could not be read surface as quiet, non-counting items
+  // (never a badge number) and ride read freshness so a stale read can be aged.
+  // The formula feed is no longer a source (it produced the gc-1920 phantom roots
+  // and flapped 6<->13), so #91's feed-derived emitters are gone; only the
+  // summary-derived degraded reads survive.
   if (summary.lanesPartial === true) {
     items.push(
       domainUnavailable(
@@ -261,131 +272,38 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
       ),
     );
   }
-
-  // gascity-dashboard-4xcv: blocked lanes moved out of summary.lanes into
-  // their own bucket; they still need the operator, so both sets contribute.
   for (const lane of [...summary.lanes, ...summary.blockedLanes]) {
-    const item = attentionForRunLane(lane, freshness);
-    if (item !== null) items.push(item);
-  }
-  return items;
-}
-
-function appendFormulaFeedAttention(
-  items: AttentionItem[],
-  feed: FormulaFeedBody,
-  freshness: ReadFreshness,
-): void {
-  if (feed.partial) {
-    const summary = feed.partial_errors?.join('; ');
+    if (lane.health.status === 'available') continue;
     items.push(
       domainUnavailable(
         'runs',
         {
-          id: 'runs:feed-partial',
-          title: 'Formula run feed incomplete',
-          href: '/runs',
-          ...(summary === undefined ? {} : { summary }),
+          id: `runs:${lane.id}:health-unavailable`,
+          title: `${lane.title} health unavailable`,
+          summary: lane.health.error,
+          href: runDetailHref(lane.id, lane.scope),
         },
         freshness,
       ),
     );
   }
-  for (const item of feed.items ?? []) {
-    const attention = attentionForFormulaFeedItem(item, freshness);
-    if (attention !== null) items.push(attention);
-  }
-}
 
-function attentionForFormulaFeedItem(
-  item: MonitorFeedItemResponse,
-  freshness: ReadFreshness,
-): AttentionItem | null {
-  const status = item.status.toLowerCase();
-  const href = runHref(item.id, item.scope_kind, item.scope_ref);
-  if (isRunAttentionStatus(status)) {
-    return domainAttention('runs', {
-      id: `runs:${item.id}:${status}`,
-      title: item.title,
-      summary: item.status,
-      href,
-      updatedAt: item.started_at,
-    });
-  }
-  if (item.run_detail_available === false || item.detail_available === false) {
-    return domainUnavailable(
-      'runs',
-      {
-        id: `runs:${item.id}:detail-unavailable`,
-        title: `${item.title} detail unavailable`,
-        href,
-        updatedAt: item.started_at,
-      },
-      freshness,
+  // gascity-dashboard-2j8e.2: the Runs badge counts GENUINELY-BLOCKED runs only
+  // — exactly the selectBlockedRuns set the /runs page renders, so the badge
+  // number and the page's Blocked count read one selector and cannot disagree.
+  // A supervisor `partial` read is never counted (it lands in the unavailable
+  // tier above), so the count no longer flaps on a partial fan-out.
+  for (const run of selectBlockedRuns(summary.blockedLanes)) {
+    items.push(
+      domainAttention('runs', {
+        id: `runs:${run.id}:blocked`,
+        title: `${run.title} blocked`,
+        summary: run.reason,
+        href: runDetailHref(run.id, run.scope),
+      }),
     );
   }
-  if (isRunWatchStatus(status)) {
-    return domainWatch('runs', {
-      id: `runs:${item.id}:${status}`,
-      title: item.title,
-      summary: item.status,
-      href,
-      updatedAt: item.started_at,
-    });
-  }
-  return null;
-}
-
-function attentionForRunLane(lane: RunLane, freshness: ReadFreshness): AttentionItem | null {
-  const href =
-    lane.scope?.status === 'available'
-      ? runHref(lane.id, lane.scope.kind, lane.scope.ref)
-      : runHref(lane.id);
-  if (lane.health.status !== 'available') {
-    return domainUnavailable(
-      'runs',
-      {
-        id: `runs:${lane.id}:health-unavailable`,
-        title: `${lane.title} health unavailable`,
-        summary: lane.health.error,
-        href,
-      },
-      freshness,
-    );
-  }
-
-  const health = lane.health.data;
-  if (health.needsOperator || lane.phase === 'blocked') {
-    return domainAttention('runs', {
-      id: `runs:${lane.id}:needs-operator`,
-      title: `${lane.title} needs operator`,
-      href,
-    });
-  }
-  if (health.phaseConfidence === 'known' && health.thrashingDetected) {
-    return domainAttention('runs', {
-      id: `runs:${lane.id}:thrashing`,
-      title: `${lane.title} is thrashing`,
-      href,
-    });
-  }
-  if (health.phaseConfidence === 'inferred') {
-    return domainWatch('runs', {
-      id: `runs:${lane.id}:unverifiable`,
-      title: `${lane.title} health unverifiable`,
-      href,
-    });
-  }
-  return null;
-}
-
-function runHref(runId: string, scopeKind?: string, scopeRef?: string): string {
-  const path = `/runs/${encodeURIComponent(runId)}`;
-  if (scopeKind === undefined || scopeRef === undefined) return path;
-  const search = new URLSearchParams();
-  search.set('scope_kind', scopeKind);
-  search.set('scope_ref', scopeRef);
-  return `${path}?${search.toString()}`;
+  return items;
 }
 
 function deriveAgentsAttention(facts: AgentsAttentionFacts | undefined): readonly AttentionItem[] {
@@ -1083,24 +1001,6 @@ function formatElapsed(ageMs: number): string {
 
 function isFailureState(state: string): boolean {
   return state === 'failed' || state === 'errored' || state === 'stuck' || state === 'crashed';
-}
-
-function isRunAttentionStatus(status: string): boolean {
-  return (
-    status === 'failed' ||
-    status === 'error' ||
-    status === 'errored' ||
-    status === 'blocked' ||
-    status === 'waiting' ||
-    status === 'needs_operator' ||
-    status === 'needs-operator'
-  );
-}
-
-function isRunWatchStatus(status: string): boolean {
-  return (
-    status === 'partial' || status === 'unknown' || status === 'inferred' || status === 'stale'
-  );
 }
 
 function addressMatches(raw: string, alias: string): boolean {

--- a/frontend/src/components/PartialDataNotice.test.tsx
+++ b/frontend/src/components/PartialDataNotice.test.tsx
@@ -19,4 +19,12 @@ describe('PartialDataNotice', () => {
 
     expect(screen.queryByRole('status')).toBeNull();
   });
+
+  it('pairs an optional leading glyph with the word (DESIGN.md status = glyph + word)', () => {
+    render(<PartialDataNotice glyph="◐" label="runs partial" title="one rig unavailable" />);
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('◐');
+    expect(status.textContent).toContain('runs partial');
+  });
 });

--- a/frontend/src/components/PartialDataNotice.tsx
+++ b/frontend/src/components/PartialDataNotice.tsx
@@ -2,13 +2,21 @@ interface PartialDataNoticeProps {
   label: string;
   title: string;
   show?: boolean;
+  /**
+   * Optional leading status glyph (aria-hidden), so the indicator reads as
+   * glyph + word per DESIGN.md "status = glyph + word, never color alone".
+   * gascity-dashboard-2j8e.2: the Runs partial indicator pairs ◐ with "partial"
+   * so a partial fan-out is legible in greyscale, not carried by the warn tint.
+   */
+  glyph?: string;
 }
 
-export function PartialDataNotice({ label, title, show = true }: PartialDataNoticeProps) {
+export function PartialDataNotice({ label, title, show = true, glyph }: PartialDataNoticeProps) {
   if (!show) return null;
 
   return (
     <span className="normal-case text-body text-warn" role="status" title={title}>
+      {glyph !== undefined && <span aria-hidden="true">{glyph} </span>}
       {label}
     </span>
   );

--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { BadgeSeverity } from '../../attention/compose';
 import { attentionListItemProps } from '../../attention/routeHighlight';
 import { formatRelative } from '../../hooks/time';
+import { runDetailHref } from '../../supervisor/runHref';
 import { StageLadder } from './StageLadder';
 
 // Per-lane typographic row. No card chrome — vertical rhythm carries the
@@ -16,6 +17,12 @@ interface LaneCardProps {
   lane: RunLane;
   now: number;
   attentionSeverity?: BadgeSeverity | null;
+  /**
+   * gascity-dashboard-2j8e.2: why-blocked + how-to-unblock, shown only in the
+   * Blocked section so a blocked run reads as actionable (which step, what to
+   * do) rather than just "blocked". Derived by selectBlockedRuns.
+   */
+  blocked?: { reason: string; remedy: string };
 }
 
 /**
@@ -37,7 +44,7 @@ function phaseLabelTone(phase: RunLane['phase']): 'text-accent' | 'text-fg-muted
   return 'text-fg';
 }
 
-export function LaneCard({ lane, now, attentionSeverity = null }: LaneCardProps) {
+export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneCardProps) {
   const statusEntries = Object.entries(lane.statusCounts).sort((a, b) =>
     statusSortKey(a[0]).localeCompare(statusSortKey(b[0])),
   );
@@ -62,7 +69,7 @@ export function LaneCard({ lane, now, attentionSeverity = null }: LaneCardProps)
       </div>
 
       <Link
-        to={runDetailHref(lane)}
+        to={runDetailHref(lane.id, lane.scope)}
         className="focus-mark mt-1 block text-body text-fg leading-snug hover:text-accent"
       >
         {lane.title}
@@ -109,18 +116,20 @@ export function LaneCard({ lane, now, attentionSeverity = null }: LaneCardProps)
           </span>
         )}
       </div>
+
+      {blocked !== undefined && (
+        <div className="mt-2">
+          <p className="text-body text-fg leading-snug">
+            <span aria-hidden="true" className="text-accent">
+              ✕
+            </span>{' '}
+            {blocked.reason}
+          </p>
+          <p className="mt-1 text-body text-fg-muted leading-snug">{blocked.remedy}</p>
+        </div>
+      )}
     </li>
   );
-}
-
-function runDetailHref(lane: RunLane): string {
-  const search = new URLSearchParams();
-  if (lane.scope.status === 'available') {
-    search.set('scope_kind', lane.scope.kind);
-    search.set('scope_ref', lane.scope.ref);
-  }
-  const qs = search.toString();
-  return `/runs/${encodeURIComponent(lane.id)}${qs ? `?${qs}` : ''}`;
 }
 
 function statusSortKey(status: string): string {

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
-import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
+import {
+  selectBlockedRuns,
+  type RunLane,
+  type RunSummary,
+  type SourceState,
+} from 'gas-city-dashboard-shared';
 import type { BadgeSeverity } from '../../attention/compose';
 import { LaneCard } from './LaneCard';
 
@@ -199,15 +204,34 @@ function BlockedSection({
   now: number;
   attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
-  if (summary.blockedLanes.length === 0) return null;
+  // gascity-dashboard-2j8e.2: selectBlockedRuns is the SAME selector the nav
+  // badge counts, so the header count here and the badge number are one number.
+  // Each row carries why-blocked + how-to-unblock (LaneCard `blocked`), so the
+  // destination is a path to action, not just a list. Rendered inline rather
+  // than through the shared LaneList so that generic list stays blocked-unaware.
+  const detailById = new Map(selectBlockedRuns(summary.blockedLanes).map((run) => [run.id, run]));
+  if (detailById.size === 0) return null;
   return (
     <section aria-label="Blocked runs" className="mt-12">
-      <h2 className="text-label uppercase tracking-wider text-fg-faint">Blocked</h2>
-      <LaneList
-        lanes={summary.blockedLanes}
-        now={now}
-        {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
-      />
+      <h2 className="text-label uppercase tracking-wider text-fg-faint tnum">
+        Blocked ({detailById.size})
+      </h2>
+      <ol className="mt-3 divide-y divide-rule">
+        {summary.blockedLanes.map((lane) => {
+          const detail = detailById.get(lane.id);
+          return (
+            <LaneCard
+              key={lane.id}
+              lane={lane}
+              now={now}
+              {...(attentionSeverity === undefined
+                ? {}
+                : { attentionSeverity: attentionSeverity(lane) })}
+              {...(detail === undefined ? {} : { blocked: detail })}
+            />
+          );
+        })}
+      </ol>
     </section>
   );
 }

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -619,6 +619,49 @@ describe('RunsPage — blocked lanes are not Active (gascity-dashboard-4xcv)', (
   });
 });
 
+describe('RunsPage — blocked legibility + partial glyph (gascity-dashboard-2j8e.2)', () => {
+  it('shows why-blocked and how-to-unblock per blocked run, headed by the count', async () => {
+    const source = buildRunSource('fresh');
+    const runs = requireRunData(source);
+    runs.blockedLanes = [
+      activeLane({
+        id: 'gc-1920',
+        title: 'mol-focus-review latch',
+        phase: 'blocked',
+        phaseLabel: 'blocked',
+        statusCounts: { blocked: 1 },
+        activeAssignees: [],
+      }),
+    ];
+    runs.runCounts = { ...runs.runCounts, blocked: 1 };
+    mockLoadRunSummary.mockResolvedValue(source);
+
+    mount();
+    await waitForMount();
+
+    const blockedSection = await screen.findByRole('region', { name: /blocked runs/i });
+    // The header count is the same selectBlockedRuns the nav badge counts.
+    expect(blockedSection.textContent).toContain('Blocked (1)');
+    // Why-blocked (the completedLane base resolves the Finalization stage).
+    expect(blockedSection.textContent).toContain('Blocked at Finalization');
+    // How-to-unblock.
+    expect(blockedSection.textContent).toContain('No worker assigned. Claim or dispatch one.');
+  });
+
+  it('pairs the partial indicator with a ◐ glyph (DESIGN.md status = glyph + word)', async () => {
+    const source = buildRunSource('fresh');
+    requireRunData(source).lanesPartial = true;
+    mockLoadRunSummary.mockResolvedValue(source);
+
+    mount();
+    await waitForMount();
+
+    const marker = await screen.findByRole('status');
+    expect(marker.textContent).toContain('◐');
+    expect(marker.textContent).toContain('runs partial');
+  });
+});
+
 describe('RunsPage — run scope labels (gascity-dashboard-4xcv)', () => {
   it('groups city-scoped and scope-unavailable lanes under a single "city" header, never "unknown rig"', async () => {
     const source = buildRunSource('fresh');

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -209,6 +209,7 @@ export function RunsPage() {
               <span>
                 {lanesPartial ? (
                   <PartialDataNotice
+                    glyph="◐"
                     label="runs partial"
                     title="one or more rigs' recent runs were unavailable; the lane set may be incomplete"
                   />

--- a/frontend/src/supervisor/runHref.ts
+++ b/frontend/src/supervisor/runHref.ts
@@ -1,0 +1,16 @@
+import type { RunLaneScope } from 'gas-city-dashboard-shared';
+
+/**
+ * The run-detail route href for a run id + its scope. Centralises the
+ * `/runs/:id?scope_kind=&scope_ref=` construction — path segment encoded, the
+ * scope query appended only when the scope resolved — so the nav-badge link and
+ * the lane-card link to the same run cannot drift (gascity-dashboard-2j8e.2).
+ */
+export function runDetailHref(runId: string, scope: RunLaneScope): string {
+  const path = `/runs/${encodeURIComponent(runId)}`;
+  if (scope.status !== 'available') return path;
+  const search = new URLSearchParams();
+  search.set('scope_kind', scope.kind);
+  search.set('scope_ref', scope.ref);
+  return `${path}?${search.toString()}`;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -12,6 +12,7 @@ export * from './session-id.js';
 export * from './work-in-flight.js';
 export type * from './viewing-as.js';
 export * from './runs/bead-fields.js';
+export * from './runs/blocked.js';
 export * from './runs/display-state.js';
 export * from './runs/edges.js';
 export * from './runs/enrich.js';

--- a/shared/src/runs/blocked.test.ts
+++ b/shared/src/runs/blocked.test.ts
@@ -1,0 +1,113 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { blockedRunReason, blockedRunRemedy, selectBlockedRuns } from './blocked.js';
+import type { RunLane } from '../snapshot/types.js';
+
+// gascity-dashboard-2j8e.2: the single genuinely-blocked-runs selector. Both
+// the Runs nav badge and the /runs page read it, so the badge count and the
+// page count cannot disagree. Input is buildRunSummary's blockedLanes, which is
+// already dangling-root + non-graph.v2 suppressed upstream — the gc-1920-class
+// phantom never reaches here.
+
+function lane(overrides: Partial<RunLane> = {}): RunLane {
+  return {
+    id: 'gc-100',
+    title: 'mol-focus-review',
+    formula: { status: 'known', name: 'mol-focus-review' },
+    scope: { status: 'available', kind: 'rig', ref: 'app', rootStoreRef: 'rig:app' },
+    external: { status: 'unavailable', error: 'external reference unavailable' },
+    phase: 'blocked',
+    phaseLabel: 'blocked',
+    statusCounts: { blocked: 1, open: 2 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-06-01T00:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+    ...overrides,
+  };
+}
+
+describe('selectBlockedRuns — gascity-dashboard-2j8e.2', () => {
+  test('projects one BlockedRun per blocked lane, preserving id/title/scope', () => {
+    const scope = {
+      status: 'available',
+      kind: 'rig',
+      ref: 'app',
+      rootStoreRef: 'rig:app',
+    } as const;
+    const runs = selectBlockedRuns([
+      lane({ id: 'gc-1', title: 'Run one', scope }),
+      lane({ id: 'gc-2', title: 'Run two', scope }),
+    ]);
+    assert.equal(runs.length, 2);
+    assert.deepEqual(
+      runs.map((r) => r.id),
+      ['gc-1', 'gc-2'],
+    );
+    assert.equal(runs[0]?.title, 'Run one');
+    assert.deepEqual(runs[0]?.scope, scope);
+  });
+
+  test('selects only blocked lanes — active and complete are excluded', () => {
+    const runs = selectBlockedRuns([
+      lane({ id: 'active', phase: 'implementation' }),
+      lane({ id: 'done', phase: 'complete' }),
+      lane({ id: 'blocked', phase: 'blocked' }),
+    ]);
+    assert.deepEqual(
+      runs.map((r) => r.id),
+      ['blocked'],
+    );
+  });
+
+  test('empty input yields no blocked runs', () => {
+    assert.deepEqual(selectBlockedRuns([]), []);
+  });
+});
+
+describe('blockedRunReason — why-blocked', () => {
+  test('names the blocked stage when the active stage resolved', () => {
+    const reason = blockedRunReason(
+      lane({
+        progress: {
+          status: 'active_step',
+          stepId: 'review.adopt',
+          stage: { status: 'available', index: 2, key: 'review', label: 'Review' },
+          attempt: { status: 'unavailable', error: 'run step attempt unavailable' },
+        },
+      }),
+    );
+    assert.equal(reason, 'Blocked at Review');
+  });
+
+  test('falls back to the blocked-step count when no stage resolved', () => {
+    assert.equal(blockedRunReason(lane({ statusCounts: { blocked: 2 } })), '2 blocked steps');
+    assert.equal(blockedRunReason(lane({ statusCounts: { blocked: 1 } })), '1 blocked step');
+  });
+
+  test('uses a generic phrase when neither stage nor a blocked step is known', () => {
+    assert.equal(
+      blockedRunReason(lane({ statusCounts: { open: 1 } })),
+      'Blocked, awaiting operator',
+    );
+  });
+});
+
+describe('blockedRunRemedy — how-to-unblock', () => {
+  test('tells the operator to dispatch when no worker is assigned', () => {
+    assert.equal(
+      blockedRunRemedy(lane({ activeAssignees: [] })),
+      'No worker assigned. Claim or dispatch one.',
+    );
+  });
+
+  test('points to the run detail when a worker is assigned', () => {
+    assert.equal(
+      blockedRunRemedy(lane({ activeAssignees: ['claude-1'] })),
+      'Open run detail to review the blocked step.',
+    );
+  });
+});

--- a/shared/src/runs/blocked.ts
+++ b/shared/src/runs/blocked.ts
@@ -1,0 +1,60 @@
+import type { RunLane, RunLaneScope } from '../snapshot/types.js';
+
+// gascity-dashboard-2j8e.2: the genuinely-blocked-runs selector. The Runs nav
+// badge and the /runs page both read this one projection, so the badge count
+// and the page count read the same selector and cannot disagree. Its input is
+// buildRunSummary's `blockedLanes` — already dangling-root + non-graph.v2
+// suppressed (the gc-1920-class phantom: codeprobe upstream_error, no backing
+// bead, never a graph.v2 run) — so phantom suppression is upstream, not a dead
+// per-lane guard here. A supervisor `partial` read is never counted: this
+// selector only ever sees real blocked beads.
+
+export interface BlockedRun {
+  id: string;
+  title: string;
+  /** Why the run is blocked — a structural, glyph+word-friendly phrase. */
+  reason: string;
+  /** The operator's next step to clear the block. */
+  remedy: string;
+  scope: RunLaneScope;
+}
+
+/** Project the genuinely-blocked lanes into operator-actionable rows. */
+export function selectBlockedRuns(blockedLanes: readonly RunLane[]): BlockedRun[] {
+  return blockedLanes
+    .filter((lane) => lane.phase === 'blocked')
+    .map((lane) => ({
+      id: lane.id,
+      title: lane.title,
+      reason: blockedRunReason(lane),
+      remedy: blockedRunRemedy(lane),
+      scope: lane.scope,
+    }));
+}
+
+/** Structural why-blocked phrase derived from the lane's own facts (ZFC). */
+export function blockedRunReason(lane: RunLane): string {
+  const stageLabel = blockedStageLabel(lane);
+  if (stageLabel !== null) return `Blocked at ${stageLabel}`;
+  const blockedSteps = lane.statusCounts['blocked'] ?? 0;
+  if (blockedSteps > 0) {
+    return `${blockedSteps} blocked step${blockedSteps === 1 ? '' : 's'}`;
+  }
+  return 'Blocked, awaiting operator';
+}
+
+/** The single next step the operator takes to clear the block. */
+export function blockedRunRemedy(lane: RunLane): string {
+  if (lane.activeAssignees.length === 0) {
+    return 'No worker assigned. Claim or dispatch one.';
+  }
+  return 'Open run detail to review the blocked step.';
+}
+
+function blockedStageLabel(lane: RunLane): string | null {
+  if (lane.progress.status === 'active_step' || lane.progress.status === 'stage_only') {
+    const stage = lane.progress.stage;
+    if (stage.status === 'available') return stage.label;
+  }
+  return null;
+}

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -144,6 +144,34 @@ describe('buildRunSummary — dangling-root groups are not surfaced (gascity-das
     assert.deepEqual(summary.historicalLanes, []);
     assert.equal(summary.runCounts.total, 1);
   });
+
+  // gascity-dashboard-2j8e.2: the Runs badge counts selectBlockedRuns over
+  // blockedLanes, so a dangling-root group whose orphan step is BLOCKED must
+  // not reach blockedLanes — else the phantom inflates the badge. Pins the
+  // #87/#89 intent (suppress phantom roots with no backing bead) for the
+  // badge's source, not just the Active set.
+  function blockedOrphanStep(rootId: string): RunIssue {
+    return {
+      id: `${rootId}-step-1`,
+      title: 'Blocked patch',
+      status: 'blocked',
+      issue_type: 'task',
+      updated_at: '2026-06-01T00:05:00Z',
+      metadata: {
+        'gc.kind': 'step',
+        'gc.formula_contract': 'graph.v2',
+        'gc.root_bead_id': rootId,
+        'gc.step_id': 'implementation.patch',
+      },
+    };
+  }
+
+  test('a dangling-root group with a blocked step never reaches blockedLanes', () => {
+    const summary = buildRunSummary([blockedOrphanStep('gc-1920'), ...activeRun('run-1')]);
+
+    assert.deepEqual(summary.blockedLanes, []);
+    assert.equal(summary.runCounts.blocked, 0);
+  });
 });
 
 // gascity-dashboard-5e5v: supervisor-controlled rig/scope refs are rendered


### PR DESCRIPTION
## What

Fixes the Formula Runs view: the nav **Runs** badge and the page now derive from **one** bead-based selector (`selectBlockedRuns` over `summary.blockedLanes`), so they agree by construction (nav badge == page Blocked(N)).

- Badge counts **genuinely-blocked runs only** — phantom/dangling roots (no backing bead, e.g. the codeprobe `gc-1920` upstream_error run) and feed-thrash are dropped.
- **`partial` is never counted** → the 6↔13 lane-count flap operators saw is killed; partial is surfaced as a **non-counting glyph indicator** (◐) instead.
- Blocked section shows **why-blocked + how-to-unblock**.
- DESIGN.md honored (✕ blocked / ◐ partial glyphs, glyph+word, no color-only, flat). No new shared wire DTO.

First slice of the nav-badge epic (Runs); Beads/Agents/Mail reuse this selector + parity pattern.

## Note

The deeper supervisor-side cause of the flap (unordered bounded `/beads` page + `/formulas/feed` latency) is filed separately as gastownhall/gascity#3208 — this PR is the operator-visible dashboard fix + resilience (stable count, no flap).
