### PR TITLE
fix(runs): nav-badge parity for Runs view (2j8e)

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -37,15 +37,19 @@ vi.mock('../api/client', () => ({
     err instanceof Error ? err.message : fallback,
 }));
 
+const mockSupervisorApiForRequestBudget = vi.hoisted(() => vi.fn());
+
 vi.mock('../supervisor/client', () => ({
   supervisorApi: () => mockSupervisorApi,
-  supervisorApiForRequestBudget: vi.fn(() => mockSupervisorApi),
+  supervisorApiForRequestBudget: mockSupervisorApiForRequestBudget,
 }));
 
 describe('useLiveAttentionContributors', () => {
   beforeEach(() => {
     setActiveCity('test-city');
     invalidate('attention:');
+    mockSupervisorApiForRequestBudget.mockReset();
+    mockSupervisorApiForRequestBudget.mockReturnValue(mockSupervisorApi);
     for (const fn of [
       mockApi.doltTrend,
       mockApi.listBuilds,
@@ -325,6 +329,25 @@ describe('useLiveAttentionContributors', () => {
     expect(mockApi.maintainerTriage).toHaveBeenCalledTimes(1);
     expect(mockApi.systemHealth).toHaveBeenCalledTimes(1);
     expect(mockApi.doltTrend).toHaveBeenCalledTimes(1);
+  });
+
+  it('drives the runs badge from the full run-summary snapshot, not the cheap preview (gascity-dashboard-2j8e.6)', async () => {
+    const { result } = renderHook(() => useLiveAttentionContributors(['maintainer'], testOperator));
+
+    await waitFor(() => {
+      // The runs contributor has resolved (no blocked graph.v2 runs in this
+      // fixture, so 0 — the count itself is exercised in registry.test.ts).
+      expect(composeAttention(result.current).byDomain.runs.attention).toBe(0);
+    });
+
+    // The badge must read the SAME complete snapshot the /runs page renders.
+    // The page upgrades to the full source (REFRESH_ENRICHMENT_TIMEOUT_MS = 30s,
+    // session-enriched) on its first refresh; the badge previously stayed on the
+    // 2.5s preview budget and persistently undercounted blocked runs
+    // (gascity-dashboard-2j8e.6). The 30s enrichment budget is unique to the full
+    // run-summary source, so its presence proves the badge is on the full path
+    // (the old preview path only ever used the 2.5s / 5s budgets).
+    expect(mockSupervisorApiForRequestBudget).toHaveBeenCalledWith(30_000);
   });
 
   it('does not fetch maintainer triage before the enabled module config is loaded', async () => {

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -8,7 +8,7 @@ import { listAgentPendingInteractions } from '../supervisor/agentPending';
 import { listSupervisorBeads } from '../supervisor/beadReads';
 import { supervisorApi, supervisorApiForRequestBudget } from '../supervisor/client';
 import { DEFAULT_MAIL_HISTORY_LIMIT, listSupervisorMail } from '../supervisor/mailReads';
-import { loadSupervisorRunSummaryPreviewSource } from '../supervisor/runSummary';
+import { loadSupervisorRunSummarySource } from '../supervisor/runSummary';
 import type { AttentionContributor } from './compose';
 import {
   createAttentionContributors,
@@ -113,21 +113,29 @@ function withRunsFreshness(
 
 async function fetchRunsAttention(cityName: string | null): Promise<RunsAttentionFacts> {
   if (cityName === null) return {};
-  // gascity-dashboard-2j8e.2: the badge derives genuinely-blocked runs from the
-  // bead-derived run summary — the SAME source the /runs page reads — so the
-  // badge and the page count one selector and cannot disagree. The preview
-  // source is sufficient: `phase === 'blocked'` is decided from bead state in
-  // buildRunSummary and needs no session enrichment. The formula feed (the old
-  // source) is dropped: it counted phantom feed-only roots and flapped on
-  // partial fan-outs.
+  // gascity-dashboard-2j8e.6: the badge must derive its genuinely-blocked count
+  // from the SAME COMPLETE snapshot the /runs page renders, not just the same
+  // selector. #95 (2j8e.2) unified the selector (selectBlockedRuns) but left the
+  // badge on the cheap preview source while the page upgrades to the full source
+  // on its first refresh — so the two read DIFFERENT-completeness snapshots and
+  // the badge persistently undercounted (operator saw page Blocked(4), nav badge
+  // empty). The preview budget (2.5s) lets the recent-run fan-out time out under
+  // a slow supervisor, dropping the very lanes that map to `phase === 'blocked'`;
+  // the page's full source (30s budget + session enrichment) loads them. Reading
+  // the full source here makes the badge's blocked set as complete as the page's,
+  // so the counts agree in steady state rather than only "by construction" over a
+  // snapshot neither side actually shares.
   //
-  // This refetches the summary under the attention cache key rather than sharing
-  // the page's `runs:summary:*` entry, so when the operator is on /runs the
-  // fan-out runs twice. The attention fetch is mount-driven (no recurring poll),
-  // so the cost is bounded to cold load / city switch; unifying the two cache
-  // entries is a worthwhile follow-up but a cross-cutting cache change kept out
-  // of this focused fix.
-  const source = await loadSupervisorRunSummaryPreviewSource();
+  // The formula feed (the pre-#95 source) stays dropped: it counted phantom
+  // feed-only roots and flapped on partial fan-outs.
+  //
+  // This still refetches under the attention cache key rather than sharing the
+  // page's `runs:summary:*` entry, so on /runs the fan-out runs twice. The fetch
+  // is mount-driven (no recurring poll), so the cost is bounded to cold load /
+  // city switch; lifting the run summary into one shared subscription that both
+  // the header badge and the page read is the proper follow-up (a cross-cutting
+  // change kept out of this focused parity fix).
+  const source = await loadSupervisorRunSummarySource();
   if (source.status === 'error') {
     return { error: source.error };
   }

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -15,7 +15,7 @@ import type {
   Message,
   TypedEventStreamEnvelope,
 } from 'gas-city-dashboard-shared/gc-supervisor';
-import { selectAgentsNeedingYou } from 'gas-city-dashboard-shared';
+import { selectAgentsNeedingYou, selectBlockedRuns } from 'gas-city-dashboard-shared';
 import { ATTENTION_DOMAINS, composeAttention } from './compose';
 import { createAttentionContributors, type AgentsAttentionFacts } from './registry';
 
@@ -218,6 +218,55 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.runs.watch).toBe(0);
     expect(model.byDomain.runs.items.map((item) => item.id)).toEqual(['runs:blocked-1:blocked']);
     expect(model.byDomain.runs.items[0]?.href).toBe('/runs/blocked-1');
+  });
+
+  it('nav badge count equals the page Blocked count for a mixed summary (gascity-dashboard-2j8e.6)', () => {
+    // #95 (2j8e.2) claimed the badge and the /runs page "cannot disagree by
+    // construction" but never asserted it. This pins the invariant over ONE
+    // summary with a non-trivial mix of phases: the nav badge number
+    // (byDomain.runs.attention), the page Blocked CountTile (runCounts.blocked),
+    // and the page Blocked section header (selectBlockedRuns(blockedLanes).length)
+    // must all be the SAME number. A regression that counts all lanes, or that
+    // lets runCounts.blocked drift from the selectBlockedRuns phase filter, fails
+    // here instead of silently shipping a mismatched badge.
+    const summary = runSummary([
+      runLane({
+        id: 'blocked-1',
+        title: 'First stuck run',
+        phase: 'blocked',
+        statusCounts: { blocked: 1 },
+        health: { phaseConfidence: 'known', needsOperator: true, thrashingDetected: false },
+      }),
+      runLane({
+        id: 'active-1',
+        title: 'Healthy active run',
+        phase: 'implementation',
+        health: { phaseConfidence: 'known', needsOperator: false, thrashingDetected: false },
+      }),
+      runLane({
+        id: 'blocked-2',
+        title: 'Second stuck run',
+        phase: 'blocked',
+        statusCounts: { blocked: 2 },
+        health: { phaseConfidence: 'known', needsOperator: true, thrashingDetected: false },
+      }),
+      runLane({
+        id: 'done-1',
+        title: 'Finished run',
+        phase: 'complete',
+        health: { phaseConfidence: 'known', needsOperator: false, thrashingDetected: false },
+      }),
+    ]);
+
+    const model = composeAttention(createAttentionContributors({ runs: { summary } }));
+
+    const navBadgeCount = model.byDomain.runs.attention;
+    const pageBlockedTile = summary.runCounts.blocked;
+    const pageBlockedSection = selectBlockedRuns(summary.blockedLanes).length;
+
+    expect(navBadgeCount).toBe(2);
+    expect(pageBlockedTile).toBe(navBadgeCount);
+    expect(pageBlockedSection).toBe(navBadgeCount);
   });
 
   it('never counts a supervisor partial read as a run (gascity-dashboard-2j8e.2)', () => {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -75,11 +75,23 @@ interface ProgressState {
 
 const progressStateByCity = new Map<string, ProgressState>();
 
-// Runs.tsx background refresh ONLY (gascity-dashboard-4bol): the wide enrichment
-// budget lets slow-but-available list/feed reads land and clear the spurious
-// "runs partial" badge (upstream gascity-dashboard#88). Do NOT use as a
-// mount/first-paint fetcher — it can block up to REFRESH_ENRICHMENT_TIMEOUT_MS;
-// mount consumers (Home, Formula Run Detail) use loadSupervisorRunSummaryMountSource.
+// The wide-budget run-summary source (gascity-dashboard-4bol): the wide
+// enrichment budget lets slow-but-available list/feed reads land and clear the
+// spurious "runs partial" badge (upstream gascity-dashboard#88). It is the
+// /runs page's authoritative refresh snapshot.
+//
+// Do NOT use this as a ROUTE first-paint fetcher — it can block a route view for
+// up to REFRESH_ENRICHMENT_TIMEOUT_MS; route mount consumers (Home, Formula Run
+// Detail) use loadSupervisorRunSummaryMountSource on the tight budget instead.
+//
+// The nav attention badge (liveContributors `fetchRunsAttention`) is an APPROVED
+// caller despite being mount-driven (gascity-dashboard-2j8e.6): it is cache-
+// backed and renders in the always-mounted header, so its latency never blocks a
+// route view — and it MUST read this exact snapshot. The badge counts the same
+// genuinely-blocked runs the page shows; using a narrower budget would let the
+// recent-run fan-out time out on a slow supervisor where the page's 30s budget
+// succeeds, re-introducing the badge-vs-page undercount this source was chosen to
+// eliminate. Parity requires the same budget, not merely the same selector.
 export async function loadSupervisorRunSummarySource(): Promise<SourceState<RunSummary>> {
   return loadRunSummarySource(REFRESH_ENRICHMENT_TIMEOUT_MS);
 }


### PR DESCRIPTION
Runs nav-badge parity (gascity-dashboard-888w @f156545, rebased onto post-bhvn main fb5ecdb). All-in merge train (Stephanie), item 3/4. Reviewed via dashboard ship pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)