### PR TITLE
Render v1 (wisp) runs in /runs + recency-bound historical lanes

### DIFF
--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -31,7 +31,10 @@ function historicalLane(id: string): RunLane {
   };
 }
 
-function runsSource(historicalLanes: RunLane[]): SourceState<RunSummary> {
+function runsSource(
+  historicalLanes: RunLane[],
+  totalHistorical = historicalLanes.length,
+): SourceState<RunSummary> {
   return {
     source: 'runs',
     status: 'fresh',
@@ -40,7 +43,7 @@ function runsSource(historicalLanes: RunLane[]): SourceState<RunSummary> {
     error: { kind: 'none' },
     data: {
       ...emptyRunSummary(),
-      totalHistorical: historicalLanes.length,
+      totalHistorical,
       historicalLanes,
     },
   };
@@ -50,11 +53,11 @@ function makeLanes(count: number): RunLane[] {
   return Array.from({ length: count }, (_, i) => historicalLane(`gc-hist-${i}`));
 }
 
-function renderHistory(historicalLanes: RunLane[]) {
+function renderHistory(historicalLanes: RunLane[], totalHistorical?: number) {
   return render(
     <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <RunMap
-        source={runsSource(historicalLanes)}
+        source={runsSource(historicalLanes, totalHistorical)}
         now={Date.parse('2026-05-24T12:01:00Z')}
         showHistory={true}
       />
@@ -97,5 +100,25 @@ describe('RunMap historical expand-in-place (gascity-dashboard-l9q9)', () => {
     const section = screen.getByRole('region', { name: /historical runs/i });
     expect(within(section).getAllByRole('listitem')).toHaveLength(5);
     expect(within(section).queryByRole('button')).toBeNull();
+  });
+});
+
+describe('RunMap historical recency-cap disclosure (gascity-dashboard-9w3k)', () => {
+  it('discloses the cap when totalHistorical exceeds the rendered lane count', () => {
+    // The wire caps historicalLanes at MAX_HISTORICAL_LANES but totalHistorical
+    // reports the true completed count, so the section must say it is a window.
+    const lanes = makeLanes(50);
+    renderHistory(lanes, 60);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getByText(/showing 50 most-recent of 60/i)).toBeTruthy();
+  });
+
+  it('omits the disclosure when the full history fits the wire', () => {
+    const lanes = makeLanes(7);
+    renderHistory(lanes);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).queryByText(/most-recent of/i)).toBeNull();
   });
 });

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -37,7 +37,8 @@ const COUNT_LABELS: Array<[keyof RunSummary['runCounts'], string]> = [
 const HISTORICAL_SECTION_ID = 'runs-historical-section';
 const HISTORICAL_LIST_ID = 'runs-historical-list';
 // How many completed runs show before the operator opts into the rest.
-// The wire carries every historical lane (gascity-dashboard-l9q9); this
+// The wire carries up to MAX_HISTORICAL_LANES most-recent historical lanes
+// (gascity-dashboard-l9q9, recency-bounded in gascity-dashboard-9w3k); this
 // preview keeps the section ambient by default per DESIGN.md.
 const HISTORICAL_PREVIEW = 5;
 

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -276,6 +276,16 @@ function HistoricalSection({
               {expanded ? 'Show fewer' : `Show ${lanes.length - HISTORICAL_PREVIEW} more`}
             </button>
           )}
+          {/* gascity-dashboard-9w3k: the wire caps historicalLanes at
+              MAX_HISTORICAL_LANES while totalHistorical keeps the true count.
+              Disclose the cap so the operator knows the rendered set is the
+              recent window, not the whole history — mirroring the Active
+              section's "N more not shown" note (same typographic register). */}
+          {summary.totalHistorical > lanes.length && (
+            <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
+              Showing {lanes.length} most-recent of {summary.totalHistorical}
+            </p>
+          )}
         </>
       )}
     </section>

--- a/frontend/src/hooks/useFormulaRunDetail.test.tsx
+++ b/frontend/src/hooks/useFormulaRunDetail.test.tsx
@@ -128,6 +128,23 @@ describe('useFormulaRunDetail', () => {
     expect(supervisor.formulaDetail).not.toHaveBeenCalled();
     expect(mockReportClientError).not.toHaveBeenCalled();
   });
