### PR TITLE
fix(nav): unify nav-attention SSE (2j8e.7)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,19 @@
-import { Suspense, lazy, useMemo } from 'react';
+import { Suspense, lazy, useMemo, type ReactNode } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { api } from './api/client';
 import { AttentionProvider } from './attention/context';
 import { useLiveAttentionContributors } from './attention/liveContributors';
 import { Layout } from './components/Layout';
 import { NowProvider } from './contexts/NowContext';
-import { OperatorConfigProvider, resolveOperatorConfig } from './contexts/OperatorConfigContext';
+import {
+  OperatorConfigProvider,
+  resolveOperatorConfig,
+  type OperatorConfig,
+} from './contexts/OperatorConfigContext';
 import { ReadOnlyProvider, resolveReadOnly } from './contexts/ReadOnlyContext';
 import { ViewingAsProvider } from './contexts/ViewingAsContext';
 import { useCachedData } from './hooks/useCachedData';
+import { RunSummaryProvider, useRunSummary } from './runs/runSummarySubscription';
 import { ALL_VIEWS } from './views/registry';
 import { filterEnabledViews, resolveDefaultViewWithLogging } from './views/resolve';
 
@@ -45,10 +50,9 @@ export function App() {
   // gate stays the real enforcement throughout.
   const readOnly = resolveReadOnly(config, configError);
   // Operator identity from /config (gascity-dashboard-bhvn). Resolved once and
-  // shared by the attention hook (which runs in App's body, outside the
-  // provider tree) and the OperatorConfigProvider below.
+  // shared by the AttentionRoot (which computes contributors under the
+  // RunSummaryProvider) and the OperatorConfigProvider below.
   const operator = resolveOperatorConfig(config);
-  const attentionContributors = useLiveAttentionContributors(enabledModules, operator);
 
   const enabledViews = useMemo(
     () => filterEnabledViews(ALL_VIEWS, enabledModules),
@@ -72,51 +76,72 @@ export function App() {
       <ViewingAsProvider>
         <NowProvider>
           <ReadOnlyProvider readOnly={readOnly}>
-            <AttentionProvider contributors={attentionContributors}>
-              <Layout>
-                <Suspense fallback={null}>
-                  <Routes>
-                    {/* `/` resolution (PRD §6 / bead 9yj.5):
+            <RunSummaryProvider>
+              <AttentionRoot enabledModules={enabledModules} operator={operator}>
+                <Layout>
+                  <Suspense fallback={null}>
+                    <Routes>
+                      {/* `/` resolution (PRD §6 / bead 9yj.5):
                   DEFAULT_VIEW env → descriptor `defaultRoute: true` →
                   kb3 ambient home fallback. The resolver runs once per
                   enabled-set / env change; warnings surface in the
                   browser console for premortem #5 visibility. */}
-                    <Route
-                      path="/"
-                      element={
-                        defaultRedirectTo !== null ? (
-                          <Navigate to={defaultRedirectTo} replace />
-                        ) : DefaultViewElement !== null ? (
-                          <DefaultViewElement />
-                        ) : (
-                          <AmbientHomePage />
-                        )
-                      }
-                    />
-                    <Route path="/agents" element={<AgentsPage />} />
-                    <Route path="/agents/:slug" element={<AgentDetailPage />} />
-                    <Route path="/beads" element={<BeadsPage />} />
-                    <Route path="/runs" element={<RunsPage />} />
-                    <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
-                    <Route path="/mail" element={<MailPage />} />
-                    {/* Modular-dashboard registry routes, filtered by the
+                      <Route
+                        path="/"
+                        element={
+                          defaultRedirectTo !== null ? (
+                            <Navigate to={defaultRedirectTo} replace />
+                          ) : DefaultViewElement !== null ? (
+                            <DefaultViewElement />
+                          ) : (
+                            <AmbientHomePage />
+                          )
+                        }
+                      />
+                      <Route path="/agents" element={<AgentsPage />} />
+                      <Route path="/agents/:slug" element={<AgentDetailPage />} />
+                      <Route path="/beads" element={<BeadsPage />} />
+                      <Route path="/runs" element={<RunsPage />} />
+                      <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
+                      <Route path="/mail" element={<MailPage />} />
+                      {/* Modular-dashboard registry routes, filtered by the
                   backend's enabledModules set. A disabled module's path
                   is absent so deep-link bookmarks surface the operator's
                   MODULES_ENABLED change as the explicit catch-all route. */}
-                    {enabledViews.map((v) => {
-                      const Element = v.element;
-                      return <Route key={v.id} path={v.path} element={<Element />} />;
-                    })}
-                    <Route path="*" element={<NotFoundPage />} />
-                  </Routes>
-                </Suspense>
-              </Layout>
-            </AttentionProvider>
+                      {enabledViews.map((v) => {
+                        const Element = v.element;
+                        return <Route key={v.id} path={v.path} element={<Element />} />;
+                      })}
+                      <Route path="*" element={<NotFoundPage />} />
+                    </Routes>
+                  </Suspense>
+                </Layout>
+              </AttentionRoot>
+            </RunSummaryProvider>
           </ReadOnlyProvider>
         </NowProvider>
       </ViewingAsProvider>
     </OperatorConfigProvider>
   );
+}
+
+/**
+ * Compute the live attention contributors under the RunSummaryProvider so the
+ * Runs badge reads the same shared run-summary source the /runs page renders
+ * (gascity-dashboard-2j8e.7), then expose the composed model to the tree.
+ */
+function AttentionRoot({
+  enabledModules,
+  operator,
+  children,
+}: {
+  enabledModules: readonly string[] | null;
+  operator: OperatorConfig;
+  children: ReactNode;
+}) {
+  const { source } = useRunSummary();
+  const contributors = useLiveAttentionContributors(enabledModules, operator, source);
+  return <AttentionProvider contributors={contributors}>{children}</AttentionProvider>;
 }
 
 function NotFoundPage() {

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -1,10 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { invalidate } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
 import type { OperatorConfig } from '../contexts/OperatorConfigContext';
 import { composeAttention } from './compose';
-import { useLiveAttentionContributors } from './liveContributors';
+import { runsFactsFromSource, useLiveAttentionContributors } from './liveContributors';
 
 // Operator identity the live hook reads from /config (gascity-dashboard-bhvn).
 const testOperator: OperatorConfig = {
@@ -12,6 +13,34 @@ const testOperator: OperatorConfig = {
   operatorWireAlias: 'human',
   decisionLabel: 'needs/stephanie',
 };
+
+function freshRunsSource(): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-06-01T00:00:00.000Z',
+    staleAt: '2026-06-01T00:01:00.000Z',
+    error: { kind: 'none' },
+    data: {
+      totalActive: 0,
+      totalHistorical: 0,
+      historicalLanes: [],
+      blockedLanes: [],
+      runCounts: {
+        total: 0,
+        visible: 0,
+        prReview: 0,
+        designReview: 0,
+        bugfix: 0,
+        blocked: 0,
+        other: 0,
+      },
+      lanes: [],
+      recentChanges: [],
+      census: { status: 'unavailable', error: 'run health has not been derived' },
+    },
+  };
+}
 
 const mockApi = vi.hoisted(() => ({
   doltTrend: vi.fn(),
@@ -279,16 +308,17 @@ describe('useLiveAttentionContributors', () => {
   });
 
   it('composes Home/nav attention from direct supervisor facts and enabled dashboard-local module facts', async () => {
-    const { result } = renderHook(() => useLiveAttentionContributors(['maintainer'], testOperator));
+    const { result } = renderHook(() =>
+      useLiveAttentionContributors(['maintainer'], testOperator, undefined),
+    );
 
     await waitFor(() => {
       const model = composeAttention(result.current);
-      // gascity-dashboard-2j8e.2: the Runs badge now counts genuinely-blocked
-      // runs from the bead-derived run summary, not the formula feed. This
-      // fixture has no graph.v2 run beads (only a plain task bead + a city feed
-      // item), so there are no blocked runs to count. The blocked-counting
-      // logic is covered in registry.test.ts; here we assert the contributor is
-      // wired to the summary loader (listBeads({ limit: 500 }) below).
+      // gascity-dashboard-2j8e.7: the Runs badge reads the shared run-summary
+      // subscription (passed in as the runsSource arg), not its own fan-out.
+      // With no source here it contributes nothing; the blocked-counting logic
+      // is covered in registry.test.ts and the source projection in
+      // runsFactsFromSource below.
       expect(model.byDomain.runs.attention).toBe(0);
       // gascity-dashboard-2j8e.4: the one agent ('reviewer') is both in a
       // failure state AND awaiting an input decision; selectAgentsNeedingYou
@@ -304,9 +334,6 @@ describe('useLiveAttentionContributors', () => {
       expect(model.byDomain.maintainer.attention).toBe(1);
     });
 
-    // The Runs contributor drives the bead-derived run summary loader, whose
-    // required read is the active run-bead list (gascity-dashboard-2j8e.2).
-    expect(mockSupervisorApi.listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
     expect(mockSupervisorApi.listAgents).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApi.listSessions).toHaveBeenCalledWith('test-city');
     expect(mockSupervisorApi.sessionPending).toHaveBeenCalledWith('test-city', 'gc-2568');
@@ -331,27 +358,31 @@ describe('useLiveAttentionContributors', () => {
     expect(mockApi.doltTrend).toHaveBeenCalledTimes(1);
   });
 
-  it('drives the runs badge from the full run-summary snapshot, not the cheap preview (gascity-dashboard-2j8e.6)', async () => {
-    const { result } = renderHook(() => useLiveAttentionContributors(['maintainer'], testOperator));
+  it('projects the shared run-summary source onto the Runs badge facts (gascity-dashboard-2j8e.7)', () => {
+    // The badge reads the SAME source object the /runs page renders, so a fresh
+    // source carries its summary + status through, an error source carries the
+    // message, and an absent source contributes nothing — by-construction parity
+    // with no second fan-out.
+    expect(runsFactsFromSource(undefined)).toBeUndefined();
 
-    await waitFor(() => {
-      // The runs contributor has resolved (no blocked graph.v2 runs in this
-      // fixture, so 0 — the count itself is exercised in registry.test.ts).
-      expect(composeAttention(result.current).byDomain.runs.attention).toBe(0);
+    const errorFacts = runsFactsFromSource({
+      source: 'runs',
+      status: 'error',
+      error: 'supervisor warming up',
     });
+    expect(errorFacts).toEqual({ error: 'supervisor warming up', provenance: 'error' });
 
-    // The badge must read the SAME complete snapshot the /runs page renders.
-    // The page upgrades to the full source (REFRESH_ENRICHMENT_TIMEOUT_MS = 30s,
-    // session-enriched) on its first refresh; the badge previously stayed on the
-    // 2.5s preview budget and persistently undercounted blocked runs
-    // (gascity-dashboard-2j8e.6). The 30s enrichment budget is unique to the full
-    // run-summary source, so its presence proves the badge is on the full path
-    // (the old preview path only ever used the 2.5s / 5s budgets).
-    expect(mockSupervisorApiForRequestBudget).toHaveBeenCalledWith(30_000);
+    const fresh = freshRunsSource();
+    const freshFacts = runsFactsFromSource(fresh);
+    expect(freshFacts?.summary).toBe(fresh.status === 'error' ? undefined : fresh.data);
+    expect(freshFacts?.provenance).toBe('fresh');
+    expect(freshFacts?.fetchedAt).toBe('2026-06-01T00:00:00.000Z');
   });
 
   it('does not fetch maintainer triage before the enabled module config is loaded', async () => {
-    const { result } = renderHook(() => useLiveAttentionContributors(null, testOperator));
+    const { result } = renderHook(() =>
+      useLiveAttentionContributors(null, testOperator, undefined),
+    );
 
     await waitFor(() => {
       const model = composeAttention(result.current);
@@ -363,7 +394,7 @@ describe('useLiveAttentionContributors', () => {
   });
 
   it('does not fetch maintainer triage when the maintainer module is disabled', async () => {
-    const { result } = renderHook(() => useLiveAttentionContributors([], testOperator));
+    const { result } = renderHook(() => useLiveAttentionContributors([], testOperator, undefined));
 
     await waitFor(() => {
       const model = composeAttention(result.current);

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { type SourceStatus } from 'gas-city-dashboard-shared';
+import { type RunSummary, type SourceState } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { type OperatorConfig } from '../contexts/OperatorConfigContext';
@@ -8,7 +8,6 @@ import { listAgentPendingInteractions } from '../supervisor/agentPending';
 import { listSupervisorBeads } from '../supervisor/beadReads';
 import { supervisorApi, supervisorApiForRequestBudget } from '../supervisor/client';
 import { DEFAULT_MAIL_HISTORY_LIMIT, listSupervisorMail } from '../supervisor/mailReads';
-import { loadSupervisorRunSummarySource } from '../supervisor/runSummary';
 import type { AttentionContributor } from './compose';
 import {
   createAttentionContributors,
@@ -31,6 +30,7 @@ const HEALTH_ATTENTION_SUPERVISOR_TIMEOUT_MS = 2_500;
 export function useLiveAttentionContributors(
   enabledModules: readonly string[] | null,
   operator: OperatorConfig,
+  runsSource: SourceState<RunSummary> | undefined,
 ): readonly AttentionContributor[] {
   const cityName = getActiveCity();
   const cacheSuffix = cityName ?? 'no-city';
@@ -40,9 +40,10 @@ export function useLiveAttentionContributors(
   // pre-config fallback → real-config transition refetches with the resolved
   // identity (useCachedData only refetches on key change).
   const { decisionLabel, operatorWireAlias } = operator;
-  const runs = useCachedData<RunsAttentionFacts>(`attention:runs:${cacheSuffix}`, () =>
-    fetchRunsAttention(cityName),
-  );
+  // gascity-dashboard-2j8e.7: the Runs badge reads the SAME shared run-summary
+  // subscription the /runs page renders (passed in as runsSource), not its own
+  // fan-out — one fetch, by-construction parity, and SSE refresh reach the badge.
+  const runs = useMemo(() => runsFactsFromSource(runsSource), [runsSource]);
   const agents = useCachedData<AgentsAttentionFacts>(`attention:agents:${cacheSuffix}`, () =>
     fetchAgentsAttention(cityName),
   );
@@ -75,71 +76,31 @@ export function useLiveAttentionContributors(
           health: health.data,
           mail: mail.data,
           maintainer: maintainer.data,
-          runs: withRunsFreshness(runs.data, runs.error, runs.fetchedAt),
+          runs,
         }),
       ),
-    [
-      activity.data,
-      agents.data,
-      beads.data,
-      health.data,
-      mail.data,
-      maintainer.data,
-      runs.data,
-      runs.error,
-      runs.fetchedAt,
-    ],
+    [activity.data, agents.data, beads.data, health.data, mail.data, maintainer.data, runs],
   );
 }
 
 /**
- * Stamp the runs read's provenance + fetch timestamp onto its facts so the
- * registry can carry them onto `unavailable`-tier items. A degraded read can
- * then be aged (gascity-dashboard issue-88 follow-up) rather than rendered as
- * current truth. The cache is event-refreshed (no TTL), so provenance is the
- * coarse read status — `error` on failure, otherwise `fresh`; `fetchedAt`
+ * Project the shared run-summary subscription's source onto the Runs badge
+ * facts. The badge counts genuinely-blocked runs from `summary.blockedLanes` —
+ * the same selectBlockedRuns the /runs page renders — so reading the page's exact
+ * source object makes the badge and the page agree by construction, not merely by
+ * shared selector (gascity-dashboard-2j8e.7). The source's own status flows
+ * through as provenance and is carried onto `unavailable`-tier items so a
+ * degraded read can be aged rather than rendered as current truth; `fetchedAt`
  * carries the exact read time for any age comparison.
  */
-function withRunsFreshness(
-  facts: RunsAttentionFacts | undefined,
-  error: string | null,
-  fetchedAt: string | undefined,
+export function runsFactsFromSource(
+  source: SourceState<RunSummary> | undefined,
 ): RunsAttentionFacts | undefined {
-  if (facts === undefined) return undefined;
-  const provenance: SourceStatus =
-    error !== null || (facts.error !== undefined && facts.error.length > 0) ? 'error' : 'fresh';
-  return { ...facts, provenance, ...(fetchedAt === undefined ? {} : { fetchedAt }) };
-}
-
-async function fetchRunsAttention(cityName: string | null): Promise<RunsAttentionFacts> {
-  if (cityName === null) return {};
-  // gascity-dashboard-2j8e.6: the badge must derive its genuinely-blocked count
-  // from the SAME COMPLETE snapshot the /runs page renders, not just the same
-  // selector. #95 (2j8e.2) unified the selector (selectBlockedRuns) but left the
-  // badge on the cheap preview source while the page upgrades to the full source
-  // on its first refresh — so the two read DIFFERENT-completeness snapshots and
-  // the badge persistently undercounted (operator saw page Blocked(4), nav badge
-  // empty). The preview budget (2.5s) lets the recent-run fan-out time out under
-  // a slow supervisor, dropping the very lanes that map to `phase === 'blocked'`;
-  // the page's full source (30s budget + session enrichment) loads them. Reading
-  // the full source here makes the badge's blocked set as complete as the page's,
-  // so the counts agree in steady state rather than only "by construction" over a
-  // snapshot neither side actually shares.
-  //
-  // The formula feed (the pre-#95 source) stays dropped: it counted phantom
-  // feed-only roots and flapped on partial fan-outs.
-  //
-  // This still refetches under the attention cache key rather than sharing the
-  // page's `runs:summary:*` entry, so on /runs the fan-out runs twice. The fetch
-  // is mount-driven (no recurring poll), so the cost is bounded to cold load /
-  // city switch; lifting the run summary into one shared subscription that both
-  // the header badge and the page read is the proper follow-up (a cross-cutting
-  // change kept out of this focused parity fix).
-  const source = await loadSupervisorRunSummarySource();
+  if (source === undefined) return undefined;
   if (source.status === 'error') {
-    return { error: source.error };
+    return { error: source.error, provenance: 'error' };
   }
-  return { summary: source.data };
+  return { summary: source.data, provenance: source.status, fetchedAt: source.fetchedAt };
 }
 
 async function fetchAgentsAttention(cityName: string | null): Promise<AgentsAttentionFacts> {

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -12,6 +12,7 @@ import { invalidateKey } from '../api/cache';
 import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor } from '../attention/compose';
 import { RunsPage } from './Runs';
+import { RunSummaryProvider } from '../runs/runSummarySubscription';
 import { MemoryRouter } from 'react-router-dom';
 import { NowProvider } from '../contexts/NowContext';
 import {
@@ -197,7 +198,9 @@ function mount(initialPath = '/runs', contributors: readonly AttentionContributo
     >
       <NowProvider intervalMs={1_000_000}>
         <AttentionProvider contributors={contributors}>
-          <RunsPage />
+          <RunSummaryProvider>
+            <RunsPage />
+          </RunSummaryProvider>
         </AttentionProvider>
       </NowProvider>
     </MemoryRouter>,

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -1,13 +1,6 @@
-import {
-  GC_EVENT_PREFIX,
-  type RunLane,
-  type RunSummary,
-  type SourceState,
-  type SourceStatus,
-} from 'gas-city-dashboard-shared';
-import { useCallback, useEffect, useRef } from 'react';
+import { type RunLane, type RunSummary, type SourceState } from 'gas-city-dashboard-shared';
+import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { getActiveCity } from '../api/cityBase';
 import { useAttentionModel } from '../attention/context';
 import { resourceAttentionSeverity } from '../attention/routeHighlight';
 import { Button } from '../components/Button';
@@ -17,72 +10,37 @@ import { SseIndicator } from '../components/SseIndicator';
 import { RunMap, RUNS_HISTORICAL_SECTION_ID } from '../components/run/RunMap';
 import { useNow } from '../contexts/NowContext';
 import { formatRelative } from '../hooks/time';
-import { useCachedData } from '../hooks/useCachedData';
-import { useGcEventRefresh } from '../hooks/useGcEvents';
-import {
-  loadSupervisorRunSummaryPreviewSource,
-  loadSupervisorRunSummarySource,
-} from '../supervisor/runSummary';
+import { useRunSummary } from '../runs/runSummarySubscription';
 
-// /runs route (gascity-dashboard-0t6, made live in
-// gascity-dashboard-bqn). Reads the direct supervisor run summary source
-// through useCachedData for the initial cache-warm paint. Both the manual
-// Refresh button and the SSE-driven onMatch callback share that one loader
-// path, so the in-memory run-summary cache and React state always reflect the
-// same refresh result — no last-write-wins race between concurrent initial
-// load and event-driven refresh.
+// /runs route (gascity-dashboard-0t6, made live in gascity-dashboard-bqn). The
+// fetch, SSE refresh, and degraded-load retry now live in the shared
+// run-summary subscription (gascity-dashboard-2j8e.7), which the nav badge reads
+// too — so the page and the badge render the same source by construction. This
+// component is the source's renderer: it owns only the ?history=1 toggle,
+// freshness label, and lane layout.
 //
-// Live updates: useGcEventRefresh subscribes to the direct supervisor city
-// event stream and
-// fires onMatch when a bead.* event arrives. The hook coalesces its
-// own bursts to ~1 fire per 2.5s; we layer a 10s in-component debounce
-// floor on top because runs refresh triggers a full upstream
-// supervisor listBeads({ limit: 1000 }) call (architect H2 — upstream-load
-// protection during slung-pipeline bursts). The callback also no-ops
-// when the runs source is in fixture-fallback mode (gc down) so
-// the dashboard's own host doesn't get hammered with loadFixture calls
-// every coalesce tick during a gc outage (architect H1).
-//
-// The app-level NowProvider refreshes relative-time labels in lane cards;
-// SSE is the path for actual data updates.
+// The app-level NowProvider refreshes relative-time labels in lane cards; the
+// shared subscription's SSE path drives actual data updates.
 
-const REFRESH_DEBOUNCE_MS = 10_000;
-// gascity-dashboard-4xcv: bounded retry backoff for a degraded first load
-// (error source, or a partial fetch that produced zero lanes). The operator
-// saw an empty tab that needed 2-3 manual refreshes; these retries recover
-// transient supervisor warm-up failures without her. After the budget is
-// spent, SSE events and the manual Refresh button take over.
-const RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 const RUN_PHASE_GRAMMAR = 'Phase grammar: intake, implementation, review, approval, finalization.';
 const HISTORY_QUERY_PARAM = 'history';
 const HISTORY_QUERY_VALUE = '1';
 
 export function RunsPage() {
   const attention = useAttentionModel();
-  const cityName = getActiveCity();
-  const { data, loading, error, refresh } = useCachedData(
-    `runs:summary:${cityName ?? 'no-city'}`,
-    loadSupervisorRunSummaryPreviewSource,
-    { refreshFetcher: loadSupervisorRunSummarySource },
-  );
+  const { source: data, loading, error, refresh, sseState } = useRunSummary();
   const [searchParams, setSearchParams] = useSearchParams();
   // gascity-dashboard-yh5i: ?history=1 toggles the historical lane
   // section. Pure render-time state — the summary already carries both
   // active + historical arrays, so the toggle does not trigger a fetch
-  // and useCachedData's run-summary cache key stays stable across modes.
+  // and the shared run-summary subscription stays stable across modes.
   const showHistory = searchParams.get(HISTORY_QUERY_PARAM) === HISTORY_QUERY_VALUE;
   const now = useNow();
-  const runsStatusRef = useRef<SourceStatus | null>(null);
-  const loadingRef = useRef(loading);
-  loadingRef.current = loading;
-  const lastRefreshAtRef = useRef(0);
   const runs = data ?? null;
-  runsStatusRef.current = runs?.status ?? null;
   const runsData =
     runs?.status === 'fresh' || runs?.status === 'fixture' || runs?.status === 'stale'
       ? runs.data
       : null;
-  const fullRefreshKeyRef = useRef<string | null>(null);
   const totalHistorical = runsData?.totalHistorical ?? 0;
   // gascity-dashboard-n6f1: the backend now degrades (not collapses) when a
   // single rig's recent-run query fails, flagging lanesPartial. Surface it
@@ -105,64 +63,6 @@ export function RunsPage() {
     );
   }, [showHistory, setSearchParams]);
 
-  useEffect(() => {
-    if (runs === null || runs.status === 'error') return;
-    const refreshKey = cityName ?? 'no-city';
-    if (fullRefreshKeyRef.current === refreshKey) return;
-    fullRefreshKeyRef.current = refreshKey;
-    void refresh().catch(() => {
-      fullRefreshKeyRef.current = null;
-    });
-  }, [cityName, refresh, runs]);
-
-  // gascity-dashboard-4xcv: bounded auto-retry on a degraded load. An error
-  // source (or a partial fetch with zero lanes) used to latch the page dead:
-  // the SSE callback skipped non-fresh sources and the one-time full refresh
-  // bailed on error, so only a manual Refresh recovered. Retry a few times
-  // with backoff, and reset the budget once a healthy load lands.
-  const retryAttemptRef = useRef(0);
-  useEffect(() => {
-    if (runs === null) return;
-    const degraded =
-      runs.status === 'error'
-        ? true
-        : runs.data.lanesPartial === true &&
-          runs.data.lanes.length === 0 &&
-          runs.data.blockedLanes.length === 0;
-    if (!degraded) {
-      retryAttemptRef.current = 0;
-      return;
-    }
-    const delay = RETRY_DELAYS_MS[retryAttemptRef.current];
-    if (delay === undefined) return;
-    retryAttemptRef.current += 1;
-    const timer = setTimeout(() => void refresh(), delay);
-    return () => clearTimeout(timer);
-  }, [runs, refresh]);
-
-  const onSseMatch = useCallback(() => {
-    // Skip when fixtures are serving (supervisor down) — every forced
-    // refresh under fixture-fallback re-runs loadFixture(), which is wasted
-    // file IO. An 'error' or 'stale' source is the opposite case: a bead
-    // event is exactly the cue to try loading live data again
-    // (gascity-dashboard-4xcv).
-    if (runsStatusRef.current === null || runsStatusRef.current === 'fixture') return;
-    // Skip when an explicit refresh is already in flight. Without this
-    // guard, a fast SSE event firing while a slow upstream call is
-    // still resolving lets two requests race; older-completion can
-    // overwrite newer data via last-write-wins in setCached.
-    if (loadingRef.current) return;
-    const elapsed = Date.now() - lastRefreshAtRef.current;
-    if (elapsed < REFRESH_DEBOUNCE_MS) return;
-    lastRefreshAtRef.current = Date.now();
-    void refresh().catch(() => {
-      // Reset on error so the next event retries instead of being
-      // silently dropped for the rest of the 10s debounce window.
-      lastRefreshAtRef.current = 0;
-    });
-  }, [refresh]);
-
-  const sseState = useGcEventRefresh([GC_EVENT_PREFIX.bead], onSseMatch);
   const runAttentionSeverity = useCallback(
     (lane: RunLane) => resourceAttentionSeverity(attention, 'runs', lane.id),
     [attention],

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -142,6 +142,48 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     expect(screen.getByTestId('page').textContent).toBe('fresh:1');
   });
 
+  it('queues a trailing refresh when an SSE event lands mid-load (no stale latch)', async () => {
+    // The exact race the CI flake exposed: an SSE event arrives WHILE a load is
+    // already in flight. That load started before the event, so it can return
+    // the pre-event snapshot — if the event is dropped, the snapshot latches
+    // stale and every consumer drifts. Park the full upgrade in flight to drive
+    // the race deterministically instead of relying on machine speed.
+    let resolveFull: (source: SourceState<RunSummary>) => void = () => {};
+    mockFull.mockImplementationOnce(
+      () =>
+        new Promise<SourceState<RunSummary>>((resolve) => {
+          resolveFull = resolve;
+        }),
+    );
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="badge" />
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // The full upgrade has been kicked off and is parked, mid-flight.
+    await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
+
+    // A bead event lands while the load is in flight; the next load must carry
+    // the newly-blocked run.
+    mockFull.mockResolvedValue(buildRunSource('fresh', 1));
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    // Let the in-flight load settle with the pre-event snapshot...
+    await act(async () => {
+      resolveFull(buildRunSource('fresh', 0));
+    });
+
+    // ...and the queued trailing refresh reconciles every consumer to the
+    // post-event snapshot — no stale latch, no drift.
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('fresh:1'));
+    expect(screen.getByTestId('page').textContent).toBe('fresh:1');
+  });
+
   it('throws when used outside a RunSummaryProvider', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => renderHook(() => useRunSummary())).toThrow(/RunSummaryProvider/);

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -1,0 +1,150 @@
+import { act, cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { type RunSummary, type SourceState, type SourceStatus } from 'gas-city-dashboard-shared';
+import { invalidateKey } from '../api/cache';
+import { setActiveCity } from '../api/cityBase';
+import {
+  loadSupervisorRunSummaryPreviewSource,
+  loadSupervisorRunSummarySource,
+} from '../supervisor/runSummary';
+import { RunSummaryProvider, useRunSummary } from './runSummarySubscription';
+
+// gascity-dashboard-2j8e.7: the nav badge and the /runs page used to run two
+// separate run-summary fan-outs (separate cache keys) and the badge never
+// SSE-refreshed, so it double-fetched on /runs and drifted after mount. This
+// pins the unification: ONE provider-owned subscription serves every consumer
+// (one fan-out) and an SSE event refreshes the source every consumer reads
+// (no post-mount drift).
+
+vi.mock('../supervisor/runSummary', () => ({
+  loadSupervisorRunSummaryPreviewSource: vi.fn(),
+  loadSupervisorRunSummarySource: vi.fn(),
+}));
+
+const lastHookCall: { prefixes: ReadonlyArray<string> | null; onMatch: (() => void) | null } = {
+  prefixes: null,
+  onMatch: null,
+};
+vi.mock('../hooks/useGcEvents', () => ({
+  useGcEventRefresh: vi.fn((prefixes: ReadonlyArray<string>, onMatch: () => void) => {
+    lastHookCall.prefixes = prefixes;
+    lastHookCall.onMatch = onMatch;
+    return 'open' as const;
+  }),
+}));
+
+const mockPreview = loadSupervisorRunSummaryPreviewSource as Mock;
+const mockFull = loadSupervisorRunSummarySource as Mock;
+
+function buildRunSource(
+  status: Exclude<SourceStatus, 'error'>,
+  blocked = 0,
+): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status,
+    fetchedAt: '2026-06-01T00:00:00.000Z',
+    staleAt: '2026-06-01T00:01:00.000Z',
+    error: { kind: 'none' },
+    data: {
+      totalActive: 0,
+      totalHistorical: 0,
+      historicalLanes: [],
+      blockedLanes: [],
+      runCounts: {
+        total: 0,
+        visible: 0,
+        prReview: 0,
+        designReview: 0,
+        bugfix: 0,
+        blocked,
+        other: 0,
+      },
+      lanes: [],
+      recentChanges: [],
+      census: { status: 'unavailable', error: 'run health has not been derived' },
+    },
+  };
+}
+
+// A stand-in for the two real consumers — the nav badge and the /runs page —
+// rendering the status + blocked count of the source it reads.
+function Consumer({ label }: { label: string }) {
+  const { source } = useRunSummary();
+  const blocked = source && source.status !== 'error' ? source.data.runCounts.blocked : -1;
+  return <div data-testid={label}>{`${source?.status ?? 'pending'}:${blocked}`}</div>;
+}
+
+beforeEach(() => {
+  setActiveCity('racoon-city');
+  mockPreview.mockReset();
+  mockFull.mockReset();
+  lastHookCall.prefixes = null;
+  lastHookCall.onMatch = null;
+  invalidateKey('runs:summary:racoon-city');
+  mockPreview.mockResolvedValue(buildRunSource('fresh'));
+  mockFull.mockResolvedValue(buildRunSource('fresh'));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e.7)', () => {
+  it('serves many consumers from a single fan-out (no double fetch)', async () => {
+    render(
+      <RunSummaryProvider>
+        <Consumer label="badge" />
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // One preview paint + one full upgrade for the whole tree, regardless of
+    // how many consumers read it — the badge no longer runs its own fan-out.
+    await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
+    expect(mockPreview).toHaveBeenCalledTimes(1);
+
+    // Both consumers read the same source object → identical render.
+    expect(screen.getByTestId('badge').textContent).toBe(screen.getByTestId('page').textContent);
+  });
+
+  it('subscribes to bead events once for the whole tree', async () => {
+    render(
+      <RunSummaryProvider>
+        <Consumer label="badge" />
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+    await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
+    expect(lastHookCall.prefixes).toEqual(['bead.']);
+    expect(typeof lastHookCall.onMatch).toBe('function');
+  });
+
+  it('refreshes every consumer on an SSE event (no post-mount drift)', async () => {
+    render(
+      <RunSummaryProvider>
+        <Consumer label="badge" />
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+    await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('badge').textContent).toBe('fresh:0');
+
+    // A bead event lands and the next load carries a newly-blocked run.
+    mockFull.mockResolvedValue(buildRunSource('fresh', 1));
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('fresh:1'));
+    // The page sees the same update in the same pass — they cannot drift apart.
+    expect(screen.getByTestId('page').textContent).toBe('fresh:1');
+  });
+
+  it('throws when used outside a RunSummaryProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useRunSummary())).toThrow(/RunSummaryProvider/);
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -104,17 +104,23 @@ export function useRunSummarySubscription(): RunSummarySubscription {
     return () => clearTimeout(timer);
   }, [runs, refresh]);
 
-  const onSseMatch = useCallback(() => {
-    // Skip when fixtures are serving (supervisor down) — every forced refresh
-    // under fixture-fallback re-runs loadFixture(), wasted file IO. An 'error'
-    // or 'stale' source is the opposite case: a bead event is exactly the cue
-    // to try loading live data again (gascity-dashboard-4xcv).
-    if (runsStatusRef.current === null || runsStatusRef.current === 'fixture') return;
-    // Skip when an explicit refresh is already in flight, so a fast SSE event
-    // can't race a slow upstream call into a last-write-wins overwrite.
-    if (loadingRef.current) return;
-    const elapsed = Date.now() - lastRefreshAtRef.current;
-    if (elapsed < REFRESH_DEBOUNCE_MS) return;
+  // A bead event arriving while a load is already in flight is queued, not
+  // dropped: that load started before the event, so it can return the pre-event
+  // snapshot, and dropping the event would latch it stale until the next event
+  // (post-mount drift — the exact thing 2j8e.7 exists to kill). One flag
+  // coalesces a whole in-flight burst into a single trailing refresh.
+  const pendingRefreshRef = useRef(false);
+  const trailingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runRefresh = useCallback(() => {
+    // Any refresh — leading or trailing — satisfies a queued trailing refresh,
+    // so cancel a pending trailing timer here rather than only in the effect
+    // cleanup: that closes the window where a leading refresh and a due-but-not-
+    // yet-fired trailing timer both run and double-fetch inside one floor.
+    if (trailingTimerRef.current !== null) {
+      clearTimeout(trailingTimerRef.current);
+      trailingTimerRef.current = null;
+    }
     lastRefreshAtRef.current = Date.now();
     void refresh().catch(() => {
       // Reset on error so the next event retries instead of being silently
@@ -122,6 +128,43 @@ export function useRunSummarySubscription(): RunSummarySubscription {
       lastRefreshAtRef.current = 0;
     });
   }, [refresh]);
+
+  const onSseMatch = useCallback(() => {
+    // Skip when fixtures are serving (supervisor down) — every forced refresh
+    // under fixture-fallback re-runs loadFixture(), wasted file IO. An 'error'
+    // or 'stale' source is the opposite case: a bead event is exactly the cue
+    // to try loading live data again (gascity-dashboard-4xcv).
+    if (runsStatusRef.current === null || runsStatusRef.current === 'fixture') return;
+    // A refresh is already in flight: a fast SSE event can't race it into a
+    // last-write-wins overwrite, but it must not be lost either — queue a single
+    // trailing refresh to reconcile once the in-flight load settles.
+    if (loadingRef.current) {
+      pendingRefreshRef.current = true;
+      return;
+    }
+    const elapsed = Date.now() - lastRefreshAtRef.current;
+    if (elapsed < REFRESH_DEBOUNCE_MS) return;
+    runRefresh();
+  }, [runRefresh]);
+
+  // Trailing edge: fire the queued refresh once the in-flight load settles. The
+  // debounce floor still applies on this edge — a slung-pipeline burst becomes
+  // one follow-up fan-out, not a hammer (architect H1/H2 upstream-load
+  // protection) — so a too-recent refresh defers to the remainder of the floor
+  // (remaining 0 → next tick). The handle lives in a ref so runRefresh can
+  // cancel it from the leading path too (see runRefresh).
+  useEffect(() => {
+    if (loading || !pendingRefreshRef.current) return;
+    pendingRefreshRef.current = false;
+    const remaining = Math.max(0, REFRESH_DEBOUNCE_MS - (Date.now() - lastRefreshAtRef.current));
+    trailingTimerRef.current = setTimeout(runRefresh, remaining);
+    return () => {
+      if (trailingTimerRef.current !== null) {
+        clearTimeout(trailingTimerRef.current);
+        trailingTimerRef.current = null;
+      }
+    };
+  }, [loading, runRefresh]);
 
   const sseState = useGcEventRefresh([GC_EVENT_PREFIX.bead], onSseMatch);
 

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -1,0 +1,144 @@
+import {
+  GC_EVENT_PREFIX,
+  type RunSummary,
+  type SourceState,
+  type SourceStatus,
+} from 'gas-city-dashboard-shared';
+import { createContext, useCallback, useContext, useEffect, useRef, type ReactNode } from 'react';
+import { getActiveCity } from '../api/cityBase';
+import { useCachedData } from '../hooks/useCachedData';
+import { useGcEventRefresh, type GcEventConnState } from '../hooks/useGcEvents';
+import {
+  loadSupervisorRunSummaryPreviewSource,
+  loadSupervisorRunSummarySource,
+} from '../supervisor/runSummary';
+
+// gascity-dashboard-2j8e.7: ONE shared, SSE-refreshed run-summary subscription.
+//
+// Before this, the /runs page and the nav attention badge each ran their OWN
+// full run-summary fan-out under separate cache keys (`runs:summary:*` vs
+// `attention:runs:*`), so visiting /runs fetched the supervisor twice, and the
+// badge — fetched once at mount with no SSE wiring — drifted from the live page
+// after any post-mount churn. This subscription is owned once at the App root
+// (always mounted, so the always-visible header badge stays live) and exposed
+// via context, so the badge and the page read literally the SAME source object:
+// one fan-out, by-construction parity, and a single SSE refresh path feeding
+// both. The page reads it through useRunSummary(); the badge reads its `source`
+// through the attention layer (liveContributors `runsFactsFromSource`).
+//
+// The fetch contract is unchanged from the page's prior implementation: the
+// cheap preview (2.5s budget) paints first, a one-time full refresh (30s,
+// session-enriched) upgrades the snapshot to the page-complete one, a bounded
+// backoff recovers a degraded first load, and SSE-driven refetches are gated by
+// an in-component debounce floor on top of useGcEventRefresh's own coalescing
+// (architect H1/H2 upstream-load protection during slung-pipeline bursts).
+
+const REFRESH_DEBOUNCE_MS = 10_000;
+// gascity-dashboard-4xcv: bounded retry backoff for a degraded first load (error
+// source, or a partial fetch that produced zero lanes). After the budget is
+// spent, SSE events and the manual Refresh button take over.
+const RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+
+export interface RunSummarySubscription {
+  /** The shared run-summary source state; undefined until the first read lands. */
+  source: SourceState<RunSummary> | undefined;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  sseState: GcEventConnState;
+}
+
+/**
+ * Own the single run-summary subscription: cache-warm preview paint, one-time
+ * full-source upgrade, bounded degraded-load retry, and SSE-driven refresh. Call
+ * once near the App root via {@link RunSummaryProvider}; everything else reads
+ * the result through {@link useRunSummary}.
+ */
+export function useRunSummarySubscription(): RunSummarySubscription {
+  const cityName = getActiveCity();
+  const { data, loading, error, refresh } = useCachedData(
+    `runs:summary:${cityName ?? 'no-city'}`,
+    loadSupervisorRunSummaryPreviewSource,
+    { refreshFetcher: loadSupervisorRunSummarySource },
+  );
+  const runs = data ?? null;
+  const runsStatusRef = useRef<SourceStatus | null>(null);
+  runsStatusRef.current = runs?.status ?? null;
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
+  const lastRefreshAtRef = useRef(0);
+
+  // Upgrade the cheap first-paint preview to the full session-enriched snapshot
+  // exactly once per city — the snapshot the page renders and the badge counts.
+  const fullRefreshKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (runs === null || runs.status === 'error') return;
+    const refreshKey = cityName ?? 'no-city';
+    if (fullRefreshKeyRef.current === refreshKey) return;
+    fullRefreshKeyRef.current = refreshKey;
+    void refresh().catch(() => {
+      fullRefreshKeyRef.current = null;
+    });
+  }, [cityName, refresh, runs]);
+
+  // gascity-dashboard-4xcv: bounded auto-retry on a degraded load. An error
+  // source (or a partial fetch with zero lanes) used to latch the page dead;
+  // retry a few times with backoff and reset once a healthy load lands.
+  const retryAttemptRef = useRef(0);
+  useEffect(() => {
+    if (runs === null) return;
+    const degraded =
+      runs.status === 'error'
+        ? true
+        : runs.data.lanesPartial === true &&
+          runs.data.lanes.length === 0 &&
+          runs.data.blockedLanes.length === 0;
+    if (!degraded) {
+      retryAttemptRef.current = 0;
+      return;
+    }
+    const delay = RETRY_DELAYS_MS[retryAttemptRef.current];
+    if (delay === undefined) return;
+    retryAttemptRef.current += 1;
+    const timer = setTimeout(() => void refresh(), delay);
+    return () => clearTimeout(timer);
+  }, [runs, refresh]);
+
+  const onSseMatch = useCallback(() => {
+    // Skip when fixtures are serving (supervisor down) — every forced refresh
+    // under fixture-fallback re-runs loadFixture(), wasted file IO. An 'error'
+    // or 'stale' source is the opposite case: a bead event is exactly the cue
+    // to try loading live data again (gascity-dashboard-4xcv).
+    if (runsStatusRef.current === null || runsStatusRef.current === 'fixture') return;
+    // Skip when an explicit refresh is already in flight, so a fast SSE event
+    // can't race a slow upstream call into a last-write-wins overwrite.
+    if (loadingRef.current) return;
+    const elapsed = Date.now() - lastRefreshAtRef.current;
+    if (elapsed < REFRESH_DEBOUNCE_MS) return;
+    lastRefreshAtRef.current = Date.now();
+    void refresh().catch(() => {
+      // Reset on error so the next event retries instead of being silently
+      // dropped for the rest of the debounce window.
+      lastRefreshAtRef.current = 0;
+    });
+  }, [refresh]);
+
+  const sseState = useGcEventRefresh([GC_EVENT_PREFIX.bead], onSseMatch);
+
+  return { source: data, loading, error, refresh, sseState };
+}
+
+const RunSummaryContext = createContext<RunSummarySubscription | null>(null);
+
+export function RunSummaryProvider({ children }: { children: ReactNode }) {
+  const subscription = useRunSummarySubscription();
+  return <RunSummaryContext.Provider value={subscription}>{children}</RunSummaryContext.Provider>;
+}
+
+export function useRunSummary(): RunSummarySubscription {
+  const subscription = useContext(RunSummaryContext);
+  if (subscription === null) {
+    throw new Error('useRunSummary must be used within a RunSummaryProvider');
+  }
+  return subscription;
+}

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -29,8 +29,9 @@ import { listIsIncomplete, listIsPartial } from './listPartial';
 import { normalizeSessions } from './sessionReads';
 
 // Pre-exposure load bound (gascity-dashboard-q89b): the primary in-flight
-// bead fetch refreshes on SSE bursts (10s debounce floor in Runs.tsx) per
-// client. listIsIncomplete keeps truncation visible in the lanes-partial signal.
+// bead fetch refreshes on SSE bursts (10s debounce floor in the shared
+// run-summary subscription) per client. listIsIncomplete keeps truncation
+// visible in the lanes-partial signal.
 const RUNS_FETCH_LIMIT = 500;
 // gascity-dashboard-4xcv: the supervisor's bead list has no sort/recency
 // guarantee, so a small `all=true` window can drop run roots and step beads
@@ -46,8 +47,9 @@ const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 5_000;
 // is best-effort: a miss degrades the lanes to "partial" rather than failing the
 // load. The budget is split by call site (gascity-dashboard-4bol). The preview
 // runs on first paint and blocks it, so it keeps a tight bound and the tab paints
-// fast even when the supervisor is slow. The full source runs only as Runs.tsx's
-// background refreshFetcher, so it can afford a far wider budget matching the 30s
+// fast even when the supervisor is slow. The full source runs only as the shared
+// run-summary subscription's background refreshFetcher, so it can afford a far
+// wider budget matching the 30s
 // background status samplers: on the bloated store the supervisor's list/feed
 // reads run ~10-38s (upstream gascity-dashboard#88), so a 2.5s interactive bound
 // always times out and latches a spurious "runs partial" badge. The wider refresh
@@ -78,20 +80,16 @@ const progressStateByCity = new Map<string, ProgressState>();
 // The wide-budget run-summary source (gascity-dashboard-4bol): the wide
 // enrichment budget lets slow-but-available list/feed reads land and clear the
 // spurious "runs partial" badge (upstream gascity-dashboard#88). It is the
-// /runs page's authoritative refresh snapshot.
+// authoritative refresh snapshot for the shared run-summary subscription
+// (runs/runSummarySubscription), which both the /runs page and the nav attention
+// badge read — so the badge counts the same genuinely-blocked runs the page
+// shows, by construction, off a single fan-out (gascity-dashboard-2j8e.7).
 //
 // Do NOT use this as a ROUTE first-paint fetcher — it can block a route view for
 // up to REFRESH_ENRICHMENT_TIMEOUT_MS; route mount consumers (Home, Formula Run
 // Detail) use loadSupervisorRunSummaryMountSource on the tight budget instead.
-//
-// The nav attention badge (liveContributors `fetchRunsAttention`) is an APPROVED
-// caller despite being mount-driven (gascity-dashboard-2j8e.6): it is cache-
-// backed and renders in the always-mounted header, so its latency never blocks a
-// route view — and it MUST read this exact snapshot. The badge counts the same
-// genuinely-blocked runs the page shows; using a narrower budget would let the
-// recent-run fan-out time out on a slow supervisor where the page's 30s budget
-// succeeds, re-introducing the badge-vs-page undercount this source was chosen to
-// eliminate. Parity requires the same budget, not merely the same selector.
+// The shared subscription is exempt: it is cache-backed and the always-mounted
+// header reads its result, so its latency never blocks a route view.
 export async function loadSupervisorRunSummarySource(): Promise<SourceState<RunSummary>> {
   return loadRunSummarySource(REFRESH_ENRICHMENT_TIMEOUT_MS);
 }


### PR DESCRIPTION
Unify nav/attention SSE (gascity-dashboard-2j8e.7 @e3138b5, rebased onto post-mp3g main e0f97fe). Reviewed via dashboard ship pipeline (sentinel ready). Batch-redeploy with mp3g after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)