### PR TITLE
Runs view: survive supervisor slowness under load (no blank / no latch)

### DIFF
--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -320,7 +320,17 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     expect(calmLink.closest('li')?.getAttribute('data-attention-severity')).toBeNull();
   });
 
-  it('does not flatten an unavailable run count into zero', async () => {
+  it('does not flatten an unavailable run count into zero (first load, no prior data)', async () => {
+    // A GENUINE first-load failure — both the preview paint and the full refresh
+    // error with no prior good snapshot to retain — still surfaces the error, so
+    // an empty view never lies about the store. (A refresh that errors AFTER a
+    // good paint is covered by the last-good-retention test in
+    // runSummarySubscription.test.tsx: it keeps the good lanes as stale.)
+    mockLoadRunSummaryPreview.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'run collector unavailable in test',
+    } satisfies SourceState<RunSummary>);
     mockLoadRunSummary.mockResolvedValue({
       source: 'runs',
       status: 'error',

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -184,6 +184,84 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     expect(screen.getByTestId('page').textContent).toBe('fresh:1');
   });
 
+  it('keeps the last-good summary as stale when a refresh errors (no blank on transient timeout)', async () => {
+    // The /runs UX bug: first paint renders lanes, then a background refresh
+    // times out under city load and used to OVERWRITE the good render with the
+    // full "Run data unavailable" error state. A transient refresh failure must
+    // retain the last-good snapshot, re-published as 'stale' (which RunMap and
+    // Runs.tsx render as data), not transition the view to 'error'.
+    mockFull.mockResolvedValue(buildRunSource('fresh', 2));
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="badge" />
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // First good load lands.
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('fresh:2'));
+
+    // A bead event triggers a refresh that resolves to an error source (the
+    // supervisor list timed out). Prior good data exists, so the published
+    // state must keep that data as 'stale', not flip to 'error'.
+    mockFull.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'gc supervisor request timed out after 5000ms',
+    } satisfies SourceState<RunSummary>);
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('stale:2'));
+    expect(screen.getByTestId('page').textContent).toBe('stale:2');
+  });
+
+  it('keeps the last-good summary as stale when a refresh throws', async () => {
+    mockFull.mockResolvedValue(buildRunSource('fresh', 3));
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('fresh:3'));
+
+    // A refresh that rejects (rather than resolving to an error source) must
+    // also retain the last-good snapshot rather than latching the view dead.
+    mockFull.mockRejectedValue(new Error('gc supervisor request timed out after 5000ms'));
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('stale:3'));
+  });
+
+  it('surfaces error when the FIRST load fails with no prior good data', async () => {
+    // The genuine first-load failure is unchanged: with no prior snapshot to
+    // retain, the error state still surfaces so the operator is not shown an
+    // empty store as if it were healthy.
+    mockPreview.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'formula runs unavailable',
+    } satisfies SourceState<RunSummary>);
+    mockFull.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'formula runs unavailable',
+    } satisfies SourceState<RunSummary>);
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('error:-1'));
+  });
+
   it('throws when used outside a RunSummaryProvider', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => renderHook(() => useRunSummary())).toThrow(/RunSummaryProvider/);

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -238,6 +238,72 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('stale:3'));
   });
 
