### PR TITLE
fix(beads): badge counts ready-unclaimed + escalated, excludes dep-blocked; Needs-you section + parity

### DIFF
--- a/frontend/src/attention/beadsNeedingAttention.test.ts
+++ b/frontend/src/attention/beadsNeedingAttention.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
+import { selectBeadsNeedingAttention } from './beadsNeedingAttention';
+
+const NOW = Date.parse('2026-06-07T12:00:00.000Z');
+
+function bead(overrides: Partial<Bead>): Bead {
+  return {
+    created_at: '2026-06-07T11:00:00.000Z',
+    id: 'B-0',
+    issue_type: 'task',
+    status: 'open',
+    title: 'Bead',
+    ...overrides,
+  };
+}
+
+function select(inputs: { beads?: readonly Bead[]; escalations?: readonly Bead[] }, now = NOW) {
+  return selectBeadsNeedingAttention(
+    { beads: inputs.beads ?? [], escalations: inputs.escalations ?? [] },
+    now,
+  );
+}
+
+describe('selectBeadsNeedingAttention (gascity-dashboard-2j8e.3)', () => {
+  it('includes a ready-unclaimed bead once it has aged past the watch window', () => {
+    const rows = select({
+      beads: [bead({ id: 'B-ready', status: 'open', created_at: '2026-06-05T11:00:00.000Z' })],
+    });
+    expect(rows).toEqual([
+      expect.objectContaining({ beadId: 'B-ready', reason: 'ready-unclaimed', severity: 'watch' }),
+    ]);
+  });
+
+  it('escalates a long-stale ready-unclaimed bead to attention', () => {
+    const rows = select({
+      beads: [bead({ id: 'B-stale', status: 'open', created_at: '2026-06-01T11:00:00.000Z' })],
+    });
+    expect(rows[0]).toEqual(
+      expect.objectContaining({ reason: 'ready-unclaimed', severity: 'attention' }),
+    );
+  });
+
+  it('does not surface a freshly-filed open bead as noise', () => {
+    const rows = select({
+      beads: [bead({ id: 'B-fresh', status: 'open', created_at: '2026-06-07T11:30:00.000Z' })],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('does not surface an assigned open bead as ready-unclaimed', () => {
+    const rows = select({
+      beads: [
+        bead({
+          id: 'B-assigned',
+          status: 'open',
+          assignee: 'worker-1',
+          created_at: '2026-06-01T11:00:00.000Z',
+        }),
+      ],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('includes an abnormally-blocked (escalated) bead immediately, regardless of age', () => {
+    const rows = select({
+      escalations: [
+        bead({
+          id: 'B-esc',
+          status: 'blocked',
+          labels: ['gc:escalation'],
+          created_at: '2026-06-07T11:55:00.000Z',
+        }),
+      ],
+    });
+    expect(rows).toEqual([
+      expect.objectContaining({ beadId: 'B-esc', reason: 'escalated', severity: 'attention' }),
+    ]);
+  });
+
+  it('excludes a plain dependency-blocked bead (working-as-intended queuing)', () => {
+    const rows = select({
+      beads: [bead({ id: 'B-dep', status: 'blocked', created_at: '2026-06-01T11:00:00.000Z' })],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('excludes a closed (resolved) escalation', () => {
+    const rows = select({
+      escalations: [bead({ id: 'B-done', status: 'closed', labels: ['gc:escalation'] })],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('does not count a P1 high-priority open bead just for its priority', () => {
+    const rows = select({
+      beads: [
+        bead({
+          id: 'B-p1',
+          status: 'open',
+          priority: 1,
+          assignee: 'worker-1',
+          created_at: '2026-06-07T11:55:00.000Z',
+        }),
+      ],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('combines ready-unclaimed and escalated across both inputs', () => {
+    const rows = select({
+      beads: [bead({ id: 'B-ready', status: 'open', created_at: '2026-06-05T11:00:00.000Z' })],
+      escalations: [bead({ id: 'B-esc', status: 'blocked', labels: ['gc:escalation'] })],
+    });
+    expect(rows.map((row) => `${row.beadId}:${row.reason}`)).toEqual([
+      'B-esc:escalated',
+      'B-ready:ready-unclaimed',
+    ]);
+  });
+});

--- a/frontend/src/attention/beadsNeedingAttention.ts
+++ b/frontend/src/attention/beadsNeedingAttention.ts
@@ -1,0 +1,109 @@
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
+import { elapsedSince, formatElapsed } from './elapsed';
+
+// gascity-dashboard-2j8e.3: the single selector behind the Beads nav badge AND
+// the /beads "Needs you" section. It counts beads that genuinely need the
+// operator — ready-unclaimed work and abnormally-blocked (escalated /
+// help-requested) beads — and EXCLUDES plain dependency-blocked beads. bd
+// defines `blocked` as "blocked by a dependency": a bead waiting on its blocker
+// is working-as-intended queuing, not attention. The badge (registry
+// deriveBeadsAttention) and the page both read this projection, so the nav
+// count and the page count cannot disagree — the parity contract the Runs badge
+// established (selectBlockedRuns, gascity-dashboard-2j8e.2).
+//
+// Two inputs because they arrive from two reads with opposite filtering:
+//  - `beads` is the general engineering-bead list. The dashboard's bead reads
+//    drop `gc:`-labelled bookkeeping beads, so escalations never appear here.
+//  - `escalations` is the dedicated open-`gc:escalation` queue (the marker the
+//    prior `gc dashboard` escalations panel keyed on), fetched separately so the
+//    gc:-label filter does not hide it — the same shape as the mayor-decision
+//    queue.
+
+// Aging for ready-unclaimed work: a just-filed open bead is normal churn, not
+// attention. It enters the badge as `watch` once it has sat unclaimed past the
+// watch window, and escalates to `attention` once it is genuinely stale.
+const READY_UNCLAIMED_WATCH_MS = 24 * 60 * 60 * 1000;
+const READY_UNCLAIMED_STALE_MS = 72 * 60 * 60 * 1000;
+
+/**
+ * Why a bead needs the operator. `escalated` is an abnormally-blocked bead that
+ * raised the escalation marker (a help-request / escalation); `ready-unclaimed`
+ * is open work nobody claimed. Plain dependency-blocked is neither — excluded.
+ */
+export type BeadAttentionReason = 'ready-unclaimed' | 'escalated';
+
+/** The badge-driving severities — escalation acts now, stale unclaimed escalates. */
+export type BeadAttentionSeverity = 'attention' | 'watch';
+
+export interface BeadAttentionRow {
+  beadId: string;
+  reason: BeadAttentionReason;
+  severity: BeadAttentionSeverity;
+  /** Operator-facing one-line context, leading with the bead title (why it is here). */
+  summary: string;
+  /** Movement timestamp used for ordering and aging. */
+  updatedAt: string;
+}
+
+export interface BeadAttentionInputs {
+  /** The general engineering-bead list (gc:-labelled bookkeeping already dropped). */
+  beads: readonly Bead[];
+  /** The dedicated open-`gc:escalation` queue (help-request / escalation). */
+  escalations: readonly Bead[];
+}
+
+/**
+ * Project the bead reads into the operator-actionable attention set. Pure and
+ * deterministic given (inputs, nowMs) — the badge and the page read the same
+ * output, so their counts agree by construction.
+ */
+export function selectBeadsNeedingAttention(
+  inputs: BeadAttentionInputs,
+  nowMs: number,
+): BeadAttentionRow[] {
+  const rows: BeadAttentionRow[] = [];
+  for (const bead of inputs.escalations) {
+    const row = escalatedRow(bead);
+    if (row !== null) rows.push(row);
+  }
+  for (const bead of inputs.beads) {
+    const row = readyUnclaimedRow(bead, nowMs);
+    if (row !== null) rows.push(row);
+  }
+  return rows;
+}
+
+// Escalated / help-requested: an open escalation bead is abnormal blocking —
+// counted immediately, regardless of age. A resolved (closed) escalation is not.
+function escalatedRow(bead: Bead): BeadAttentionRow | null {
+  if (bead.status === 'closed') return null;
+  return {
+    beadId: bead.id,
+    reason: 'escalated',
+    severity: 'attention',
+    summary: `${bead.title} — escalation raised`,
+    updatedAt: bead.updated_at ?? bead.created_at,
+  };
+}
+
+// Ready-unclaimed: open work with no assignee, aged past the watch window so
+// normal churn does not inflate the badge. Plain dependency-blocked (bd
+// `blocked` = "blocked by a dependency") and in-progress/closed work are not
+// surfaced — only genuinely-claimable open beads.
+function readyUnclaimedRow(bead: Bead, nowMs: number): BeadAttentionRow | null {
+  if (bead.status !== 'open' || hasAssignee(bead)) return null;
+  const ageMs = elapsedSince(bead.created_at, nowMs);
+  if (ageMs === null || ageMs < READY_UNCLAIMED_WATCH_MS) return null;
+  const stale = ageMs >= READY_UNCLAIMED_STALE_MS;
+  return {
+    beadId: bead.id,
+    reason: 'ready-unclaimed',
+    severity: stale ? 'attention' : 'watch',
+    summary: `${bead.title} opened ${formatElapsed(ageMs)} ago`,
+    updatedAt: bead.created_at,
+  };
+}
+
+function hasAssignee(bead: Bead): boolean {
+  return bead.assignee !== undefined && bead.assignee.trim().length > 0;
+}

--- a/frontend/src/attention/elapsed.ts
+++ b/frontend/src/attention/elapsed.ts
@@ -1,0 +1,19 @@
+// Shared age helpers for the attention layer. Used by the registry's
+// agent/mail emitters and the beads selector to derive and phrase how long ago
+// something happened, so the two read one implementation.
+
+/** Milliseconds since `rawTimestamp`, or null if it is absent, unparseable, or in the future. */
+export function elapsedSince(rawTimestamp: string | undefined, nowMs: number): number | null {
+  if (rawTimestamp === undefined || rawTimestamp.length === 0) return null;
+  const timestampMs = Date.parse(rawTimestamp);
+  if (!Number.isFinite(timestampMs)) return null;
+  const ageMs = nowMs - timestampMs;
+  return ageMs >= 0 ? ageMs : null;
+}
+
+/** A coarse, operator-readable age phrase ("3h", "5d"). */
+export function formatElapsed(ageMs: number): string {
+  const hours = Math.max(1, Math.round(ageMs / (60 * 60 * 1000)));
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -115,24 +115,30 @@ describe('useLiveAttentionContributors', () => {
       },
     });
     mockSupervisorApi.listBeads.mockImplementation((_city, query) => {
-      // The label-filtered call is the dedicated mayor-decision queue; the
-      // unfiltered call is the general bead list.
+      // Two dedicated label-filtered queues — the escalation queue surfaces the
+      // one abnormally-blocked bead; the mayor-decision queue is empty here. The
+      // unfiltered calls (general bead list + the runs summary loader) return no
+      // engineering beads, so the Beads badge count is the lone escalation.
+      if (query?.label === 'gc:escalation') {
+        return Promise.resolve({
+          total: 1,
+          items: [
+            {
+              created_at: '2026-05-29T20:00:00.000Z',
+              id: 'B-1',
+              issue_type: 'task',
+              priority: null,
+              status: 'blocked',
+              title: 'Escalated bead',
+              labels: ['gc:escalation'],
+            },
+          ],
+        });
+      }
       if (query?.label !== undefined) {
         return Promise.resolve({ total: 0, items: [] });
       }
-      return Promise.resolve({
-        total: 1,
-        items: [
-          {
-            created_at: '2026-05-29T20:00:00.000Z',
-            id: 'B-1',
-            issue_type: 'task',
-            priority: null,
-            status: 'blocked',
-            title: 'Blocked bead',
-          },
-        ],
-      });
+      return Promise.resolve({ total: 0, items: [] });
     });
     mockSupervisorApi.listMail.mockResolvedValue({
       total: 2,
@@ -291,6 +297,10 @@ describe('useLiveAttentionContributors', () => {
     expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', { limit: 1000 });
     expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', {
       label: 'needs/stephanie',
+      status: 'open',
+    });
+    expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', {
+      label: 'gc:escalation',
       status: 'open',
     });
     expect(mockSupervisorApi.listEvents).toHaveBeenCalledWith('test-city', {

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -15,6 +15,7 @@ import { loadSupervisorRunSummaryPreviewSource } from '../supervisor/runSummary'
 import type { AttentionContributor } from './compose';
 import {
   createAttentionContributors,
+  GC_ESCALATION_LABEL,
   NEEDS_STEPHANIE_LABEL,
   type ActivityAttentionFacts,
   type AgentsAttentionFacts,
@@ -155,13 +156,16 @@ async function fetchAgentsAttention(cityName: string | null): Promise<AgentsAtte
 
 async function fetchBeadsAttention(cityName: string | null): Promise<BeadsAttentionFacts> {
   if (cityName === null) return {};
-  // Two independent reads: the general bead list (capped) and the dedicated
-  // mayor-decision queue (label+status filtered, always complete). Settled
-  // separately so one failing does not blank the other — the decision queue
-  // and generic bead alerts are distinct signals.
-  const [list, decisions] = await Promise.allSettled([
+  // Three independent reads: the general bead list (capped) and two dedicated
+  // label+status-filtered queues — the mayor-decision queue and the escalation
+  // queue. Both queues bypass the general list's gc:-label filter and are always
+  // complete. Settled separately so one failing does not blank the others — the
+  // decision queue, the escalation queue, and generic bead alerts are distinct
+  // signals (gascity-dashboard-2j8e.3).
+  const [list, decisions, escalations] = await Promise.allSettled([
     listSupervisorBeads({ limit: ATTENTION_LIST_LIMIT }),
     listDecisionBeads(cityName),
+    listEscalationBeads(cityName),
   ]);
   const facts: BeadsAttentionFacts = { nowMs: Date.now() };
   if (list.status === 'fulfilled') {
@@ -175,12 +179,24 @@ async function fetchBeadsAttention(cityName: string | null): Promise<BeadsAttent
   } else {
     facts.decisionsError = formatApiError(decisions.reason, 'decision queue unavailable');
   }
+  if (escalations.status === 'fulfilled') {
+    facts.escalations = escalations.value.items ?? [];
+  } else {
+    facts.escalationsError = formatApiError(escalations.reason, 'escalation queue unavailable');
+  }
   return facts;
 }
 
 async function listDecisionBeads(cityName: string) {
   return supervisorApi().listBeads(cityName, {
     label: NEEDS_STEPHANIE_LABEL,
+    status: 'open',
+  });
+}
+
+async function listEscalationBeads(cityName: string) {
+  return supervisorApi().listBeads(cityName, {
+    label: GC_ESCALATION_LABEL,
     status: 'open',
   });
 }

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -141,11 +141,12 @@ describe('createAttentionContributors', () => {
           ],
         },
         beads: {
-          items: [
+          escalations: [
             bead({
               id: 'B-1',
               title: 'Fix broken formula',
               status: 'blocked',
+              labels: ['gc:escalation'],
             }),
           ],
         },
@@ -423,13 +424,15 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.agents.items.map((item) => item.id)).toContain(
       'agents:idle-agent:stale-idle',
     );
+    // gascity-dashboard-2j8e.3: a long-stale ready-unclaimed open bead surfaces
+    // (attention tier); an assigned in-progress bead is working-as-intended and
+    // no longer counts (the stale-assigned emitter was removed with the badge
+    // redefinition).
     expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
-      'beads:B-stale-open:stale-unclaimed',
-      'beads:B-stale-assigned:stale-assigned',
+      'beads:B-stale-open:ready-unclaimed',
     ]);
     expect(model.byDomain.beads.items.map((item) => item.href)).toEqual([
       '/beads?bead=B-stale-open',
-      '/beads?bead=B-stale-assigned',
     ]);
     expect(model.byDomain.mail.items.map((item) => item.id)).toContain(
       'mail:M-stale-unread:unread-stale',
@@ -476,35 +479,50 @@ describe('createAttentionContributors', () => {
     ]);
   });
 
-  it('uses bead update movement, not creation age, for stale assigned attention', () => {
+  it('counts ready-unclaimed + escalated beads and excludes plain dependency-blocked (gascity-dashboard-2j8e.3)', () => {
     const nowMs = Date.parse('2026-06-01T12:00:00.000Z');
     const model = composeAttention(
       createAttentionContributors({
         beads: {
           nowMs,
           items: [
+            // ready-unclaimed: open, no assignee, aged past the watch window.
             bead({
-              assignee: 'reviewer',
               created_at: '2026-05-29T11:00:00.000Z',
-              id: 'B-active-assigned',
-              status: 'in_progress',
-              updated_at: '2026-06-01T11:30:00.000Z',
+              id: 'B-ready',
+              status: 'open',
             }),
+            // plain dependency-blocked: working-as-intended queuing — excluded.
+            bead({
+              created_at: '2026-05-29T11:00:00.000Z',
+              id: 'B-dep',
+              status: 'blocked',
+            }),
+            // assigned in-progress work — excluded (no longer a bead alert).
             bead({
               assignee: 'reviewer',
               created_at: '2026-05-29T11:00:00.000Z',
-              id: 'B-stale-assigned',
+              id: 'B-assigned',
               status: 'in_progress',
-              updated_at: '2026-05-29T11:30:00.000Z',
+            }),
+          ],
+          // abnormally-blocked: an escalation marker — counted immediately, from
+          // the dedicated gc:escalation queue (the general list drops gc: labels).
+          escalations: [
+            bead({
+              created_at: '2026-06-01T11:55:00.000Z',
+              id: 'B-esc',
+              status: 'blocked',
+              labels: ['gc:escalation'],
             }),
           ],
         },
       }),
     );
 
-    expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
-      'beads:B-stale-assigned:stale-assigned',
-    ]);
+    const ids = model.byDomain.beads.items.map((item) => item.id);
+    expect([...ids].sort()).toEqual(['beads:B-esc:escalated', 'beads:B-ready:ready-unclaimed']);
+    expect(model.byDomain.beads.attention).toBe(2);
   });
 
   it('surfaces each open mayor-decision bead as an attention item linked to the bead view', () => {
@@ -563,7 +581,8 @@ describe('createAttentionContributors', () => {
       createAttentionContributors({
         beads: {
           // Same bead in both the dedicated queue and the capped general list:
-          // priority 1 would otherwise also trip the generic high-priority branch.
+          // the isMayorDecision filter in the generic loop is what keeps it from
+          // surfacing twice.
           decisions: [
             bead({
               id: 'dec-nqy',
@@ -594,14 +613,21 @@ describe('createAttentionContributors', () => {
       createAttentionContributors({
         beads: {
           decisionsError: 'decision queue unavailable: ECONNREFUSED',
-          items: [bead({ id: 'B-1', title: 'Fix broken formula', status: 'blocked' })],
+          escalations: [
+            bead({
+              id: 'B-1',
+              title: 'Fix broken formula',
+              status: 'blocked',
+              labels: ['gc:escalation'],
+            }),
+          ],
         },
       }),
     );
 
     const ids = model.byDomain.beads.items.map((item) => item.id);
     expect(ids).toContain('beads:decisions-unavailable');
-    expect(ids).toContain('beads:B-1:blocked');
+    expect(ids).toContain('beads:B-1:escalated');
   });
 
   it('derives maintainer attention from needs-you, awaiting-triage, and blocked slung facts', () => {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -8,6 +8,8 @@ import type {
   TriageItem,
 } from 'gas-city-dashboard-shared';
 import { selectBlockedRuns } from 'gas-city-dashboard-shared';
+import { selectBeadsNeedingAttention, type BeadAttentionReason } from './beadsNeedingAttention';
+import { elapsedSince, formatElapsed } from './elapsed';
 import { runDetailHref } from '../supervisor/runHref';
 import type {
   AgentResponse,
@@ -79,11 +81,21 @@ export interface BeadsAttentionFacts {
    * their own attention identity, never re-triaged (ZFC).
    */
   decisions?: readonly Bead[];
+  /**
+   * The open-`gc:escalation` queue: the help-request / escalation beads
+   * (gascity-dashboard-2j8e.3). Fetched with the dedicated label+status filter
+   * because the general bead list drops `gc:`-labelled bookkeeping beads, so an
+   * escalation would never reach the generic triage. The same dedicated-queue
+   * shape as `decisions`.
+   */
+  escalations?: readonly Bead[];
   nowMs?: number;
   partial?: boolean;
   error?: string;
   /** Failure of the dedicated decision-queue fetch, independent of `error`. */
   decisionsError?: string;
+  /** Failure of the dedicated escalation-queue fetch, independent of `error`. */
+  escalationsError?: string;
 }
 
 export interface MailAttentionFacts {
@@ -121,8 +133,6 @@ export interface AttentionContributorFacts {
 }
 
 const AGENT_IDLE_WATCH_MS = 4 * 60 * 60 * 1000;
-const BEAD_UNCLAIMED_WATCH_MS = 24 * 60 * 60 * 1000;
-const BEAD_STALE_ATTENTION_MS = 72 * 60 * 60 * 1000;
 const MAIL_UNREAD_STALE_MS = 24 * 60 * 60 * 1000;
 const DASHBOARD_PROCESS_STARTING_UPTIME_SEC = 30;
 const DASHBOARD_PROCESS_RSS_HIGH_BYTES = 2_000_000_000;
@@ -137,6 +147,16 @@ const DASHBOARD_PROCESS_HEAP_ELEVATED_BYTES = 512_000_000;
  * generic-loop skip below resolve the same marker — a rename touches one line.
  */
 export const NEEDS_STEPHANIE_LABEL = 'needs/stephanie';
+
+/**
+ * The gc-native escalation marker (gascity-dashboard-2j8e.3). An open bead
+ * carrying it has raised a help-request / escalation — abnormal blocking that
+ * needs a human, unlike a bead in `blocked` status that is merely waiting on a
+ * dependency. The same marker the prior `gc dashboard` escalations panel keyed
+ * on. Exported so the dedicated fetch filter (liveContributors) resolves the
+ * same marker — a rename touches one line.
+ */
+export const GC_ESCALATION_LABEL = 'gc:escalation';
 
 /**
  * Flat metadata key for the mayor's one-sentence decision question (the spec's
@@ -441,83 +461,51 @@ function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly 
       }),
     );
   }
+  if (facts.escalationsError !== undefined && facts.escalationsError.length > 0) {
+    items.push(
+      domainAttention('beads', {
+        id: 'beads:escalations-unavailable',
+        title: 'Escalation queue unavailable',
+        summary: facts.escalationsError,
+        href: '/beads',
+      }),
+    );
+  }
   for (const decision of facts.decisions ?? []) {
     items.push(mayorDecisionAttention(decision));
   }
   const nowMs = facts.nowMs ?? Date.now();
-  for (const bead of facts.items ?? []) {
-    // Marker beads surface via the dedicated decision queue above; skip them
-    // here so a priority-1 decision bead is not also surfaced as a generic
-    // high-priority/stale bead alert (double-surfacing).
-    if (isMayorDecision(bead)) continue;
-    if (bead.status === 'blocked') {
-      items.push(
-        domainAttention('beads', {
-          id: `beads:${bead.id}:blocked`,
-          title: `${bead.id} blocked`,
-          summary: bead.title,
-          href: beadHref(bead.id),
-        }),
-      );
-      continue;
-    }
-    if (
-      bead.status !== 'closed' &&
-      bead.priority !== null &&
-      bead.priority !== undefined &&
-      bead.priority <= 1
-    ) {
-      items.push(
-        domainAttention('beads', {
-          id: `beads:${bead.id}:high-priority`,
-          title: `${bead.id} high priority`,
-          summary: bead.title,
-          href: beadHref(bead.id),
-        }),
-      );
-    }
-    const stale = attentionForStaleBead(bead, nowMs);
-    if (stale !== null) items.push(stale);
+  // gascity-dashboard-2j8e.3: the Beads badge counts exactly the ready-unclaimed
+  // + abnormally-blocked (escalated / help-requested) set — plain
+  // dependency-blocked is excluded (bd `blocked` = "blocked by a dependency",
+  // working-as-intended queuing). Ready-unclaimed comes from the general list;
+  // escalations from the dedicated gc:escalation queue (the general list drops
+  // gc:-labelled beads). Marker beads surface via the decision queue above, so
+  // skip them in the general list (no double-surfacing). selectBeadsNeedingAttention
+  // is the membership SSOT the /beads page also reads, so the nav badge count
+  // and the page count cannot disagree.
+  const generic = (facts.items ?? []).filter((bead) => !isMayorDecision(bead));
+  for (const row of selectBeadsNeedingAttention(
+    { beads: generic, escalations: facts.escalations ?? [] },
+    nowMs,
+  )) {
+    const builder = row.severity === 'attention' ? domainAttention : domainWatch;
+    items.push(
+      builder('beads', {
+        id: `beads:${row.beadId}:${row.reason}`,
+        title: `${row.beadId} ${beadAttentionWord(row.reason)}`,
+        summary: row.summary,
+        href: beadHref(row.beadId),
+        updatedAt: row.updatedAt,
+      }),
+    );
   }
   return items;
 }
 
-function attentionForStaleBead(bead: Bead, nowMs: number): AttentionItem | null {
-  if (bead.status === 'closed') return null;
-  const createdAgeMs = elapsedSince(bead.created_at, nowMs);
-  if (createdAgeMs === null) return null;
-  const hasAssignee = bead.assignee !== undefined && bead.assignee.trim().length > 0;
-
-  if (!hasAssignee && createdAgeMs >= BEAD_STALE_ATTENTION_MS) {
-    return domainAttention('beads', {
-      id: `beads:${bead.id}:stale-unclaimed`,
-      title: `${bead.id} unclaimed`,
-      summary: `${bead.title} opened ${formatElapsed(createdAgeMs)} ago`,
-      href: beadHref(bead.id),
-      updatedAt: bead.created_at,
-    });
-  }
-  if (!hasAssignee && createdAgeMs >= BEAD_UNCLAIMED_WATCH_MS) {
-    return domainWatch('beads', {
-      id: `beads:${bead.id}:ready-unclaimed`,
-      title: `${bead.id} still unclaimed`,
-      summary: `${bead.title} opened ${formatElapsed(createdAgeMs)} ago`,
-      href: beadHref(bead.id),
-      updatedAt: bead.created_at,
-    });
-  }
-  const movementAt = bead.updated_at ?? bead.created_at;
-  const movementAgeMs = elapsedSince(movementAt, nowMs);
-  if (hasAssignee && movementAgeMs !== null && movementAgeMs >= BEAD_STALE_ATTENTION_MS) {
-    return domainAttention('beads', {
-      id: `beads:${bead.id}:stale-assigned`,
-      title: `${bead.id} assigned without movement`,
-      summary: `${bead.title} assigned to ${bead.assignee} without movement for ${formatElapsed(movementAgeMs)}`,
-      href: beadHref(bead.id),
-      updatedAt: movementAt,
-    });
-  }
-  return null;
+/** The glyph+word noun for a bead-attention reason (DESIGN.md §Status). */
+function beadAttentionWord(reason: BeadAttentionReason): string {
+  return reason === 'escalated' ? 'escalated' : 'unclaimed';
 }
 
 function beadHref(beadId: string): string {
@@ -983,20 +971,6 @@ function formatBytes(bytes: number): string {
 function safeRatio(numerator: number, denominator: number): number | null {
   if (denominator <= 0) return null;
   return numerator / denominator;
-}
-
-function elapsedSince(rawTimestamp: string | undefined, nowMs: number): number | null {
-  if (rawTimestamp === undefined || rawTimestamp.length === 0) return null;
-  const timestampMs = Date.parse(rawTimestamp);
-  if (!Number.isFinite(timestampMs)) return null;
-  const ageMs = nowMs - timestampMs;
-  return ageMs >= 0 ? ageMs : null;
-}
-
-function formatElapsed(ageMs: number): string {
-  const hours = Math.max(1, Math.round(ageMs / (60 * 60 * 1000)));
-  if (hours < 48) return `${hours}h`;
-  return `${Math.round(hours / 24)}d`;
 }
 
 function isFailureState(state: string): boolean {

--- a/frontend/src/components/beads/BeadAttentionPanel.test.tsx
+++ b/frontend/src/components/beads/BeadAttentionPanel.test.tsx
@@ -1,0 +1,168 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AttentionItem } from '../../attention/compose';
+import { composeAttention } from '../../attention/compose';
+import { createAttentionContributors } from '../../attention/registry';
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { SupervisorBead } from '../../supervisor/beadReads';
+import { BeadAttentionPanel, beadIdFromHref } from './BeadAttentionPanel';
+
+afterEach(() => cleanup());
+
+function attentionItem(
+  overrides: Partial<AttentionItem> & Pick<AttentionItem, 'id'>,
+): AttentionItem {
+  return {
+    domain: 'beads',
+    severity: 'attention',
+    title: 'Bead',
+    ...overrides,
+  };
+}
+
+function supervisorBead(overrides: Partial<SupervisorBead> & { id: string }): SupervisorBead {
+  return {
+    created_at: '2026-06-07T11:00:00.000Z',
+    issue_type: 'task',
+    status: 'open',
+    title: 'Bead',
+    ...overrides,
+  };
+}
+
+function bead(overrides: Partial<Bead>): Bead {
+  return {
+    created_at: '2026-06-01T11:00:00.000Z',
+    id: 'B-0',
+    issue_type: 'task',
+    status: 'open',
+    title: 'Bead',
+    ...overrides,
+  };
+}
+
+describe('beadIdFromHref', () => {
+  it('extracts the bead id from a /beads?bead=… href', () => {
+    expect(beadIdFromHref('/beads?bead=B-1')).toBe('B-1');
+  });
+  it('returns null for an href with no bead param', () => {
+    expect(beadIdFromHref('/beads')).toBeNull();
+    expect(beadIdFromHref(undefined)).toBeNull();
+  });
+});
+
+describe('BeadAttentionPanel (gascity-dashboard-2j8e.3)', () => {
+  const noop = () => undefined;
+
+  it('offers Claim for a ready-unclaimed bead the board loaded, Open otherwise', () => {
+    const onClaim = vi.fn();
+    const onOpen = vi.fn();
+    render(
+      <BeadAttentionPanel
+        items={[
+          attentionItem({
+            id: 'beads:B-ready:ready-unclaimed',
+            severity: 'watch',
+            title: 'B-ready unclaimed',
+            href: '/beads?bead=B-ready',
+          }),
+          attentionItem({
+            id: 'beads:B-esc:escalated',
+            title: 'B-esc escalated',
+            href: '/beads?bead=B-esc',
+          }),
+        ]}
+        beadById={(id) => (id === 'B-ready' ? supervisorBead({ id: 'B-ready' }) : undefined)}
+        onOpen={onOpen}
+        onClaim={onClaim}
+        readOnly={false}
+        claimingId={null}
+      />,
+    );
+
+    expect(screen.getByText('Needs you').textContent).toContain('(2)');
+    const readyRow = screen.getByText('B-ready unclaimed').closest('li') as HTMLElement;
+    within(readyRow).getByRole('button', { name: 'Claim' }).click();
+    expect(onClaim).toHaveBeenCalledWith(expect.objectContaining({ id: 'B-ready' }));
+
+    const escRow = screen.getByText('B-esc escalated').closest('li') as HTMLElement;
+    expect(within(escRow).queryByRole('button', { name: 'Claim' })).toBeNull();
+    within(escRow).getByRole('button', { name: 'Open' }).click();
+    expect(onOpen).toHaveBeenCalledWith('B-esc');
+  });
+
+  it('disables Claim in read-only mode', () => {
+    render(
+      <BeadAttentionPanel
+        items={[
+          attentionItem({
+            id: 'beads:B-ready:ready-unclaimed',
+            severity: 'watch',
+            title: 'B-ready unclaimed',
+            href: '/beads?bead=B-ready',
+          }),
+        ]}
+        beadById={() => supervisorBead({ id: 'B-ready' })}
+        onOpen={noop}
+        onClaim={noop}
+        readOnly
+        claimingId={null}
+      />,
+    );
+    expect((screen.getByRole('button', { name: 'Claim' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it('renders nothing when there are no badge-counting items', () => {
+    const { container } = render(
+      <BeadAttentionPanel
+        items={[]}
+        beadById={() => undefined}
+        onOpen={noop}
+        onClaim={noop}
+        readOnly={false}
+        claimingId={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders exactly the nav-badge count — page and badge read the same model', () => {
+    // Build the real composed model the nav badge reads, then assert the panel
+    // renders one row per badge-counted item (attention + watch).
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: {
+          nowMs: Date.parse('2026-06-07T12:00:00.000Z'),
+          items: [
+            bead({ id: 'B-ready', status: 'open', created_at: '2026-06-04T11:00:00.000Z' }),
+            // plain dependency-blocked — excluded from both badge and page.
+            bead({ id: 'B-dep', status: 'blocked' }),
+          ],
+          escalations: [bead({ id: 'B-esc', status: 'blocked', labels: ['gc:escalation'] })],
+          // mayor-decision items count toward the badge too — they must also
+          // render in the panel, so the parity holds across every source.
+          decisions: [bead({ id: 'B-dec', title: 'Decide: X', labels: ['needs/stephanie'] })],
+        },
+      }),
+    );
+    const summary = model.byDomain.beads;
+    const navTotal = summary.attention + summary.watch;
+    expect(navTotal).toBe(3);
+
+    render(
+      <BeadAttentionPanel
+        items={summary.items}
+        beadById={() => undefined}
+        onOpen={noop}
+        onClaim={noop}
+        readOnly={false}
+        claimingId={null}
+      />,
+    );
+
+    expect(screen.getByText('Needs you').textContent).toContain(`(${navTotal})`);
+    expect(screen.getAllByRole('button', { name: 'Open' })).toHaveLength(navTotal);
+  });
+});

--- a/frontend/src/components/beads/BeadAttentionPanel.tsx
+++ b/frontend/src/components/beads/BeadAttentionPanel.tsx
@@ -1,0 +1,102 @@
+import type { AttentionItem } from '../../attention/compose';
+import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge } from '../../contexts/ReadOnlyContext';
+import type { SupervisorBead } from '../../supervisor/beadReads';
+import { Button } from '../Button';
+import { StatusBadge } from '../StatusBadge';
+
+// gascity-dashboard-2j8e.3: the /beads "Needs you" section — the on-page
+// counterpart of the Beads nav badge. It renders the badge-counting attention
+// items (attention + watch tiers, the same `summary.attention + summary.watch`
+// the nav indicator shows), so the page count and the nav badge cannot
+// disagree, and gives each item a path to act: Claim a ready-unclaimed bead, or
+// Open an escalation / decision to answer it.
+
+interface BeadAttentionPanelProps {
+  /** The beads-domain attention items from the composed model (any severity). */
+  items: readonly AttentionItem[];
+  /** Resolve a bead the page already loaded, for inline Claim. */
+  beadById: (beadId: string) => SupervisorBead | undefined;
+  onOpen: (beadId: string) => void;
+  onClaim: (bead: SupervisorBead) => void;
+  readOnly: boolean;
+  /** The bead id whose claim is in flight, if any. */
+  claimingId: string | null;
+}
+
+/** Extract the `bead` query param from an attention item's `/beads?bead=…` href. */
+export function beadIdFromHref(href: string | undefined): string | null {
+  if (href === undefined) return null;
+  const queryStart = href.indexOf('?');
+  if (queryStart < 0) return null;
+  const beadId = new URLSearchParams(href.slice(queryStart + 1)).get('bead');
+  return beadId !== null && beadId.length > 0 ? beadId : null;
+}
+
+export function BeadAttentionPanel({
+  items,
+  beadById,
+  onOpen,
+  onClaim,
+  readOnly,
+  claimingId,
+}: BeadAttentionPanelProps) {
+  // The nav badge counts attention + watch; mirror that exactly so the counts agree.
+  const counted = items.filter(
+    (item) => item.severity === 'attention' || item.severity === 'watch',
+  );
+  if (counted.length === 0) return null;
+
+  return (
+    <section aria-labelledby="beads-attention-title" className="mb-8 space-y-3">
+      <h2 id="beads-attention-title" className="text-label uppercase tracking-wider text-fg-muted">
+        Needs you <span className="tnum text-fg">({counted.length})</span>
+      </h2>
+      <ul className="space-y-2">
+        {counted.map((item) => {
+          const beadId = beadIdFromHref(item.href);
+          const bead = beadId === null ? undefined : beadById(beadId);
+          const claimable =
+            bead !== undefined &&
+            bead.status === 'open' &&
+            (bead.assignee?.trim() ?? '').length === 0;
+          return (
+            <li
+              key={item.id}
+              className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1"
+            >
+              <div className="min-w-0 space-y-0.5">
+                <StatusBadge
+                  tone={item.severity === 'attention' ? 'stuck' : 'warn'}
+                  label={item.title}
+                />
+                {item.summary !== undefined && (
+                  <p className="text-body text-fg-muted">{item.summary}</p>
+                )}
+              </div>
+              {beadId !== null && (
+                <div className="flex items-center gap-2">
+                  {readOnly && claimable && <ReadOnlyBadge />}
+                  {claimable && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      tone="quiet"
+                      title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
+                      disabled={readOnly || claimingId !== null}
+                      onClick={() => onClaim(bead)}
+                    >
+                      {claimingId === beadId ? 'Claiming' : 'Claim'}
+                    </Button>
+                  )}
+                  <Button type="button" size="sm" tone="quiet" onClick={() => onOpen(beadId)}>
+                    Open
+                  </Button>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -132,10 +132,10 @@ describe('BeadsPage supervisor reads', () => {
     renderPage('/beads', [
       contributor('beads', [
         {
-          id: 'beads:td-bead-abc123:high-priority',
+          id: 'beads:td-bead-abc123:ready-unclaimed',
           domain: 'beads',
           severity: 'attention',
-          title: 'td-bead-abc123 high priority',
+          title: 'td-bead-abc123 unclaimed',
         },
       ]),
     ]);

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -5,6 +5,7 @@ import { formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { useAttentionModel } from '../attention/context';
 import { resourceAttentionSeverity } from '../attention/routeHighlight';
+import { BeadAttentionPanel } from '../components/beads/BeadAttentionPanel';
 import { BeadBoardSection } from '../components/beads/BeadBoardSection';
 import { BeadDetailModal } from '../components/BeadDetailModal';
 import { Button } from '../components/Button';
@@ -306,6 +307,13 @@ export function BeadsPage() {
     [attention],
   );
 
+  // The "Needs you" section (gascity-dashboard-2j8e.3) renders the same
+  // beads-domain attention items the nav badge counts, so the page count and the
+  // badge agree. Claim is offered inline for a ready-unclaimed bead the board
+  // already loaded; everything else opens the bead to act on it.
+  const beadById = useCallback((beadId: string) => rows.find((b) => b.id === beadId), [rows]);
+  const claimingId = actionInFlight?.action === 'claim' ? actionInFlight.id : null;
+
   const renderBeadActions = useCallback(
     (bead: SupervisorBead) => {
       const assignee = bead.assignee?.trim() ?? '';
@@ -448,6 +456,15 @@ export function BeadsPage() {
           </p>
         )}
       </div>
+
+      <BeadAttentionPanel
+        items={attention.byDomain.beads.items}
+        beadById={beadById}
+        onOpen={setSelectedId}
+        onClaim={(bead) => void runAction(bead, 'claim')}
+        readOnly={readOnly}
+        claimingId={claimingId}
+      />
 
       <div className="mb-6 space-y-3">
         <ListSearchBar


### PR DESCRIPTION
## What

Beads nav badge + new "Needs you" /beads section count **ready-unclaimed + abnormally-blocked** (escalated / `help_request`), and **exclude plain dependency-blocked** (normal queuing — not actionable). Each row is actionable: **Claim** (ready-unclaimed) or **Open** (escalation). nav badge == page count by construction, asserted by a parity test.

Part of the nav-badge epic; reuses the Runs (#95) selectBlockedRuns + parity pattern. Attention types stay frontend-internal (no shared DTO).
