### PR TITLE
feat(mail): bulk-select + mark read/unread + select-all (mp3g)

### DIFF
--- a/frontend/src/routes/Mail.render.test.tsx
+++ b/frontend/src/routes/Mail.render.test.tsx
@@ -17,6 +17,16 @@ interface FetchCall {
 
 const fetchCalls: FetchCall[] = [];
 
+// Stateful read-state overrides so a mark-read/unread POST is reflected by the
+// next mailbox GET — lets the bulk-mark tests assert the needs-you count (the
+// same selectOperatorActionableUnread the nav badge reads) actually updates.
+const markedRead = new Map<string, boolean>();
+
+function applyReadState(item: Record<string, unknown>): Record<string, unknown> {
+  const id = item.id as string;
+  return markedRead.has(id) ? { ...item, read: markedRead.get(id) } : item;
+}
+
 vi.mock('../contexts/ViewingAsContext', () => ({
   useViewingAs: () => ({
     viewingAs: { alias: 'stephanie', isOperator: true },
@@ -94,7 +104,7 @@ function stubFetch() {
               created_at: '2026-06-01T10:02:00Z',
               thread_id: 'thread-other',
             }),
-          ],
+          ].map(applyReadState),
           total: 4,
         });
       }
@@ -183,13 +193,14 @@ function stubFetch() {
           201,
         );
       }