+  it('self-recovers from a stale-retention: schedules a re-refresh that lands fresh with no SSE event', async () => {
+    // The latch bug: a good preview paints, then the one-time full refresh times
+    // out ONCE. Last-good retention keeps the view as 'stale' (good UX, never
+    // blanks) — but because the masked failure looked like a healthy snapshot to
+    // the retry path, nothing re-attempted, and the view stayed stuck on the
+    // preview-grade snapshot until some unrelated SSE event happened to fire.
+    // The fix decouples what we DISPLAY (stale, not blank) from whether we keep
+    // RETRYING (yes, with backoff). Here the full refresh fails once, then the
+    // backed-off re-refresh succeeds with full data — all driven by timers, with
+    // no SSE event in the test.
+    vi.useFakeTimers();
+    // Preview paints good data (blocked=4 stands in for preview-grade).
+    mockPreview.mockResolvedValue(buildRunSource('fresh', 4));
+    // The one-time full upgrade times out the FIRST time it is called...
+    mockFull.mockRejectedValueOnce(new Error('gc supervisor request timed out after 5000ms'));
+    // ...and every later attempt lands the full session-enriched snapshot.
+    mockFull.mockResolvedValue(buildRunSource('fresh', 7));
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // Preview lands, then the full refresh fails and is retained as 'stale' over
+    // the preview-grade data — the view shows data, never blanks.
+    await vi.waitFor(() => expect(screen.getByTestId('page').textContent).toBe('stale:4'));
+    // No SSE event has fired; the only thing that can recover us is the scheduled
+    // backoff re-refresh (first delay = 2_000ms).
+    expect(lastHookCall.onMatch).toBeTypeOf('function');
+
+    // Advance past the first backoff delay to fire the scheduled re-refresh,
+    // which now succeeds with the full snapshot.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    // The view self-recovered to fresh, full data — no external SSE event.
+    await vi.waitFor(() => expect(screen.getByTestId('page').textContent).toBe('fresh:7'));
+  });
+
+  it('does not leak the recovery timer on unmount', async () => {
+    vi.useFakeTimers();
+    mockPreview.mockResolvedValue(buildRunSource('fresh', 4));
+    mockFull.mockRejectedValue(new Error('gc supervisor request timed out after 5000ms'));
+
+    const { unmount } = render(
+      <RunSummaryProvider>
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // A stale-retention is published and a recovery timer is armed.
+    await vi.waitFor(() => expect(screen.getByTestId('page').textContent).toBe('stale:4'));
+    const fullCallsBeforeUnmount = mockFull.mock.calls.length;
+
+    unmount();
+
+    // After unmount, advancing well past the whole backoff budget must not fire
+    // any further refresh — the timer was cleaned up.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(mockFull.mock.calls.length).toBe(fullCallsBeforeUnmount);
+  });
+
   it('surfaces error when the FIRST load fails with no prior good data', async () => {
     // The genuine first-load failure is unchanged: with no prior snapshot to
     // retain, the error state still surfaces so the operator is not shown an

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -1,6 +1,7 @@
 import {
   GC_EVENT_PREFIX,
   type RunSummary,
+  type SourceAvailableState,
   type SourceState,
   type SourceStatus,
 } from 'gas-city-dashboard-shared';
@@ -56,11 +57,41 @@ export interface RunSummarySubscription {
  */
 export function useRunSummarySubscription(): RunSummarySubscription {
   const cityName = getActiveCity();
+
+  // Last-good retention (the /runs blank-on-transient-timeout bug): a background
+  // refresh that resolves to status:'error' — or throws — under city load used
+  // to OVERWRITE the already-rendered lanes with the full "Run data unavailable"
+  // page. A transient refresh failure must not blank a good view: if a prior
+  // available snapshot exists, keep serving it, re-published as 'stale' (which
+  // RunMap and Runs.tsx already render as data, with a subtle stale hint). The
+  // error state is only published when there is NO prior good snapshot — a
+  // genuine first-load failure, where an empty view would lie about the store.
+  const lastGoodRef = useRef<SourceAvailableState<RunSummary> | null>(null);
+  const refreshWithLastGoodRetention = useCallback(async (): Promise<SourceState<RunSummary>> => {
+    const result = await loadSupervisorRunSummarySource().catch(
+      (err): SourceState<RunSummary> => ({
+        source: 'runs',
+        status: 'error',
+        error: err instanceof Error ? err.message : 'formula runs unavailable',
+      }),
+    );
+    if (result.status !== 'error') return result;
+    const lastGood = lastGoodRef.current;
+    if (lastGood === null) return result;
+    return { ...lastGood, status: 'stale' };
+  }, []);
+
   const { data, loading, error, refresh } = useCachedData(
     `runs:summary:${cityName ?? 'no-city'}`,
     loadSupervisorRunSummaryPreviewSource,
-    { refreshFetcher: loadSupervisorRunSummarySource },
+    { refreshFetcher: refreshWithLastGoodRetention },
   );
+  // Capture the latest available snapshot so the next failed refresh can fall
+  // back to it. A re-published 'stale' snapshot stays good data, so it keeps
+  // being retained across a run of consecutive failures.
+  if (data !== undefined && data.status !== 'error') {
+    lastGoodRef.current = data;
+  }
   const runs = data ?? null;
   const runsStatusRef = useRef<SourceStatus | null>(null);
   runsStatusRef.current = runs?.status ?? null;

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -67,6 +67,15 @@ export function useRunSummarySubscription(): RunSummarySubscription {
   // error state is only published when there is NO prior good snapshot — a
   // genuine first-load failure, where an empty view would lie about the store.
   const lastGoodRef = useRef<SourceAvailableState<RunSummary> | null>(null);
+  // The recovery signal, kept distinct from the PUBLISHED status. When a refresh
+  // fails but we serve last-good as 'stale', the view shows data — but a 'stale'
+  // status is indistinguishable from a healthy snapshot to the retry effect, so
+  // it would treat the failure as resolved and stop trying. That latches the
+  // preview-grade snapshot until an unrelated SSE event happens to fire. This
+  // flag records "the last refresh failed; the displayed data is stale BECAUSE
+  // of a failure" so recovery keeps driving regardless of what we display, and
+  // is cleared the moment a genuine fresh/full result lands.
+  const staleDueToFailureRef = useRef(false);
   const refreshWithLastGoodRetention = useCallback(async (): Promise<SourceState<RunSummary>> => {
     const result = await loadSupervisorRunSummarySource().catch(
       (err): SourceState<RunSummary> => ({
@@ -75,9 +84,13 @@ export function useRunSummarySubscription(): RunSummarySubscription {
         error: err instanceof Error ? err.message : 'formula runs unavailable',
       }),
     );
-    if (result.status !== 'error') return result;
+    if (result.status !== 'error') {
+      staleDueToFailureRef.current = false;
+      return result;
+    }
     const lastGood = lastGoodRef.current;
     if (lastGood === null) return result;
+    staleDueToFailureRef.current = true;
     return { ...lastGood, status: 'stale' };
   }, []);
 
@@ -115,15 +128,25 @@ export function useRunSummarySubscription(): RunSummarySubscription {
   // gascity-dashboard-4xcv: bounded auto-retry on a degraded load. An error
   // source (or a partial fetch with zero lanes) used to latch the page dead;
   // retry a few times with backoff and reset once a healthy load lands.
+  //
+  // A stale-due-to-failure snapshot is degraded too, even though it RENDERS as
+  // healthy data: the displayed lanes are last-good (possibly preview-grade),
+  // and the refresh that should have upgraded them failed. We must keep
+  // attempting recovery off `staleDueToFailureRef` — NOT off the published
+  // status — so the view self-recovers to fresh/full data without depending on
+  // an unrelated SSE event ever firing. The same backoff budget bounds it; once
+  // a genuine fresh result lands, the failure flag is cleared (in
+  // refreshWithLastGoodRetention) and the next effect run resets the attempt.
   const retryAttemptRef = useRef(0);
   useEffect(() => {
     if (runs === null) return;
     const degraded =
       runs.status === 'error'
         ? true
-        : runs.data.lanesPartial === true &&
-          runs.data.lanes.length === 0 &&
-          runs.data.blockedLanes.length === 0;
+        : staleDueToFailureRef.current ||
+          (runs.data.lanesPartial === true &&
+            runs.data.lanes.length === 0 &&
+            runs.data.blockedLanes.length === 0);
     if (!degraded) {
       retryAttemptRef.current = 0;
       return;

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -552,6 +552,65 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.lanesPartial).toBe(true);
   });
 
+  it('keeps active lanes and marks partial when the molecule-history read rejects (gascity-dashboard-9rk2)', async () => {
+    // The molecule(all=true) scan surfaces historical run roots only; it is
+    // best-effort. A rejection must fold to `partial` with the active lanes still
+    // present — never escalate to a whole-view error/"Run data unavailable".
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') throw new Error('molecule history unavailable');
+      if (query?.rig === 'rig-a') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
+  it('bounds a slow molecule-history read to its own timeout and folds it to partial (gascity-dashboard-9rk2)', async () => {
+    // Live the molecule scan runs ~6.8s — past the 5s required-fetch budget. On
+    // the wide 30s refresh it would otherwise stall the whole refresh; its own
+    // 3s bound caps it so the active set still paints and only the historical
+    // lanes degrade to partial.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') {
+        return new Promise<ListBodyBead>((resolve) => {
+          setTimeout(() => resolve(beadList([])), 6_800);
+        });
+      }
+      if (query?.rig === 'rig-a') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummarySource();
+    // Advance past the molecule's own 3s bound but well short of its 6.8s
+    // completion: the bound fires, the active set still resolves.
+    await vi.advanceTimersByTimeAsync(3_000);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
   it('returns an error source when the active bead list fails', async () => {
     setSupervisorApiForTests({
       ...baseApi,

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -8,7 +8,9 @@ import type {
   MonitorFeedItemResponse,
 } from 'gas-city-dashboard-shared/gc-supervisor';
 import { resetSupervisorApiForTests, setSupervisorApiForTests, type SupervisorApi } from './client';
+import { SupervisorApiError } from './errors';
 import {
+  CORE_RUN_SUMMARY_TIMEOUT_MS,
   loadSupervisorRunSummaryMountSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
@@ -629,6 +631,100 @@ describe('loadSupervisorRunSummarySource', () => {
       status: 'error',
       error: 'beads unavailable',
     });
+  });
+
+  // gascity-dashboard fix/runs-fetch-resilience: a transient core-read timeout
+  // under a CPU burst must not blank the view on a first load (no last-good
+  // snapshot yet). The core active-bead read retries once before giving up.
+  it('retries the core active-bead read once on a transient timeout and resolves to data', async () => {
+    let coreAttempts = 0;
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      coreAttempts += 1;
+      if (coreAttempts === 1) {
+        throw new SupervisorApiError(
+          undefined,
+          'gc supervisor request timed out after 15000ms',
+          undefined,
+        );
+      }
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummarySource();
+    // Drain the short retry backoff so the second attempt fires.
+    await vi.advanceTimersByTimeAsync(250);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(coreAttempts).toBe(2);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+  });
+
+  it('surfaces an error when the core active-bead read times out on every attempt', async () => {
+    let coreAttempts = 0;
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      coreAttempts += 1;
+      throw new SupervisorApiError(
+        undefined,
+        'gc supervisor request timed out after 15000ms',
+        undefined,
+      );
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const pending = loadSupervisorRunSummarySource();
+    await vi.advanceTimersByTimeAsync(250);
+    const source = await pending;
+
+    // A sustained failure is not hidden: after the retries are spent the view
+    // still surfaces the error so a real outage isn't masked forever.
+    expect(coreAttempts).toBe(2);
+    expect(source.status).toBe('error');
+    if (source.status !== 'error') throw new Error('expected error source');
+    expect(source.error).toContain('timed out after 15000ms');
+  });
+
+  it('does not retry the core read on a non-transient (4xx) failure', async () => {
+    let coreAttempts = 0;
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      coreAttempts += 1;
+      throw new SupervisorApiError(400, 'bad request', undefined);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(coreAttempts).toBe(1);
+    expect(source.status).toBe('error');
+  });
+
+  it('reads the core active-bead fetch on the raised burst-tolerant budget', () => {
+    // The path is ~0.02s normally, so the higher ceiling only matters during a
+    // spike; it must stay well above the old 5s budget to absorb a burst.
+    expect(CORE_RUN_SUMMARY_TIMEOUT_MS).toBe(15_000);
+    expect(CORE_RUN_SUMMARY_TIMEOUT_MS).toBeGreaterThan(5_000);
   });
 });
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -23,8 +23,8 @@ import {
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
-import type { Bead, FormulaFeedBody } from 'gas-city-dashboard-shared/gc-supervisor';
-import { supervisorApiForRequestBudget } from './client';
+import type { Bead, FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
+import { SupervisorApiError, supervisorApiForRequestBudget } from './client';
 import { listIsIncomplete, listIsPartial } from './listPartial';
 import { normalizeSessions } from './sessionReads';
 
@@ -42,7 +42,22 @@ const RUNS_FETCH_LIMIT = 500;
 // real fix beyond raising the cap means cursor pagination.
 const RECENT_RUN_FETCH_LIMIT = 500;
 const RUNS_STALE_AFTER_MS = 60 * 1000;
-const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 5_000;
+// The CORE active-bead read is the one fetch whose failure blanks the whole runs
+// view (everything else degrades to `partial`). The proxy path is ~0.02s
+// normally, but the box runs at load avg ~30 under a slung-pipeline burst (the
+// supervisor reconciler alone hits ~274% CPU), and during a spike a single core
+// read occasionally crosses the old 5s budget → a first load with no last-good
+// snapshot blanks to "Run data unavailable". Raise this read's ceiling to absorb
+// a burst (the higher bound only costs time when actually slow), and retry once
+// on a transient timeout/5xx before giving up. A real outage still surfaces an
+// error after the retries are spent — the resilience only hides a brief spike,
+// never a sustained failure (upstream gascity-dashboard#88).
+const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 15_000;
+// One retry on a transient core-read failure, after a short fixed backoff. The
+// common (fast) path never reaches the retry, so first-paint stays prompt; the
+// retry only adds latency when a burst already made the first attempt fail.
+const CORE_FETCH_RETRIES = 1;
+const CORE_FETCH_RETRY_BACKOFF_MS = 250;
 // Optional run-summary enrichment (recent-bead / formula-feed / session reads)
 // is best-effort: a miss degrades the lanes to "partial" rather than failing the
 // load. The budget is split by call site (gascity-dashboard-4bol). The preview
@@ -181,8 +196,43 @@ export function resetSupervisorRunSummaryStateForTests(): void {
   progressStateByCity.clear();
 }
 
+// Exposed for tests: the raised core-read budget that absorbs a CPU-burst spike.
+export const CORE_RUN_SUMMARY_TIMEOUT_MS = REQUIRED_RUN_SUMMARY_TIMEOUT_MS;
+
 function requiredRunSummaryApi() {
   return supervisorApiForRequestBudget(REQUIRED_RUN_SUMMARY_TIMEOUT_MS);
+}
+
+// The core active-bead read, with a bounded retry on a transient failure. This
+// is the one read whose rejection blanks the whole runs view, so a brief CPU
+// burst that times out the first attempt should not lose the load; a sustained
+// failure still propagates after the retries are spent. Optional enrichment
+// reads keep their own degrade-to-partial handling and are NOT retried here.
+async function fetchCoreActiveBeads(cityName: string, limit: number): Promise<ListBodyBead> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= CORE_FETCH_RETRIES; attempt += 1) {
+    try {
+      return await requiredRunSummaryApi().listBeads(cityName, { limit });
+    } catch (err) {
+      lastError = err;
+      if (attempt === CORE_FETCH_RETRIES || !isTransientSupervisorError(err)) throw err;
+      await delay(CORE_FETCH_RETRY_BACKOFF_MS);
+    }
+  }
+  throw lastError;
+}
+
+// A timeout (status undefined, "timed out after Nms") or a 5xx is transient: the
+// supervisor is briefly overloaded, not reporting a stable failure. A 4xx is the
+// caller's fault and must not be retried.
+function isTransientSupervisorError(err: unknown): boolean {
+  if (!(err instanceof SupervisorApiError)) return false;
+  if (err.status === undefined) return /timed out after \d+ms/.test(err.message);
+  return err.status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function optionalRunSummaryApi(budgetMs: number) {
@@ -207,7 +257,7 @@ async function loadRunBeads(
     Math.min(MOLECULE_HISTORY_TIMEOUT_MS, enrichmentBudgetMs),
   );
   const [activeList, feedDiscovery] = await Promise.all([
-    requiredRunSummaryApi().listBeads(cityName, { limit }),
+    fetchCoreActiveBeads(cityName, limit),
     discoverFromFeed(cityName, enrichmentBudgetMs),
   ]);
   const active = normalizeBeads(activeList.items ?? []);

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -57,6 +57,18 @@ const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 5_000;
 // first-paint spinner a single global raise would cause.
 const PREVIEW_ENRICHMENT_TIMEOUT_MS = 2_500;
 const REFRESH_ENRICHMENT_TIMEOUT_MS = 30_000;
+// gascity-dashboard-9rk2: the molecule(all=true) read scans the full (large,
+// ~340k-row) molecule history purely to surface HISTORICAL run roots, which the
+// view already caps at MAX_HISTORICAL_LANES (50). Live it runs ~6.8s — past the
+// 5s required-fetch budget — and the supervisor exposes no recency-ordered or
+// bounded molecule query, so it cannot be made cheaper server-side without a new
+// endpoint. It is therefore the FIRST optional read to dominate the wider refresh
+// budget. Bound it well under REQUIRED_RUN_SUMMARY_TIMEOUT_MS so a slow scan
+// degrades the historical lanes to "partial" fast instead of holding the refresh
+// (and so it can never out-wait the active set, which paints from the fast
+// open/active read). It still rides the surrounding enrichment budget too via the
+// min() at the call site, so the tight first-paint path is never loosened.
+const MOLECULE_HISTORY_TIMEOUT_MS = 3_000;
 
 interface LoadedRunBeads {
   beads: DashboardBead[];
@@ -182,6 +194,9 @@ async function loadRunBeads(
   limit: number,
   enrichmentBudgetMs: number,
 ): Promise<LoadedRunBeads> {
+  // The molecule-history read gets its own tight bound (gascity-dashboard-9rk2),
+  // capped to the surrounding enrichment budget so the first-paint path is never
+  // loosened: a slow scan folds to `partial` instead of dominating the refresh.
   const moleculeFetch = settledRecentFetch(
     cityName,
     {
@@ -189,7 +204,7 @@ async function loadRunBeads(
       type: 'molecule',
       all: true,
     },
-    enrichmentBudgetMs,
+    Math.min(MOLECULE_HISTORY_TIMEOUT_MS, enrichmentBudgetMs),
   );
   const [activeList, feedDiscovery] = await Promise.all([
     requiredRunSummaryApi().listBeads(cityName, { limit }),


### PR DESCRIPTION
Makes the `/runs` view survive the supervisor being slow under heavy city load (it was blanking with "Run data unavailable: gc supervisor request timed out after 5000ms"). Frontend-only; CI-green; verified live on :8082 (the list now holds during a load-avg ~30-46 catch-up storm).

## Changes (frontend/src/supervisor/runSummary.ts + frontend/src/runs/runSummarySubscription.tsx)
1. **Bound the slow molecule-history sub-fetch** — `molecule all=true` measured ~6.8s on the live store; it now has a 3s timeout (min with the enrichment budget) and folds to the existing `partial` flag on timeout/reject, so the fast active set still renders.
2. **Retain last-good on refresh failure** — a refresh that resolves to / throws an error no longer overwrites a rendered summary with the whole-view error; it re-serves the prior snapshot as `status:'stale'` (the existing "stale Ns ago" hint). The full error state is reserved for a genuine first-load failure (no prior data).
3. **Retry + tolerant timeout on the core active fetch** — the one fetch whose failure blanks the view now retries once (250ms backoff) on a *transient* SupervisorApiError (timeout / 5xx, never 4xx), and its per-call timeout is raised 5s → 15s (via `supervisorApiForRequestBudget`, not global). Absorbs brief CPU-contention spikes on first load; the ~0.02s common path is unaffected.

## Scope / safety
No `shared/` wire-shape change. Reuses existing `partial`/`stale` machinery and the partial badge. Optional enrichment sub-fetches already degraded to partial — unchanged.

## Tests / CI
New tests for each: molecule timeout → partial; refresh-error retains last-good (resolve + throw); first-load error still surfaces error; core retry-then-succeed, retry-exhausted-still-errors, 4xx-not-retried; raised-timeout assertion. typecheck (src+test), lint, prettier, shared/backend/frontend suites all green.

## Known follow-up (separate, NOT in this PR)
The run-DETAIL fetch (`workflowRun`) still has the default 5s/no-retry timeout, so clicking into a run can still time out under load — being investigated separately (apply the same resilience + profile the detail path).
