### PR TITLE
fix(mail): operator unread mail badge (Option A) (2j8e)

### DIFF
--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -219,8 +219,11 @@ async function fetchMailAttention(
   cityName: string | null,
   operator: OperatorConfig,
 ): Promise<MailAttentionFacts> {
-  if (cityName === null) return { operatorAlias: operator.operatorWireAlias };
+  if (cityName === null) return {};
   try {
+    // The operator inbox (to:operator). selectOperatorActionableUnread then
+    // folds the pool-worker firehose, so the badge counts only needs-you mail
+    // (gascity-dashboard-2j8e.5).
     const list = await listSupervisorMail(
       'inbox',
       operator.operatorAlias,
@@ -230,12 +233,10 @@ async function fetchMailAttention(
     return {
       items: list.items ?? [],
       nowMs: Date.now(),
-      operatorAlias: operator.operatorWireAlias,
       partial: list.partial === true,
     };
   } catch (err) {
     return {
-      operatorAlias: operator.operatorWireAlias,
       error: formatApiError(err, 'mail list unavailable'),
     };
   }

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { selectOperatorActionableUnread } from 'gas-city-dashboard-shared';
 import type {
   DeployList,
   DoltNomsTrend,
@@ -153,7 +154,6 @@ describe('createAttentionContributors', () => {
           ],
         },
         mail: {
-          operatorAlias: 'stephanie',
           items: [
             message({
               id: 'M-1',
@@ -267,6 +267,66 @@ describe('createAttentionContributors', () => {
     expect(navBadgeCount).toBe(2);
     expect(pageBlockedTile).toBe(navBadgeCount);
     expect(pageBlockedSection).toBe(navBadgeCount);
+  });
+
+  it('counts operator needs-you mail only — folds the pool-worker firehose (gascity-dashboard-2j8e.5)', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        mail: {
+          nowMs: Date.parse('2026-06-07T12:00:00.000Z'),
+          items: [
+            message({
+              id: 'M-mayor',
+              from: 'mayor',
+              subject: 'Decision needed',
+              read: false,
+              created_at: '2026-06-07T11:00:00.000Z',
+            }),
+            message({
+              id: 'M-pl',
+              from: 'zeldascension/oversight-rig.project-lead',
+              subject: 'Review escalation',
+              read: false,
+              created_at: '2026-06-07T10:00:00.000Z',
+            }),
+            // The worker firehose (the ~93 inflation) — folded out of the badge.
+            message({ id: 'M-pc1', from: '/home/ds/gascity/polecat-1', read: false }),
+            message({ id: 'M-pc2', from: '/home/ds/gascity/polecat-2', read: false }),
+          ],
+        },
+      }),
+    );
+
+    expect(model.byDomain.mail.attention).toBe(2);
+    expect(model.byDomain.mail.watch).toBe(0);
+    expect(model.byDomain.mail.items.map((item) => item.id)).toEqual([
+      'mail:M-mayor:unread',
+      'mail:M-pl:unread',
+    ]);
+    expect(model.byDomain.mail.items.map((item) => item.href)).toEqual([
+      '/mail?message=M-mayor',
+      '/mail?message=M-pl',
+    ]);
+  });
+
+  it('Mail badge count equals the Mail page selector count — one selectOperatorActionableUnread (gascity-dashboard-2j8e.5)', () => {
+    const items = [
+      message({ id: 'A', from: 'mayor', read: false, created_at: '2026-06-07T11:00:00.000Z' }),
+      message({ id: 'B', from: '/home/ds/gascity/polecat-1', read: false }),
+      message({ id: 'C', from: 'clerk', read: false, created_at: '2026-06-07T11:30:00.000Z' }),
+      message({ id: 'D', from: 'mayor', read: true }),
+    ];
+    const badge = composeAttention(
+      createAttentionContributors({
+        mail: { items, nowMs: Date.parse('2026-06-07T12:00:00.000Z') },
+      }),
+    ).byDomain.mail;
+    // The Mail page derives its count from the SAME selector, so the two cannot
+    // disagree: the polecat firehose (B) and the read message (D) drop, leaving
+    // the mayor + clerk escalations.
+    const pageCount = selectOperatorActionableUnread(items).length;
+    expect(pageCount).toBe(2);
+    expect(badge.attention + badge.watch).toBe(pageCount);
   });
 
   it('never counts a supervisor partial read as a run (gascity-dashboard-2j8e.2)', () => {
@@ -446,7 +506,6 @@ describe('createAttentionContributors', () => {
         },
         mail: {
           nowMs,
-          operatorAlias: 'stephanie',
           items: [
             message({
               created_at: '2026-05-31T08:00:00.000Z',

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -7,7 +7,11 @@ import type {
   SystemHealth,
   TriageItem,
 } from 'gas-city-dashboard-shared';
-import { selectAgentsNeedingYou, selectBlockedRuns } from 'gas-city-dashboard-shared';
+import {
+  selectAgentsNeedingYou,
+  selectBlockedRuns,
+  selectOperatorActionableUnread,
+} from 'gas-city-dashboard-shared';
 import { selectBeadsNeedingAttention, type BeadAttentionReason } from './beadsNeedingAttention';
 import { elapsedSince, formatElapsed } from './elapsed';
 import { runDetailHref } from '../supervisor/runHref';
@@ -74,10 +78,9 @@ export interface BeadsAttentionFacts {
   items?: readonly Bead[];
   /**
    * The label marking a bead as a mayor-decision (DASHBOARD_DECISION_LABEL,
-   * gascity-dashboard-bhvn). Carried in the facts — like `MailAttentionFacts`
-   * carries `operatorAlias` — so the registry derives the decision skip from
-   * runtime config instead of a hardcoded literal. The live producer
-   * (liveContributors) sets it from the operator config.
+   * gascity-dashboard-bhvn). Carried in the facts so the registry derives the
+   * decision skip from runtime config instead of a hardcoded literal. The live
+   * producer (liveContributors) sets it from the operator config.
    */
   decisionLabel: string;
   /**
@@ -108,7 +111,6 @@ export interface BeadsAttentionFacts {
 
 export interface MailAttentionFacts {
   items?: readonly Message[];
-  operatorAlias: string;
   nowMs?: number;
   partial?: boolean;
   error?: string;
@@ -524,14 +526,17 @@ function deriveMailAttention(facts: MailAttentionFacts | undefined): readonly At
     );
   }
   const nowMs = facts.nowMs ?? Date.now();
-  for (const message of facts.items ?? []) {
-    if (message.read) continue;
-    const addressedToOperator = addressMatches(message.to, facts.operatorAlias);
-    const builder = addressedToOperator ? domainAttention : domainWatch;
+  // gascity-dashboard-2j8e.5: the Mail badge counts the operator's needs-you
+  // mail — unread, minus the pool-worker firehose (the ~93 inflation) — via the
+  // SAME selectOperatorActionableUnread the Mail page reads over the operator
+  // inbox, so the badge and the page agree on one selector (mirrors the Runs
+  // selectBlockedRuns). Every kept message is addressed to the operator (the
+  // fetch reads the operator inbox), so each surfaces as an attention item.
+  for (const message of selectOperatorActionableUnread(facts.items ?? [])) {
     const staleAgeMs = elapsedSince(message.created_at, nowMs);
     const stale = staleAgeMs !== null && staleAgeMs >= MAIL_UNREAD_STALE_MS;
     items.push(
-      builder('mail', {
+      domainAttention('mail', {
         id: `mail:${message.id}:${stale ? 'unread-stale' : 'unread'}`,
         title: message.subject,
         summary: stale
@@ -929,12 +934,6 @@ function formatBytes(bytes: number): string {
 function safeRatio(numerator: number, denominator: number): number | null {
   if (denominator <= 0) return null;
   return numerator / denominator;
-}
-
-function addressMatches(raw: string, alias: string): boolean {
-  const normalizedAlias = alias.trim().toLowerCase();
-  if (normalizedAlias.length === 0) return false;
-  return raw.split(/[,\s;]+/).some((part) => part.trim().toLowerCase() === normalizedAlias);
 }
 
 function healthAttention(

--- a/frontend/src/routes/Mail.render.test.tsx
+++ b/frontend/src/routes/Mail.render.test.tsx
@@ -63,6 +63,18 @@ function stubFetch() {
               created_at: '2026-06-01T10:00:00Z',
               thread_id: 'thread-direct',
             }),
+            // Unread and addressed to the operator, but pool-worker firehose: it
+            // counts as inbox unread yet must NOT count toward "needs you"
+            // (gascity-dashboard-2j8e.5).
+            mail({
+              id: 'mail-firehose',
+              from: '/home/ds/gascity/polecat-2',
+              to: 'human',
+              subject: 'worker firehose noise',
+              body: 'status update preview',
+              created_at: '2026-06-01T09:59:00Z',
+              thread_id: 'thread-firehose',
+            }),
             mail({
               id: 'mail-sent',
               from: 'human',
@@ -83,7 +95,7 @@ function stubFetch() {
               thread_id: 'thread-other',
             }),
           ],
-          total: 3,
+          total: 4,
         });
       }
       if (url === '/gc-supervisor/v0/city/test-city/mail?limit=1000') {
@@ -281,6 +293,27 @@ describe('MailPage supervisor reads', () => {
     expect(fetchCalls.some((call) => call.url.startsWith('/api/city/test-city/mail'))).toBe(false);
     expect(screen.queryByText('operator sent only')).toBeNull();
     expect(screen.queryByText('other inbox')).toBeNull();
+  });
+
+  it('foregrounds the operator needs-you count, folding the pool-worker firehose (gascity-dashboard-2j8e.5)', async () => {
+    renderMailPage();
+
+    await screen.findByText('direct supervisor inbox');
+    // Two unread to:human (mayor + a polecat firehose message), but only the
+    // mayor escalation needs the operator — the same count the nav badge shows.
+    expect(screen.getByText(/1 need you of 2 unread/)).toBeTruthy();
+  });
+
+  it('the needs-you chip surfaces operator escalations and hides the firehose (gascity-dashboard-2j8e.5)', async () => {
+    renderMailPage();
+
+    await screen.findByText('direct supervisor inbox');
+    expect(screen.getByText('worker firehose noise')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'needs you' }));
+
+    expect(screen.getByText('direct supervisor inbox')).toBeTruthy();
+    expect(screen.queryByText('worker firehose noise')).toBeNull();
   });
 
   it('expands mailbox history through the generated supervisor limit query', async () => {

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { isPoolWorkerSender, selectOperatorActionableUnread } from 'gas-city-dashboard-shared';
 import { formatApiError } from '../api/client';
 import { formatMailSender } from '../lib/mailSender';
 import { useCachedData } from '../hooks/useCachedData';
@@ -48,6 +49,16 @@ const MAIL_CHIPS: ReadonlyArray<FilterChip<SupervisorMailItem>> = [
   { id: 'unread', label: 'unread', match: (m) => !m.read },
   { id: 'read', label: 'read', match: (m) => m.read },
 ];
+
+// gascity-dashboard-2j8e.5: the operator's "needs you" filter — unread mail
+// minus the pool-worker firehose, the same predicate selectOperatorActionableUnread
+// applies, so the chip surfaces exactly the set the nav badge counts. Operator-only
+// (it is the operator's signal); composed ahead of the read-state chips.
+const NEEDS_YOU_CHIP: FilterChip<SupervisorMailItem> = {
+  id: 'needs-you',
+  label: 'needs you',
+  match: (m) => !m.read && !isPoolWorkerSender(m.from),
+};
 
 const MAIL_SEARCH_FIELDS = (m: SupervisorMailItem): ReadonlyArray<string | undefined> => [
   m.from,
@@ -249,13 +260,38 @@ export function MailPage() {
     [viewingAs.alias, operator.operatorAlias],
   );
 
+  // gascity-dashboard-2j8e.5: the operator inbox's needs-you count — the same
+  // selectOperatorActionableUnread the Mail nav badge reads, so the count and
+  // the badge agree on the default operator inbox (the badge's canonical
+  // source). Only meaningful on the operator's own inbox — it is their signal.
+  const needsYou = useMemo(
+    () =>
+      box === 'inbox' && viewingAs.isOperator ? selectOperatorActionableUnread(items).length : 0,
+    [box, items, viewingAs.isOperator],
+  );
+
   const synopsis = useMemo(() => {
     const noun = box === 'all' ? 'all mail' : box === 'inbox' ? 'inbox' : 'sent';
     if (items.length === 0) return `${capitalize(noun)} empty for ${aliasLabel}.`;
     const unread = box === 'sent' ? 0 : items.filter((m) => !m.read).length;
+    if (box === 'inbox' && viewingAs.isOperator) {
+      // Foreground the needs-you count and name the folded pool-worker firehose
+      // (unread − needsYou) so the smaller badge number is legible, not a mystery.
+      if (unread === 0) return `${items.length} in inbox, all read.`;
+      return needsYou > 0
+        ? `${items.length} in inbox, ${needsYou} need you of ${unread} unread.`
+        : `${items.length} in inbox, ${unread} unread, none need you.`;
+    }
     if (unread > 0) return `${items.length} in ${noun}, ${unread} unread.`;
     return `${items.length} in ${noun}.`;
-  }, [box, items, aliasLabel]);
+  }, [box, items, aliasLabel, needsYou, viewingAs.isOperator]);
+
+  // The operator gets the needs-you chip ahead of the read-state chips; other
+  // aliases see read-state only (needs-you is the operator's signal).
+  const mailChips = useMemo<ReadonlyArray<FilterChip<SupervisorMailItem>>>(
+    () => (viewingAs.isOperator ? [NEEDS_YOU_CHIP, ...MAIL_CHIPS] : MAIL_CHIPS),
+    [viewingAs.isOperator],
+  );
 
   // Mail view key includes box so collapsed-project state is independent
   // between inbox and sent (different mental models).
@@ -264,7 +300,7 @@ export function MailPage() {
     rows: items,
     projectOf: mailProject,
     searchOf: MAIL_SEARCH_FIELDS,
-    chips: MAIL_CHIPS,
+    chips: mailChips,
   });
   // gascity-dashboard-s464: mail is not an alert by default. We keep the
   // data-attention-severity attribute (so the home-alerts panel and
@@ -282,7 +318,7 @@ export function MailPage() {
   );
 
   // Sent box has no unread concept; suppress those chips there.
-  const visibleChips = box === 'sent' ? [] : MAIL_CHIPS;
+  const visibleChips = box === 'sent' ? [] : mailChips;
   const replyDisabled =
     readOnly ||
     threadFor === null ||

--- a/shared/src/operator-mail.test.ts
+++ b/shared/src/operator-mail.test.ts
@@ -1,0 +1,79 @@
+// Run with: npx tsx --test shared/src/operator-mail.test.ts
+//
+// gascity-dashboard-2j8e.5: the operator-mail needs-you selector. The Mail nav
+// badge and the Mail page both read selectOperatorActionableUnread, so the
+// badge count and the page count cannot disagree. These tests pin the two
+// behaviours the bead asks for: the pool-worker firehose is folded away, and
+// unread escalations from the mayor / role agents are kept.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isPoolWorkerSender,
+  selectOperatorActionableUnread,
+  type OperatorMailItem,
+} from './operator-mail.js';
+
+function mail(overrides: Partial<OperatorMailItem>): OperatorMailItem {
+  return {
+    from: 'mayor',
+    read: false,
+    created_at: '2026-06-07T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// The supervisor reports a mail sender inconsistently — a bare name, a session
+// id, or a filesystem path — so the polecat token can sit anywhere in the
+// basename. All of these are the worker firehose.
+test('isPoolWorkerSender classifies polecat senders in every wire form', () => {
+  assert.equal(isPoolWorkerSender('/home/ds/gascity/polecat-2'), true);
+  assert.equal(isPoolWorkerSender('polecat-gc-243376'), true);
+  assert.equal(isPoolWorkerSender('/home/ds/gascity-packs/gascity-packs-polecat-1'), true);
+  assert.equal(isPoolWorkerSender('POLECAT-7'), true);
+});
+
+test('isPoolWorkerSender does not flag the mayor, role agents, or the operator', () => {
+  assert.equal(isPoolWorkerSender('mayor'), false);
+  assert.equal(isPoolWorkerSender('zeldascension/oversight-rig.project-lead'), false);
+  assert.equal(isPoolWorkerSender('human'), false);
+  assert.equal(isPoolWorkerSender('stephanie'), false);
+  assert.equal(isPoolWorkerSender(''), false);
+});
+
+test('selectOperatorActionableUnread keeps mayor/role escalations, drops the pool firehose', () => {
+  const items = [
+    mail({ from: 'mayor', read: false }),
+    mail({ from: '/home/ds/gascity/polecat-2', read: false }),
+    mail({ from: '/home/ds/gascity/polecat-1', read: false }),
+    mail({ from: 'zeldascension/oversight-rig.project-lead', read: false }),
+  ];
+  assert.deepEqual(
+    selectOperatorActionableUnread(items).map((m) => m.from),
+    ['mayor', 'zeldascension/oversight-rig.project-lead'],
+  );
+});
+
+test('selectOperatorActionableUnread drops already-read mail', () => {
+  const items = [mail({ from: 'mayor', read: true }), mail({ from: 'mayor', read: false })];
+  assert.equal(selectOperatorActionableUnread(items).length, 1);
+});
+
+test('selectOperatorActionableUnread returns nothing for a pure pool firehose (the ~93 inflation)', () => {
+  const firehose = Array.from({ length: 93 }, (_, i) =>
+    mail({ from: `/home/ds/gascity/polecat-${i}`, read: false }),
+  );
+  assert.equal(selectOperatorActionableUnread(firehose).length, 0);
+});
+
+test('selectOperatorActionableUnread preserves input order (caller owns sort)', () => {
+  const items = [
+    mail({ from: 'mayor', created_at: '2026-06-07T09:00:00.000Z' }),
+    mail({ from: '/home/ds/gascity/polecat-2' }),
+    mail({ from: 'clerk', created_at: '2026-06-07T11:00:00.000Z' }),
+  ];
+  assert.deepEqual(
+    selectOperatorActionableUnread(items).map((m) => m.from),
+    ['mayor', 'clerk'],
+  );
+});

--- a/shared/src/operator-mail.ts
+++ b/shared/src/operator-mail.ts
@@ -52,6 +52,37 @@ export function basename(path: string | null | undefined): string {
   return seg || trimmed;
 }
 
+/** The pool-worker template token. A pool worker is a "polecat" by Gas City
+ *  convention (see {@link agentKind}); the dashboard has no other pool kind. */
+const POLECAT = 'polecat';
+
+/**
+ * A mail sender that is a pool worker (a "polecat") — the worker firehose the
+ * operator's nav badge folds away (gascity-dashboard-2j8e.5). Classified from
+ * the `from` STRING, not a live session: pool workers are ephemeral, so the
+ * session that sent a message is often already gone and cannot be looked up.
+ * The supervisor reports the sender inconsistently (a bare name, a session id,
+ * or a filesystem path), so the polecat token is matched anywhere in the
+ * basename — mirroring the template check {@link agentKind} runs on a session.
+ */
+export function isPoolWorkerSender(from: string): boolean {
+  return basename(from).toLowerCase().includes(POLECAT);
+}
+
+/**
+ * The operator's needs-you mail (gascity-dashboard-2j8e.5): unread messages that
+ * are NOT pool-worker firehose. The single selector the Mail nav badge and the
+ * Mail page both read, so the badge count and the page count cannot disagree
+ * (mirrors {@link selectBlockedRuns} for the Runs badge). Recipient scoping is
+ * the caller's job — both feed it the operator inbox — so this stays a pure
+ * sender/read filter. Input order is preserved; the caller owns sort.
+ */
+export function selectOperatorActionableUnread<T extends OperatorMailItem>(
+  mail: readonly T[],
+): readonly T[] {
+  return mail.filter((m) => !m.read && !isPoolWorkerSender(m.from));
+}
+
 /**
  * Canonical rig label. The supervisor reports a rig inconsistently — sometimes
  * a filesystem path (`/home/ds/projects/scix_experiments`), sometimes a name


### PR DESCRIPTION
Mail badge Option A (gascity-dashboard-imfo @54d60d6, rebased onto post-Runs-parity main f549502). Final item (4/4) of the all-in merge train (Stephanie). Reviewed via dashboard ship pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)