### PR TITLE
Runs view: fix detail scope, phase derivation, and v1/not-found detail state

### DIFF
--- a/frontend/src/hooks/useFormulaRunDetail.test.tsx
+++ b/frontend/src/hooks/useFormulaRunDetail.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vite
 import { invalidate } from '../api/cache';
 import { reportClientError } from '../lib/clientErrorReporting';
 import { supervisorApi } from '../supervisor/client';
+import { SupervisorApiError } from '../supervisor/errors';
 import { useFormulaRunDetail } from './useFormulaRunDetail';
 
 vi.mock('../api/cityBase', () => ({
@@ -141,6 +142,20 @@ describe('useFormulaRunDetail', () => {
     );
 
     const { result } = renderHook(() => useFormulaRunDetail('wf-1', 'city', 'test-city'));
+
+    await waitFor(() => expect(result.current.kind).toBe('unsupported'));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 404 from the workflow endpoint (v1 wisp id) as unsupported', async () => {
+    // The supervisor only knows graph.v2 workflows; a v1/wisp run id 404s the
+    // workflow endpoint outright, before any snapshot is returned. That must map
+    // to the list-only 'unsupported' state, not the generic load failure.
+    supervisor.workflowRun.mockRejectedValue(
+      new SupervisorApiError(404, 'workflow gc-p7yf1m not found', undefined),
+    );
+
+    const { result } = renderHook(() => useFormulaRunDetail('gc-p7yf1m', 'city', 'test-city'));
 
     await waitFor(() => expect(result.current.kind).toBe('unsupported'));
     expect(mockReportClientError).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useFormulaRunDetail.test.tsx
+++ b/frontend/src/hooks/useFormulaRunDetail.test.tsx
@@ -147,17 +147,22 @@ describe('useFormulaRunDetail', () => {
     expect(mockReportClientError).not.toHaveBeenCalled();
   });
 
-  it('surfaces a 404 from the workflow endpoint (v1 wisp id) as unsupported', async () => {
-    // The supervisor only knows graph.v2 workflows; a v1/wisp run id 404s the
-    // workflow endpoint outright, before any snapshot is returned. That must map
-    // to the list-only 'unsupported' state, not the generic load failure.
+  it('surfaces a raw 404 from the workflow endpoint as not_found, not v1-unsupported', async () => {
+    // gascity-dashboard (Major 2): a raw SupervisorApiError 404 (no snapshot at
+    // all) is AMBIGUOUS — a v1/wisp id the workflow endpoint never knew, a
+    // completed run whose snapshot wasn't retained, a pruned/deleted run, or a
+    // stale/wrong derived scope. It must NOT be mislabeled as the definitive v1
+    // 'unsupported' state, and it must NOT collapse into the generic 'failed'
+    // transport state — it gets its own honest 'not_found' state.
     supervisor.workflowRun.mockRejectedValue(
       new SupervisorApiError(404, 'workflow gc-p7yf1m not found', undefined),
     );
 
     const { result } = renderHook(() => useFormulaRunDetail('gc-p7yf1m', 'city', 'test-city'));
 
-    await waitFor(() => expect(result.current.kind).toBe('unsupported'));
+    await waitFor(() => expect(result.current.kind).toBe('not_found'));
+    expect(result.current.kind).not.toBe('unsupported');
+    expect(result.current.kind).not.toBe('failed');
     expect(mockReportClientError).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useFormulaRunDetail.ts
+++ b/frontend/src/hooks/useFormulaRunDetail.ts
@@ -6,7 +6,7 @@ import { SupervisorApiError } from '../supervisor/errors';
 import { useCachedData } from './useCachedData';
 
 interface FormulaRunDetailState {
-  kind: 'idle' | 'loading' | 'ready' | 'failed' | 'unsupported';
+  kind: 'idle' | 'loading' | 'ready' | 'failed' | 'unsupported' | 'not_found';
   refresh: () => Promise<void>;
 }
 
@@ -16,14 +16,23 @@ type FormulaRunRefreshState =
   | { kind: 'failed'; error: string };
 
 // gascity-dashboard-9w3k: a v1 / wisp run (not graph.v2) is surfaced in the run
-// list but has no graph.v2 step-detail view. enrichFormulaRun throws an
-// UnsupportedRunError('not_run_view') for it. We carry that as a DISTINCT
-// frontend payload (not a thrown error → not the generic failed state) so the
-// detail page can render an honest "list-only" message instead of an opaque
-// "Formula run unavailable." dead-end. No shared wire-shape field is added.
+// list but has no graph.v2 step-detail view. When its snapshot LOADS but isn't a
+// run view, enrichFormulaRun throws UnsupportedRunError('not_run_view') — the
+// RELIABLE v1 signal. We carry that as a DISTINCT 'unsupported' payload (not a
+// thrown error → not the generic failed state) so the page can render an honest
+// "list-only" message instead of the opaque "Formula run unavailable." dead-end.
+//
+// gascity-dashboard (Major 2): a raw SupervisorApiError 404 (no snapshot at all)
+// is AMBIGUOUS — it can be a v1/wisp id the workflow endpoint never knew, a
+// completed run whose snapshot wasn't retained, a pruned/deleted run, or a
+// stale/wrong derived scope. We must NOT assert it is definitively v1. It maps
+// to a distinct 'not_found' payload with honest copy that lists the
+// possibilities, kept separate from both 'unsupported' (which over-claims v1)
+// and the generic transport 'failed' state. No shared wire-shape field is added.
 type FormulaRunDetailPayload =
   | { kind: 'unrequested' }
   | { kind: 'unsupported' }
+  | { kind: 'not_found' }
   | {
       kind: 'loaded';
       detail: FormulaRunDetail;
@@ -38,6 +47,7 @@ export type FormulaRunDetailLoadState =
       refreshState: FormulaRunRefreshState;
     })
   | (FormulaRunDetailState & { kind: 'unsupported' })
+  | (FormulaRunDetailState & { kind: 'not_found' })
   | (FormulaRunDetailState & { kind: 'failed'; error: string });
 
 export function useFormulaRunDetail(
@@ -66,6 +76,7 @@ export function useFormulaRunDetail(
     };
   }
   if (data?.kind === 'unsupported') return { kind: 'unsupported', refresh };
+  if (data?.kind === 'not_found') return { kind: 'not_found', refresh };
   if (error !== null) return { kind: 'failed', error, refresh };
   return { kind: 'loading', refresh };
 }
@@ -83,19 +94,22 @@ async function loadFormulaRunDetail(
     const detail = await loadSupervisorFormulaRunDetail(runId, params.scopeKind, params.scopeRef);
     return { kind: 'loaded', detail };
   } catch (err) {
-    // gascity-dashboard-9w3k: a v1 / wisp run has no graph.v2 detail view. Two
-    // expected shapes for that case, both mapped to the 'unsupported' payload so
-    // the page renders the honest list-only message instead of a raw error:
-    //   1. the snapshot loads but isn't graph.v2 -> UnsupportedRunError('not_run_view');
-    //   2. the supervisor's workflow endpoint 404s the wisp id outright (it only
-    //      knows graph.v2 workflows) -> SupervisorApiError status 404.
-    // A malformed graph.v2 snapshot ('invalid_snapshot') and any other transport
-    // failure still propagate as a generic load error.
-    if (
-      (err instanceof UnsupportedRunError && err.reason === 'not_run_view') ||
-      (err instanceof SupervisorApiError && err.status === 404)
-    ) {
+    // gascity-dashboard-9w3k: a snapshot that LOADS but isn't a graph.v2 run
+    // view throws UnsupportedRunError('not_run_view'). That is the RELIABLE v1 /
+    // wisp signal, so it maps to the 'unsupported' payload and the page renders
+    // the honest list-only message instead of a raw error.
+    if (err instanceof UnsupportedRunError && err.reason === 'not_run_view') {
       return { kind: 'unsupported' };
+    }
+    // gascity-dashboard (Major 2): a raw SupervisorApiError 404 (no snapshot at
+    // all) is AMBIGUOUS — v1/wisp id the workflow endpoint never knew, a
+    // completed run whose snapshot wasn't retained, a pruned/deleted run, or a
+    // stale/wrong derived scope. We do NOT claim it is definitively v1; it maps
+    // to the distinct 'not_found' payload whose copy lists the possibilities
+    // without over-claiming. A malformed graph.v2 snapshot ('invalid_snapshot')
+    // and any other transport failure still propagate as a generic load error.
+    if (err instanceof SupervisorApiError && err.status === 404) {
+      return { kind: 'not_found' };
     }
     throw err;
   }

--- a/frontend/src/hooks/useFormulaRunDetail.ts
+++ b/frontend/src/hooks/useFormulaRunDetail.ts
@@ -2,6 +2,7 @@ import type { FormulaRunDetail, RunScopeKind } from 'gas-city-dashboard-shared';
 import { errorMessage, UnsupportedRunError } from 'gas-city-dashboard-shared';
 import { reportClientError } from '../lib/clientErrorReporting';
 import { loadSupervisorFormulaRunDetail } from '../supervisor/runDetail';
+import { SupervisorApiError } from '../supervisor/errors';
 import { useCachedData } from './useCachedData';
 
 interface FormulaRunDetailState {
@@ -82,11 +83,18 @@ async function loadFormulaRunDetail(
     const detail = await loadSupervisorFormulaRunDetail(runId, params.scopeKind, params.scopeRef);
     return { kind: 'loaded', detail };
   } catch (err) {
-    // gascity-dashboard-9w3k: a v1 / wisp run has no graph.v2 detail view. Map
-    // that one expected case to an 'unsupported' payload so the page renders the
-    // list-only message; a malformed graph.v2 snapshot ('invalid_snapshot') and
-    // any transport failure still propagate as a generic load error.
-    if (err instanceof UnsupportedRunError && err.reason === 'not_run_view') {
+    // gascity-dashboard-9w3k: a v1 / wisp run has no graph.v2 detail view. Two
+    // expected shapes for that case, both mapped to the 'unsupported' payload so
+    // the page renders the honest list-only message instead of a raw error:
+    //   1. the snapshot loads but isn't graph.v2 -> UnsupportedRunError('not_run_view');
+    //   2. the supervisor's workflow endpoint 404s the wisp id outright (it only
+    //      knows graph.v2 workflows) -> SupervisorApiError status 404.
+    // A malformed graph.v2 snapshot ('invalid_snapshot') and any other transport
+    // failure still propagate as a generic load error.
+    if (
+      (err instanceof UnsupportedRunError && err.reason === 'not_run_view') ||
+      (err instanceof SupervisorApiError && err.status === 404)
+    ) {
       return { kind: 'unsupported' };
     }
     throw err;

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -18,6 +18,7 @@ import {
   type SourceState,
   UnsupportedRunError,
 } from 'gas-city-dashboard-shared';
+import { SupervisorApiError } from '../supervisor/errors';
 import rawFormulaRunDetailFixture from '../test/fixtures/formula-run-detail.json';
 
 const loadSupervisorFormulaRunDetail = vi.hoisted(() => vi.fn());
@@ -646,9 +647,29 @@ describe('FormulaRunDetailPage', () => {
     renderPage();
 
     await screen.findByText(
-      /detailed step view isn’t available for this run \(v1\/wisp runs and runs without a retained snapshot are list-only\)/i,
+      /detailed step view isn’t available for this run \(v1\/wisp runs are list-only\)/i,
     );
     expect(screen.getByText(/appears in the run list only/i)).toBeTruthy();
+    // Not the generic dead-end, and not an error alert.
+    expect(screen.queryByText(/^formula run unavailable\.$/i)).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('renders an honest not-found message for a raw 404 (ambiguous), not the v1 over-claim or the generic failure (Major 2)', async () => {
+    // gascity-dashboard (Major 2): a raw SupervisorApiError 404 (no snapshot at
+    // all) is ambiguous — it can be a v1/wisp id, a completed run whose snapshot
+    // wasn't retained, a pruned run, or a stale/wrong derived scope. The page
+    // must NOT assert it is definitively v1 (the 'unsupported' copy) and must NOT
+    // fall to the generic "Formula run unavailable." dead-end either.
+    loadSupervisorFormulaRunDetail.mockImplementation(async () => {
+      throw new SupervisorApiError(404, 'workflow gc-p7yf1m not found', undefined);
+    });
+
+    renderPage();
+
+    await screen.findByText(/this run’s detail snapshot was not found/i);
+    // Does not over-claim v1.
+    expect(screen.queryByText(/v1\/wisp runs are list-only/i)).toBeNull();
     // Not the generic dead-end, and not an error alert.
     expect(screen.queryByText(/^formula run unavailable\.$/i)).toBeNull();
     expect(screen.queryByRole('alert')).toBeNull();

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -645,7 +645,9 @@ describe('FormulaRunDetailPage', () => {
 
     renderPage();
 
-    await screen.findByText(/detailed step view isn’t available for v1 \(wisp\) runs yet/i);
+    await screen.findByText(
+      /detailed step view isn’t available for this run \(v1\/wisp runs and runs without a retained snapshot are list-only\)/i,
+    );
     expect(screen.getByText(/appears in the run list only/i)).toBeTruthy();
     // Not the generic dead-end, and not an error alert.
     expect(screen.queryByText(/^formula run unavailable\.$/i)).toBeNull();

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -63,6 +63,11 @@ export function FormulaRunDetailPage() {
   // 'unsupported' state (not a generic load failure) so we can render an honest
   // list-only message instead of the opaque "Formula run unavailable." dead-end.
   const unsupported = runDetail.kind === 'unsupported';
+  // gascity-dashboard (Major 2): a raw 404 from the workflow endpoint (no
+  // snapshot at all) is ambiguous — distinct from the reliable v1 'unsupported'
+  // signal and from a generic transport failure. We surface it as its own honest
+  // "detail snapshot not found" state instead of mislabeling it as v1.
+  const notFound = runDetail.kind === 'not_found';
   const runDiff = useRunDiff(
     routeError || detail === null ? undefined : runId,
     detail?.executionPath,
@@ -132,7 +137,7 @@ export function FormulaRunDetailPage() {
 
   const synopsis = detail
     ? `${detail.progress.visibleNodeCount} nodes. ${summarizeNodeStatuses(detail.progress)}. Local changes are shown for the run execution folder.`
-    : (initialLoading && !routeError) || unsupported
+    : (initialLoading && !routeError) || unsupported || notFound
       ? undefined
       : 'Formula run unavailable.';
 
@@ -194,8 +199,13 @@ export function FormulaRunDetailPage() {
         )
       ) : unsupported ? (
         <p className="text-body text-fg-muted" role="status">
-          Detailed step view isn&rsquo;t available for this run (v1/wisp runs and runs without a
-          retained snapshot are list-only) — this run appears in the run list only.
+          Detailed step view isn&rsquo;t available for this run (v1/wisp runs are list-only) — this
+          run appears in the run list only.
+        </p>
+      ) : notFound ? (
+        <p className="text-body text-fg-muted" role="status">
+          This run&rsquo;s detail snapshot was not found. It may be a v1/wisp run, a completed run
+          whose snapshot wasn&rsquo;t retained, or no longer available.
         </p>
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -194,8 +194,8 @@ export function FormulaRunDetailPage() {
         )
       ) : unsupported ? (
         <p className="text-body text-fg-muted" role="status">
-          Detailed step view isn&rsquo;t available for v1 (wisp) runs yet — this run appears in the
-          run list only.
+          Detailed step view isn&rsquo;t available for this run (v1/wisp runs and runs without a
+          retained snapshot are list-only) — this run appears in the run list only.
         </p>
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">

--- a/frontend/src/supervisor/runHref.test.ts
+++ b/frontend/src/supervisor/runHref.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunLaneScope } from 'gas-city-dashboard-shared';
+import { runDetailHref } from './runHref';
+
+describe('runDetailHref', () => {
+  it('appends scope query for an available rig scope (gascity-dashboard-km0w)', () => {
+    // A lane whose scope was derived from gc.root_store_ref:'rig:gascity-packs'
+    // must deep-link to the correctly-scoped detail fetch, not the default
+    // (city) scope that triggers the 12-14s full-store scan + 404.
+    const scope: RunLaneScope = {
+      status: 'available',
+      kind: 'rig',
+      ref: 'gascity-packs',
+      rootStoreRef: 'rig:gascity-packs',
+    };
+
+    expect(runDetailHref('gpk-4fyo6', scope)).toBe(
+      '/runs/gpk-4fyo6?scope_kind=rig&scope_ref=gascity-packs',
+    );
+  });
+
+  it('appends scope query for an available city scope', () => {
+    const scope: RunLaneScope = {
+      status: 'available',
+      kind: 'city',
+      ref: 'ds-research',
+      rootStoreRef: 'city:ds-research',
+    };
+
+    expect(runDetailHref('city-run', scope)).toBe(
+      '/runs/city-run?scope_kind=city&scope_ref=ds-research',
+    );
+  });
+
+  it('omits the scope query when the scope is unavailable', () => {
+    const scope: RunLaneScope = {
+      status: 'unavailable',
+      error: 'run scope metadata unavailable',
+    };
+
+    expect(runDetailHref('gpk-4fyo6', scope)).toBe('/runs/gpk-4fyo6');
+  });
+
+  it('encodes the run id path segment', () => {
+    const scope: RunLaneScope = { status: 'unavailable', error: 'x' };
+    expect(runDetailHref('a/b c', scope)).toBe('/runs/a%2Fb%20c');
+  });
+});

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -325,12 +325,12 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.runCounts.total).toBe(1);
   });
 
-  it('keeps a session-less approval gate that is still recent (gascity-dashboard-s4rp)', async () => {
+  it('keeps a session-less recent latch in the Active set (gascity-dashboard-s4rp)', async () => {
     const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
       if (query?.type === 'molecule') return beadList([]);
       if (query?.rig === 'rig-a') return beadList([]);
-      // Same shape as the stale latch but written 30 minutes ago — a real
-      // approval gate waiting on a human must still appear as Active.
+      // Same shape as the stale latch but written 30 minutes ago — a recent
+      // session-less latch must still appear as Active (not demoted by liveness).
       return beadList([{ ...staleLatch(), updated_at: '2026-06-01T11:30:00.000Z' }]);
     });
     setSupervisorApiForTests({
@@ -346,7 +346,14 @@ describe('loadSupervisorRunSummarySource', () => {
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanes.map((lane) => lane.id)).toEqual(['gc-1920']);
-    expect(source.data.lanes[0]?.phase).toBe('approval');
+    // gascity-dashboard-q3p1: this latch is a bare root with NO step beads, so
+    // phase comes from the tightened keyword fallback. Its title
+    // ('mol-focus-review') carries a 'review' signal → 'review'. The old
+    // assertion was 'approval', which was the bug itself: the OLD scan read
+    // 'approval'/'gate' out of the run's DESCRIPTION ("Approval gate, review.")
+    // even though no approval-gate step exists. The lane staying Active — the
+    // actual subject of this test — is unchanged.
+    expect(source.data.lanes[0]?.phase).toBe('review');
   });
 
   it('demotes a phantom exactly even when active runs exceed the visible cap (gascity-dashboard-s4rp)', async () => {

--- a/shared/src/run-scope.ts
+++ b/shared/src/run-scope.ts
@@ -72,16 +72,31 @@ export function fromFeedScope(feed: FeedScopeFields): RunScopeWithStoreRef | nul
 export function fromRootMetadataScope(
   metadata: Record<string, string> | undefined,
 ): RunScopeWithStoreRef | null {
+  const rootStoreRef = stringValue(metadata?.['gc.root_store_ref']);
+
+  // Primary source: the explicit gc.scope_kind / gc.scope_ref pair. When
+  // present and valid it wins, and the existing behaviour is unchanged.
   const scopeKind = parseRunScopeKind(metadata?.['gc.scope_kind']);
   const scopeRef = stringValue(metadata?.['gc.scope_ref']);
-  if (scopeKind === null || scopeRef === null || !SCOPE_REF_RE.test(scopeRef)) {
+  if (scopeKind !== null && scopeRef !== null && SCOPE_REF_RE.test(scopeRef)) {
+    return {
+      scopeKind,
+      scopeRef,
+      rootStoreRef: rootStoreRef ?? `${scopeKind}:${scopeRef}`,
+    };
+  }
+
+  // Fallback (gascity-dashboard-km0w): live run-root beads carry only
+  // gc.root_store_ref ("<kind>:<ref>") — never the gc.scope_ref pair. Recover
+  // the lane scope from it. fromStoreRef rejects any prefix that is not exactly
+  // 'rig'/'city' and any colon-less value (no guessing); the parsed ref is then
+  // validated against the same SCOPE_REF_RE the explicit path uses.
+  if (rootStoreRef === null) return null;
+  const parsed = fromStoreRef(rootStoreRef);
+  if (parsed === null || !SCOPE_REF_RE.test(parsed.scopeRef)) {
     return null;
   }
-  return {
-    scopeKind,
-    scopeRef,
-    rootStoreRef: stringValue(metadata?.['gc.root_store_ref']) ?? `${scopeKind}:${scopeRef}`,
-  };
+  return { ...parsed, rootStoreRef };
 }
 
 export function fromStoreRef(rootStoreRef: unknown): RunScope | null {

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -170,6 +170,57 @@ describe('mapRunPhase — incidental text never forces approval (the core regres
   });
 });
 
+describe('mapRunPhase — deterministic current-step pick without updated_at (gascity-dashboard Major 3)', () => {
+  // The run-detail snapshot adapter (formula-run.ts fromRunSnapshotBead) sets
+  // every bead updated_at=''. With no in_progress step the old timestamp-based
+  // pick was input-ORDER-dependent (Date.parse('') === NaN). The fallback must
+  // be deterministic and pick the furthest-advanced stage, and a summary-context
+  // version of the same run (real timestamps) must agree with the detail context.
+
+  function snapshotStep(stepId: string, status: string): RunIssue {
+    // Detail-snapshot shape: no per-bead timestamp.
+    return {
+      id: `step-${stepId}`,
+      title: 'step',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      metadata: { 'gc.kind': 'step', 'gc.step_id': stepId },
+    };
+  }
+
+  test('no in_progress step + empty updated_at → deterministic furthest stage, order-independent', () => {
+    const forward = mapRunPhase([
+      root({ id: 'd1', updated_at: '' }),
+      snapshotStep('implement-change', 'closed'),
+      snapshotStep('code-review-loop', 'closed'),
+    ]);
+    const reversed = mapRunPhase([
+      root({ id: 'd1', updated_at: '' }),
+      snapshotStep('code-review-loop', 'closed'),
+      snapshotStep('implement-change', 'closed'),
+    ]);
+    // Furthest advanced of the two closed steps is the review loop.
+    assert.equal(forward.phase, 'review');
+    // Input order must not change the result.
+    assert.equal(reversed.phase, forward.phase);
+  });
+
+  test('summary-context (real timestamps) and detail-context (empty) of the same run agree', () => {
+    const detail = mapRunPhase([
+      root({ id: 'd2', updated_at: '' }),
+      snapshotStep('implement-change', 'closed'),
+      snapshotStep('code-review-loop', 'closed'),
+    ]);
+    const summary = mapRunPhase([
+      root({ id: 'd2' }),
+      step('d2-s1', 'implement-change', 'closed', { updated_at: '2026-06-06T00:01:00.000Z' }),
+      step('d2-s2', 'code-review-loop', 'closed', { updated_at: '2026-06-06T02:00:00.000Z' }),
+    ]);
+    assert.equal(detail.phase, summary.phase);
+  });
+});
+
 describe('mapRunPhase — status branches remain authoritative', () => {
   test('any blocked bead → blocked, regardless of step identity', () => {
     const phase = mapRunPhase([root({ id: 'b1' }), step('b1-s1', 'implement-change', 'blocked')]);
@@ -235,5 +286,42 @@ describe('stepIdPhase — step-identity classification', () => {
 
   test('unknown step id is conservative (active), never invents a late phase', () => {
     assert.equal(stepIdPhase('totally-unknown-step'), 'active');
+  });
+
+  // gascity-dashboard (Major 1): tokenized whole-token matching, not raw
+  // substring includes(). A leading/CI step that merely CONTAINS a late-stage
+  // word as a substring (or as a token behind a negating prefix) must not be
+  // misbucketed onto the late stage — that falsely surfaces a CI step as
+  // "waiting on human" through needsOperator (health.ts keys on phase==='approval').
+  test('pre-approval-ci is NOT approval (negating `pre` prefix on the gate token)', () => {
+    assert.notEqual(stepIdPhase('pre-approval-ci'), 'approval');
+  });
+
+  test('dispatch-implementation is implementation, not finalization', () => {
+    assert.equal(stepIdPhase('dispatch-implementation'), 'implementation');
+  });
+
+  test('prepare-review-context is review, never approval or finalization', () => {
+    const phase = stepIdPhase('prepare-review-context');
+    assert.notEqual(phase, 'approval');
+    assert.notEqual(phase, 'finalization');
+    assert.equal(phase, 'review');
+  });
+
+  test('whole real step ids still classify correctly after tokenization', () => {
+    assert.equal(stepIdPhase('review'), 'review');
+    assert.equal(stepIdPhase('approval'), 'approval');
+    assert.equal(stepIdPhase('approve'), 'approval');
+    assert.equal(stepIdPhase('implementation'), 'implementation');
+    assert.equal(stepIdPhase('do-work'), 'implementation');
+    assert.equal(stepIdPhase('load-context'), 'intake');
+    assert.equal(stepIdPhase('finalize'), 'finalization');
+  });
+
+  test('a substring that is not a whole token does not match (e.g. `approval` inside a longer token)', () => {
+    // `disapproval-note` tokenizes to [disapproval, note]; neither token is a
+    // recognized stage word, so the old includes('approval') false positive
+    // is gone.
+    assert.equal(stepIdPhase('disapproval-note'), 'active');
   });
 });

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -324,4 +324,88 @@ describe('stepIdPhase — step-identity classification', () => {
     // is gone.
     assert.equal(stepIdPhase('disapproval-note'), 'active');
   });
+
+  // gascity-dashboard (Residual A): the gate stages (approval, finalization)
+  // reject the stage token when ANY lead-up qualifier token appears anywhere in
+  // the step-id tokens — not only when the qualifier immediately precedes the
+  // stage token. `wait-for-approval` ([wait,for,approval]) and `prepare-for-merge`
+  // ([prepare,for,merge]) are steps that LEAD UP TO the gate, so they must not
+  // classify as the gate even though the token before the stage token is `for`.
+  describe('gate stages reject any lead-up qualifier token anywhere (Residual A)', () => {
+    test('pre-approval-ci is NOT approval (qualifier `pre` anywhere)', () => {
+      assert.notEqual(stepIdPhase('pre-approval-ci'), 'approval');
+    });
+
+    test('wait-for-approval is NOT approval (qualifier `wait`/`for`, not adjacent)', () => {
+      assert.notEqual(stepIdPhase('wait-for-approval'), 'approval');
+    });
+
+    test('prepare-for-merge is NOT finalization (qualifier `prepare`/`for`, not adjacent)', () => {
+      assert.notEqual(stepIdPhase('prepare-for-merge'), 'finalization');
+    });
+
+    test('true gates still classify: approval/approve → approval', () => {
+      assert.equal(stepIdPhase('approval'), 'approval');
+      assert.equal(stepIdPhase('approve'), 'approval');
+    });
+
+    test('true gates still classify: finalize/finalization → finalization', () => {
+      assert.equal(stepIdPhase('finalize'), 'finalization');
+      assert.equal(stepIdPhase('finalization'), 'finalization');
+    });
+
+    test('approve-merge is approval — it IS the approval step, no lead-up qualifier', () => {
+      assert.equal(stepIdPhase('approve-merge'), 'approval');
+    });
+
+    test('non-gate stages keep classifying on a whole stage token (no qualifier rejection)', () => {
+      assert.equal(stepIdPhase('review'), 'review');
+      assert.equal(stepIdPhase('do-work'), 'implementation');
+      assert.equal(stepIdPhase('implementation'), 'implementation');
+      assert.equal(stepIdPhase('load-context'), 'intake');
+    });
+  });
+});
+
+// gascity-dashboard (Residual B): furthestStageStepId / latestStepId stage
+// tiebreak rank the lifecycle order intake → implementation → review → approval
+// → finalization, so finalization is the FURTHEST stage. A no-in_progress run
+// whose furthest closed step is finalization must read as finalization, not
+// approval. The mapRunPhase CURRENT-phase precedence (approval before
+// finalization) is a separate concern and stays as-is.
+describe('mapRunPhase — finalization is the furthest lifecycle stage (Residual B)', () => {
+  function snapshotStep(stepId: string, status: string): RunIssue {
+    return {
+      id: `step-${stepId}`,
+      title: 'step',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      metadata: { 'gc.kind': 'step', 'gc.step_id': stepId },
+    };
+  }
+
+  test('no in_progress, closed approve-merge + closed merge-and-finalize → finalization (NOT approval)', () => {
+    const forward = mapRunPhase([
+      root({ id: 'fb1', updated_at: '' }),
+      snapshotStep('approve-merge', 'closed'),
+      snapshotStep('merge-and-finalize', 'closed'),
+    ]);
+    const reversed = mapRunPhase([
+      root({ id: 'fb1', updated_at: '' }),
+      snapshotStep('merge-and-finalize', 'closed'),
+      snapshotStep('approve-merge', 'closed'),
+    ]);
+    assert.equal(forward.phase, 'finalization');
+    assert.equal(reversed.phase, forward.phase);
+  });
+
+  test('no in_progress, closed review + closed approval → approval (approval furthest of the two)', () => {
+    const phase = mapRunPhase([
+      root({ id: 'fb2', updated_at: '' }),
+      snapshotStep('code-review-loop', 'closed'),
+      snapshotStep('human-approval', 'closed'),
+    ]);
+    assert.equal(phase.phase, 'approval');
+  });
 });

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1,0 +1,239 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mapRunPhase, stepIdPhase, type RunIssue } from './phaseMapping.js';
+
+// gascity-dashboard-q3p1: phase is derived from the run's CURRENT step
+// (structured-first), not from a keyword scan over title+description+metadata.
+// The old scan collapsed almost every real formula run onto 'approval' because
+// broad needles like 'gate' (order:gate-sweep, "ship gate") and 'human' (the
+// ubiquitous summary_for_human metadata key) matched incidental text in some
+// bead of the group.
+
+function root(overrides: Partial<RunIssue> & Pick<RunIssue, 'id'>): RunIssue {
+  return {
+    title: 'run root',
+    status: 'open',
+    issue_type: 'molecule',
+    updated_at: '2026-06-06T00:00:00.000Z',
+    metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+    ...overrides,
+  };
+}
+
+function step(
+  id: string,
+  stepId: string,
+  status: string,
+  overrides: Partial<RunIssue> = {},
+): RunIssue {
+  return {
+    id,
+    title: 'step',
+    status,
+    issue_type: 'task',
+    updated_at: '2026-06-06T00:01:00.000Z',
+    metadata: { 'gc.kind': 'step', 'gc.step_id': stepId },
+    ...overrides,
+  };
+}
+
+describe('mapRunPhase — structured derivation from the current step (gascity-dashboard-q3p1)', () => {
+  test('an in_progress implementation step → implementation', () => {
+    const phase = mapRunPhase([
+      root({ id: 'r1' }),
+      step('r1-s1', 'implement-change', 'in_progress'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('an in_progress review step → review (with a review round)', () => {
+    const phase = mapRunPhase([
+      root({ id: 'r2' }),
+      step('r2-s1', 'code-review-loop', 'in_progress'),
+    ]);
+    assert.equal(phase.phase, 'review');
+    assert.ok(phase.reviewRound !== null && phase.reviewRound >= 1);
+  });
+
+  test('an in_progress approval/gate step → approval (true positive still works)', () => {
+    const phase = mapRunPhase([root({ id: 'r3' }), step('r3-s1', 'human-approval', 'in_progress')]);
+    assert.equal(phase.phase, 'approval');
+  });
+
+  test('an in_progress finalize step → finalization', () => {
+    const phase = mapRunPhase([
+      root({ id: 'r4' }),
+      step('r4-s1', 'merge-and-finalize', 'in_progress'),
+    ]);
+    assert.equal(phase.phase, 'finalization');
+  });
+
+  test('phase advances as the active step advances (graph.v2 progression)', () => {
+    const base = [root({ id: 'rp' })];
+    // 1. implementation in progress, later steps not yet started.
+    const atImpl = mapRunPhase([
+      ...base,
+      step('rp-s1', 'implement-change', 'in_progress'),
+      step('rp-s2', 'code-review-loop', 'open'),
+      step('rp-s3', 'human-approval', 'open'),
+    ]);
+    assert.equal(atImpl.phase, 'implementation');
+
+    // 2. implementation closed, review now in progress.
+    const atReview = mapRunPhase([
+      ...base,
+      step('rp-s1', 'implement-change', 'closed'),
+      step('rp-s2', 'code-review-loop', 'in_progress', {
+        updated_at: '2026-06-06T01:00:00.000Z',
+      }),
+      step('rp-s3', 'human-approval', 'open'),
+    ]);
+    assert.equal(atReview.phase, 'review');
+
+    // 3. review closed, approval now in progress.
+    const atApproval = mapRunPhase([
+      ...base,
+      step('rp-s1', 'implement-change', 'closed'),
+      step('rp-s2', 'code-review-loop', 'closed'),
+      step('rp-s3', 'human-approval', 'in_progress', {
+        updated_at: '2026-06-06T02:00:00.000Z',
+      }),
+    ]);
+    assert.equal(atApproval.phase, 'approval');
+  });
+
+  test('falls back to latest advanced step when nothing is in_progress', () => {
+    const phase = mapRunPhase([
+      root({ id: 'rl' }),
+      step('rl-s1', 'implement-change', 'closed', { updated_at: '2026-06-06T00:01:00.000Z' }),
+      step('rl-s2', 'code-review-loop', 'closed', { updated_at: '2026-06-06T02:00:00.000Z' }),
+    ]);
+    // Latest advanced step is the review-loop, so the run reads as review.
+    assert.equal(phase.phase, 'review');
+  });
+});
+
+describe('mapRunPhase — incidental text never forces approval (the core regression)', () => {
+  test('a summary_for_human metadata key does NOT classify the run as approval', () => {
+    const phase = mapRunPhase([
+      root({
+        id: 'h1',
+        metadata: {
+          'gc.formula_contract': 'graph.v2',
+          'gc.kind': 'run',
+          summary_for_human: 'the run summary that operators read',
+        },
+      }),
+      step('h1-s1', 'implement-change', 'in_progress', {
+        metadata: {
+          'gc.kind': 'step',
+          'gc.step_id': 'implement-change',
+          summary_for_human: 'implementing the change',
+        },
+      }),
+    ]);
+    assert.notEqual(phase.phase, 'approval');
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('a "gate" reference (order:gate-sweep dep / "Run BLOCKING gates" desc) does NOT classify as approval', () => {
+    const phase = mapRunPhase([
+      root({
+        id: 'g1',
+        description: 'Run BLOCKING gates before merge; order:gate-sweep dependency',
+      }),
+      step('g1-s1', 'implement-change', 'in_progress', {
+        title: 'Run BLOCKING gates',
+        description: 'order:gate-sweep — ship gate',
+      }),
+    ]);
+    assert.notEqual(phase.phase, 'approval');
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('a run with summary_for_human but NO step beads stays conservative, not approval', () => {
+    const phase = mapRunPhase([
+      root({
+        id: 'n1',
+        title: 'A generic run',
+        metadata: {
+          'gc.kind': 'run',
+          summary_for_human: 'a human-readable summary that mentions a gate',
+        },
+      }),
+    ]);
+    // No step identity, and the summary_for_human value (with its 'gate'/'human'
+    // text) is no longer scanned — so the fallback stays conservative.
+    assert.notEqual(phase.phase, 'approval');
+    assert.equal(phase.phase, 'active');
+  });
+});
+
+describe('mapRunPhase — status branches remain authoritative', () => {
+  test('any blocked bead → blocked, regardless of step identity', () => {
+    const phase = mapRunPhase([root({ id: 'b1' }), step('b1-s1', 'implement-change', 'blocked')]);
+    assert.equal(phase.phase, 'blocked');
+  });
+
+  test('all closed → complete, regardless of step identity', () => {
+    const phase = mapRunPhase([
+      root({ id: 'c1', status: 'closed' }),
+      step('c1-s1', 'implement-change', 'closed'),
+    ]);
+    assert.equal(phase.phase, 'complete');
+  });
+});
+
+describe('mapRunPhase — tightened keyword fallback (no structured steps)', () => {
+  test('a do-work title (no gc.step_id) still reads as implementation', () => {
+    const phase = mapRunPhase([
+      root({ id: 'f1', title: 'mol-do-work' }),
+      {
+        id: 'f1-c1',
+        title: 'Do the work',
+        status: 'in_progress',
+        issue_type: 'task',
+        updated_at: '2026-06-06T00:02:00.000Z',
+        metadata: { molecule_id: 'f1' },
+      },
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('a description-only "gate"/"human"/"merge" mention does NOT reach approval/finalization in the fallback', () => {
+    const phase = mapRunPhase([
+      root({
+        id: 'f2',
+        title: 'A generic run',
+        description: 'review the gate, ask a human, then merge and report',
+      }),
+    ]);
+    // Description is no longer scanned and the title carries no step signal →
+    // conservative active. The incidental 'gate'/'human'/'merge' words in the
+    // description never force a late phase.
+    assert.notEqual(phase.phase, 'approval');
+    assert.notEqual(phase.phase, 'finalization');
+    assert.equal(phase.phase, 'active');
+  });
+});
+
+describe('stepIdPhase — step-identity classification', () => {
+  test('classifies representative declared step ids', () => {
+    assert.equal(stepIdPhase('bootstrap-run'), 'intake');
+    assert.equal(stepIdPhase('preflight'), 'intake');
+    assert.equal(stepIdPhase('implement-change'), 'implementation');
+    assert.equal(stepIdPhase('implementation.patch'), 'implementation');
+    assert.equal(stepIdPhase('do-work'), 'implementation');
+    assert.equal(stepIdPhase('review-pipeline.review-claude'), 'review');
+    assert.equal(stepIdPhase('code-review-loop'), 'review');
+    assert.equal(stepIdPhase('human-approval'), 'approval');
+    assert.equal(stepIdPhase('approve-merge'), 'approval');
+    assert.equal(stepIdPhase('merge-and-finalize'), 'finalization');
+    assert.equal(stepIdPhase('cleanup-worktree'), 'finalization');
+  });
+
+  test('unknown step id is conservative (active), never invents a late phase', () => {
+    assert.equal(stepIdPhase('totally-unknown-step'), 'active');
+  });
+});

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -78,7 +78,15 @@ export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
 function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   const primary = issues.filter(isPrimaryStepIssue);
   const inProgressStep = latestStepId(primary.filter((i) => i.status === 'in_progress'));
-  const activeStepId = inProgressStep ?? latestStepId(primary);
+  // gascity-dashboard (Major 3): when no step is in_progress, the current step
+  // is the FURTHEST-ADVANCED step by stage rank — a deterministic, order- and
+  // timestamp-independent signal. The run-detail snapshot adapter sets every
+  // bead updated_at='' (the snapshot carries no per-bead timestamp), so a
+  // timestamp-based pick there is input-order-dependent and can drift from the
+  // summary lane. Stage rank is derived from gc.step_id alone, so the summary
+  // context (real timestamps) and the detail context (empty timestamps) resolve
+  // the same run to the same phase.
+  const activeStepId = inProgressStep ?? furthestStageStepId(primary);
   if (activeStepId === null) {
     return null;
   }
@@ -92,73 +100,114 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
 }
 
 /**
- * Classify a single gc.step_id into a generic RunPhase. Matches against the
- * structural step identifier only (not free description text). Approval is
- * checked before finalization so an approval gate that mentions its successor
- * (`approve-merge`, `verify-merge-approval`) resolves to approval, not
- * finalization, while a pure finalization step (`merge-and-finalize`, which
- * contains no approval marker) still resolves to finalization. Returns 'active'
- * when the step name carries no recognizable stage marker — deliberately
+ * Classify a single gc.step_id into a generic RunPhase. The step id is split on
+ * its structural delimiters (`-`, `.`, `_`, `:`, `/`) into TOKENS and matched
+ * WHOLE-TOKEN against per-stage keyword sets — never as raw substrings. Whole-
+ * token matching is what stops a CI/leading step from being misbucketed onto a
+ * late stage: `pre-approval-ci` is not approval, `dispatch-implementation` is
+ * implementation (not finalization), `prepare-review-context` is review (not
+ * approval/finalization).
+ *
+ * Precedence is latest-stage-first (approval > finalization > review >
+ * implementation > intake), preserving the approval-before-finalization rule so
+ * an approval gate that names its successor (`approve-merge`,
+ * `verify-merge-approval`) resolves to approval, not finalization, while a pure
+ * finalization step (`merge-and-finalize`) still resolves to finalization.
+ *
+ * The gate stages (approval, finalization) additionally reject a stage token
+ * that is immediately preceded by a NEGATING prefix token (`pre`, `prepare`,
+ * `wait`) — those are steps that LEAD UP TO the gate, not the gate itself
+ * (`pre-approval-ci`). Implementation/review/intake do not apply the negating
+ * rule: a real stage token there is a reliable signal regardless of qualifier.
+ *
+ * Returns 'active' when no token names a recognizable stage — deliberately
  * conservative, so an unknown step never invents a specific late phase.
  */
 export function stepIdPhase(stepId: string): SharedRunPhase {
-  const id = stepId.toLowerCase();
-  if (matchesStepNeedle(id, APPROVAL_STEP_NEEDLES)) return 'approval';
-  if (matchesStepNeedle(id, FINALIZATION_STEP_NEEDLES)) return 'finalization';
-  if (matchesStepNeedle(id, REVIEW_STEP_NEEDLES)) return 'review';
-  if (matchesStepNeedle(id, IMPLEMENTATION_STEP_NEEDLES)) return 'implementation';
-  if (matchesStepNeedle(id, INTAKE_STEP_NEEDLES)) return 'intake';
+  const tokens = tokenizeStepId(stepId);
+  if (hasStageToken(tokens, APPROVAL_STAGE_TOKENS, { rejectAfterNegatingPrefix: true })) {
+    return 'approval';
+  }
+  if (hasStageToken(tokens, FINALIZATION_STAGE_TOKENS, { rejectAfterNegatingPrefix: true })) {
+    return 'finalization';
+  }
+  if (hasStageToken(tokens, REVIEW_STAGE_TOKENS)) return 'review';
+  if (hasStageToken(tokens, IMPLEMENTATION_STAGE_TOKENS)) return 'implementation';
+  if (hasStageToken(tokens, INTAKE_STAGE_TOKENS)) return 'intake';
   return 'active';
 }
 
-function matchesStepNeedle(id: string, needles: readonly string[]): boolean {
-  return needles.some((n) => id.includes(n));
+const STEP_ID_DELIMITERS = /[-._:/]+/;
+
+function tokenizeStepId(stepId: string): string[] {
+  return stepId.toLowerCase().split(STEP_ID_DELIMITERS).filter(Boolean);
 }
 
-// Step-identity needles, matched against gc.step_id values only. Ordered by
-// caller (stepIdPhase) latest-stage-first. Drawn from the declared step ids in
-// stagesForFormula plus the v1/wisp step names (do-work, load-context, …).
-const FINALIZATION_STEP_NEEDLES = [
+// Prefix tokens that mark a step as LEADING UP TO a gate rather than being the
+// gate itself: `pre-approval-ci`, `prepare-merge`, `wait-for-approval`.
+const NEGATING_PREFIX_TOKENS: ReadonlySet<string> = new Set(['pre', 'prepare', 'wait']);
+
+function hasStageToken(
+  tokens: readonly string[],
+  stageTokens: ReadonlySet<string>,
+  options: { rejectAfterNegatingPrefix?: boolean } = {},
+): boolean {
+  return tokens.some((token, index) => {
+    if (!stageTokens.has(token)) return false;
+    if (!options.rejectAfterNegatingPrefix) return true;
+    const prev = index > 0 ? tokens[index - 1] : undefined;
+    return prev === undefined || !NEGATING_PREFIX_TOKENS.has(prev);
+  });
+}
+
+// Whole-token stage vocabularies, matched against tokenized gc.step_id values.
+// Drawn from the declared step ids in stagesForFormula plus the v1/wisp step
+// names (do-work, load-context, …). Multi-word step ids contribute each of
+// their tokens (e.g. `merge-and-finalize` → merge, finalize).
+const APPROVAL_STAGE_TOKENS: ReadonlySet<string> = new Set([
+  'approval',
+  'approve',
+  'approved',
+  'gate',
+]);
+const FINALIZATION_STAGE_TOKENS: ReadonlySet<string> = new Set([
   'finalize',
+  'finalization',
   'merge',
   'cleanup',
   'publish',
-  'open-or-update-pr',
-  'open-pr',
-  'dispatch-implementation',
-] as const;
-const APPROVAL_STEP_NEEDLES = ['approval', 'approve'] as const;
-const REVIEW_STEP_NEEDLES = [
+]);
+const REVIEW_STAGE_TOKENS: ReadonlySet<string> = new Set([
   'review',
+  'reviewer',
   'scorecard',
   'persona',
+  'personas',
   'audit',
   'repro',
   'baseline',
   'investigation',
   'classify',
   'classification',
-] as const;
-const IMPLEMENTATION_STEP_NEEDLES = [
+]);
+const IMPLEMENTATION_STAGE_TOKENS: ReadonlySet<string> = new Set([
   'implement',
   'implementation',
   'patch',
-  'apply-fixes',
-  'apply-code-fixes',
-  'apply-design-changes',
-  'do-work',
+  'fixes',
+  'work',
   'design',
-] as const;
-const INTAKE_STEP_NEEDLES = [
+]);
+const INTAKE_STAGE_TOKENS: ReadonlySet<string> = new Set([
   'intake',
   'bootstrap',
-  'load-context',
+  'context',
   'router',
   'request',
   'preflight',
   'setup',
   'rebase',
-] as const;
+]);
 
 /**
  * Keyword fallback used only when no step carries a gc.step_id. Scans
@@ -558,10 +607,71 @@ function furthestClosedStageIndex(stages: Array<{ steps: string[] }>, issues: Ru
 export function latestStepId(issues: RunIssue[]): string | null {
   return (
     [...issues]
-      .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))
+      .sort(byMostRecentThenStage)
       .map((i) => stringValue(i.metadata?.['gc.step_id']))
       .find(Boolean) ?? null
   );
+}
+
+/**
+ * gascity-dashboard (Major 3): the deterministic current-step pick for the
+ * "no step in_progress" fallback. Among the steps that carry a gc.step_id,
+ * select the one whose stage is furthest along the ladder (approval >
+ * finalization > review > implementation > intake > active). This depends only
+ * on gc.step_id — never on updated_at — so it is stable regardless of input
+ * order and identical whether the beads come from the summary projection (real
+ * timestamps) or the run-detail snapshot adapter (updated_at=''). Ties on stage
+ * rank break on the step id string for total determinism.
+ */
+function furthestStageStepId(issues: RunIssue[]): string | null {
+  const stepIds = issues
+    .map((i) => stringValue(i.metadata?.['gc.step_id']))
+    .filter((id): id is string => id.length > 0);
+  if (stepIds.length === 0) return null;
+  return [...stepIds].sort((a, b) => {
+    const rankDelta = stageRank(stepIdPhase(b)) - stageRank(stepIdPhase(a));
+    if (rankDelta !== 0) return rankDelta;
+    return a < b ? -1 : a > b ? 1 : 0;
+  })[0]!;
+}
+
+// Stage ladder rank (higher = further along). Mirrors the latest-stage-first
+// precedence in stepIdPhase / runStages; 'active' is the conservative floor.
+const STAGE_RANK: Record<SharedRunPhase, number> = {
+  active: 0,
+  intake: 1,
+  implementation: 2,
+  review: 3,
+  finalization: 4,
+  approval: 5,
+  blocked: 6,
+  complete: 7,
+};
+
+function stageRank(phase: SharedRunPhase): number {
+  return STAGE_RANK[phase];
+}
+
+/**
+ * Deterministic step ordering: most-recently-updated first, then furthest stage,
+ * then step id. Date.parse('') is NaN, so when the run-detail snapshot adapter
+ * leaves every updated_at empty the timestamp comparison collapses to 0 and the
+ * stage / step-id tiebreakers make the pick deterministic instead of leaving it
+ * to the engine's NaN-comparator behavior (input-order-dependent).
+ */
+function byMostRecentThenStage(a: RunIssue, b: RunIssue): number {
+  const timeDelta = parseTimestamp(b.updated_at) - parseTimestamp(a.updated_at);
+  if (timeDelta !== 0) return timeDelta;
+  const aStep = stringValue(a.metadata?.['gc.step_id']);
+  const bStep = stringValue(b.metadata?.['gc.step_id']);
+  const rankDelta = stageRank(stepIdPhase(bStep)) - stageRank(stepIdPhase(aStep));
+  if (rankDelta !== 0) return rankDelta;
+  return aStep < bStep ? -1 : aStep > bStep ? 1 : 0;
+}
+
+function parseTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 export function stepIssues(issues: RunIssue[], step: string): RunIssue[] {

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -7,9 +7,13 @@
 // classifier behavior so the React translation of RunMap inherits a
 // consistent phase grammar.
 //
-// Parent keyword scans read DashboardBead.parent first and fall back to the
-// older metadata['gc.parent_bead_id'] marker when present. When neither exists,
-// classification falls back to title + description + metadata text scans.
+// Phase is derived structurally — from the run's CURRENT step (gc.step_id)
+// classified into a generic RunPhase (see structuredPhase / stepIdPhase). Only
+// when no step carries a gc.step_id does it fall back to a tightened keyword
+// scan scoped to step-identity signals (titles + gc.step_id), never the full
+// description+metadata dump (see fallbackPhase). Parent keyword scans read
+// DashboardBead.parent first and fall back to the older
+// metadata['gc.parent_bead_id'] marker when present.
 
 import type { DashboardBead } from '../dashboard-beads.js';
 import type { RunPhase as SharedRunPhase, RunStage } from '../snapshot/types.js';
@@ -34,6 +38,7 @@ export interface PhaseMapping {
 }
 
 export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
+  // Status-based branches first — these are authoritative and correct.
   if (issues.some((i) => i.status === 'blocked' || textForIssue(i).includes('blocked'))) {
     return { phase: 'blocked', label: 'blocked', reviewRound: null };
   }
@@ -42,41 +47,167 @@ export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
     return { phase: 'complete', label: 'complete', reviewRound: null };
   }
 
-  if (containsAny(issues, ['approval', 'approved', 'gate', 'human', 'finalize-scope'])) {
+  // gascity-dashboard-q3p1: structured-first phase derivation. When the run has
+  // step beads carrying gc.step_id, the run's phase is the phase of its CURRENT
+  // step (the in_progress primary step, else the latest-advanced primary step) —
+  // a real progress signal that tracks the run forward as steps advance. The old
+  // keyword scan over title+description+metadata collapsed almost every formula
+  // run to 'approval' because needles like 'gate' (order:gate-sweep, "ship gate")
+  // and 'human' (the ubiquitous summary_for_human metadata key) matched incidental
+  // text in some bead of the group. Step-id is a structural identifier, not free
+  // text, so it does not suffer that false-positive class.
+  const structured = structuredPhase(issues);
+  if (structured !== null) {
+    return structured;
+  }
+
+  // Fallback (no resolvable step identity): a tightened keyword scan scoped to
+  // step-identity signals only (titles + gc.step_id), with the incidental-match
+  // needles removed. Conservative — returns 'active' when genuinely ambiguous.
+  return fallbackPhase(issues);
+}
+
+/**
+ * gascity-dashboard-q3p1: derive the phase from the run's current step.
+ *
+ * The active step is the latest in_progress primary step; if none is in_progress
+ * (e.g. between steps) it is the latest primary step that carries a gc.step_id.
+ * The step-id is classified into a generic RunPhase by stepIdPhase. Returns null
+ * when no primary step carries a gc.step_id (no structured signal to use).
+ */
+function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
+  const primary = issues.filter(isPrimaryStepIssue);
+  const inProgressStep = latestStepId(primary.filter((i) => i.status === 'in_progress'));
+  const activeStepId = inProgressStep ?? latestStepId(primary);
+  if (activeStepId === null) {
+    return null;
+  }
+
+  const phase = stepIdPhase(activeStepId);
+  if (phase === 'review') {
+    const resolved = reviewRoundForIssues(issues) ?? fallbackReviewRound(issues);
+    return { phase: 'review', label: `review round ${resolved}`, reviewRound: resolved };
+  }
+  return { phase, label: phase, reviewRound: null };
+}
+
+/**
+ * Classify a single gc.step_id into a generic RunPhase. Matches against the
+ * structural step identifier only (not free description text). Approval is
+ * checked before finalization so an approval gate that mentions its successor
+ * (`approve-merge`, `verify-merge-approval`) resolves to approval, not
+ * finalization, while a pure finalization step (`merge-and-finalize`, which
+ * contains no approval marker) still resolves to finalization. Returns 'active'
+ * when the step name carries no recognizable stage marker — deliberately
+ * conservative, so an unknown step never invents a specific late phase.
+ */
+export function stepIdPhase(stepId: string): SharedRunPhase {
+  const id = stepId.toLowerCase();
+  if (matchesStepNeedle(id, APPROVAL_STEP_NEEDLES)) return 'approval';
+  if (matchesStepNeedle(id, FINALIZATION_STEP_NEEDLES)) return 'finalization';
+  if (matchesStepNeedle(id, REVIEW_STEP_NEEDLES)) return 'review';
+  if (matchesStepNeedle(id, IMPLEMENTATION_STEP_NEEDLES)) return 'implementation';
+  if (matchesStepNeedle(id, INTAKE_STEP_NEEDLES)) return 'intake';
+  return 'active';
+}
+
+function matchesStepNeedle(id: string, needles: readonly string[]): boolean {
+  return needles.some((n) => id.includes(n));
+}
+
+// Step-identity needles, matched against gc.step_id values only. Ordered by
+// caller (stepIdPhase) latest-stage-first. Drawn from the declared step ids in
+// stagesForFormula plus the v1/wisp step names (do-work, load-context, …).
+const FINALIZATION_STEP_NEEDLES = [
+  'finalize',
+  'merge',
+  'cleanup',
+  'publish',
+  'open-or-update-pr',
+  'open-pr',
+  'dispatch-implementation',
+] as const;
+const APPROVAL_STEP_NEEDLES = ['approval', 'approve'] as const;
+const REVIEW_STEP_NEEDLES = [
+  'review',
+  'scorecard',
+  'persona',
+  'audit',
+  'repro',
+  'baseline',
+  'investigation',
+  'classify',
+  'classification',
+] as const;
+const IMPLEMENTATION_STEP_NEEDLES = [
+  'implement',
+  'implementation',
+  'patch',
+  'apply-fixes',
+  'apply-code-fixes',
+  'apply-design-changes',
+  'do-work',
+  'design',
+] as const;
+const INTAKE_STEP_NEEDLES = [
+  'intake',
+  'bootstrap',
+  'load-context',
+  'router',
+  'request',
+  'preflight',
+  'setup',
+  'rebase',
+] as const;
+
+/**
+ * Keyword fallback used only when no step carries a gc.step_id. Scans
+ * step-identity signals (issue titles + any gc.step_id present) rather than the
+ * full description+metadata dump, and drops the incidental-matching needles
+ * ('gate', 'human', 'merge', 'close', 'report', 'work', 'fix', 'code') that
+ * collapsed real runs onto late phases. Conservative: 'active' when ambiguous.
+ */
+function fallbackPhase(issues: RunIssue[]): PhaseMapping {
+  if (stepSignalContainsAny(issues, ['approval', 'approved', 'finalize-scope'])) {
     return { phase: 'approval', label: 'approval', reviewRound: null };
   }
 
-  if (containsAny(issues, ['post-merge', 'merge', 'close', 'report', 'finalization', 'finalize'])) {
-    return {
-      phase: 'finalization',
-      label: 'finalization',
-      reviewRound: null,
-    };
+  if (stepSignalContainsAny(issues, ['post-merge', 'finalization', 'finalize'])) {
+    return { phase: 'finalization', label: 'finalization', reviewRound: null };
   }
 
   const round = reviewRoundForIssues(issues);
-  if (round !== null || containsAny(issues, ['review', 'reviewer', 'scorecard'])) {
+  if (round !== null || stepSignalContainsAny(issues, ['review', 'reviewer', 'scorecard'])) {
     const resolved = round ?? fallbackReviewRound(issues);
-    return {
-      phase: 'review',
-      label: `review round ${resolved}`,
-      reviewRound: resolved,
-    };
+    return { phase: 'review', label: `review round ${resolved}`, reviewRound: resolved };
   }
 
-  if (containsAny(issues, ['implementation', 'work', 'patch', 'code', 'fix', 'do-work'])) {
-    return {
-      phase: 'implementation',
-      label: 'implementation',
-      reviewRound: null,
-    };
+  if (stepSignalContainsAny(issues, ['implementation', 'patch', 'do-work'])) {
+    return { phase: 'implementation', label: 'implementation', reviewRound: null };
   }
 
-  if (containsAny(issues, ['intake', 'load-context', 'router', 'request'])) {
+  if (stepSignalContainsAny(issues, ['intake', 'load-context', 'router', 'request'])) {
     return { phase: 'intake', label: 'intake', reviewRound: null };
   }
 
   return { phase: 'active', label: 'active', reviewRound: null };
+}
+
+/**
+ * Step-identity text for fallback scanning: the issue title plus any gc.step_id.
+ * Excludes description and the metadata dump so incidental words (e.g. a
+ * summary_for_human value, a "ship gate" mention) never drive the phase.
+ */
+function stepSignalText(issue: RunIssue): string {
+  const stepId = stringValue(issue.metadata?.['gc.step_id']);
+  return [issue.title, stepId].filter(Boolean).join(' ').toLowerCase();
+}
+
+function stepSignalContainsAny(issues: RunIssue[], needles: string[]): boolean {
+  return issues.some((i) => {
+    const text = stepSignalText(i);
+    return needles.some((n) => text.includes(n));
+  });
 }
 
 /**
@@ -155,13 +286,6 @@ export function textForIssue(issue: RunIssue): string {
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
-}
-
-export function containsAny(issues: RunIssue[], needles: string[]): boolean {
-  return issues.some((i) => {
-    const text = textForIssue(i);
-    return needles.some((n) => text.includes(n));
-  });
 }
 
 export function stringValue(value: unknown): string {

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -114,10 +114,12 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
  * `verify-merge-approval`) resolves to approval, not finalization, while a pure
  * finalization step (`merge-and-finalize`) still resolves to finalization.
  *
- * The gate stages (approval, finalization) additionally reject a stage token
- * that is immediately preceded by a NEGATING prefix token (`pre`, `prepare`,
- * `wait`) — those are steps that LEAD UP TO the gate, not the gate itself
- * (`pre-approval-ci`). Implementation/review/intake do not apply the negating
+ * The gate stages (approval, finalization) additionally reject the stage token
+ * when ANY lead-up qualifier token (`pre`, `prepare`, `wait`, `await`,
+ * `pending`, `before`, `for`, `to`) appears anywhere in the step-id tokens —
+ * not only immediately before the stage token. Those are steps that LEAD UP TO
+ * the gate, not the gate itself (`pre-approval-ci`, `wait-for-approval`,
+ * `prepare-for-merge`). Implementation/review/intake do not apply the qualifier
  * rule: a real stage token there is a reliable signal regardless of qualifier.
  *
  * Returns 'active' when no token names a recognizable stage — deliberately
@@ -125,10 +127,10 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
  */
 export function stepIdPhase(stepId: string): SharedRunPhase {
   const tokens = tokenizeStepId(stepId);
-  if (hasStageToken(tokens, APPROVAL_STAGE_TOKENS, { rejectAfterNegatingPrefix: true })) {
+  if (hasStageToken(tokens, APPROVAL_STAGE_TOKENS, { rejectWithLeadUpQualifier: true })) {
     return 'approval';
   }
-  if (hasStageToken(tokens, FINALIZATION_STAGE_TOKENS, { rejectAfterNegatingPrefix: true })) {
+  if (hasStageToken(tokens, FINALIZATION_STAGE_TOKENS, { rejectWithLeadUpQualifier: true })) {
     return 'finalization';
   }
   if (hasStageToken(tokens, REVIEW_STAGE_TOKENS)) return 'review';
@@ -143,21 +145,32 @@ function tokenizeStepId(stepId: string): string[] {
   return stepId.toLowerCase().split(STEP_ID_DELIMITERS).filter(Boolean);
 }
 
-// Prefix tokens that mark a step as LEADING UP TO a gate rather than being the
-// gate itself: `pre-approval-ci`, `prepare-merge`, `wait-for-approval`.
-const NEGATING_PREFIX_TOKENS: ReadonlySet<string> = new Set(['pre', 'prepare', 'wait']);
+// Qualifier tokens that mark a step as LEADING UP TO a gate rather than being
+// the gate itself, wherever they appear in the step id: `pre-approval-ci`,
+// `wait-for-approval`, `prepare-for-merge`, `before-merge`, `pending-approval`.
+const LEAD_UP_QUALIFIER_TOKENS: ReadonlySet<string> = new Set([
+  'pre',
+  'prepare',
+  'wait',
+  'await',
+  'pending',
+  'before',
+  'for',
+  'to',
+]);
 
 function hasStageToken(
   tokens: readonly string[],
   stageTokens: ReadonlySet<string>,
-  options: { rejectAfterNegatingPrefix?: boolean } = {},
+  options: { rejectWithLeadUpQualifier?: boolean } = {},
 ): boolean {
-  return tokens.some((token, index) => {
-    if (!stageTokens.has(token)) return false;
-    if (!options.rejectAfterNegatingPrefix) return true;
-    const prev = index > 0 ? tokens[index - 1] : undefined;
-    return prev === undefined || !NEGATING_PREFIX_TOKENS.has(prev);
-  });
+  if (!tokens.some((token) => stageTokens.has(token))) return false;
+  // Gate stages: a stage token is the gate only when no lead-up qualifier token
+  // appears anywhere in the step id (a step that LEADS UP TO the gate is not it).
+  if (options.rejectWithLeadUpQualifier) {
+    return !tokens.some((token) => LEAD_UP_QUALIFIER_TOKENS.has(token));
+  }
+  return true;
 }
 
 // Whole-token stage vocabularies, matched against tokenized gc.step_id values.
@@ -635,21 +648,32 @@ function furthestStageStepId(issues: RunIssue[]): string | null {
   })[0]!;
 }
 
-// Stage ladder rank (higher = further along). Mirrors the latest-stage-first
-// precedence in stepIdPhase / runStages; 'active' is the conservative floor.
-const STAGE_RANK: Record<SharedRunPhase, number> = {
+// Lifecycle rank (higher = further along the run lifecycle), used ONLY to pick
+// the furthest-reached stage among steps (furthestStageStepId, and the latest-
+// step stage tiebreak in byMostRecentThenStage). The lifecycle order is
+// intake → implementation → review → approval → finalization, so finalization
+// is the FURTHEST stage. 'active' is the conservative floor.
+//
+// NOTE: this is deliberately decoupled from the CURRENT-phase precedence in
+// stepIdPhase, which checks approval BEFORE finalization so an approval gate
+// that names its successor (`approve-merge`) resolves to approval. That
+// precedence is encoded in the if-order of stepIdPhase, not here — the two
+// concerns must not be conflated (a closed approval + closed finalization run
+// has its furthest stage = finalization, while a single `approve-merge` step
+// is classified as the approval phase).
+const LIFECYCLE_RANK: Record<SharedRunPhase, number> = {
   active: 0,
   intake: 1,
   implementation: 2,
   review: 3,
-  finalization: 4,
-  approval: 5,
+  approval: 4,
+  finalization: 5,
   blocked: 6,
   complete: 7,
 };
 
 function stageRank(phase: SharedRunPhase): number {
-  return STAGE_RANK[phase];
+  return LIFECYCLE_RANK[phase];
 }
 
 /**

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -345,6 +345,116 @@ describe('buildRunSummary — historical lanes are recency-bounded (gascity-dash
   });
 });
 
+// gascity-dashboard-km0w: live run-root beads carry gc.root_store_ref
+// ("rig:gascity-packs") plus gc.var.rig_name, but NOT gc.scope_kind /
+// gc.scope_ref. Before this fix the scope derived to unavailable for EVERY
+// run, so runDetailHref omitted the scope query and the detail fetch hit the
+// supervisor at the default city scope (12-14s full-store scan then 404).
+// The scope must be recovered from gc.root_store_ref when the explicit
+// gc.scope_ref pair is absent, while gc.scope_ref stays primary when present.
+describe('runLane scope derives from gc.root_store_ref fallback — gascity-dashboard-km0w', () => {
+  function rootOnly(id: string, metadata: Record<string, string>): RunIssue[] {
+    return [
+      runIssue({
+        id,
+        title: 'mol-focus-review',
+        issue_type: 'molecule',
+        metadata,
+      }),
+    ];
+  }
+
+  test('derives rig scope from gc.root_store_ref when gc.scope_ref is absent', () => {
+    const lane = runLane(
+      'gpk-4fyo6',
+      rootOnly('gpk-4fyo6', { 'gc.root_store_ref': 'rig:gascity-packs' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'available');
+    if (lane.scope.status !== 'available') return;
+    assert.equal(lane.scope.kind, 'rig');
+    assert.equal(lane.scope.ref, 'gascity-packs');
+    assert.equal(lane.scope.rootStoreRef, 'rig:gascity-packs');
+  });
+
+  test('derives city scope from a city: gc.root_store_ref', () => {
+    const lane = runLane(
+      'city-run',
+      rootOnly('city-run', { 'gc.root_store_ref': 'city:ds-research' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'available');
+    if (lane.scope.status !== 'available') return;
+    assert.equal(lane.scope.kind, 'city');
+    assert.equal(lane.scope.ref, 'ds-research');
+  });
+
+  test('explicit gc.scope_ref still wins over gc.root_store_ref', () => {
+    const lane = runLane(
+      'mixed',
+      rootOnly('mixed', {
+        'gc.scope_kind': 'rig',
+        'gc.scope_ref': 'gascity-dashboard',
+        'gc.root_store_ref': 'rig:gascity-packs',
+      }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'available');
+    if (lane.scope.status !== 'available') return;
+    assert.equal(lane.scope.kind, 'rig');
+    assert.equal(lane.scope.ref, 'gascity-dashboard');
+    // rootStoreRef is still carried through verbatim.
+    assert.equal(lane.scope.rootStoreRef, 'rig:gascity-packs');
+  });
+
+  test('an unknown-prefix gc.root_store_ref is not guessed — scope unavailable', () => {
+    const lane = runLane(
+      'bad-prefix',
+      rootOnly('bad-prefix', { 'gc.root_store_ref': 'workspace:ds-research' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'unavailable');
+  });
+
+  test('a colon-less gc.root_store_ref is not guessed — scope unavailable', () => {
+    const lane = runLane(
+      'no-colon',
+      rootOnly('no-colon', { 'gc.root_store_ref': 'gascity-packs' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'unavailable');
+  });
+
+  test('a malformed parsed ref (fails SCOPE_REF_RE) is rejected — scope unavailable', () => {
+    const lane = runLane(
+      'malformed',
+      // leading '-' violates SCOPE_REF_RE (must start alnum).
+      rootOnly('malformed', { 'gc.root_store_ref': 'rig:-bad ref' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'unavailable');
+  });
+
+  test('a control sequence in the derived ref fails SCOPE_REF_RE — scope unavailable', () => {
+    // The fallback validates the parsed ref against SCOPE_REF_RE BEFORE the DTO
+    // edge, so an injected ESC byte (which the pattern rejects) yields
+    // unavailable rather than a sanitised-but-spoofed ref.
+    const lane = runLane(
+      'sanitise',
+      rootOnly('sanitise', { 'gc.root_store_ref': 'rig:gascity-packs\x1b[31m' }),
+      new Map(),
+    );
+
+    assert.equal(lane.scope.status, 'unavailable');
+  });
+});
+
 describe('runLane scope sanitisation — gascity-dashboard-5e5v', () => {
   test('strips ANSI/OSC from rootStoreRef on the metadata path', () => {
     const lane = runLane(


### PR DESCRIPTION
Consolidates three runs-view fixes found while live-verifying #105 with the operator. All three are CI-green and were verified running on the live `:8082` dashboard (operator + maintainer confirmed: phase column accurate, formulas open fast live+history, v1 runs show an honest message).

## Fixes

**1. Run detail opens for all runs (scope fix).** Run-root beads carry `gc.root_store_ref` (e.g. `rig:gascity-packs`) but not `gc.scope_ref`, so `fromRootMetadataScope` returned scope=unavailable for every run → the detail link dropped scope → the supervisor did a 12–14s full-store scan at city scope → 404. `fromRootMetadataScope` now falls back to parsing `gc.root_store_ref` (`"rig:X"`→`{rig,X}`, validated by `SCOPE_REF_RE`) when `gc.scope_ref` is absent. Detail now loads in ~0.2–0.5s, live **and** from history.

**2. Phase is derived from the run's current step, not keyword soup.** `mapRunPhase` keyword-scanned each run's full text+metadata; the `approval` needles `gate`/`human` matched ubiquitous content (`order:gate-sweep`, `summary_for_human`, "human" assignee) so nearly every run collapsed to "approval" (also inflating the `needsOperator` count). Now derives phase from the current step (`gc.step_id`→stage) and only falls back to a tightened keyword scan (broad needles removed) for bare-root runs.

**3. v1/wisp detail is an honest message, not a dead-end.** A v1 run (or a workflow the supervisor 404s) now renders "detailed step view isn't available for this run (v1/wisp + no-snapshot runs are list-only)" instead of a raw error. Frontend-only (`UnsupportedRunError.reason` + a `SupervisorApiError` 404 map); no wire-shape field added.

## Scope / safety
No `shared/` wire-shape type changed (only logic + JSDoc). No backend/bind/proxy change. Reuses existing lane/stage/scope primitives.

## CI / tests
typecheck (src+test), lint, prettier, openapi drift, shared/backend/frontend suites all green locally; new tests for scope derivation, phase-from-step, v1/404 mapping (+ updated fixtures where the old assertion encoded the bug).

## Follow-ups (separate, not in this PR)
v1/v2 list label + click-gate; runs-fetch graceful degradation under load; beads-view per-rig attention board.