+
+  it('surfaces a v1 / non-graph.v2 run as unsupported, not a generic failure', async () => {
+    // A v1 / wisp run: the root bead carries no gc.formula_contract=graph.v2,
+    // so enrichFormulaRun throws UnsupportedRunError('not_run_view'). The hook
+    // must map ONLY that case to {kind:'unsupported'} (the detail view then
+    // shows a list-only message) and NOT route it through the error path.
+    // The generic-failure branch is locked separately by the load-failure test
+    // above (a plain Error -> kind 'failed').
+    supervisor.workflowRun.mockResolvedValue(
+      workflowSnapshot({ metadata: { 'gc.kind': 'workflow' } }),
+    );
+
+    const { result } = renderHook(() => useFormulaRunDetail('wf-1', 'city', 'test-city'));
+
+    await waitFor(() => expect(result.current.kind).toBe('unsupported'));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
 });
 
 function workflowSnapshot(

--- a/frontend/src/hooks/useFormulaRunDetail.ts
+++ b/frontend/src/hooks/useFormulaRunDetail.ts
@@ -1,11 +1,11 @@
 import type { FormulaRunDetail, RunScopeKind } from 'gas-city-dashboard-shared';
-import { errorMessage } from 'gas-city-dashboard-shared';
+import { errorMessage, UnsupportedRunError } from 'gas-city-dashboard-shared';
 import { reportClientError } from '../lib/clientErrorReporting';
 import { loadSupervisorFormulaRunDetail } from '../supervisor/runDetail';
 import { useCachedData } from './useCachedData';
 
 interface FormulaRunDetailState {
-  kind: 'idle' | 'loading' | 'ready' | 'failed';
+  kind: 'idle' | 'loading' | 'ready' | 'failed' | 'unsupported';
   refresh: () => Promise<void>;
 }
 
@@ -14,8 +14,15 @@ type FormulaRunRefreshState =
   | { kind: 'refreshing' }
   | { kind: 'failed'; error: string };
 
+// gascity-dashboard-9w3k: a v1 / wisp run (not graph.v2) is surfaced in the run
+// list but has no graph.v2 step-detail view. enrichFormulaRun throws an
+// UnsupportedRunError('not_run_view') for it. We carry that as a DISTINCT
+// frontend payload (not a thrown error → not the generic failed state) so the
+// detail page can render an honest "list-only" message instead of an opaque
+// "Formula run unavailable." dead-end. No shared wire-shape field is added.
 type FormulaRunDetailPayload =
   | { kind: 'unrequested' }
+  | { kind: 'unsupported' }
   | {
       kind: 'loaded';
       detail: FormulaRunDetail;
@@ -29,6 +36,7 @@ export type FormulaRunDetailLoadState =
       detail: FormulaRunDetail;
       refreshState: FormulaRunRefreshState;
     })
+  | (FormulaRunDetailState & { kind: 'unsupported' })
   | (FormulaRunDetailState & { kind: 'failed'; error: string });
 
 export function useFormulaRunDetail(
@@ -56,6 +64,7 @@ export function useFormulaRunDetail(
       refreshState: refreshState(loading, error),
     };
   }
+  if (data?.kind === 'unsupported') return { kind: 'unsupported', refresh };
   if (error !== null) return { kind: 'failed', error, refresh };
   return { kind: 'loading', refresh };
 }
@@ -69,8 +78,19 @@ async function loadFormulaRunDetail(
   const params: { scopeKind?: RunScopeKind; scopeRef?: string } = {};
   if (scopeKind !== undefined) params.scopeKind = scopeKind;
   if (scopeRef !== undefined) params.scopeRef = scopeRef;
-  const detail = await loadSupervisorFormulaRunDetail(runId, params.scopeKind, params.scopeRef);
-  return { kind: 'loaded', detail };
+  try {
+    const detail = await loadSupervisorFormulaRunDetail(runId, params.scopeKind, params.scopeRef);
+    return { kind: 'loaded', detail };
+  } catch (err) {
+    // gascity-dashboard-9w3k: a v1 / wisp run has no graph.v2 detail view. Map
+    // that one expected case to an 'unsupported' payload so the page renders the
+    // list-only message; a malformed graph.v2 snapshot ('invalid_snapshot') and
+    // any transport failure still propagate as a generic load error.
+    if (err instanceof UnsupportedRunError && err.reason === 'not_run_view') {
+      return { kind: 'unsupported' };
+    }
+    throw err;
+  }
 }
 
 async function noopRefresh(): Promise<void> {}

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -16,6 +16,7 @@ import {
   type RunLane,
   type RunSummary,
   type SourceState,
+  UnsupportedRunError,
 } from 'gas-city-dashboard-shared';
 import rawFormulaRunDetailFixture from '../test/fixtures/formula-run-detail.json';
 
