### PR TITLE
fix(agents): badge counts needs-you agents (stalled/errored/rate-limited/awaiting-input), not active-count; + parity

### DIFF
--- a/frontend/src/attention/agentNeedsYou.ts
+++ b/frontend/src/attention/agentNeedsYou.ts
@@ -1,0 +1,46 @@
+import type { AgentNeedsYouAction, AgentNeedsYouReason } from 'gas-city-dashboard-shared';
+import type { StatusTone } from '../components/StatusBadge';
+
+// gascity-dashboard-2j8e.4: UI copy for the agents "needs you" set. The reason
+// enum lives in shared (the SSOT selector); the words, action guidance, and
+// status tone are presentation, so they live at the frontend edge. The nav
+// badge title and the /agents "Needs you" section both read these, so the
+// vocabulary stays in one place (DRY). Every reason carries a word, so the
+// signal survives the Greyscale Test (DESIGN.md §Status).
+
+const REASON_LABEL: Record<AgentNeedsYouReason, string> = {
+  'awaiting-input': 'awaiting input',
+  errored: 'errored',
+  'rate-limited': 'rate limited',
+  stalled: 'stalled',
+};
+
+// Imperative next step shown beside the row, mirroring the Runs blocked
+// "remedy" line. No em dashes (DESIGN.md §Don'ts).
+const ACTION_LABEL: Record<AgentNeedsYouAction, string> = {
+  respond: 'Respond to its prompt.',
+  reset: 'Reset the agent.',
+  nudge: 'Nudge it to resume.',
+};
+
+// A direct ask or a hard failure earns the maroon (stuck) mark; a throttle or
+// a stall reads as caution (warn). StatusBadge pairs every tone with a glyph
+// and the word above, so this never carries meaning by color alone.
+const REASON_TONE: Record<AgentNeedsYouReason, StatusTone> = {
+  'awaiting-input': 'stuck',
+  errored: 'stuck',
+  'rate-limited': 'warn',
+  stalled: 'warn',
+};
+
+export function agentNeedsYouReasonLabel(reason: AgentNeedsYouReason): string {
+  return REASON_LABEL[reason];
+}
+
+export function agentNeedsYouActionLabel(action: AgentNeedsYouAction): string {
+  return ACTION_LABEL[action];
+}
+
+export function agentNeedsYouReasonTone(reason: AgentNeedsYouReason): StatusTone {
+  return REASON_TONE[reason];
+}

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -278,7 +278,11 @@ describe('useLiveAttentionContributors', () => {
       // logic is covered in registry.test.ts; here we assert the contributor is
       // wired to the summary loader (listBeads({ limit: 500 }) below).
       expect(model.byDomain.runs.attention).toBe(0);
-      expect(model.byDomain.agents.attention).toBe(2);
+      // gascity-dashboard-2j8e.4: the one agent ('reviewer') is both in a
+      // failure state AND awaiting an input decision; selectAgentsNeedingYou
+      // counts it once with its highest-priority reason (awaiting-input), so
+      // the badge is 1, not the old double-count of 2.
+      expect(model.byDomain.agents.attention).toBe(1);
       expect(model.byDomain.beads.attention).toBe(1);
       expect(model.byDomain.mail.attention).toBe(1);
       expect(model.byDomain.mail.watch).toBe(0);

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -136,7 +136,6 @@ async function fetchAgentsAttention(cityName: string | null): Promise<AgentsAtte
     const list = await supervisorApi().listAgents(cityName);
     const facts: AgentsAttentionFacts = {
       items: list.items ?? [],
-      nowMs: Date.now(),
       partial: list.partial === true,
     };
     try {

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -15,6 +15,7 @@ import type {
   Message,
   TypedEventStreamEnvelope,
 } from 'gas-city-dashboard-shared/gc-supervisor';
+import { selectAgentsNeedingYou } from 'gas-city-dashboard-shared';
 import { ATTENTION_DOMAINS, composeAttention } from './compose';
 import {
   createAttentionContributors,
@@ -303,11 +304,11 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.runs.items[0]?.id).toBe('runs:unavailable');
   });
 
-  it('derives agent attention from pending supervisor interactions', () => {
+  it('counts an agent awaiting an input decision as needs-you', () => {
     const model = composeAttention(
       createAttentionContributors({
         agents: {
-          items: [],
+          items: [agent({ name: 'mayor', running: true, state: 'active' })],
           pendingInteractions: [
             {
               agentName: 'mayor',
@@ -326,8 +327,9 @@ describe('createAttentionContributors', () => {
 
     expect(model.byDomain.agents.attention).toBe(1);
     expect(model.byDomain.agents.items[0]).toMatchObject({
-      id: 'agents:mayor:pending:req-1',
-      title: 'mayor needs you',
+      id: 'agents:mayor:needs-you',
+      title: 'mayor awaiting input',
+      summary: 'Approve deployment?',
       href: '/agents/mayor',
     });
   });
@@ -371,24 +373,10 @@ describe('createAttentionContributors', () => {
     ]);
   });
 
-  it('derives stale-threshold attention from agent, bead, and mail timestamps', () => {
+  it('derives stale-threshold attention from bead and mail timestamps', () => {
     const nowMs = Date.parse('2026-06-01T12:00:00.000Z');
     const model = composeAttention(
       createAttentionContributors({
-        agents: {
-          nowMs,
-          items: [
-            agent({
-              name: 'idle-agent',
-              running: true,
-              session: {
-                attached: true,
-                last_activity: '2026-06-01T07:30:00.000Z',
-                name: 'idle-agent',
-              },
-            }),
-          ],
-        },
         beads: {
           nowMs,
           items: [
@@ -421,9 +409,6 @@ describe('createAttentionContributors', () => {
       }),
     );
 
-    expect(model.byDomain.agents.items.map((item) => item.id)).toContain(
-      'agents:idle-agent:stale-idle',
-    );
     // gascity-dashboard-2j8e.3: a long-stale ready-unclaimed open bead surfaces
     // (attention tier); an assigned in-progress bead is working-as-intended and
     // no longer counts (the stale-assigned emitter was removed with the badge
@@ -442,40 +427,93 @@ describe('createAttentionContributors', () => {
     );
   });
 
-  it('waits for the idle threshold before surfacing asleep agents', () => {
-    const nowMs = Date.parse('2026-06-01T12:00:00.000Z');
+  it('does not count actively-running, idle, asleep, or suspended agents', () => {
     const model = composeAttention(
       createAttentionContributors({
         agents: {
-          nowMs,
           items: [
-            agent({
-              name: 'recent-asleep',
-              running: true,
-              state: 'asleep',
-              session: {
-                attached: true,
-                last_activity: '2026-06-01T11:45:00.000Z',
-                name: 'recent-asleep',
-              },
-            }),
-            agent({
-              name: 'stale-asleep',
-              running: true,
-              state: 'asleep',
-              session: {
-                attached: true,
-                last_activity: '2026-06-01T07:30:00.000Z',
-                name: 'stale-asleep',
-              },
-            }),
+            agent({ name: 'running', running: true, state: 'active', session: liveSession }),
+            agent({ name: 'asleep', running: true, state: 'asleep', session: liveSession }),
+            agent({ name: 'idle', state: 'idle', session: liveSession }),
+            agent({ name: 'suspended', suspended: true, state: 'active', session: liveSession }),
           ],
         },
       }),
     );
 
+    expect(model.byDomain.agents.attention).toBe(0);
+    expect(model.byDomain.agents.watch).toBe(0);
+    expect(model.byDomain.agents.items).toEqual([]);
+  });
+
+  it('counts each needs-you reason and keeps the badge equal to selectAgentsNeedingYou', () => {
+    const items = [
+      agent({ name: 'mayor', running: true, state: 'active' }),
+      agent({ name: 'crashed', state: 'failed' }),
+      agent({ name: 'throttled', running: true, state: 'rate-limited' }),
+      agent({ name: 'ghost', running: true, state: 'active' }),
+      agent({ name: 'calm', running: true, state: 'active', session: liveSession }),
+    ];
+    const pendingInteractions = [
+      {
+        agentName: 'mayor',
+        sessionId: 'gc-1',
+        sessionName: 'mayor',
+        pending: { kind: 'tool_approval', prompt: 'Approve?', request_id: 'req-1' },
+      },
+    ];
+    const model = composeAttention(
+      createAttentionContributors({
+        agents: { items, pendingInteractions } as AgentsAttentionFacts,
+      }),
+    );
+
+    const needsYou = selectAgentsNeedingYou(
+      items,
+      pendingInteractions.map((p) => ({ agentName: p.agentName, prompt: p.pending.prompt })),
+    );
+    // The nav badge counts attention + watch; needs-you is the ONLY agent
+    // attention source and it never emits watch, so the badge equals the
+    // selector the /agents page renders (count parity).
+    expect(needsYou).toHaveLength(4);
+    expect(model.byDomain.agents.attention).toBe(needsYou.length);
+    expect(model.byDomain.agents.watch).toBe(0);
+    expect(model.byDomain.agents.items.map((item) => item.id).sort()).toEqual([
+      'agents:crashed:needs-you',
+      'agents:ghost:needs-you',
+      'agents:mayor:needs-you',
+      'agents:throttled:needs-you',
+    ]);
+  });
+
+  it('reports a roster read failure in the non-counting unavailable tier', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        agents: { error: 'agent list unavailable' },
+      }),
+    );
+
+    expect(model.byDomain.agents.attention).toBe(0);
+    expect(model.byDomain.agents.watch).toBe(0);
+    expect(model.byDomain.agents.unavailable).toBe(1);
+    expect(model.byDomain.agents.items[0]?.id).toBe('agents:unavailable');
+  });
+
+  it('reports a partial roster in the non-counting unavailable tier', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        agents: {
+          partial: true,
+          items: [agent({ name: 'crashed', state: 'failed' })],
+        },
+      }),
+    );
+
+    expect(model.byDomain.agents.attention).toBe(1);
+    expect(model.byDomain.agents.unavailable).toBe(1);
     expect(model.byDomain.agents.items.map((item) => item.id)).toEqual([
-      'agents:stale-asleep:stale-idle',
+      'agents:partial',
+      'agents:crashed:needs-you',
     ]);
   });
 
@@ -849,6 +887,8 @@ function healthUnavailableLane(id: string, title: string): RunLane {
     health: { status: 'unavailable', error: 'health probe failed' },
   } as RunLane;
 }
+
+const liveSession = { attached: true, last_activity: '2026-06-01T11:59:00.000Z', name: 'agent' };
 
 function agent(overrides: Partial<AgentResponse>): AgentResponse {
   return {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -7,10 +7,11 @@ import type {
   SystemHealth,
   TriageItem,
 } from 'gas-city-dashboard-shared';
-import { selectBlockedRuns } from 'gas-city-dashboard-shared';
+import { selectAgentsNeedingYou, selectBlockedRuns } from 'gas-city-dashboard-shared';
 import { selectBeadsNeedingAttention, type BeadAttentionReason } from './beadsNeedingAttention';
 import { elapsedSince, formatElapsed } from './elapsed';
 import { runDetailHref } from '../supervisor/runHref';
+import { agentNeedsYouReasonLabel } from './agentNeedsYou';
 import type {
   AgentResponse,
   Bead,
@@ -64,7 +65,6 @@ export interface RunsAttentionFacts {
 export interface AgentsAttentionFacts {
   items?: readonly AgentResponse[];
   pendingInteractions?: readonly AgentPendingInteraction[];
-  nowMs?: number;
   partial?: boolean;
   error?: string;
   pendingError?: string;
@@ -132,7 +132,6 @@ export interface AttentionContributorFacts {
   runs?: RunsAttentionFacts;
 }
 
-const AGENT_IDLE_WATCH_MS = 4 * 60 * 60 * 1000;
 const MAIL_UNREAD_STALE_MS = 24 * 60 * 60 * 1000;
 const DASHBOARD_PROCESS_STARTING_UPTIME_SEC = 30;
 const DASHBOARD_PROCESS_RSS_HIGH_BYTES = 2_000_000_000;
@@ -329,19 +328,26 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
 function deriveAgentsAttention(facts: AgentsAttentionFacts | undefined): readonly AttentionItem[] {
   const items: AttentionItem[] = [];
   if (facts === undefined) return items;
+
+  // gascity-dashboard-2j8e.4: data-availability degradation lands in the
+  // `unavailable` tier (BadgeSeverity excludes it), so a failed/partial read
+  // surfaces the degradation WITHOUT inflating the needs-you badge number. A
+  // whole-roster failure can't be projected into needs-you, so return with just
+  // the degradation marker.
   if (facts.error !== undefined && facts.error.length > 0) {
     items.push(
-      domainAttention('agents', {
+      domainUnavailable('agents', {
         id: 'agents:unavailable',
         title: 'Agent data unavailable',
         summary: facts.error,
         href: '/agents',
       }),
     );
+    return items;
   }
   if (facts.partial === true) {
     items.push(
-      domainWatch('agents', {
+      domainUnavailable('agents', {
         id: 'agents:partial',
         title: 'Agent list incomplete',
         href: '/agents',
@@ -350,7 +356,7 @@ function deriveAgentsAttention(facts: AgentsAttentionFacts | undefined): readonl
   }
   if (facts.pendingError !== undefined && facts.pendingError.length > 0) {
     items.push(
-      domainWatch('agents', {
+      domainUnavailable('agents', {
         id: 'agents:pending-unavailable',
         title: 'Agent pending state unavailable',
         summary: facts.pendingError,
@@ -358,75 +364,27 @@ function deriveAgentsAttention(facts: AgentsAttentionFacts | undefined): readonl
       }),
     );
   }
-  for (const interaction of facts.pendingInteractions ?? []) {
+
+  // The Agents badge counts agents that NEED THE OPERATOR — exactly the
+  // selectAgentsNeedingYou set the /agents page renders, so the badge number and
+  // the page's "Needs you" count read one selector and cannot disagree.
+  // Actively-running, idle, asleep, and suspended agents are ambient roster
+  // state, never a badge number.
+  const pendingSignals = (facts.pendingInteractions ?? []).map((interaction) => ({
+    agentName: interaction.agentName,
+    ...(interaction.pending.prompt === undefined ? {} : { prompt: interaction.pending.prompt }),
+  }));
+  for (const need of selectAgentsNeedingYou(facts.items ?? [], pendingSignals)) {
     items.push(
       domainAttention('agents', {
-        id: `agents:${interaction.agentName}:pending:${interaction.pending.request_id}`,
-        title: `${interaction.agentName} needs you`,
-        summary: interaction.pending.prompt ?? interaction.pending.kind,
-        href: `/agents/${encodeURIComponent(interaction.agentName)}`,
+        id: `agents:${need.name}:needs-you`,
+        title: `${need.name} ${agentNeedsYouReasonLabel(need.reason)}`,
+        summary: need.detail,
+        href: `/agents/${encodeURIComponent(need.name)}`,
       }),
     );
   }
-  const nowMs = facts.nowMs ?? Date.now();
-  for (const agent of facts.items ?? []) {
-    const item = attentionForAgent(agent, nowMs);
-    if (item !== null) items.push(item);
-  }
   return items;
-}
-
-function attentionForAgent(agent: AgentResponse, nowMs: number): AttentionItem | null {
-  const href = `/agents/${encodeURIComponent(agent.name)}`;
-  const state = agent.state.toLowerCase();
-  const idleAgeMs = elapsedSince(agent.session?.last_activity, nowMs);
-  if (agent.running && agent.session === undefined) {
-    return domainAttention('agents', {
-      id: `agents:${agent.name}:no-session`,
-      title: `${agent.name} has no live session`,
-      href,
-    });
-  }
-  if (isFailureState(state)) {
-    return domainAttention('agents', {
-      id: `agents:${agent.name}:failed`,
-      title: `${agent.name} ${agent.state}`,
-      href,
-    });
-  }
-  if (state === 'detached') {
-    return domainAttention('agents', {
-      id: `agents:${agent.name}:detached`,
-      title: `${agent.name} detached`,
-      href,
-    });
-  }
-  if (agent.suspended || state === 'asleep' || state === 'idle') {
-    if (idleAgeMs !== null && idleAgeMs < AGENT_IDLE_WATCH_MS) return null;
-    return domainWatch('agents', {
-      id: idleAgeMs === null ? `agents:${agent.name}:idle` : `agents:${agent.name}:stale-idle`,
-      title: `${agent.name} idle`,
-      ...(idleAgeMs === null ? {} : { summary: `last activity ${formatElapsed(idleAgeMs)} ago` }),
-      href,
-    });
-  }
-  if (!agent.available) {
-    return domainWatch('agents', {
-      id: `agents:${agent.name}:unavailable`,
-      title: `${agent.name} unavailable`,
-      href,
-      ...(agent.unavailable_reason === undefined ? {} : { summary: agent.unavailable_reason }),
-    });
-  }
-  if (agent.running && idleAgeMs !== null && idleAgeMs >= AGENT_IDLE_WATCH_MS) {
-    return domainWatch('agents', {
-      id: `agents:${agent.name}:stale-idle`,
-      title: `${agent.name} idle`,
-      summary: `last activity ${formatElapsed(idleAgeMs)} ago`,
-      href,
-    });
-  }
-  return null;
 }
 
 function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly AttentionItem[] {
@@ -971,10 +929,6 @@ function formatBytes(bytes: number): string {
 function safeRatio(numerator: number, denominator: number): number | null {
   if (denominator <= 0) return null;
   return numerator / denominator;
-}
-
-function isFailureState(state: string): boolean {
-  return state === 'failed' || state === 'errored' || state === 'stuck' || state === 'crashed';
 }
 
 function addressMatches(raw: string, alias: string): boolean {

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentsPage } from './Agents';
@@ -368,7 +368,8 @@ describe('AgentsPage (post-ay6 regressions)', () => {
     );
 
     expect(await screen.findByText('needs you')).toBeTruthy();
-    expect(screen.getByText('Approve deployment?')).toBeTruthy();
+    // The prompt shows in both the "Needs you" section and the roster row.
+    expect(within(screen.getByRole('table')).getByText('Approve deployment?')).toBeTruthy();
     expect(fetchUrls()).toContain('/gc-supervisor/v0/city/test-city/session/gc-2568/pending');
 
     fireEvent.click(screen.getByRole('button', { name: /copy attach/i }));
@@ -416,7 +417,8 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('Approve deployment?')).toBeTruthy();
+    const table = await screen.findByRole('table');
+    expect(within(table).getByText('Approve deployment?')).toBeTruthy();
 
     const approve = screen.getByRole('button', { name: /approve/i }) as HTMLButtonElement;
     const deny = screen.getByRole('button', { name: /deny/i }) as HTMLButtonElement;
@@ -446,8 +448,11 @@ describe('AgentsPage (post-ay6 regressions)', () => {
     // Link, but the title must differ — session-bound agents promise a
     // real drilldown; orphan agents warn the detail page shows no session.
     await showAllAgents();
-    const mayorLink = await screen.findByRole('link', { name: /mayor/i });
-    const orphanLink = await screen.findByRole('link', { name: /control-dispatcher/i });
+    // mayor also appears in the "Needs you" section (it has a pending ask), so
+    // scope the roster-row tooltip assertions to the table.
+    const roster = within(await screen.findByRole('table'));
+    const mayorLink = await roster.findByRole('link', { name: /mayor/i });
+    const orphanLink = await roster.findByRole('link', { name: /control-dispatcher/i });
 
     const mayorTitle = mayorLink.getAttribute('title') ?? '';
     const orphanTitle = orphanLink.getAttribute('title') ?? '';
@@ -484,11 +489,35 @@ describe('AgentsPage (post-ay6 regressions)', () => {
 
     // Toggle off the default 'running' chip so the asleep orphan shows.
     await showAllAgents();
-    const orphanLink = await screen.findByRole('link', { name: /control-dispatcher/i });
-    const mayorLink = await screen.findByRole('link', { name: /mayor/i });
+    // mayor also appears in the "Needs you" section; the row-marking assertion
+    // is about the roster <tr>, so scope the lookup to the table.
+    const roster = within(await screen.findByRole('table'));
+    const orphanLink = await roster.findByRole('link', { name: /control-dispatcher/i });
+    const mayorLink = await roster.findByRole('link', { name: /mayor/i });
 
     expect(orphanLink.closest('tr')?.getAttribute('data-attention-severity')).toBe('watch');
     expect(mayorLink.closest('tr')?.getAttribute('data-attention-severity')).toBeNull();
+  });
+
+  it('lists agents needing the operator with reason and next step, excluding calm agents', async () => {
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <NowProvider intervalMs={1_000_000}>
+          <AgentsPage />
+        </NowProvider>
+      </MemoryRouter>,
+    );
+
+    const section = within(await screen.findByRole('region', { name: /agents needing you/i }));
+    // The header count is the same selectAgentsNeedingYou the nav badge counts;
+    // only mayor (a pending ask) needs the operator here.
+    expect(section.getByRole('heading', { name: /needs you \(1\)/i })).toBeTruthy();
+    // Reason word (survives the greyscale test), the prompt, and the next step.
+    expect(section.getByText('awaiting input')).toBeTruthy();
+    expect(section.getByText('Approve deployment?')).toBeTruthy();
+    expect(section.getByText('Respond to its prompt.')).toBeTruthy();
+    // The asleep orphan is calm; it must never appear in the needs-you list.
+    expect(section.queryByText(/control-dispatcher/i)).toBeNull();
   });
 });
 

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -1,8 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { GC_EVENT_PREFIX, effectiveContextPct } from 'gas-city-dashboard-shared';
+import {
+  GC_EVENT_PREFIX,
+  effectiveContextPct,
+  selectAgentsNeedingYou,
+  type AgentNeedsYou,
+} from 'gas-city-dashboard-shared';
 import { Button } from '../components/Button';
 import { useAttentionModel } from '../attention/context';
+import {
+  agentNeedsYouActionLabel,
+  agentNeedsYouReasonLabel,
+  agentNeedsYouReasonTone,
+} from '../attention/agentNeedsYou';
 import { attentionDataProps, resourceAttentionSeverity } from '../attention/routeHighlight';
 import { ListSearchBar } from '../components/ListSearchBar';
 import { Modal } from '../components/Modal';
@@ -124,6 +134,24 @@ export function AgentsPage() {
     }
     return map;
   }, [pendingCache.data]);
+  // gascity-dashboard-2j8e.4: the same selectAgentsNeedingYou the nav badge
+  // counts, so the "Needs you" section header and the badge number are one
+  // number (count parity). The detail rows pair each agent with the cleaned
+  // 'rig · agent' label and a drilldown link (the path to address it).
+  const needsYouRows = useMemo(() => {
+    const pending = (pendingCache.data ?? []).map((p) => ({
+      agentName: p.agentName,
+      ...(p.pending.prompt === undefined ? {} : { prompt: p.pending.prompt }),
+    }));
+    const byName = new Map(rows.map((a) => [a.name, a]));
+    return selectAgentsNeedingYou(rows, pending).flatMap((need) => {
+      const agent = byName.get(need.name);
+      // need.name came from `rows`, so the lookup always resolves; flatMap with
+      // an empty fallback narrows the type without inventing a label.
+      if (agent === undefined) return [];
+      return [{ need, label: agentRowLabel(agent), slug: agentSlug(agent) }];
+    });
+  }, [rows, pendingCache.data]);
   const now = useNow();
 
   // Default to the actively-running view (restores the older simple view).
@@ -445,6 +473,8 @@ export function AgentsPage() {
         }
       />
 
+      <NeedsYouSection rows={needsYouRows} />
+
       <WorkInFlight
         beads={beadsCache.data?.items ?? []}
         sessions={sessionsCache.data?.items ?? []}
@@ -552,6 +582,49 @@ export function AgentsPage() {
           showCaption
         />
       </Modal>
+    </section>
+  );
+}
+
+interface NeedsYouRow {
+  need: AgentNeedsYou;
+  label: string;
+  slug: string;
+}
+
+// gascity-dashboard-2j8e.4: the agents that need the operator, each with the
+// reason (glyph + word) and the next step. Mirrors the Runs Blocked section:
+// hairline-divided rows, no card chrome, hidden entirely when nothing needs
+// you (the calm room does not announce the absence of trouble).
+function NeedsYouSection({ rows }: { rows: readonly NeedsYouRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <section aria-label="Agents needing you" className="mb-10">
+      <h2 className="text-label uppercase tracking-wider text-fg-faint tnum">
+        Needs you ({rows.length})
+      </h2>
+      <ol className="mt-3 divide-y divide-rule">
+        {rows.map(({ need, label, slug }) => (
+          <li key={need.name} className="py-3">
+            <div className="flex items-baseline justify-between gap-4">
+              <Link
+                to={`/agents/${encodeURIComponent(slug)}`}
+                className="focus-mark block min-w-0 truncate text-title text-fg hover:text-accent"
+              >
+                {label}
+              </Link>
+              <StatusBadge
+                tone={agentNeedsYouReasonTone(need.reason)}
+                label={agentNeedsYouReasonLabel(need.reason)}
+              />
+            </div>
+            <p className="mt-1 text-body text-fg leading-snug">{need.detail}</p>
+            <p className="mt-0.5 text-body text-fg-muted leading-snug">
+              {agentNeedsYouActionLabel(need.action)}
+            </p>
+          </li>
+        ))}
+      </ol>
     </section>
   );
 }

--- a/shared/src/agents/needsYou.test.ts
+++ b/shared/src/agents/needsYou.test.ts
@@ -1,0 +1,114 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  selectAgentsNeedingYou,
+  type AgentNeedsYouReason,
+  type AgentPendingSignal,
+} from './needsYou.js';
+import type { AgentResponse } from '../generated/gc-supervisor-client/index.js';
+
+// gascity-dashboard-2j8e.4: the single agents "needs you" selector. Both the
+// Agents nav badge and the /agents page read it, so the badge count and the
+// page count cannot disagree. Actively-running, idle, asleep, and suspended
+// agents are ambient roster state, never counted.
+
+function agent(overrides: Partial<AgentResponse>): AgentResponse {
+  return {
+    available: true,
+    name: 'agent',
+    running: false,
+    state: 'active',
+    suspended: false,
+    ...overrides,
+  };
+}
+
+const liveSession = { attached: true, last_activity: '2026-06-01T11:59:00.000Z', name: 'agent' };
+
+describe('selectAgentsNeedingYou', () => {
+  test('does NOT count actively-running, idle, asleep, or suspended agents', () => {
+    const result = selectAgentsNeedingYou(
+      [
+        agent({ name: 'running', running: true, state: 'active', session: liveSession }),
+        agent({ name: 'idle', state: 'idle', session: liveSession }),
+        agent({ name: 'asleep', running: true, state: 'asleep', session: liveSession }),
+        agent({ name: 'suspended', suspended: true, state: 'active', session: liveSession }),
+        agent({ name: 'unavailable', available: false, state: 'idle' }),
+      ],
+      [],
+    );
+    assert.deepEqual(result, []);
+  });
+
+  test('counts each needs-you reason: awaiting-input, errored, rate-limited, stalled', () => {
+    const pending: AgentPendingSignal[] = [{ agentName: 'mayor', prompt: 'Approve deployment?' }];
+    const result = selectAgentsNeedingYou(
+      [
+        agent({ name: 'mayor', running: true, state: 'active', session: liveSession }),
+        agent({ name: 'crashed', state: 'failed' }),
+        agent({ name: 'throttled', running: true, state: 'rate-limited', session: liveSession }),
+        agent({ name: 'ghost', running: true, state: 'active' }),
+      ],
+      pending,
+    );
+
+    const byName = new Map<string, AgentNeedsYouReason>(result.map((r) => [r.name, r.reason]));
+    assert.equal(byName.get('mayor'), 'awaiting-input');
+    assert.equal(byName.get('crashed'), 'errored');
+    assert.equal(byName.get('throttled'), 'rate-limited');
+    assert.equal(byName.get('ghost'), 'stalled');
+    assert.equal(result.length, 4);
+  });
+
+  test('treats a detached agent as stalled', () => {
+    const result = selectAgentsNeedingYou([agent({ name: 'lost', state: 'detached' })], []);
+    assert.deepEqual(result, [
+      { name: 'lost', reason: 'stalled', detail: 'Detached from its session.', action: 'nudge' },
+    ]);
+  });
+
+  test('ranks an awaiting-input ask above a coincident failure state', () => {
+    const result = selectAgentsNeedingYou(
+      [agent({ name: 'mayor', state: 'stuck' })],
+      [{ agentName: 'mayor', prompt: 'Approve?' }],
+    );
+    assert.deepEqual(result, [
+      { name: 'mayor', reason: 'awaiting-input', detail: 'Approve?', action: 'respond' },
+    ]);
+  });
+
+  test('carries the action verb per reason and a structural detail phrase', () => {
+    const result = selectAgentsNeedingYou(
+      [
+        agent({ name: 'crashed', state: 'errored' }),
+        agent({ name: 'throttled', running: true, state: 'waiting', session: liveSession }),
+        agent({ name: 'ghost', running: true, state: 'running' }),
+      ],
+      [],
+    );
+    assert.deepEqual(result, [
+      { name: 'crashed', reason: 'errored', detail: 'Exited errored.', action: 'reset' },
+      {
+        name: 'throttled',
+        reason: 'rate-limited',
+        detail: 'Throttled by a provider limit.',
+        action: 'nudge',
+      },
+      {
+        name: 'ghost',
+        reason: 'stalled',
+        detail: 'Running with no live session.',
+        action: 'nudge',
+      },
+    ]);
+  });
+
+  test('falls back to a generic awaiting phrase when the prompt is absent', () => {
+    const result = selectAgentsNeedingYou(
+      [agent({ name: 'mayor', state: 'active' })],
+      [{ agentName: 'mayor' }],
+    );
+    assert.equal(result[0]?.detail, 'Awaiting your decision.');
+  });
+});

--- a/shared/src/agents/needsYou.ts
+++ b/shared/src/agents/needsYou.ts
@@ -1,0 +1,120 @@
+import type { AgentResponse } from '../generated/gc-supervisor-client/index.js';
+
+// gascity-dashboard-2j8e.4: the agents "needs you" selector. The Agents nav
+// badge and the /agents page both read this one projection, so the badge count
+// and the on-page "Needs you" count read the same selector and cannot disagree.
+// It mirrors selectBlockedRuns (gascity-dashboard-2j8e.2): a pure projection of
+// the live roster into operator-actionable rows, with NO clock and NO age
+// threshold, so a borderline read can never flap the count between the nav and
+// the page.
+//
+// "Needs you" is the operator-blocking set ONLY: an agent awaiting an input
+// decision, exited in a failure state, throttled by a provider limit, or
+// claiming to run with no live session backing it. Actively-running, idle,
+// asleep, suspended, and merely-unavailable agents are ambient roster state
+// (surfaced in the page synopsis), never a badge number.
+
+/** Why an agent needs the operator. Greyscale-safe words, never color-only. */
+export type AgentNeedsYouReason = 'awaiting-input' | 'errored' | 'rate-limited' | 'stalled';
+
+/** The single next operator step for a needs-you reason. */
+export type AgentNeedsYouAction = 'respond' | 'reset' | 'nudge';
+
+export interface AgentNeedsYou {
+  /** Agent name: stable row key and attention identity (`agents:<name>:...`). */
+  name: string;
+  reason: AgentNeedsYouReason;
+  /** Structural why-phrase derived from the agent's own facts (ZFC). */
+  detail: string;
+  /** The operator's next step to clear it. */
+  action: AgentNeedsYouAction;
+}
+
+/** An agent has a pending interaction awaiting an operator decision. */
+export interface AgentPendingSignal {
+  readonly agentName: string;
+  /** Prompt the supervisor carried with the interaction, when present. */
+  readonly prompt?: string;
+}
+
+// Free-form supervisor `state` strings (no enum upstream), matched
+// case-insensitively. Aligned with StatusBadge.stateTone and Agents synopsis
+// bucketing so the three readers classify a state the same way.
+const FAILURE_STATES: ReadonlySet<string> = new Set(['failed', 'errored', 'stuck', 'crashed']);
+const RATE_LIMITED_STATES: ReadonlySet<string> = new Set([
+  'rate-limited',
+  'rate_limited',
+  'waiting',
+]);
+
+const ACTION_BY_REASON: Record<AgentNeedsYouReason, AgentNeedsYouAction> = {
+  'awaiting-input': 'respond',
+  errored: 'reset',
+  'rate-limited': 'nudge',
+  stalled: 'nudge',
+};
+
+/** Project the live roster into the agents that need the operator. */
+export function selectAgentsNeedingYou(
+  agents: readonly AgentResponse[],
+  pending: readonly AgentPendingSignal[],
+): AgentNeedsYou[] {
+  const promptByAgent = new Map<string, string | undefined>();
+  for (const signal of pending) promptByAgent.set(signal.agentName, signal.prompt);
+
+  const rows: AgentNeedsYou[] = [];
+  for (const agent of agents) {
+    const hasPending = promptByAgent.has(agent.name);
+    const reason = needsYouReason(agent, hasPending);
+    if (reason === null) continue;
+    rows.push({
+      name: agent.name,
+      reason,
+      detail: needsYouDetail(agent, reason, promptByAgent.get(agent.name)),
+      action: ACTION_BY_REASON[reason],
+    });
+  }
+  return rows;
+}
+
+/** First match wins: an awaiting-input ask outranks a failure/throttle/stall. */
+function needsYouReason(agent: AgentResponse, hasPending: boolean): AgentNeedsYouReason | null {
+  if (hasPending) return 'awaiting-input';
+  const state = agent.state.toLowerCase();
+  if (FAILURE_STATES.has(state)) return 'errored';
+  if (RATE_LIMITED_STATES.has(state)) return 'rate-limited';
+  if (isStalled(agent, state)) return 'stalled';
+  return null;
+}
+
+/** Detached, or claiming to run with no live session backing the claim. */
+function isStalled(agent: AgentResponse, state: string): boolean {
+  if (state === 'detached') return true;
+  return agent.running && agent.session === undefined;
+}
+
+function needsYouDetail(
+  agent: AgentResponse,
+  reason: AgentNeedsYouReason,
+  prompt: string | undefined,
+): string {
+  switch (reason) {
+    case 'awaiting-input':
+      return promptLine(prompt);
+    case 'errored':
+      return `Exited ${agent.state}.`;
+    case 'rate-limited':
+      return 'Throttled by a provider limit.';
+    case 'stalled':
+      return agent.state.toLowerCase() === 'detached'
+        ? 'Detached from its session.'
+        : 'Running with no live session.';
+  }
+}
+
+/** First non-empty line of the prompt, for a one-line row detail. */
+function promptLine(prompt: string | undefined): string {
+  if (prompt === undefined) return 'Awaiting your decision.';
+  const firstLine = prompt.split('\n', 1)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : 'Awaiting your decision.';
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './strip-non-printable.js';
 export * from './session-id.js';
 export * from './work-in-flight.js';
 export type * from './viewing-as.js';
+export * from './agents/needsYou.js';
 export * from './runs/bead-fields.js';
 export * from './runs/blocked.js';
 export * from './runs/display-state.js';


### PR DESCRIPTION
## What

Agents nav badge counts **agents that need the operator** — stalled / errored / rate-limited / awaiting-input — **not** a count of active agents. The Agents page surfaces each with its **reason + action**. nav badge == page count by construction, asserted by a parity test.

Part of the nav-badge epic; reuses the Runs (#95) attention + parity pattern.
