### PR TITLE
fix(runs): detail-fetch resilience + rig scope, and runs bugs (0gww, bvu4)

### DIFF
--- a/frontend/src/components/ambient/StatusSentence.tsx
+++ b/frontend/src/components/ambient/StatusSentence.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { laneNeedsOperator } from 'gas-city-dashboard-shared';
 import type { RunLane } from 'gas-city-dashboard-shared';
 
 // gascity-dashboard-kb3 PRD §4 line 2 — "the lean-in read".
@@ -70,7 +71,7 @@ function laneToken(lane: RunLane): string {
 }
 
 function pickConcernPhrasing(lane: RunLane): string {
-  if (lane.health.status === 'available' && lane.health.data.needsOperator) {
+  if (laneNeedsOperator(lane)) {
     // Grammatically-extensible: the duration clause "for N min" attaches
     // cleanly to "has been waiting on your decision". The earlier
     // present-tense form left "22 min" stranded. (Phase 4 LOW.)

--- a/frontend/src/hooks/useFormulaRunDetail.test.tsx
+++ b/frontend/src/hooks/useFormulaRunDetail.test.tsx
@@ -2,9 +2,10 @@ import { cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { invalidate } from '../api/cache';
 import { reportClientError } from '../lib/clientErrorReporting';
-import { supervisorApi } from '../supervisor/client';
+import { supervisorApi, supervisorApiForRequestBudget } from '../supervisor/client';
+import type * as SupervisorClient from '../supervisor/client';
 import { SupervisorApiError } from '../supervisor/errors';
-import { useFormulaRunDetail } from './useFormulaRunDetail';
+import { formulaRunDetailCacheKey, useFormulaRunDetail } from './useFormulaRunDetail';
 
 vi.mock('../api/cityBase', () => ({
   getActiveCity: () => 'test-city',
@@ -15,12 +16,20 @@ vi.mock('../lib/clientErrorReporting', () => ({
   reportClientError: vi.fn(() => Promise.resolve({ status: 'reported' })),
 }));
 
-vi.mock('../supervisor/client', () => ({
-  supervisorApi: vi.fn(),
-}));
+vi.mock('../supervisor/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof SupervisorClient>();
+  return {
+    // Keep the real SupervisorApiError so runDetail's `instanceof` checks work,
+    // and route the request-budget client to the same mock as the default one.
+    ...actual,
+    supervisorApi: vi.fn(),
+    supervisorApiForRequestBudget: vi.fn(),
+  };
+});
 
 const mockReportClientError = reportClientError as Mock;
 const mockSupervisorApi = supervisorApi as Mock;
+const mockSupervisorApiForRequestBudget = supervisorApiForRequestBudget as Mock;
 const supervisor = {
   workflowRun: vi.fn(),
   listSessions: vi.fn(),
@@ -35,11 +44,13 @@ afterEach(() => {
   supervisor.listSessions.mockReset();
   supervisor.formulaDetail.mockReset();
   mockSupervisorApi.mockReturnValue(supervisor);
+  mockSupervisorApiForRequestBudget.mockReturnValue(supervisor);
 });
 
 describe('useFormulaRunDetail', () => {
   beforeEach(() => {
     mockSupervisorApi.mockReturnValue(supervisor);
+    mockSupervisorApiForRequestBudget.mockReturnValue(supervisor);
     supervisor.workflowRun.mockResolvedValue(workflowSnapshot());
     supervisor.listSessions.mockResolvedValue({ items: [], total: 0 });
     supervisor.formulaDetail.mockResolvedValue(formulaDetail());
@@ -164,6 +175,26 @@ describe('useFormulaRunDetail', () => {
     expect(result.current.kind).not.toBe('unsupported');
     expect(result.current.kind).not.toBe('failed');
     expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+});
+
+describe('formulaRunDetailCacheKey (bvu4)', () => {
+  // SCOPE_REF_RE permits ':' in scopeRef (and run ids can carry it), so a bare
+  // ':'-join let two distinct (runId, scopeKind, scopeRef) tuples collapse to the
+  // same key — a refresh for one run then served/overwrote another run's detail.
+  it('does not collide when a colon-bearing part shifts the join boundary', () => {
+    // Both tuples produced the SAME key under the old un-escaped ':'-join
+    // ('formula-run:a:rig:rig:y'): runId 'a' + scopeRef 'rig:y' vs runId 'a:rig'
+    // + scopeRef 'y'. Distinct runs must map to distinct cache slots.
+    const a = formulaRunDetailCacheKey('a', 'rig', 'rig:y');
+    const b = formulaRunDetailCacheKey('a:rig', 'rig', 'y');
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps distinct scopes on the same run apart', () => {
+    expect(formulaRunDetailCacheKey('run', 'rig', 'app')).not.toBe(
+      formulaRunDetailCacheKey('run', 'city', 'app'),
+    );
   });
 });
 

--- a/frontend/src/hooks/useFormulaRunDetail.ts
+++ b/frontend/src/hooks/useFormulaRunDetail.ts
@@ -130,11 +130,16 @@ function reportRunDetailError(operation: string, runId: string, err: unknown): v
   });
 }
 
-function formulaRunDetailCacheKey(
+export function formulaRunDetailCacheKey(
   runId: string | undefined,
   scopeKind?: RunScopeKind,
   scopeRef?: string,
 ): string {
+  // gascity-dashboard (bvu4): runId and scopeRef can both contain ':'
+  // (SCOPE_REF_RE permits it, e.g. 'rig:foo'), so a bare ':'-join lets two
+  // distinct (runId, scopeKind, scopeRef) tuples collapse to one key — a refresh
+  // for run B then serves or overwrites run A's cached detail. Percent-encode
+  // each part so the delimiter can never shift a boundary.
   const parts = ['formula-run', runId ?? 'missing', scopeKind ?? 'default', scopeRef ?? 'default'];
-  return parts.join(':');
+  return parts.map(encodeURIComponent).join(':');
 }

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -89,10 +89,18 @@ interface LaneFixture {
   scopeKind?: 'city' | 'rig';
   scopeRef?: string;
   updatedAt?: string;
-  health: RunLaneHealth;
+  phase?: RunLane['phase'];
+  /** When set, the lane's health is the genuine 'unavailable' shell (no
+   *  session list), exercising the structural-needsOperator path. */
+  healthUnavailable?: boolean;
+  health?: RunLaneHealth;
 }
 
 function lane(f: LaneFixture): RunLane {
+  const phase = f.phase ?? 'implementation';
+  const health: RunLane['health'] = f.healthUnavailable
+    ? { status: 'unavailable', error: 'run session list unavailable' }
+    : { status: 'available', data: f.health ?? knownHealth() };
   return {
     id: f.id,
     title: f.title ?? f.id,
@@ -114,8 +122,8 @@ function lane(f: LaneFixture): RunLane {
             url: `https://example.com/${f.externalLabel}`,
           }
         : { status: 'unavailable', error: 'unused' },
-    phase: 'implementation',
-    phaseLabel: 'implementation',
+    phase,
+    phaseLabel: phase,
     statusCounts: { in_progress: 1 },
     activeAssignees: [],
     updatedAt:
@@ -125,7 +133,7 @@ function lane(f: LaneFixture): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'unused' },
     formulaStageResolved: false,
-    health: { status: 'available', data: f.health },
+    health,
   };
 }
 
@@ -412,23 +420,25 @@ describe('AmbientHomePage', () => {
 
   it('shows a needsOperator concern row even when no lane is failing', async () => {
     // R10 boundary: healthy-in-flight stays withheld; needsOperator
-    // surfaces. No maroon on either.
+    // surfaces. needsOperator is STRUCTURAL — derived from the lane's phase
+    // (approval/blocked), not from health.data — so the approval-phase lane
+    // surfaces while the implementation-phase calm lane is withheld. No
+    // maroon on either.
     const decisionLane = lane({
       id: 'decide-me',
       externalLabel: 'issue-99',
       updatedAt: '2026-05-29T19:59:00.000Z',
-      health: knownHealth({ needsOperator: true }),
+      phase: 'approval',
     });
     const calmLane = lane({
       id: 'calm',
       updatedAt: '2026-05-29T19:59:30.000Z',
-      health: knownHealth(),
     });
     const census: RunCensus = {
       ...DEFAULT_CENSUS,
       totalInFlight: 2,
       knownDenominator: 2,
-      byPhase: { ...DEFAULT_CENSUS.byPhase, implementation: 2 },
+      byPhase: { ...DEFAULT_CENSUS.byPhase, approval: 1, implementation: 1 },
     };
     mockLoadRunSummary.mockResolvedValue(runSource({ lanes: [decisionLane, calmLane], census }));
 
@@ -443,6 +453,40 @@ describe('AmbientHomePage', () => {
     // (the mark fires only on the maroon run-id token); the helper
     // pins <=1, the status-sentence absence pins that it's zero.
     assertAtMostOneMark(container);
+  });
+
+  it('surfaces a needsOperator lane (and counts it as waiting) even when its health is unavailable (0gww)', async () => {
+    // Regression (Codex Fix #3): needsOperator is a STRUCTURAL signal
+    // (lane.phase ∈ {approval, blocked}), not session-derived. During a
+    // session-list outage deriveRunHealth returns health.status:'unavailable'
+    // for every lane; a blocked/approval lane that needs an operator decision
+    // must STILL appear in the concern region AND be counted in the waiting
+    // census, instead of vanishing behind a health.status==='available' gate.
+    const blockedUnavailable = lane({
+      id: 'blocked-no-sessions',
+      externalLabel: 'pr-77',
+      updatedAt: '2026-05-29T19:59:00.000Z',
+      phase: 'blocked',
+      healthUnavailable: true,
+    });
+    const census: RunCensus = {
+      ...DEFAULT_CENSUS,
+      totalInFlight: 1,
+      // sessions unavailable ⇒ health is not 'known' ⇒ unverifiable, not in
+      // the known denominator. The structural waiting count is independent.
+      unverifiable: 1,
+      knownDenominator: 0,
+      byPhase: { ...DEFAULT_CENSUS.byPhase, blocked: 1 },
+    };
+    mockLoadRunSummary.mockResolvedValue(runSource({ lanes: [blockedUnavailable], census }));
+
+    mount();
+    await waitFor(() => expect(screen.getByTestId('phase-census')).toBeTruthy());
+
+    // The row survives the health-unavailable state.
+    expect(screen.getByTestId('concern-row-blocked-no-sessions')).toBeTruthy();
+    // And it is counted in the waiting census (synopsis "1 waiting").
+    expect(screen.getByTestId('phase-census').textContent).toContain('1 waiting');
   });
 
   it('renders a clear error when the runs source is in error state', async () => {

--- a/frontend/src/routes/AmbientHome.tsx
+++ b/frontend/src/routes/AmbientHome.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { laneNeedsOperator } from 'gas-city-dashboard-shared';
 import type { DashboardMetric, RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { getActiveCity } from '../api/cityBase';
 import { AttentionSummaryPanel } from '../attention/AttentionSummaryPanel';
@@ -61,23 +62,26 @@ function buildConcernRows(
   // double-surfacing.
   //
   // Note (Phase 4 code-review M5): needsOperator INTENTIONALLY bypasses
-  // the phaseConfidence gate. The backend at health.ts:175 derives
-  // needsOperator from lane.phase ∈ {'approval','blocked'} — a structural
-  // bead-state fact, not a phase-resolution conclusion. A human-gate
-  // decision must surface even when the engine can't confidently classify
-  // the lane's stage, because the decision is exactly what the operator
-  // is being asked to make. The R2 maroon-on-inferred constraint applies
-  // only to the One Mark Rule (which ConcernRegion does not paint), not
-  // to surfacing the row.
+  // the phaseConfidence gate AND the health.status === 'available' gate.
+  // needsOperator is a STRUCTURAL signal derived from lane.phase ∈
+  // {'approval','blocked'} (laneNeedsOperator) — a bead-state fact, not a
+  // session-derived phase-resolution conclusion. A human-gate decision must
+  // surface even when the session list is unavailable (health degrades to
+  // status:'unavailable') and the engine can't confidently classify the
+  // lane's stage, because the decision is exactly what the operator is being
+  // asked to make. The thrashing/stalled branch IS legitimately
+  // session-derived, so it keeps the health-available + phaseConfidence
+  // gate. The R2 maroon-on-inferred constraint applies only to the One Mark
+  // Rule (which ConcernRegion does not paint), not to surfacing the row.
   const rows: ConcernRow[] = [];
   for (const lane of lanes) {
     if (lane.id === topConcernId) continue;
-    if (lane.health.status !== 'available') continue;
-    const health = lane.health.data;
-    if (health.needsOperator) {
+    if (laneNeedsOperator(lane)) {
       rows.push({ lane, reason: 'needsOperator' });
       continue;
     }
+    if (lane.health.status !== 'available') continue;
+    const health = lane.health.data;
     if (health.phaseConfidence !== 'known') continue;
     if (health.thrashingDetected || staleness.byLane.get(lane.id)?.isStalled) {
       rows.push({ lane, reason: 'stalled' });
@@ -90,7 +94,7 @@ function countWaiting(lanes: readonly RunLane[]): number {
   // "waiting" census-vocab (Phase 1 architect M4) — operator-decision-pending.
   let count = 0;
   for (const lane of lanes) {
-    if (lane.health.status === 'available' && lane.health.data.needsOperator) count += 1;
+    if (laneNeedsOperator(lane)) count += 1;
   }
   return count;
 }

--- a/frontend/src/supervisor/coreRead.ts
+++ b/frontend/src/supervisor/coreRead.ts
@@ -1,0 +1,41 @@
+import { SupervisorApiError } from './client';
+
+// A core read is the one supervisor fetch whose failure blanks a whole view
+// (the runs list's active-bead read, the run-detail's workflow snapshot). The
+// box runs at high load under a slung-pipeline burst, so a single core read
+// occasionally crosses an interactive budget. Retry once on a transient
+// timeout/5xx before giving up; a sustained failure still propagates after the
+// retry is spent (upstream gascity-dashboard#88).
+export const CORE_FETCH_RETRIES = 1;
+export const CORE_FETCH_RETRY_BACKOFF_MS = 250;
+
+// Run a core read with one bounded retry on a transient failure. The common
+// (fast) path never reaches the retry, so first-paint stays prompt; the retry
+// only adds latency when a burst already made the first attempt fail. Optional
+// enrichment reads keep their own degrade handling and are NOT routed here.
+export async function fetchCoreRead<T>(read: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= CORE_FETCH_RETRIES; attempt += 1) {
+    try {
+      return await read();
+    } catch (err) {
+      lastError = err;
+      if (attempt === CORE_FETCH_RETRIES || !isTransientSupervisorError(err)) throw err;
+      await delay(CORE_FETCH_RETRY_BACKOFF_MS);
+    }
+  }
+  throw lastError;
+}
+
+// A timeout (status undefined, "timed out after Nms") or a 5xx is transient: the
+// supervisor is briefly overloaded, not reporting a stable failure. A 4xx is the
+// caller's fault and must not be retried.
+export function isTransientSupervisorError(err: unknown): boolean {
+  if (!(err instanceof SupervisorApiError)) return false;
+  if (err.status === undefined) return /timed out after \d+ms/.test(err.message);
+  return err.status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/frontend/src/supervisor/runDetail.test.ts
+++ b/frontend/src/supervisor/runDetail.test.ts
@@ -209,6 +209,42 @@ describe('loadSupervisorFormulaRunDetail', () => {
       reasons: ['formula_detail_fetch_failed'],
     });
   });
+
+  // Fix A: the workflow snapshot is the run-detail core read; a transient
+  // timeout/5xx is retried once before it blanks the view, mirroring the runs
+  // list core read. A 4xx is the caller's fault and is never retried.
+  it('retries the workflow core read once on a transient timeout', async () => {
+    let attempts = 0;
+    workflowRun.mockImplementation(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new SupervisorApiError(
+          undefined,
+          'gc supervisor request timed out after 15000ms',
+          undefined,
+        );
+      }
+      return workflowSnapshot();
+    });
+
+    const detail = await loadSupervisorFormulaRunDetail('wf-1', 'rig', 'app');
+
+    expect(attempts).toBe(2);
+    expect(detail.completeness).toEqual({ kind: 'complete' });
+  });
+
+  it('does not retry the workflow core read on a non-transient (4xx) failure', async () => {
+    let attempts = 0;
+    workflowRun.mockImplementation(async () => {
+      attempts += 1;
+      throw new SupervisorApiError(400, 'bad request', undefined);
+    });
+
+    await expect(loadSupervisorFormulaRunDetail('wf-1', 'rig', 'app')).rejects.toThrow(
+      'bad request',
+    );
+    expect(attempts).toBe(1);
+  });
 });
 
 function workflowSnapshot(

--- a/frontend/src/supervisor/runDetail.ts
+++ b/frontend/src/supervisor/runDetail.ts
@@ -18,8 +18,20 @@ import type {
   FormulaDetailResponse,
   WorkflowSnapshotResponse,
 } from 'gas-city-dashboard-shared/gc-supervisor';
-import { SupervisorApiError, supervisorApi, type SupervisorApi } from './client';
+import { SupervisorApiError, supervisorApi, supervisorApiForRequestBudget } from './client';
+import type { SupervisorApi } from './client';
+import { fetchCoreRead } from './coreRead';
 import { normalizeSessions } from './sessionReads';
+
+// The workflow snapshot is the run-detail core read — the one fetch whose
+// failure blanks the whole detail view (sessions and formula detail degrade to
+// 'partial'). It gets the same treatment as the runs-list core read
+// (runSummary.ts): a burst-tolerant budget so a CPU spike doesn't time it out,
+// and one retry on a transient timeout/5xx. A city-scoped (no-rig) fetch hits
+// the supervisor's full-store scan (~12-14s, upstream gascity-dashboard#88), so
+// the wider budget is what lets that path complete instead of timing out; the
+// rig-scoped fetch (the common case once scope is passed) is sub-second.
+const RUN_DETAIL_CORE_TIMEOUT_MS = 15_000;
 
 export async function loadSupervisorFormulaRunDetail(
   runId: string,
@@ -28,9 +40,10 @@ export async function loadSupervisorFormulaRunDetail(
 ): Promise<FormulaRunDetail> {
   const cityName = activeCityOrThrow('load supervisor formula run detail');
   const query = runScopeQuery(scopeKind, scopeRef);
+  const coreApi = supervisorApiForRequestBudget(RUN_DETAIL_CORE_TIMEOUT_MS);
   const api = supervisorApi();
   const [raw, sessionsLookup] = await Promise.all([
-    api.workflowRun(cityName, runId, query),
+    fetchCoreRead(() => coreApi.workflowRun(cityName, runId, query)),
     loadRunSessions(cityName),
   ]);
   const snapshot = toRunSnapshot(raw);

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -225,6 +225,101 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('derives a rig lane scope from the feed root_store_ref even when the feed scope_kind is city (q89b detail scope leak)', async () => {
+    // The formula feed's top-level scope_kind is always 'city'; the rig identity
+    // lives only in root_store_ref. When the root bead carries no scope metadata
+    // (scope must come from the feed map), the lane must still resolve to its rig
+    // scope so the detail href carries it and the workflow fetch hits the fast
+    // single-store path — not the city-wide full-store scan.
+    const rootNoScope = runRoot({
+      id: 'run-2',
+      metadata: {
+        'gc.kind': 'run',
+        'gc.formula': 'mol-adopt-pr-v2',
+        'gc.formula_contract': 'graph.v2',
+      },
+    });
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig !== undefined) return beadList([]);
+      return beadList([rootNoScope]);
+    });
+    const cityScopedFeedRun = feedRun({
+      id: 'run-2',
+      root_bead_id: 'run-2',
+      workflow_id: 'run-2',
+      root_store_ref: 'rig:rig-b',
+      scope_kind: 'city',
+      scope_ref: 'test-city',
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([cityScopedFeedRun])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    const lane = source.data.lanes.find((l) => l.id === 'run-2');
+    expect(lane?.scope).toEqual({
+      status: 'available',
+      kind: 'rig',
+      ref: 'rig-b',
+      rootStoreRef: 'rig:rig-b',
+    });
+  });
+
+  it('does not emit a malformed feed root_store_ref as the lane scope (validates against SCOPE_REF_RE)', async () => {
+    // The store-ref-first branch in discoverFromFeed must validate the parsed
+    // ref against SCOPE_REF_RE before using it — fromStoreRef does not validate,
+    // so a malformed root_store_ref like 'rig:bad ref@!' would otherwise become a
+    // scope_ref the detail route rejects. It must fall back to the feed scope.
+    const rootNoScope = runRoot({
+      id: 'run-3',
+      metadata: {
+        'gc.kind': 'run',
+        'gc.formula': 'mol-adopt-pr-v2',
+        'gc.formula_contract': 'graph.v2',
+      },
+    });
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig !== undefined) return beadList([]);
+      return beadList([rootNoScope]);
+    });
+    const malformedFeedRun = feedRun({
+      id: 'run-3',
+      root_bead_id: 'run-3',
+      workflow_id: 'run-3',
+      root_store_ref: 'rig:bad ref@!',
+      scope_kind: 'city',
+      scope_ref: 'test-city',
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([malformedFeedRun])),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    const lane = source.data.lanes.find((l) => l.id === 'run-3');
+    expect(lane?.scope).toMatchObject({
+      status: 'available',
+      kind: 'city',
+      ref: 'test-city',
+    });
+    if (lane?.scope.status === 'available') {
+      expect(lane.scope.ref).not.toBe('bad ref@!');
+    }
+  });
+
   it('enriches blocked lanes with health and keeps them out of the active set (gascity-dashboard-4xcv)', async () => {
     // gc-1920 repro: a stale blocked formula latch must land in
     // blockedLanes (with derived health, so attention still sees it),

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -20,11 +20,13 @@ import {
   MAX_VISIBLE_ACTIVE_LANES,
   runBeadFilter,
   runCounts,
+  SCOPE_REF_RE,
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
 import type { Bead, FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
-import { SupervisorApiError, supervisorApiForRequestBudget } from './client';
+import { supervisorApiForRequestBudget } from './client';
+import { fetchCoreRead } from './coreRead';
 import { listIsIncomplete, listIsPartial } from './listPartial';
 import { normalizeSessions } from './sessionReads';
 
@@ -53,11 +55,6 @@ const RUNS_STALE_AFTER_MS = 60 * 1000;
 // error after the retries are spent — the resilience only hides a brief spike,
 // never a sustained failure (upstream gascity-dashboard#88).
 const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 15_000;
-// One retry on a transient core-read failure, after a short fixed backoff. The
-// common (fast) path never reaches the retry, so first-paint stays prompt; the
-// retry only adds latency when a burst already made the first attempt fail.
-const CORE_FETCH_RETRIES = 1;
-const CORE_FETCH_RETRY_BACKOFF_MS = 250;
 // Optional run-summary enrichment (recent-bead / formula-feed / session reads)
 // is best-effort: a miss degrades the lanes to "partial" rather than failing the
 // load. The budget is split by call site (gascity-dashboard-4bol). The preview
@@ -203,36 +200,14 @@ function requiredRunSummaryApi() {
   return supervisorApiForRequestBudget(REQUIRED_RUN_SUMMARY_TIMEOUT_MS);
 }
 
-// The core active-bead read, with a bounded retry on a transient failure. This
-// is the one read whose rejection blanks the whole runs view, so a brief CPU
-// burst that times out the first attempt should not lose the load; a sustained
-// failure still propagates after the retries are spent. Optional enrichment
-// reads keep their own degrade-to-partial handling and are NOT retried here.
+// The core active-bead read, with a bounded retry on a transient failure
+// (fetchCoreRead). This is the one read whose rejection blanks the whole runs
+// view, so a brief CPU burst that times out the first attempt should not lose
+// the load; a sustained failure still propagates after the retry is spent.
+// Optional enrichment reads keep their own degrade-to-partial handling and are
+// NOT routed here.
 async function fetchCoreActiveBeads(cityName: string, limit: number): Promise<ListBodyBead> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= CORE_FETCH_RETRIES; attempt += 1) {
-    try {
-      return await requiredRunSummaryApi().listBeads(cityName, { limit });
-    } catch (err) {
-      lastError = err;
-      if (attempt === CORE_FETCH_RETRIES || !isTransientSupervisorError(err)) throw err;
-      await delay(CORE_FETCH_RETRY_BACKOFF_MS);
-    }
-  }
-  throw lastError;
-}
-
-// A timeout (status undefined, "timed out after Nms") or a 5xx is transient: the
-// supervisor is briefly overloaded, not reporting a stable failure. A 4xx is the
-// caller's fault and must not be retried.
-function isTransientSupervisorError(err: unknown): boolean {
-  if (!(err instanceof SupervisorApiError)) return false;
-  if (err.status === undefined) return /timed out after \d+ms/.test(err.message);
-  return err.status >= 500;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return fetchCoreRead(() => requiredRunSummaryApi().listBeads(cityName, { limit }));
 }
 
 function optionalRunSummaryApi(budgetMs: number) {
@@ -344,12 +319,28 @@ async function discoverFromFeed(cityName: string, budgetMs: number): Promise<Fee
         rigNames.add(storeScope.scopeRef);
       }
       const rootId = run.root_bead_id ?? run.workflow_id ?? null;
-      const scope = fromFeedScope(run);
+      // gascity-dashboard-q89b (detail scope leak): the feed's top-level
+      // scope_kind is always 'city', so fromFeedScope alone makes a rig lane's
+      // detail href drop to city scope — and a city-scoped workflow fetch hits
+      // the supervisor's full-store scan (~12-14s, upstream #88) instead of the
+      // sub-second single-store rig fetch. Recover the rig from root_store_ref
+      // first (store-ref-first — deliberately the inverse of
+      // fromRootMetadataScope's pair-first rule: the metadata edge trusts its
+      // explicit pair, but the feed's pair is unreliable here, always 'city').
+      // Fall back to the feed (city) scope only when the store ref names no rig.
+      // The store ref is validated against SCOPE_REF_RE before it is emitted as
+      // a lane scope: unlike fromFeedScope/fromRootMetadataScope, fromStoreRef
+      // does not validate, so a malformed root_store_ref must fall back rather
+      // than emit a scope_ref the detail route would reject.
+      const scope =
+        storeScope?.scopeKind === 'rig' && SCOPE_REF_RE.test(storeScope.scopeRef)
+          ? storeScope
+          : fromFeedScope(run);
       if (rootId !== null && scope !== null) {
         scopes.set(rootId, {
           scopeKind: scope.scopeKind,
           scopeRef: scope.scopeRef,
-          rootStoreRef: scope.rootStoreRef,
+          rootStoreRef: run.root_store_ref ?? `${scope.scopeKind}:${scope.scopeRef}`,
         });
       }
     }

--- a/shared/src/runs/health.test.ts
+++ b/shared/src/runs/health.test.ts
@@ -1,0 +1,60 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deriveRunHealth } from './health.js';
+import type { RunLane } from '../snapshot/types.js';
+
+// gascity-dashboard (0gww): the run-lane health-unavailable attention emitter
+// guards on `lane.health.status === 'available'`. deriveRunHealth used to wrap
+// EVERY lane in status:'available' — even when the session list was unavailable
+// and health could not actually be derived — so the guard always continued and
+// the emitter was structurally dead. These tests pin the contract that drives
+// the emitter: no session list ⇒ health.status === 'unavailable'.
+
+function lane(overrides: Partial<RunLane> = {}): RunLane {
+  return {
+    id: 'run-1',
+    title: 'a run',
+    formula: { status: 'known', name: 'mol-test' },
+    scope: { status: 'available', kind: 'rig', ref: 'app', rootStoreRef: 'rig:app' },
+    external: { status: 'unavailable', error: 'external reference unavailable' },
+    phase: 'implementation',
+    phaseLabel: 'implementation',
+    statusCounts: { in_progress: 1 },
+    activeAssignees: ['app/codex'],
+    updatedAt: { status: 'available', at: '2026-06-08T00:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+    ...overrides,
+  };
+}
+
+describe('deriveRunHealth — session-list unavailability (0gww)', () => {
+  test('reports health.status unavailable for every lane when the session list is unavailable', () => {
+    const { lanes } = deriveRunHealth({
+      lanes: [lane({ id: 'run-a' }), lane({ id: 'run-b' })],
+      sessions: [],
+      sessionsAvailable: false,
+      marks: new Map(),
+    });
+
+    for (const enriched of lanes) {
+      assert.equal(enriched.health.status, 'unavailable');
+      if (enriched.health.status !== 'unavailable') continue;
+      assert.equal(enriched.health.error, 'run session list unavailable');
+    }
+  });
+
+  test('still derives available health when the session list is available', () => {
+    const { lanes } = deriveRunHealth({
+      lanes: [lane()],
+      sessions: [],
+      sessionsAvailable: true,
+      marks: new Map(),
+    });
+
+    assert.equal(lanes[0]?.health.status, 'available');
+  });
+});

--- a/shared/src/runs/health.ts
+++ b/shared/src/runs/health.ts
@@ -45,6 +45,20 @@ export interface DeriveRunHealthResult {
   census: RunCensus;
 }
 
+/**
+ * Structural needs-operator signal for a lane: true when the lane's phase is a
+ * human-gate phase ('approval' or 'blocked'). This is derived from lane.phase
+ * alone — a structural bead-state fact, NOT a session-derived health
+ * conclusion. It therefore stays valid even when the session list is
+ * unavailable and per-lane health degrades to status:'unavailable'. Consumers
+ * must read needsOperator through this accessor rather than gating it behind
+ * health.status === 'available', or a human-gate decision vanishes from the
+ * home concern region during a session-list outage.
+ */
+export function laneNeedsOperator(lane: RunLane): boolean {
+  return lane.phase === 'approval' || lane.phase === 'blocked';
+}
+
 export function advanceProgressMarks(
   previous: ReadonlyMap<string, LaneProgressMark>,
   lanes: readonly RunLane[],
@@ -83,10 +97,21 @@ export function advanceProgressMarks(
 export function deriveRunHealth(input: DeriveRunHealthInput): DeriveRunHealthResult {
   const { thrashDetectedStreak } = { ...DEFAULT_THRESHOLDS, ...input.thresholds };
 
-  const lanes = input.lanes.map((lane) => {
-    const session = input.sessionsAvailable
-      ? resolveLaneSession(lane, input.sessions)
-      : { status: 'unresolved' as const, error: 'run session list unavailable' };
+  const lanes = input.lanes.map((lane): RunLane => {
+    // gascity-dashboard (0gww): without the session list, health cannot be
+    // derived — phaseConfidence collapses to 'inferred' and the session-trust
+    // signals (needsOperator/thrash) lose their grounding. Report the lane's
+    // health as genuinely 'unavailable' rather than wrapping a degraded shell in
+    // status:'available'. That degraded-but-'available' shell is what made the
+    // attention emitter's `health.status === 'available'` guard
+    // (attention/registry.ts) skip every lane, so the per-lane
+    // health-unavailable signal never fired. Consumers already gate every
+    // .health.data read on status === 'available', so they degrade cleanly here.
+    if (!input.sessionsAvailable) {
+      return { ...lane, health: { status: 'unavailable', error: 'run session list unavailable' } };
+    }
+
+    const session = resolveLaneSession(lane, input.sessions);
     const sessionResolved = session.status === 'resolved';
 
     const phaseConfidence: RunLaneHealth['phaseConfidence'] =
@@ -96,7 +121,7 @@ export function deriveRunHealth(input: DeriveRunHealthInput): DeriveRunHealthRes
 
     const health: RunLaneHealth = {
       phaseConfidence,
-      needsOperator: lane.phase === 'approval' || lane.phase === 'blocked',
+      needsOperator: laneNeedsOperator(lane),
       stuckNode: stuckNode(lane),
       thrashingDetected: thrashStreak >= thrashDetectedStreak,
       session:


### PR DESCRIPTION
## Summary

Makes the `/runs` detail view click-through resilient under load and fixes two runs bugs. Splits the original ur45 active-count fix into a follow-up (it needs a distinct "waiting-on-deps" lane state — see Known Follow-ups).

### Detail-fetch resilience + rig scope (the click-timeout)
Clicking a run could hang / time out under load. Root cause was **scope leakage**, not the timeout value (already 60s): the formula feed's top-level `scope_kind` is always `city`, so a rig lane's detail href dropped to city scope and hit the supervisor's full-store scan (~12-14s, upstream #88) instead of the sub-second single-store rig fetch.
- `discoverFromFeed` now recovers the rig from `root_store_ref` first (store-ref-first — deliberately the inverse of `fromRootMetadataScope`'s pair-first rule, because the feed pair is unreliable here), **validated against `SCOPE_REF_RE`** with a fallback to the feed scope on a malformed ref.
- The detail core read (`workflowRun`) now routes through a 15s request budget + retry-once on a transient timeout/5xx, via a shared `coreRead` module so the list and detail core reads share one retry/transient-classification implementation. Sessions + formula detail stay best-effort (degrade to `partial`). Last-good retention on a failed refresh is already provided by `useCachedData` (verified, no change).

### Bug 0gww — health-unavailable emitter dead
`deriveRunHealth` wrapped every lane in `status:'available'` even when the session list was unavailable, so the attention emitter's `health.status === 'available'` guard always skipped. Now reports lane health as genuinely `unavailable` when there is no session list. Because `needsOperator` is a **structural** signal (`lane.phase ∈ {approval, blocked}`), not session-derived, it's exposed via `laneNeedsOperator()` so the home concern region and waiting count still surface human-gate lanes during a session-list outage instead of dropping them behind the health gate.

### Bug bvu4 — detail cache-key collision
The formula-run cache key joined `runId`/`scopeKind`/`scopeRef` with an un-escaped `:`, and both `runId` and `scopeRef` may contain `:`, so two distinct runs could collapse to one cache slot (a refresh served/overwrote the wrong run). Each part is now percent-encoded before joining.

## Verification
- Local CI parity green: typecheck (src+test), eslint (`--max-warnings=0`), prettier, openapi drift, build; tests shared 172 / backend 558 / frontend 904 (regression tests added per fix).
- Browser (Playwright, scratch port): rig-scoped run click → render → live-update in 170-360ms under load avg ~25; city-scope slow path now completes (~14.8s) and renders instead of blanking at 5s.
- Multi-reviewer review (code + security + typescript + Codex cross-provider, 3 iterations) converged clean.

## Known follow-ups (tracked, not in this PR)
- **ur45** (active-count inflation): a dependency-gated not-started run should be excluded from the active count, but the first attempt marked it `blocked`, which the UI treats as operator-waiting — so it falsely showed as "needs you". Needs a distinct queued/waiting-on-deps state (taxonomy + census + copy). Deferred to its own bead.
- Minor (informational, graceful): `fetchCoreRead` transient detection keys on the supervisor error message text; `discoverFromFeed` rig-name discovery reads `root_store_ref` before `SCOPE_REF_RE` validation (cannot emit a wrong lane scope — at worst an unnecessary optional rig-fetch that degrades to `partial`).