@@ -632,6 +633,36 @@ describe('FormulaRunDetailPage', () => {
     await screen.findByText('preserve failed attempt transcript links');
     expect(container.querySelector('.diff-code-insert')?.textContent).toContain('preserve failed');
     expect(container.querySelector('.diff-code-delete')?.textContent).toContain('old session');
+  });
+
+  it('renders an informative list-only message for a v1 / wisp (unsupported) run, not the generic failure (gascity-dashboard-9w3k)', async () => {
+    // A v1 / wisp run is clickable in the run list but has no graph.v2 detail
+    // view: enrichFormulaRun throws UnsupportedRunError('not_run_view'). The page
+    // must explain that clearly rather than show the opaque generic fallback.
+    loadSupervisorFormulaRunDetail.mockImplementation(async () => {
+      throw new UnsupportedRunError('run is not a graph.v2 run', 'not_run_view');
+    });
+
+    renderPage();
+
+    await screen.findByText(/detailed step view isn’t available for v1 \(wisp\) runs yet/i);
+    expect(screen.getByText(/appears in the run list only/i)).toBeTruthy();
+    // Not the generic dead-end, and not an error alert.
+    expect(screen.queryByText(/^formula run unavailable\.$/i)).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('still shows the generic failure for a malformed graph.v2 snapshot (invalid_snapshot)', async () => {
+    // A genuine load failure (malformed graph.v2 snapshot, or any other
+    // UnsupportedRunError reason) must NOT be mistaken for a v1 list-only run.
+    loadSupervisorFormulaRunDetail.mockImplementation(async () => {
+      throw new UnsupportedRunError('run snapshot identity is missing or invalid');
+    });
+
+    renderPage();
+
+    await screen.findByRole('alert');
+    expect(screen.queryByText(/v1 \(wisp\) runs yet/i)).toBeNull();
   });
 
   it('surfaces a partial formula run snapshot on the detail page', async () => {

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -58,6 +58,11 @@ export function FormulaRunDetailPage() {
   );
   const readyRun = runDetail.kind === 'ready' ? runDetail : null;
   const detail = readyRun?.detail ?? null;
+  // gascity-dashboard-9w3k: v1 / wisp runs are clickable in the run list but
+  // have no graph.v2 step-detail view. The hook reports this as a distinct
+  // 'unsupported' state (not a generic load failure) so we can render an honest
+  // list-only message instead of the opaque "Formula run unavailable." dead-end.
+  const unsupported = runDetail.kind === 'unsupported';
   const runDiff = useRunDiff(
     routeError || detail === null ? undefined : runId,
     detail?.executionPath,
@@ -127,7 +132,7 @@ export function FormulaRunDetailPage() {
 
   const synopsis = detail
     ? `${detail.progress.visibleNodeCount} nodes. ${summarizeNodeStatuses(detail.progress)}. Local changes are shown for the run execution folder.`
-    : initialLoading && !routeError
+    : (initialLoading && !routeError) || unsupported
       ? undefined
       : 'Formula run unavailable.';
 
@@ -187,6 +192,11 @@ export function FormulaRunDetailPage() {
         ) : (
           <p className="text-body text-fg-muted italic">Loading formula run.</p>
         )
+      ) : unsupported ? (
+        <p className="text-body text-fg-muted" role="status">
+          Detailed step view isn&rsquo;t available for v1 (wisp) runs yet — this run appears in the
+          run list only.
+        </p>
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">
           {pageError}

--- a/shared/src/runs/blocked.ts
+++ b/shared/src/runs/blocked.ts
@@ -3,11 +3,14 @@ import type { RunLane, RunLaneScope } from '../snapshot/types.js';
 // gascity-dashboard-2j8e.2: the genuinely-blocked-runs selector. The Runs nav
 // badge and the /runs page both read this one projection, so the badge count
 // and the page count read the same selector and cannot disagree. Its input is
-// buildRunSummary's `blockedLanes` — already dangling-root + non-graph.v2
-// suppressed (the gc-1920-class phantom: codeprobe upstream_error, no backing
-// bead, never a graph.v2 run) — so phantom suppression is upstream, not a dead
-// per-lane guard here. A supervisor `partial` read is never counted: this
-// selector only ever sees real blocked beads.
+// buildRunSummary's `blockedLanes` — already dangling-root suppressed and gated
+// by the isRunGroup run-marker (graph.v2 `gc.formula_contract`, OR a molecule
+// bead, OR `gc.kind=run`, OR a `gc.formula` attribution; gascity-dashboard-9w3k).
+// v1 molecule / gc.kind=run beads now reach blockedLanes, so a blocked lane is
+// not necessarily graph.v2 — only the gc-1920-class phantom (no backing bead,
+// no run marker) is suppressed, upstream, not by a dead per-lane guard here. A
+// supervisor `partial` read is never counted: this selector only ever sees real
+// blocked beads.
 
 export interface BlockedRun {
   id: string;

--- a/shared/src/runs/enrich.ts
+++ b/shared/src/runs/enrich.ts
@@ -18,16 +18,29 @@ interface EnrichOptions {
   formulaDetailState?: RunFormulaDetailState;
 }
 
+/**
+ * Why a run snapshot cannot be enriched into a detail view.
+ * gascity-dashboard-9w3k: distinguishes the expected v1 / wisp case
+ * ('not_run_view' — the run shows in the list but has no graph.v2 detail
+ * view) from a malformed graph.v2 snapshot ('invalid_snapshot' — a genuine
+ * load failure). The frontend renders these differently: the former is an
+ * honest "list-only" message, the latter a generic load error.
+ */
+export type UnsupportedRunReason = 'not_run_view' | 'invalid_snapshot';
+
 export class UnsupportedRunError extends Error {
-  constructor(message: string) {
+  readonly reason: UnsupportedRunReason;
+
+  constructor(message: string, reason: UnsupportedRunReason = 'invalid_snapshot') {
     super(message);
     this.name = 'UnsupportedRunError';
+    this.reason = reason;
   }
 }
 
 export function enrichFormulaRun(raw: RunSnapshot, opts: EnrichOptions): FormulaRunDetail {
   if (!isGraphV2(raw)) {
-    throw new UnsupportedRunError('run is not a graph.v2 run');
+    throw new UnsupportedRunError('run is not a graph.v2 run', 'not_run_view');
   }
 
   const rootBeadId = nonEmpty(raw.root_bead_id) ?? '';

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -131,7 +131,15 @@ export function fallbackReviewRound(issues: RunIssue[]): number {
 }
 
 export function textForIssue(issue: RunIssue): string {
+  // gascity-dashboard-9w3k: skip `gc.var.*` keys. v1 / wisp runs carry operator
+  // free-text template inputs there (e.g. gc.var.prompt = "review the blocked PR
+  // and merge it") which would otherwise feed phase needles ('review', 'blocked',
+  // 'merge', 'approval', ...) and mis-bucket the run's phase. These are inputs,
+  // not structural progress signals, so they are excluded from classification.
+  // graph.v2 roots derive phase from gc.step_id / status, not gc.var.*, so this
+  // does not affect graph.v2 classification.
   const metadataText = Object.entries(issue.metadata ?? {})
+    .filter(([key]) => !key.startsWith('gc.var.'))
     .map(([key, value]) => `${key} ${String(value)}`)
     .join(' ');
 

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -248,6 +248,41 @@ describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard
     assert.equal(summary.totalActive, 1);
   });
 
+  // gascity-dashboard-9w3k: a wisp run's gc.var.* free-text template inputs must
+  // NOT drive phase classification. Here gc.var.prompt contains 'review',
+  // 'blocked', and 'merge' — phase needles that would mis-bucket the run as
+  // blocked/approval/finalization — but the run's actual work (a 'do-work' step)
+  // keeps it in implementation/active.
+  test('gc.var.* free-text does not mis-classify a wisp run as blocked/approval', () => {
+    const summary = buildRunSummary([
+      runIssue({
+        id: 'wisp-var',
+        title: 'mol-do-work',
+        status: 'open',
+        issue_type: 'molecule',
+        updated_at: '2026-06-02T00:00:00Z',
+        metadata: {
+          'gc.var.prompt': 'review the blocked PR and merge it after approval, then finalize',
+        },
+      }),
+      runIssue({
+        id: 'wisp-var-child-1',
+        title: 'Do the work',
+        updated_at: '2026-06-02T00:05:00Z',
+        metadata: { molecule_id: 'wisp-var', 'gc.step_id': 'do-work' },
+      }),
+    ]);
+
+    const lane = summary.lanes[0];
+    assert.ok(lane !== undefined);
+    assert.equal(lane.id, 'wisp-var');
+    assert.notEqual(lane.phase, 'blocked');
+    assert.notEqual(lane.phase, 'approval');
+    assert.equal(summary.blockedLanes.length, 0);
+    // The 'do-work' step keeps it in the implementation register.
+    assert.equal(lane.phase, 'implementation');
+  });
+
   // Flood guard: a lone task/bug/feature bead (root = itself, no molecule /
   // gc.kind=run / gc.formula) must NOT become a run lane — otherwise every
   // engineering bead in the store would render as a phantom run.

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -192,7 +192,7 @@ function runIssue(overrides: Partial<RunIssue> & Pick<RunIssue, 'id'>): RunIssue
 
 // gascity-dashboard-9w3k: v1 / wisp (non-graph.v2) runs are surfaced as lanes
 // using the same lane/stage primitives as graph.v2. The drop used to be at the
-// `isGraphV2RunGroup` filter, which silently swallowed the entire v1 history.
+// graph.v2-only keep-filter, which silently swallowed the entire v1 history.
 // These tests pin (a) a genuine v1 wisp run becomes exactly one lane, (b) a
 // lone engineering bead is NOT promoted into a lane (flood guard), and that
 // graph.v2 lanes are unchanged.
@@ -202,28 +202,20 @@ describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard
   // back at the root. runRootId groups the child under the molecule root.
   function wispRun(id: string): RunIssue[] {
     return [
-      {
+      runIssue({
         id,
         title: 'mol-do-work',
         status: 'open',
         issue_type: 'molecule',
         updated_at: '2026-06-02T00:00:00Z',
-        metadata: {
-          'gc.var.target': 'demo-app',
-          'gc.var.prompt': 'fix the thing',
-        },
-      },
-      {
+        metadata: { 'gc.var.target': 'demo-app', 'gc.var.prompt': 'fix the thing' },
+      }),
+      runIssue({
         id: `${id}-child-1`,
         title: 'Implementation work',
-        status: 'in_progress',
-        issue_type: 'task',
         updated_at: '2026-06-02T00:05:00Z',
-        metadata: {
-          molecule_id: id,
-          'gc.step_id': 'do-work',
-        },
-      },
+        metadata: { molecule_id: id, 'gc.step_id': 'do-work' },
+      }),
     ];
   }
 
@@ -282,28 +274,23 @@ describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard
 // builder emits to the most-recent MAX_HISTORICAL_LANES, while totalHistorical
 // keeps reporting the true full count.
 describe('buildRunSummary — historical lanes are recency-bounded (gascity-dashboard-9w3k)', () => {
-  function completedV1Run(id: string, updatedAt: string): RunIssue[] {
-    return [
-      {
-        id,
-        title: 'mol-do-work',
-        status: 'closed',
-        issue_type: 'molecule',
-        updated_at: updatedAt,
-        metadata: { 'gc.var.target': 'demo-app' },
-      },
-    ];
-  }
-
   test('caps historicalLanes at MAX_HISTORICAL_LANES, keeps the most-recent ones, reports true total', () => {
     const total = MAX_HISTORICAL_LANES + 10;
     const issues: RunIssue[] = [];
     // Distinct, monotonically increasing updated_at so newest-first order is
     // unambiguous. id-N has updated_at = base + N minutes; higher N = newer.
+    // A closed molecule root is a complete v1 run (one lane each).
     const base = Date.parse('2026-01-01T00:00:00Z');
     for (let n = 0; n < total; n += 1) {
       const at = new Date(base + n * 60_000).toISOString();
-      issues.push(...completedV1Run(`hist-${String(n).padStart(3, '0')}`, at));
+      issues.push(
+        runIssue({
+          id: `hist-${String(n).padStart(3, '0')}`,
+          issue_type: 'molecule',
+          status: 'closed',
+          updated_at: at,
+        }),
+      );
     }
 
     const summary = buildRunSummary(issues);

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -1,7 +1,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildRunSummary, emptyRunSummary, runLane } from './summary.js';
+import { buildRunSummary, emptyRunSummary, runLane, MAX_HISTORICAL_LANES } from './summary.js';
 import type { RunFeedScope } from './summary.js';
 import type { RunIssue } from './phaseMapping.js';
 
@@ -189,6 +189,139 @@ function runIssue(overrides: Partial<RunIssue> & Pick<RunIssue, 'id'>): RunIssue
     ...overrides,
   };
 }
+
+// gascity-dashboard-9w3k: v1 / wisp (non-graph.v2) runs are surfaced as lanes
+// using the same lane/stage primitives as graph.v2. The drop used to be at the
+// `isGraphV2RunGroup` filter, which silently swallowed the entire v1 history.
+// These tests pin (a) a genuine v1 wisp run becomes exactly one lane, (b) a
+// lone engineering bead is NOT promoted into a lane (flood guard), and that
+// graph.v2 lanes are unchanged.
+describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard-9w3k)', () => {
+  // A real wisp run: a `molecule` root carrying gc.var.* template inputs but no
+  // gc.formula_contract, plus a child `task` whose metadata.molecule_id points
+  // back at the root. runRootId groups the child under the molecule root.
+  function wispRun(id: string): RunIssue[] {
+    return [
+      {
+        id,
+        title: 'mol-do-work',
+        status: 'open',
+        issue_type: 'molecule',
+        updated_at: '2026-06-02T00:00:00Z',
+        metadata: {
+          'gc.var.target': 'demo-app',
+          'gc.var.prompt': 'fix the thing',
+        },
+      },
+      {
+        id: `${id}-child-1`,
+        title: 'Implementation work',
+        status: 'in_progress',
+        issue_type: 'task',
+        updated_at: '2026-06-02T00:05:00Z',
+        metadata: {
+          molecule_id: id,
+          'gc.step_id': 'do-work',
+        },
+      },
+    ];
+  }
+
+  test('a v1 wisp molecule run emits exactly one lane with a phase', () => {
+    const summary = buildRunSummary(wispRun('wisp-1'));
+
+    assert.deepEqual(
+      summary.lanes.map((lane) => lane.id),
+      ['wisp-1'],
+    );
+    assert.equal(summary.totalActive, 1);
+    const lane = summary.lanes[0];
+    assert.ok(lane !== undefined);
+    assert.equal(lane.id, 'wisp-1');
+    // mapRunPhase is generic: 'work'/'implementation' text yields a real phase.
+    assert.equal(lane.phase, 'implementation');
+    // No graph.v2 formula metadata, so the formula resolves to unavailable but
+    // the generic run stages still render.
+    assert.equal(lane.formula.status, 'unavailable');
+    assert.ok(lane.stages.length > 0);
+  });
+
+  test('graph.v2 lanes still render unchanged (regression)', () => {
+    const summary = buildRunSummary(activeRun('run-1'));
+
+    assert.deepEqual(
+      summary.lanes.map((lane) => lane.id),
+      ['run-1'],
+    );
+    assert.equal(summary.totalActive, 1);
+  });
+
+  // Flood guard: a lone task/bug/feature bead (root = itself, no molecule /
+  // gc.kind=run / gc.formula) must NOT become a run lane — otherwise every
+  // engineering bead in the store would render as a phantom run.
+  test('a lone engineering bead does not become a lane', () => {
+    const loneTask: RunIssue = {
+      id: 'task-99',
+      title: 'Fix a typo',
+      status: 'open',
+      issue_type: 'task',
+      updated_at: '2026-06-02T00:00:00Z',
+    };
+    const summary = buildRunSummary([loneTask]);
+
+    assert.deepEqual(summary.lanes, []);
+    assert.deepEqual(summary.historicalLanes, []);
+    assert.deepEqual(summary.blockedLanes, []);
+    assert.equal(summary.totalActive, 0);
+    assert.equal(summary.totalHistorical, 0);
+  });
+});
+
+// gascity-dashboard-9w3k (part b): the now-much-larger v1 history can bury
+// active runs in the historical set on the wire. Cap the historical lanes the
+// builder emits to the most-recent MAX_HISTORICAL_LANES, while totalHistorical
+// keeps reporting the true full count.
+describe('buildRunSummary — historical lanes are recency-bounded (gascity-dashboard-9w3k)', () => {
+  function completedV1Run(id: string, updatedAt: string): RunIssue[] {
+    return [
+      {
+        id,
+        title: 'mol-do-work',
+        status: 'closed',
+        issue_type: 'molecule',
+        updated_at: updatedAt,
+        metadata: { 'gc.var.target': 'demo-app' },
+      },
+    ];
+  }
+
+  test('caps historicalLanes at MAX_HISTORICAL_LANES, keeps the most-recent ones, reports true total', () => {
+    const total = MAX_HISTORICAL_LANES + 10;
+    const issues: RunIssue[] = [];
+    // Distinct, monotonically increasing updated_at so newest-first order is
+    // unambiguous. id-N has updated_at = base + N minutes; higher N = newer.
+    const base = Date.parse('2026-01-01T00:00:00Z');
+    for (let n = 0; n < total; n += 1) {
+      const at = new Date(base + n * 60_000).toISOString();
+      issues.push(...completedV1Run(`hist-${String(n).padStart(3, '0')}`, at));
+    }
+
+    const summary = buildRunSummary(issues);
+
+    assert.equal(summary.historicalLanes.length, MAX_HISTORICAL_LANES);
+    assert.equal(summary.totalHistorical, total);
+
+    // The retained lanes must be the newest N (highest n), newest first.
+    const expected = Array.from({ length: MAX_HISTORICAL_LANES }, (_, i) => {
+      const n = total - 1 - i;
+      return `hist-${String(n).padStart(3, '0')}`;
+    });
+    assert.deepEqual(
+      summary.historicalLanes.map((lane) => lane.id),
+      expected,
+    );
+  });
+});
 
 describe('runLane scope sanitisation — gascity-dashboard-5e5v', () => {
   test('strips ANSI/OSC from rootStoreRef on the metadata path', () => {

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -60,14 +60,8 @@ export function buildRunSummary(
       // gascity-dashboard-s4rp: a run rooted at a bead missing from the store
       // (dangling root, gc-1920-class) has no authoritative root metadata — its
       // title is inferred from a child and its scope is unresolvable. Drop it
-      // explicitly rather than rely on the graph.v2 check incidentally failing.
-      // gascity-dashboard-9w3k: surface v1 / wisp (non-graph.v2) runs too. The
-      // grouping + lane/stage primitives are formula-agnostic, so broadening the
-      // keep-condition is all that is needed — but the v1 predicate must reject a
-      // lone engineering bead (root = itself, no run markers) so the whole bead
-      // store does not turn into phantom lanes.
-      !isDanglingRootGroup(rootId, groupIssues) &&
-      (isGraphV2RunGroup(rootId, groupIssues) || isV1RunGroup(rootId, groupIssues)),
+      // explicitly rather than rely on the run-marker check incidentally failing.
+      !isDanglingRootGroup(rootId, groupIssues) && isRunGroup(rootId, groupIssues),
   );
   const laneIssues = runGroups.flatMap(([, groupIssues]) => groupIssues);
   const sortedLanes = runGroups
@@ -107,24 +101,23 @@ export function buildRunSummary(
   return partial ? { ...summary, lanesPartial: true } : summary;
 }
 
-function isGraphV2RunGroup(rootId: string, issues: RunIssue[]): boolean {
-  const root = issues.find((issue) => issue.id === rootId);
-  return stringValue(root?.metadata?.['gc.formula_contract']) === 'graph.v2';
-}
-
-// gascity-dashboard-9w3k: a genuine v1 / wisp run root — a molecule bead, an
-// explicit `gc.kind=run` marker, or a `gc.formula` attribution. This is the
-// flood guard: a lone engineering bead (root = itself with none of these
-// markers) must NOT be promoted to a lane, or every task/bug/feature in the
-// store would render as a phantom run. Convoys are already excluded upstream by
-// runBeadFilter (ENGINEERING_TYPES has no 'convoy').
-function isV1RunGroup(rootId: string, issues: RunIssue[]): boolean {
+// gascity-dashboard-9w3k: a group is a run when its root bead carries a run
+// marker — the graph.v2 `gc.formula_contract`, or a v1 / wisp signal (a
+// molecule bead, an explicit `gc.kind=run` marker, or a `gc.formula`
+// attribution). The v1 arms are the flood guard: a lone engineering bead
+// (root = itself with none of these markers) must NOT be promoted to a lane,
+// or every task/bug/feature in the store would render as a phantom run.
+// Convoys are already excluded upstream by runBeadFilter (ENGINEERING_TYPES
+// has no 'convoy'); dangling roots are dropped separately by the caller.
+function isRunGroup(rootId: string, issues: RunIssue[]): boolean {
   const root = issues.find((issue) => issue.id === rootId);
   if (!root) return false;
+  const metadata = root.metadata;
   return (
+    stringValue(metadata?.['gc.formula_contract']) === 'graph.v2' ||
     root.issue_type === 'molecule' ||
-    stringValue(root.metadata?.['gc.kind']) === 'run' ||
-    stringValue(root.metadata?.['gc.formula']) !== ''
+    stringValue(metadata?.['gc.kind']) === 'run' ||
+    stringValue(metadata?.['gc.formula']) !== ''
   );
 }
 

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -17,6 +17,12 @@ import {
 
 export const MAX_VISIBLE_ACTIVE_LANES = 8;
 export const RECENT_CHANGES_CAP = 12;
+// gascity-dashboard-9w3k: once v1 history is surfaced the completed set can grow
+// into the thousands. Cap the historical lanes carried on the wire to the most-
+// recent N (sortedLanes is already newest-first) so a long tail of old runs
+// cannot bury or out-pay the active set. totalHistorical still reports the full
+// count so the operator sees the true number behind the window.
+export const MAX_HISTORICAL_LANES = 50;
 const ENGINEERING_TYPES = new Set([
   'feature',
   'bug',
@@ -55,7 +61,13 @@ export function buildRunSummary(
       // (dangling root, gc-1920-class) has no authoritative root metadata — its
       // title is inferred from a child and its scope is unresolvable. Drop it
       // explicitly rather than rely on the graph.v2 check incidentally failing.
-      !isDanglingRootGroup(rootId, groupIssues) && isGraphV2RunGroup(rootId, groupIssues),
+      // gascity-dashboard-9w3k: surface v1 / wisp (non-graph.v2) runs too. The
+      // grouping + lane/stage primitives are formula-agnostic, so broadening the
+      // keep-condition is all that is needed — but the v1 predicate must reject a
+      // lone engineering bead (root = itself, no run markers) so the whole bead
+      // store does not turn into phantom lanes.
+      !isDanglingRootGroup(rootId, groupIssues) &&
+      (isGraphV2RunGroup(rootId, groupIssues) || isV1RunGroup(rootId, groupIssues)),
   );
   const laneIssues = runGroups.flatMap(([, groupIssues]) => groupIssues);
   const sortedLanes = runGroups
@@ -68,7 +80,10 @@ export function buildRunSummary(
   const activeLanes = sortedLanes.filter(
     (lane) => lane.phase !== 'complete' && lane.phase !== 'blocked',
   );
-  const historicalLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
+  const completedLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
+  // gascity-dashboard-9w3k: cap on the wire, but keep the FULL count for the DTO.
+  const totalHistorical = completedLanes.length;
+  const historicalLanes = completedLanes.slice(0, MAX_HISTORICAL_LANES);
   const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
   const visibleActive = activeLanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
 
@@ -81,7 +96,7 @@ export function buildRunSummary(
   // before it reaches the DTO, so the rendered window stays capped.
   const summary: RunSummary = {
     totalActive: activeLanes.length,
-    totalHistorical: historicalLanes.length,
+    totalHistorical,
     runCounts: runCounts(activeLanes, visibleActive.length, blockedLanes.length),
     lanes: activeLanes,
     historicalLanes,
@@ -95,6 +110,22 @@ export function buildRunSummary(
 function isGraphV2RunGroup(rootId: string, issues: RunIssue[]): boolean {
   const root = issues.find((issue) => issue.id === rootId);
   return stringValue(root?.metadata?.['gc.formula_contract']) === 'graph.v2';
+}
+
+// gascity-dashboard-9w3k: a genuine v1 / wisp run root — a molecule bead, an
+// explicit `gc.kind=run` marker, or a `gc.formula` attribution. This is the
+// flood guard: a lone engineering bead (root = itself with none of these
+// markers) must NOT be promoted to a lane, or every task/bug/feature in the
+// store would render as a phantom run. Convoys are already excluded upstream by
+// runBeadFilter (ENGINEERING_TYPES has no 'convoy').
+function isV1RunGroup(rootId: string, issues: RunIssue[]): boolean {
+  const root = issues.find((issue) => issue.id === rootId);
+  if (!root) return false;
+  return (
+    root.issue_type === 'molecule' ||
+    stringValue(root.metadata?.['gc.kind']) === 'run' ||
+    stringValue(root.metadata?.['gc.formula']) !== ''
+  );
 }
 
 export function runCounts(lanes: RunLane[], visible: number, blocked: number): RunCounts {

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -307,17 +307,21 @@ export interface RunSummary {
    *  operator attention; they are simply not part of the Active set or
    *  the headline `activeRuns` metric. */
   totalActive: number;
-  /** Count of HISTORICAL lanes (phase === 'complete'). gascity-dashboard-yh5i:
+  /** TRUE count of HISTORICAL lanes (phase === 'complete'). gascity-dashboard-yh5i:
    *  /runs defaults to showing the active set; toggling `?history=1`
    *  reveals the historical section so the user can see recently-completed
-   *  runs without complete lanes crowding active out of the 8-cap window. */
+   *  runs without complete lanes crowding active out of the 8-cap window.
+   *  gascity-dashboard-9w3k: this is the full completed-lane count and may
+   *  EXCEED historicalLanes.length when the MAX_HISTORICAL_LANES cap applies,
+   *  so the operator sees the real number behind the recency window. */
   totalHistorical: number;
   runCounts: RunCounts;
   /** Active lanes, sorted by compareLanes, capped at MAX_VISIBLE_ACTIVE_LANES. */
   lanes: RunLane[];
   /** Historical (phase === 'complete') lanes, sorted by compareLanes, capped at
-   *  MAX_VISIBLE_HISTORICAL_LANES. Frontend renders these only when the user
-   *  toggles ?history=1; backend always returns the array. */
+   *  MAX_HISTORICAL_LANES (most-recent-first). Frontend renders these only when
+   *  the user toggles ?history=1; backend always returns the array. When the cap
+   *  trims older lanes, totalHistorical still reports the true count. */
   historicalLanes: RunLane[];
   /** Blocked (phase === 'blocked') lanes, sorted by compareLanes
    *  (gascity-dashboard-4xcv). Rendered as their own section so a blocked


### PR DESCRIPTION
## What

The `/runs` view only rendered graph.v2-contract runs — `buildRunSummary` dropped every group whose root lacked `gc.formula_contract === 'graph.v2'`, so all v1/wisp runs (and most recent activity) were silently invisible; the view showed only stale graph.v2 history. This surfaces v1 runs alongside graph.v2 using the same lane/stage primitives, and recency-bounds the now-larger historical set so it can't bury active runs.

## Changes

- **Surface v1 runs** — unified `isGraphV2RunGroup`/`isV1RunGroup` into one `isRunGroup` (`shared/src/runs/summary.ts`): a group is a run when its root carries a run marker — the graph.v2 contract, or a v1/wisp signal (a `molecule` bead, `gc.kind=run`, or `gc.formula`). Lone engineering beads are rejected (flood guard); convoys are already excluded by `runBeadFilter`. v1 lanes render with the existing primitives (generic stages; formula may resolve `unavailable`).
- **Recency-bound history** — `MAX_HISTORICAL_LANES = 50`; `historicalLanes` carries the 50 most-recent (lanes are already newest-first) while `totalHistorical` keeps the true count. The historical section shows "Showing N most-recent of M" when capped, mirroring the active-section disclosure.
- **v1 run detail** — v1 runs aren't graph.v2, so the detail page can't render their step graph; it now shows an explicit "detailed view isn't available for v1 (wisp) runs yet — shown in the list only" state instead of a generic error. Frontend-only (`UnsupportedRunError.reason` threading); no wire-shape change.
- **Phase classification** — `textForIssue` now excludes `gc.var.*` operator free-text from the phase-keyword scan, so a v1 run whose prompt contains "blocked"/"review"/"merge" isn't mis-bucketed.
- Doc/comment fixes (`snapshot/types.ts` JSDoc, `runs/blocked.ts`).

No `shared/` wire-shape type changed; no backend, bind-address, or proxy change; no `DESIGN.md` change (reuses existing label styling).

## Review & CI

Reviewed via the multi-model pipeline (code + security + typescript + Codex cross-provider), 2 iterations to converge: the first pass flagged two majors — v1 lanes dead-ended on click, and the historical cap had no "showing N of M" disclosure — both fixed and re-verified clean by all reviewers.

CI parity green locally: build · typecheck (src+test) · lint · prettier · openapi drift · shared (132) · backend (558) · frontend (880).

## Test plan

- **shared:** v1 wisp run → one lane; graph.v2 unchanged (regression); lone bead → no lane; recency cap keeps newest 50 with true total; `gc.var.*` free-text doesn't mis-classify phase.
- **frontend:** historical disclosure renders only when capped; v1/unsupported run-detail renders the list-only message (hook + page level); malformed graph.v2 still hits the generic failure.

## Follow-ups (not in this PR)

- Fetch-side: the run-summary bead fetch is a flat 500-cap with no recency ordering and doesn't follow `next_cursor` — a recency-ordered/paginated fetch would harden coverage on very large stores.
- The formula-feed discovery cap (50 items) bounds the "most-recent" scope window.
- Production-data assumption: every `molecule`-typed root is treated as a run root (correct for current wisp usage; worth confirming against a live-store sample).
