### PR TITLE
fix(beads): never post the human operator as bead assignee; remove operator Claim (2j8e.8)

### DIFF
--- a/frontend/src/components/beads/BeadAttentionPanel.test.tsx
+++ b/frontend/src/components/beads/BeadAttentionPanel.test.tsx
@@ -4,7 +4,6 @@ import type { AttentionItem } from '../../attention/compose';
 import { composeAttention } from '../../attention/compose';
 import { createAttentionContributors } from '../../attention/registry';
 import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
-import type { SupervisorBead } from '../../supervisor/beadReads';
 import { BeadAttentionPanel, beadIdFromHref } from './BeadAttentionPanel';
 
 afterEach(() => cleanup());
@@ -15,16 +14,6 @@ function attentionItem(
   return {
     domain: 'beads',
     severity: 'attention',
-    title: 'Bead',
-    ...overrides,
-  };
-}
-
-function supervisorBead(overrides: Partial<SupervisorBead> & { id: string }): SupervisorBead {
-  return {
-    created_at: '2026-06-07T11:00:00.000Z',
-    issue_type: 'task',
-    status: 'open',
     title: 'Bead',
     ...overrides,
   };
@@ -54,8 +43,7 @@ describe('beadIdFromHref', () => {
 describe('BeadAttentionPanel (gascity-dashboard-2j8e.3)', () => {
   const noop = () => undefined;
 
-  it('offers Claim for a ready-unclaimed bead the board loaded, Open otherwise', () => {
-    const onClaim = vi.fn();
+  it('opens each item and never offers an operator Claim (gascity-dashboard-2j8e.8)', () => {
     const onOpen = vi.fn();
     render(
       <BeadAttentionPanel
@@ -72,59 +60,25 @@ describe('BeadAttentionPanel (gascity-dashboard-2j8e.3)', () => {
             href: '/beads?bead=B-esc',
           }),
         ]}
-        beadById={(id) => (id === 'B-ready' ? supervisorBead({ id: 'B-ready' }) : undefined)}
         onOpen={onOpen}
-        onClaim={onClaim}
-        readOnly={false}
-        claimingId={null}
       />,
     );
 
     expect(screen.getByText('Needs you').textContent).toContain('(2)');
+    // The operator cannot be a bead assignee, so no row offers Claim — only Open.
+    expect(screen.queryByRole('button', { name: 'Claim' })).toBeNull();
+
     const readyRow = screen.getByText('B-ready unclaimed').closest('li') as HTMLElement;
-    within(readyRow).getByRole('button', { name: 'Claim' }).click();
-    expect(onClaim).toHaveBeenCalledWith(expect.objectContaining({ id: 'B-ready' }));
+    within(readyRow).getByRole('button', { name: 'Open' }).click();
+    expect(onOpen).toHaveBeenCalledWith('B-ready');
 
     const escRow = screen.getByText('B-esc escalated').closest('li') as HTMLElement;
-    expect(within(escRow).queryByRole('button', { name: 'Claim' })).toBeNull();
     within(escRow).getByRole('button', { name: 'Open' }).click();
     expect(onOpen).toHaveBeenCalledWith('B-esc');
   });
 
-  it('disables Claim in read-only mode', () => {
-    render(
-      <BeadAttentionPanel
-        items={[
-          attentionItem({
-            id: 'beads:B-ready:ready-unclaimed',
-            severity: 'watch',
-            title: 'B-ready unclaimed',
-            href: '/beads?bead=B-ready',
-          }),
-        ]}
-        beadById={() => supervisorBead({ id: 'B-ready' })}
-        onOpen={noop}
-        onClaim={noop}
-        readOnly
-        claimingId={null}
-      />,
-    );
-    expect((screen.getByRole('button', { name: 'Claim' }) as HTMLButtonElement).disabled).toBe(
-      true,
-    );
-  });
-
   it('renders nothing when there are no badge-counting items', () => {
-    const { container } = render(
-      <BeadAttentionPanel
-        items={[]}
-        beadById={() => undefined}
-        onOpen={noop}
-        onClaim={noop}
-        readOnly={false}
-        claimingId={null}
-      />,
-    );
+    const { container } = render(<BeadAttentionPanel items={[]} onOpen={noop} />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -151,16 +105,7 @@ describe('BeadAttentionPanel (gascity-dashboard-2j8e.3)', () => {
     const navTotal = summary.attention + summary.watch;
     expect(navTotal).toBe(3);
 
-    render(
-      <BeadAttentionPanel
-        items={summary.items}
-        beadById={() => undefined}
-        onOpen={noop}
-        onClaim={noop}
-        readOnly={false}
-        claimingId={null}
-      />,
-    );
+    render(<BeadAttentionPanel items={summary.items} onOpen={noop} />);
 
     expect(screen.getByText('Needs you').textContent).toContain(`(${navTotal})`);
     expect(screen.getAllByRole('button', { name: 'Open' })).toHaveLength(navTotal);

--- a/frontend/src/components/beads/BeadAttentionPanel.tsx
+++ b/frontend/src/components/beads/BeadAttentionPanel.tsx
@@ -1,6 +1,4 @@
 import type { AttentionItem } from '../../attention/compose';
-import { READ_ONLY_CONTROL_TITLE, ReadOnlyBadge } from '../../contexts/ReadOnlyContext';
-import type { SupervisorBead } from '../../supervisor/beadReads';
 import { Button } from '../Button';
 import { StatusBadge } from '../StatusBadge';
 
@@ -8,19 +6,15 @@ import { StatusBadge } from '../StatusBadge';
 // counterpart of the Beads nav badge. It renders the badge-counting attention
 // items (attention + watch tiers, the same `summary.attention + summary.watch`
 // the nav indicator shows), so the page count and the nav badge cannot
-// disagree, and gives each item a path to act: Claim a ready-unclaimed bead, or
-// Open an escalation / decision to answer it.
+// disagree, and gives each item a path to act: Open the escalation / decision /
+// ready-unclaimed bead to act on it. The operator does not claim beads — a bead
+// assignee must be a concrete session, never the human operator
+// (gascity-dashboard-2j8e.8) — so there is no inline Claim affordance.
 
 interface BeadAttentionPanelProps {
   /** The beads-domain attention items from the composed model (any severity). */
   items: readonly AttentionItem[];
-  /** Resolve a bead the page already loaded, for inline Claim. */
-  beadById: (beadId: string) => SupervisorBead | undefined;
   onOpen: (beadId: string) => void;
-  onClaim: (bead: SupervisorBead) => void;
-  readOnly: boolean;
-  /** The bead id whose claim is in flight, if any. */
-  claimingId: string | null;
 }
 
 /** Extract the `bead` query param from an attention item's `/beads?bead=…` href. */
@@ -32,14 +26,7 @@ export function beadIdFromHref(href: string | undefined): string | null {
   return beadId !== null && beadId.length > 0 ? beadId : null;
 }
 
-export function BeadAttentionPanel({
-  items,
-  beadById,
-  onOpen,
-  onClaim,
-  readOnly,
-  claimingId,
-}: BeadAttentionPanelProps) {
+export function BeadAttentionPanel({ items, onOpen }: BeadAttentionPanelProps) {
   // The nav badge counts attention + watch; mirror that exactly so the counts agree.
   const counted = items.filter(
     (item) => item.severity === 'attention' || item.severity === 'watch',
@@ -54,11 +41,6 @@ export function BeadAttentionPanel({
       <ul className="space-y-2">
         {counted.map((item) => {
           const beadId = beadIdFromHref(item.href);
-          const bead = beadId === null ? undefined : beadById(beadId);
-          const claimable =
-            bead !== undefined &&
-            bead.status === 'open' &&
-            (bead.assignee?.trim() ?? '').length === 0;
           return (
             <li
               key={item.id}
@@ -75,19 +57,6 @@ export function BeadAttentionPanel({
               </div>
               {beadId !== null && (
                 <div className="flex items-center gap-2">
-                  {readOnly && claimable && <ReadOnlyBadge />}
-                  {claimable && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      tone="quiet"
-                      title={readOnly ? READ_ONLY_CONTROL_TITLE : undefined}
-                      disabled={readOnly || claimingId !== null}
-                      onClick={() => onClaim(bead)}
-                    >
-                      {claimingId === beadId ? 'Claiming' : 'Claim'}
-                    </Button>
-                  )}
                   <Button type="button" size="sm" tone="quiet" onClick={() => onOpen(beadId)}>
                     Open
                   </Button>

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -97,16 +97,20 @@ describe('BeadsPage supervisor reads', () => {
     expect(screen.getByText('Read-only')).toBeTruthy();
   });
 
-  it('disables the per-bead claim/close/nudge actions in read-only mode', async () => {
+  it('disables the per-bead close/nudge actions in read-only mode', async () => {
     renderPage('/beads?bead=td-bead-abc123', [], { readOnly: true });
 
     const dialog = await screen.findByRole('dialog');
     // Scope to the bead-action group: the modal's own dismiss control also
-    // carries aria-label "Close", so query the actions row Claim sits in.
-    const actions = (within(dialog).getByRole('button', { name: 'Claim' }) as HTMLButtonElement)
+    // carries aria-label "Close", so query the actions row via Nudge (unique to
+    // the action row) and assert the writes there are disabled. There is no
+    // operator Claim action (gascity-dashboard-2j8e.8) — the human is never a
+    // bead assignee.
+    const actions = (within(dialog).getByRole('button', { name: 'Nudge' }) as HTMLButtonElement)
       .parentElement;
     expect(actions).not.toBeNull();
-    for (const name of ['Claim', 'Close', 'Nudge']) {
+    expect(within(actions as HTMLElement).queryByRole('button', { name: 'Claim' })).toBeNull();
+    for (const name of ['Close', 'Nudge']) {
       const button = within(actions as HTMLElement).getByRole('button', {
         name,
       }) as HTMLButtonElement;

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -61,6 +61,15 @@ beforeEach(() => {
       }
       if (
         url.pathname === '/gc-supervisor/v0/city/test-city/bead/gascity-0001' &&
+        method === 'GET'
+      ) {
+        // The detail modal fetches the bead by id when it opens before the
+        // board's full row is in state. Serve the full bead so the modal
+        // renders deterministically regardless of load ordering.
+        return jsonResponse(sampleBead());
+      }
+      if (
+        url.pathname === '/gc-supervisor/v0/city/test-city/bead/gascity-0001' &&
         method === 'PATCH'
       ) {
         supervisorWrites.push({
@@ -269,12 +278,13 @@ describe('BeadsPage', () => {
     ]);
   });
 
-  it('claims, closes, and nudges beads directly through the supervisor API', async () => {
+  it('closes and nudges beads directly through the supervisor API', async () => {
     renderPage('/beads?bead=gascity-0001');
 
     const detailDialog = await screen.findByRole('dialog');
-    fireEvent.click(within(detailDialog).getByRole('button', { name: /^claim$/i }));
-    await screen.findByText(/claimed gascity-0001/i);
+    // No operator Claim affordance: the human is never a bead assignee
+    // (gascity-dashboard-2j8e.8).
+    expect(within(detailDialog).queryByRole('button', { name: /^claim$/i })).toBeNull();
 
     fireEvent.click(within(detailDialog).getByRole('button', { name: /^nudge$/i }));
     await screen.findByText(/nudged mayor/i);
@@ -296,14 +306,6 @@ describe('BeadsPage', () => {
     await screen.findByText(/closed gascity-0001/i);
     await waitFor(() => {
       expect(supervisorWrites).toEqual([
-        {
-          method: 'PATCH',
-          path: '/gc-supervisor/v0/city/test-city/bead/gascity-0001',
-          body: {
-            status: 'in_progress',
-            assignee: 'stephanie',
-          },
-        },
         {
           method: 'POST',
           path: '/gc-supervisor/v0/city/test-city/agent/mayor/nudge',
@@ -351,6 +353,11 @@ function sampleBead(): SupervisorBead {
   return {
     id: `${PROJECT}-0001`,
     title: 'Sample bead',
+    // The board fetch returns full beads (description included). Carrying it
+    // here lets the detail modal render from the pre-loaded row and skip the
+    // by-id detail fetch (useBeadDetail's `description` freshness signal),
+    // matching the production path.
+    description: 'Sample bead description.',
     status: 'open',
     priority: 0,
     issue_type: 'task',

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -25,7 +25,6 @@ import { listSupervisorAgents, type SupervisorAgent } from '../supervisor/agentR
 import { listSupervisorBeads, type SupervisorBead } from '../supervisor/beadReads';
 import { listSupervisorRigs } from '../supervisor/rigReads';
 import {
-  claimSupervisorBead,
   closeSupervisorBead,
   createAndSlingSupervisorBead,
   nudgeSupervisorAgent,
@@ -44,7 +43,7 @@ const CLOSED_CHIP_ID = 'closed';
 // at most one refetch per window and a latency spike can no longer empty it.
 const BOARD_REFRESH_COALESCE_MS = 10_000;
 
-type BeadAction = 'claim' | 'close' | 'nudge';
+type BeadAction = 'close' | 'nudge';
 
 interface ActionMessage {
   tone: 'ok' | 'error';
@@ -203,10 +202,7 @@ export function BeadsPage() {
       setActionInFlight({ id: bead.id, action });
       setActionMessage(null);
       try {
-        if (action === 'claim') {
-          await claimSupervisorBead(bead.id);
-          setActionMessage({ tone: 'ok', text: `Claimed ${bead.id}.` });
-        } else if (action === 'close') {
+        if (action === 'close') {
           await closeSupervisorBead(bead.id, reason);
           setClosing(null);
           setCloseReason('');
@@ -309,11 +305,9 @@ export function BeadsPage() {
 
   // The "Needs you" section (gascity-dashboard-2j8e.3) renders the same
   // beads-domain attention items the nav badge counts, so the page count and the
-  // badge agree. Claim is offered inline for a ready-unclaimed bead the board
-  // already loaded; everything else opens the bead to act on it.
-  const beadById = useCallback((beadId: string) => rows.find((b) => b.id === beadId), [rows]);
-  const claimingId = actionInFlight?.action === 'claim' ? actionInFlight.id : null;
-
+  // badge agree. Each item opens the bead to act on it — the operator does not
+  // claim beads (a bead assignee must be a concrete session, never the human
+  // operator), so there is no inline Claim affordance.
   const renderBeadActions = useCallback(
     (bead: SupervisorBead) => {
       const assignee = bead.assignee?.trim() ?? '';
@@ -329,16 +323,6 @@ export function BeadsPage() {
           {actionLabel && (
             <span className="text-label uppercase tracking-wider text-fg-faint">{actionLabel}</span>
           )}
-          <Button
-            type="button"
-            size="sm"
-            tone="quiet"
-            title={roTitle}
-            disabled={readOnly || busy || bead.status === 'in_progress' || bead.status === 'closed'}
-            onClick={() => void runAction(bead, 'claim')}
-          >
-            Claim
-          </Button>
           <Button
             type="button"
             size="sm"
@@ -457,14 +441,7 @@ export function BeadsPage() {
         )}
       </div>
 
-      <BeadAttentionPanel
-        items={attention.byDomain.beads.items}
-        beadById={beadById}
-        onOpen={setSelectedId}
-        onClaim={(bead) => void runAction(bead, 'claim')}
-        readOnly={readOnly}
-        claimingId={claimingId}
-      />
+      <BeadAttentionPanel items={attention.byDomain.beads.items} onOpen={setSelectedId} />
 
       <div className="mb-6 space-y-3">
         <ListSearchBar

--- a/frontend/src/supervisor/beadWrites.test.ts
+++ b/frontend/src/supervisor/beadWrites.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OPERATOR_DISPLAY_ALIAS } from 'gas-city-dashboard-shared';
 import {
   GC_MUTATION_HEADERS,
   resetSupervisorApiForTests,
@@ -7,7 +8,6 @@ import {
 } from './client';
 import { setActiveCity } from '../api/cityBase';
 import {
-  claimSupervisorBead,
   closeSupervisorBead,
   createAndSlingSupervisorBead,
   nudgeSupervisorAgent,
@@ -56,18 +56,6 @@ describe('supervisor bead writes', () => {
 
   afterEach(() => {
     resetSupervisorApiForTests();
-  });
-
-  it('claims a bead directly through the supervisor API as the operator', async () => {
-    const updateBead = vi.fn(async () => ({ status: 'ok' }));
-    setSupervisorApiForTests({ ...baseApi, updateBead });
-
-    await claimSupervisorBead('td-bead-abc123');
-
-    expect(updateBead).toHaveBeenCalledWith('test-city', 'td-bead-abc123', {
-      status: 'in_progress',
-      assignee: 'stephanie',
-    });
   });
 
   it('closes a bead directly through the supervisor API with a trimmed reason', async () => {
@@ -162,5 +150,66 @@ describe('supervisor bead writes', () => {
     ).rejects.toThrow(/target is required/i);
     expect(createBead).not.toHaveBeenCalled();
     expect(sling).not.toHaveBeenCalled();
+  });
+
+  // gascity-dashboard-2j8e.8 (HARD CONSTRAINT): a bead write must NEVER post a
+  // non-session display alias (the human operator) as assignee — the supervisor
+  // rejects it ('assignee must resolve to a concrete open session bead ID'), and
+  // the operator is not a session. Exercise every write helper and assert none
+  // of them ever sends the operator alias as an assignee.
+  it('never posts the operator display alias as a bead assignee', async () => {
+    const updateBead = vi.fn(async () => ({ status: 'ok' }));
+    const createBead = vi.fn(async () => ({
+      id: 'td-new-1',
+      title: 'Route failing work',
+      status: 'open',
+      issue_type: 'task',
+      created_at: '2026-06-01T00:00:00Z',
+    }));
+    const sling = vi.fn(async () => ({ status: 'ok', bead: 'td-new-1', target: 'mayor' }));
+    const closeBead = vi.fn(async () => ({ status: 'closed' }));
+    const nudgeAgent = vi.fn(async () => ({ status: 'ok' }));
+    setSupervisorApiForTests({
+      ...baseApi,
+      updateBead,
+      createBead,
+      sling,
+      closeBead,
+      nudgeAgent,
+    });
+
+    // Exercise every exported bead-write helper. (claimSupervisorBead, the only
+    // helper that ever called updateBead, was removed in 2j8e.8.)
+    await closeSupervisorBead('td-bead-abc123', 'done');
+    await nudgeSupervisorAgent('mayor');
+    await createAndSlingSupervisorBead({
+      title: 'Route failing work',
+      description: '',
+      rig: 'east',
+      target: 'mayor',
+    });
+
+    // The write surface was actually driven — without this, the assignee
+    // assertions below could pass vacuously if a helper stopped issuing its
+    // mutation. nudgeAgent carries no body, so it has no assignee to check.
+    expect(closeBead).toHaveBeenCalled();
+    expect(nudgeAgent).toHaveBeenCalled();
+    expect(createBead).toHaveBeenCalled();
+    expect(sling).toHaveBeenCalled();
+
+    // updateBead has no caller now that claimSupervisorBead is gone. Assert that
+    // explicitly: the assignee guard for it would otherwise pass vacuously (zero
+    // calls), so a helper that reintroduces an assignee-bearing updateBead write
+    // must first trip this and be wired into the exercise block above.
+    expect(updateBead).not.toHaveBeenCalled();
+
+    // No body-bearing supervisor mutation that a helper actually issues may
+    // carry the operator alias as assignee.
+    for (const writeSpy of [createBead, sling, closeBead]) {
+      for (const call of writeSpy.mock.calls) {
+        const body = call[call.length - 1] as { assignee?: unknown } | undefined;
+        expect(body?.assignee).not.toBe(OPERATOR_DISPLAY_ALIAS);
+      }
+    }
   });
 });

--- a/frontend/src/supervisor/beadWrites.ts
+++ b/frontend/src/supervisor/beadWrites.ts
@@ -1,4 +1,3 @@
-import { OPERATOR_DISPLAY_ALIAS } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
 import { supervisorApi } from './client';
 import type {
@@ -18,13 +17,6 @@ export interface CreateAndSlingSupervisorBeadInput {
 export interface CreateAndSlingSupervisorBeadResult {
   bead: Bead;
   sling: SlingResponse;
-}
-
-export async function claimSupervisorBead(id: string): Promise<void> {
-  await supervisorApi().updateBead(activeCityOrThrow('claim supervisor bead'), id, {
-    status: 'in_progress',
-    assignee: OPERATOR_DISPLAY_ALIAS,
-  });
 }
 
 export async function closeSupervisorBead(id: string, reason?: string): Promise<void> {


### PR DESCRIPTION
Claim-fix (gascity-dashboard-2j8e.8 @2392607). Reviewed via dashboard ship pipeline (sentinel fix__2j8e8-beads-claim-no-operator-assignee.json = ready). Part of the all-in merge train (Stephanie). Deploy-blocker: stops posting the human operator alias as a bead assignee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)