-      if (url === '/gc-supervisor/v0/city/test-city/mail/mail-inbox/read' && method === 'POST') {
+      const readMatch = url.match(/\/mail\/([^/]+)\/read$/);
+      if (readMatch?.[1] !== undefined && method === 'POST') {
+        markedRead.set(readMatch[1], true);
         return jsonResponse({ status: 'ok' });
       }
-      if (
-        url === '/gc-supervisor/v0/city/test-city/mail/mail-sent/mark-unread' &&
-        method === 'POST'
-      ) {
+      const unreadMatch = url.match(/\/mail\/([^/]+)\/mark-unread$/);
+      if (unreadMatch?.[1] !== undefined && method === 'POST') {
+        markedRead.set(unreadMatch[1], false);
         return jsonResponse({ status: 'ok' });
       }
       if (url === '/gc-supervisor/v0/city/test-city/mail/mail-inbox/archive' && method === 'POST') {
@@ -272,6 +283,7 @@ function mail(overrides: Record<string, unknown>): Record<string, unknown> {
 
 beforeEach(() => {
   fetchCalls.length = 0;
+  markedRead.clear();
   invalidate('mail');
   stubFetch();
 });
@@ -575,6 +587,112 @@ describe('MailPage supervisor reads', () => {
 
     const threadArticle = (await screen.findByText('oldest in thread')).closest('article');
     expect(threadArticle?.getAttribute('data-attention-severity')).toBe('attention');
+  });
+});
+
+describe('MailPage bulk read-state selection (gascity-dashboard-mp3g)', () => {
+  it('select-all selects the whole visible set, and rows toggle independently', async () => {
+    renderMailPage();
+    await screen.findByText('direct supervisor inbox');
+
+    const selectAll = screen.getByRole('checkbox', { name: 'select all mail' });
+    fireEvent.click(selectAll);
+    // Both visible inbox rows (mayor escalation + polecat firehose) selected.
+    expect(screen.getByText('2 selected')).toBeTruthy();
+
+    fireEvent.click(selectAll);
+    expect(screen.queryByText(/selected/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /select mail: direct supervisor inbox/ }));
+    expect(screen.getByText('1 selected')).toBeTruthy();
+    // Toggling a row checkbox must not open the thread modal (no Reply field).
+    expect(screen.queryByLabelText('Reply')).toBeNull();
+  });
+
+  it('bulk-marks the selected inbox mail read through the supervisor API', async () => {
+    renderMailPage();
+    await screen.findByText('direct supervisor inbox');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'select all mail' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }));
+
+    await waitFor(() => {
+      expect(fetchCalls).toContainEqual({
+        method: 'POST',
+        url: '/gc-supervisor/v0/city/test-city/mail/mail-inbox/read',
+        body: undefined,
+        gcRequest: 'dashboard',
+      });
+    });
+    expect(fetchCalls).toContainEqual({
+      method: 'POST',
+      url: '/gc-supervisor/v0/city/test-city/mail/mail-firehose/read',
+      body: undefined,
+      gcRequest: 'dashboard',
+    });
+  });
+
+  it('bulk-marks the selected read mail unread, skipping already-unread rows (no second mark)', async () => {
+    renderMailPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'All' }));
+    await screen.findByText('operator sent only');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'select all mail' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mark unread' }));
+
+    await waitFor(() => {
+      expect(fetchCalls).toContainEqual({
+        method: 'POST',
+        url: '/gc-supervisor/v0/city/test-city/mail/mail-sent/mark-unread',
+        body: undefined,
+        gcRequest: 'dashboard',
+      });
+    });
+    // mail-inbox / mail-other are already unread — bulk mark-unread must not
+    // re-issue redundant writes for them.
+    expect(
+      fetchCalls.some(
+        (c) => c.url === '/gc-supervisor/v0/city/test-city/mail/mail-inbox/mark-unread',
+      ),
+    ).toBe(false);
+    expect(
+      fetchCalls.some(
+        (c) => c.url === '/gc-supervisor/v0/city/test-city/mail/mail-other/mark-unread',
+      ),
+    ).toBe(false);
+  });
+
+  it('updates the needs-you count after a bulk mark-read (same selector as the nav badge)', async () => {
+    renderMailPage();
+    await screen.findByText(/1 need you of 2 unread/);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'select all mail' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }));
+
+    // After both inbox rows are marked read, the re-fetched mailbox has no
+    // unread — the needs-you synopsis collapses to the all-read line.
+    expect(await screen.findByText(/all read/)).toBeTruthy();
+  });
+
+  it('offers no bulk selection in the sent box, which has no read-state concept', async () => {
+    renderMailPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Sent' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'select all mail' })).toBeNull();
+    });
+  });
+
+  it('disables the bulk mark actions in read-only mode', async () => {
+    renderMailPage('/mail', { readOnly: true });
+    await screen.findByText('direct supervisor inbox');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'select all mail' }));
+    expect((screen.getByRole('button', { name: 'Mark read' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByRole('button', { name: 'Mark unread' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/routes/Mail.tsx
+++ b/frontend/src/routes/Mail.tsx
@@ -132,6 +132,14 @@ export function MailPage() {
 
   const [composing, setComposing] = useState(false);
 
+  // Bulk read-state selection (gascity-dashboard-mp3g). Lives in component
+  // state only; switching mailbox or reading-as identity clears it (different
+  // working set). Bulk marks reuse the same per-item supervisor writes the
+  // thread modal uses, then refresh() so the needs-you count — and the nav
+  // badge, which reads the same selectOperatorActionableUnread — stay in step.
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [bulkInFlight, setBulkInFlight] = useState<'read' | 'unread' | null>(null);
+
   const openThread = useCallback(
     async (mail: SupervisorMailItem) => {
       setThreadFor(mail);
@@ -302,6 +310,79 @@ export function MailPage() {
     searchOf: MAIL_SEARCH_FIELDS,
     chips: mailChips,
   });
+
+  // Sent mail has no read-state to manage, so bulk selection is offered only on
+  // inbox / all — the same boxes that surface the read-state chips.
+  const selectable = box !== 'sent';
+  const visibleRows = useMemo(() => filters.groups.flatMap((g) => g.rows), [filters.groups]);
+  const selectedCount = useMemo(
+    () => visibleRows.reduce((n, r) => (selectedIds.has(r.id) ? n + 1 : n), 0),
+    [visibleRows, selectedIds],
+  );
+  const allSelected = visibleRows.length > 0 && selectedCount === visibleRows.length;
+
+  useEffect(() => {
+    setSelectedIds(new Set<string>());
+  }, [box, viewingAs.alias]);
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds(allSelected ? new Set<string>() : new Set(visibleRows.map((r) => r.id)));
+  }, [allSelected, visibleRows]);
+
+  const runBulkMark = useCallback(
+    async (read: boolean) => {
+      if (readOnly) return;
+      // Only write rows whose state actually changes — never re-mark a row that
+      // is already in the target state (DESIGN.md: no second mark).
+      const targets = visibleRows.filter((r) => selectedIds.has(r.id) && r.read !== read);
+      if (targets.length === 0) return;
+      setBulkInFlight(read ? 'read' : 'unread');
+      setError(null);
+      try {
+        await Promise.all(
+          targets.map((m) => (read ? markSupervisorMailRead(m) : markSupervisorMailUnread(m))),
+        );
+        setSelectedIds(new Set<string>());
+      } catch (err) {
+        setError(formatApiError(err, `bulk mark ${read ? 'read' : 'unread'} failed`));
+      } finally {
+        setBulkInFlight(null);
+        // Re-read so the table, the needs-you synopsis, and the nav badge all
+        // reflect server truth — even when a subset of the writes failed.
+        await refresh();
+      }
+    },
+    [readOnly, visibleRows, selectedIds, refresh],
+  );
+
+  const selectColumn = useMemo<TableColumn<SupervisorMailItem>>(
+    () => ({
+      key: '__select',
+      label: '',
+      className: 'w-8',
+      render: (r) => (
+        <input
+          type="checkbox"
+          className="h-3.5 w-3.5 translate-y-[2px] cursor-pointer accent-fg focus-mark"
+          checked={selectedIds.has(r.id)}
+          onChange={() => toggleSelect(r.id)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`select mail: ${r.subject}`}
+        />
+      ),
+    }),
+    [selectedIds, toggleSelect],
+  );
+  const tableColumns = selectable ? [selectColumn, ...columns] : columns;
   // gascity-dashboard-s464: mail is not an alert by default. We keep the
   // data-attention-severity attribute (so the home-alerts panel and
   // keyboard nav still see flagged rows), but DO NOT paint the warn/accent
@@ -415,9 +496,23 @@ export function MailPage() {
             )}
           </div>
 
+          {selectable && visibleRows.length > 0 && (
+            <div className="mb-6">
+              <MailSelectionBar
+                selectedCount={selectedCount}
+                allSelected={allSelected}
+                onToggleAll={toggleSelectAll}
+                onMarkRead={() => void runBulkMark(true)}
+                onMarkUnread={() => void runBulkMark(false)}
+                bulkInFlight={bulkInFlight}
+                readOnly={readOnly}
+              />
+            </div>
+          )}
+
           <GroupedTable
             groups={filters.groups}
-            columns={columns}
+            columns={tableColumns}
             rowKey={(r) => r.id}
             onToggleProject={filters.toggleProject}
             onRowClick={(r) => void openThread(r)}
@@ -530,6 +625,78 @@ function BoxTabs({ box, onChange }: { box: MailBox; onChange: (b: MailBox) => vo
           {b === 'all' ? 'All' : capitalize(b)}
         </button>
       ))}
+    </div>
+  );
+}
+
+// Editorial bulk-action line (gascity-dashboard-mp3g): a select-all affordance
+// and the read-state writes for the selected set, on one hairline-ruled row.
+// Flat page register — no card, no sticky toolbar; words on every action so the
+// row reads in greyscale (DESIGN.md §States).
+function MailSelectionBar({
+  selectedCount,
+  allSelected,
+  onToggleAll,
+  onMarkRead,
+  onMarkUnread,
+  bulkInFlight,
+  readOnly,
+}: {
+  selectedCount: number;
+  allSelected: boolean;
+  onToggleAll: () => void;
+  onMarkRead: () => void;
+  onMarkUnread: () => void;
+  bulkInFlight: 'read' | 'unread' | null;
+  readOnly: boolean;
+}) {
+  const allRef = useRef<HTMLInputElement>(null);
+  const someSelected = selectedCount > 0;
+  useEffect(() => {
+    if (allRef.current !== null) allRef.current.indeterminate = someSelected && !allSelected;
+  }, [someSelected, allSelected]);
+  const busy = bulkInFlight !== null;
+  const title = readOnly ? READ_ONLY_CONTROL_TITLE : undefined;
+  return (
+    <div
+      className="flex items-baseline justify-between gap-4 flex-wrap border-b border-rule pb-3"
+      role="region"
+      aria-label="bulk mail selection"
+    >
+      <label className="flex items-baseline gap-2 text-label uppercase tracking-wider text-fg-muted cursor-pointer">
+        <input
+          ref={allRef}
+          type="checkbox"
+          className="h-3.5 w-3.5 translate-y-[2px] cursor-pointer accent-fg focus-mark"
+          checked={allSelected}
+          onChange={onToggleAll}
+          aria-label="select all mail"
+        />
+        <span>{someSelected ? `${selectedCount} selected` : 'Select all'}</span>
+      </label>
+      {someSelected && (
+        <div className="flex items-baseline gap-3">
+          {readOnly && <ReadOnlyBadge />}
+          <Button
+            size="sm"
+            tone="quiet"
+            onClick={onMarkRead}
+            disabled={readOnly || busy}
+            title={title}
+          >
+            {bulkInFlight === 'read' ? 'Marking' : 'Mark read'}
+          </Button>
+          <Button
+            size="sm"
+            tone="quiet"
+            onClick={onMarkUnread}
+            disabled={readOnly || busy}
+            title={title}
+          >
+            {bulkInFlight === 'unread' ? 'Marking' : 'Mark unread'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Mail bulk-select / mark read-unread / select-all (gascity-dashboard-mp3g @9898fa1, Stephanie request). Reviewed via dashboard ship pipeline (sentinel ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)