### PR TITLE
perf(runs): cheap SSE refresh + proxy cache + active-lane expander

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,6 +103,13 @@ The calm "what is working right now" section at the top of the Agents view.
 - **One mark.** An active worker is the normal, calm case, so worker state reads neutral. At most one accent (maroon) badge per viewport: only the first stuck/failed worker, an actual anomaly, renders its state in tone.
 - **Empty state.** "No workers active right now." Calm, not an alert.
 
+### Expand-in-place lists (Runs view)
+
+Both the Active and Historical sections of the Runs view collapse to a small default and offer a quiet "Show N more" control.
+
+- **Same register as the Historical toggle.** The Active section gains a quiet expand-in-place control identical to the Historical "Show N more" toggle: faint tracked-uppercase text, no filled button, expands in place. Collapsed default stays MAX_VISIBLE_ACTIVE_LANES (8); no new color, no filled button, One Mark Rule unaffected.
+- **Wire carries the full set.** The collapse is a render concern: the full active set crosses the wire (`RunSummary.lanes`), and the component owns the window — mirroring `historicalLanes`/`MAX_HISTORICAL_LANES`.
+
 ## 6. Do's and Don'ts
 
 ### Do:

--- a/backend/src/lib/ttl-single-flight-cache.test.ts
+++ b/backend/src/lib/ttl-single-flight-cache.test.ts
@@ -1,0 +1,122 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createTtlSingleFlightCache, type CachedResponse } from './ttl-single-flight-cache.js';
+
+function response(status = 200, bodyText = 'ok'): CachedResponse {
+  return { status, headers: [['content-type', 'application/json']], body: Buffer.from(bodyText) };
+}
+
+describe('createTtlSingleFlightCache', () => {
+  test('coalesces concurrent identical reads into a single loader call', async () => {
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    let calls = 0;
+    let resolveLoader: (value: CachedResponse) => void = () => {};
+    const loader = () =>
+      new Promise<CachedResponse>((resolve) => {
+        calls += 1;
+        resolveLoader = resolve;
+      });
+
+    const a = cache.getOrFetch('k', loader);
+    const b = cache.getOrFetch('k', loader);
+    resolveLoader(response());
+
+    assert.deepEqual(await a, await b);
+    assert.equal(calls, 1, 'N concurrent getOrFetch share one upstream call');
+  });
+
+  test('serves the ready value within the TTL, then refetches after expiry', async () => {
+    let nowMs = 0;
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => nowMs });
+    let calls = 0;
+    const loader = async () => {
+      calls += 1;
+      return response(200, `body-${calls}`);
+    };
+
+    const first = await cache.getOrFetch('k', loader);
+    assert.equal(calls, 1);
+
+    nowMs = 999; // still within TTL
+    const cached = await cache.getOrFetch('k', loader);
+    assert.equal(calls, 1, 'a ready entry inside the TTL is a cache hit');
+    assert.deepEqual(cached, first);
+
+    nowMs = 1_001; // past TTL
+    const refetched = await cache.getOrFetch('k', loader);
+    assert.equal(calls, 2, 'expiry triggers a refetch');
+    assert.equal(refetched.body.toString(), 'body-2');
+  });
+
+  test('does not cache a rejected loader — next call retries', async () => {
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    let calls = 0;
+    const loader = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('upstream boom');
+      return response();
+    };
+
+    await assert.rejects(cache.getOrFetch('k', loader), /upstream boom/);
+    const second = await cache.getOrFetch('k', loader);
+    assert.equal(calls, 2, 'a failed load is dropped, not pinned for the TTL');
+    assert.equal(second.status, 200);
+  });
+
+  test('lazily evicts expired entries for keys that are never touched again', async () => {
+    // A ready entry is only refreshed when ITS key is touched. Without a sweep,
+    // distinct expired variants accumulate forever. Touching ANY key after
+    // expiry must drop the stale ones — proven by a fresh loader call for the
+    // expired key (no stale hit) once it is re-requested.
+    let nowMs = 0;
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => nowMs });
+    const calls = new Map<string, number>();
+    const loader = (key: string) => async () => {
+      calls.set(key, (calls.get(key) ?? 0) + 1);
+      return response(200, `${key}-${calls.get(key)}`);
+    };
+
+    await cache.getOrFetch('variant-a', loader('variant-a'));
+    await cache.getOrFetch('variant-b', loader('variant-b'));
+
+    // Both entries expire, and a DIFFERENT key is touched — the sweep runs.
+    nowMs = 2_000;
+    await cache.getOrFetch('variant-c', loader('variant-c'));
+
+    // The expired entries were evicted, so re-requesting variant-a refetches
+    // rather than serving the swept-away stale value.
+    const reloaded = await cache.getOrFetch('variant-a', loader('variant-a'));
+    assert.equal(calls.get('variant-a'), 2, 'an evicted expired entry refetches on next request');
+    assert.equal(reloaded.body.toString(), 'variant-a-2');
+  });
+
+  test('both concurrent callers receive the rejection when the loader fails (neither hangs)', async () => {
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    let resolveReject: (err: Error) => void = () => {};
+    const loader = () =>
+      new Promise<CachedResponse>((_resolve, reject) => {
+        resolveReject = reject;
+      });
+
+    const a = cache.getOrFetch('k', loader);
+    const b = cache.getOrFetch('k', loader);
+    resolveReject(new Error('shared boom'));
+
+    await assert.rejects(a, /shared boom/);
+    await assert.rejects(b, /shared boom/);
+  });
+
+  test('a thrown non-2xx (loader-side) is not cached', async () => {
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    let calls = 0;
+    const loader = async () => {
+      calls += 1;
+      throw new Error(`non-2xx-${calls}`);
+    };
+
+    await assert.rejects(cache.getOrFetch('k', loader), /non-2xx-1/);
+    await assert.rejects(cache.getOrFetch('k', loader), /non-2xx-2/);
+    assert.equal(calls, 2, 'each request retries upstream; the error is never served from cache');
+  });
+});

--- a/backend/src/lib/ttl-single-flight-cache.ts
+++ b/backend/src/lib/ttl-single-flight-cache.ts
@@ -1,0 +1,87 @@
+// Short-TTL + single-flight cache for a tiny, fixed key space (gascity-dashboard).
+//
+// The supervisor transport proxy fans every request straight upstream and
+// streams the body, so N concurrent identical city-wide reads (the
+// molecule(all=true) history scan and the city formula feed) become N upstream
+// calls — each a multi-second full-store scan that saturates the browser
+// connection pool. This collapses concurrent identical reads into ONE upstream
+// call (single-flight) and serves a short-TTL ready value for the closely-spaced
+// re-fires that arrive just after the first resolves.
+//
+// Failures and non-2xx upstreams are NEVER cached: the loader throws, the entry
+// is deleted, and the rejection propagates to every coalesced caller — a
+// transient upstream failure must not be pinned and served for the TTL. The next
+// request retries upstream.
+
+export interface CachedResponse {
+  status: number;
+  headers: ReadonlyArray<readonly [string, string]>;
+  body: Buffer;
+}
+
+type Entry =
+  | { state: 'inflight'; promise: Promise<CachedResponse> }
+  | { state: 'ready'; value: CachedResponse; expiresAt: number };
+
+export interface TtlSingleFlightCacheOptions {
+  ttlMs: number;
+  now?: () => number;
+}
+
+export interface TtlSingleFlightCache {
+  getOrFetch(key: string, loader: () => Promise<CachedResponse>): Promise<CachedResponse>;
+}
+
+export function createTtlSingleFlightCache(
+  options: TtlSingleFlightCacheOptions,
+): TtlSingleFlightCache {
+  const { ttlMs } = options;
+  const now = options.now ?? Date.now;
+  const entries = new Map<string, Entry>();
+
+  // Lazy expiry sweep: a ready entry is only refreshed when ITS key is touched,
+  // so distinct expired variants (different param sets / cities) would otherwise
+  // accumulate forever. On each getOrFetch, drop every ready entry whose TTL has
+  // passed. Inflight entries are left alone — they self-resolve or self-delete.
+  function sweepExpired(): void {
+    const t = now();
+    for (const [key, entry] of entries) {
+      if (entry.state === 'ready' && t >= entry.expiresAt) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  return {
+    async getOrFetch(key, loader) {
+      sweepExpired();
+      const existing = entries.get(key);
+      if (existing !== undefined) {
+        if (existing.state === 'ready' && now() < existing.expiresAt) {
+          return existing.value;
+        }
+        if (existing.state === 'inflight') {
+          return existing.promise;
+        }
+      }
+
+      const promise = (async () => {
+        const value = await loader();
+        entries.set(key, { state: 'ready', value, expiresAt: now() + ttlMs });
+        return value;
+      })();
+      entries.set(key, { state: 'inflight', promise });
+
+      try {
+        return await promise;
+      } catch (err) {
+        // Never cache a failure: drop the inflight entry so the next caller
+        // retries upstream instead of being served the rejection for the TTL.
+        if (entries.get(key)?.state === 'inflight') {
+          entries.delete(key);
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/backend/src/routes/supervisor-transport-proxy.test.ts
+++ b/backend/src/routes/supervisor-transport-proxy.test.ts
@@ -1,0 +1,125 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+import { cacheableCityWideRead, supervisorTransportProxy } from './supervisor-transport-proxy.js';
+
+describe('cacheableCityWideRead — only the two expensive city-wide reads match', () => {
+  const base = 'http://127.0.0.1:9999';
+  const matches = (path: string) => cacheableCityWideRead(new URL(base + path));
+
+  test('matches the city formula feed (scope_kind=city)', () => {
+    assert.equal(
+      matches('/v0/city/ds-research/formulas/feed?scope_kind=city&scope_ref=ds-research'),
+      true,
+    );
+  });
+
+  test('matches the molecule history scan (type=molecule&all=true)', () => {
+    assert.equal(matches('/v0/city/ds-research/beads?type=molecule&all=true&limit=500'), true);
+  });
+
+  test('does NOT match a scoped (non-city) feed', () => {
+    assert.equal(
+      matches('/v0/city/ds-research/formulas/feed?scope_kind=rig&scope_ref=demo'),
+      false,
+    );
+  });
+
+  test('does NOT match the core active-bead list (no all=true)', () => {
+    assert.equal(matches('/v0/city/ds-research/beads?limit=500'), false);
+  });
+
+  test('does NOT match a per-rig task read', () => {
+    assert.equal(matches('/v0/city/ds-research/beads?type=task&rig=demo&all=true'), false);
+  });
+
+  test('does NOT match a molecule read carrying an EXTRA param (overmatch guard)', () => {
+    // The exact-param-set match rejects a molecule(all=true) read with any extra
+    // param (here &rig=foo): it is a narrower query, not the city-wide scan, and
+    // must never be served the cached city-wide body.
+    assert.equal(
+      matches('/v0/city/ds-research/beads?type=molecule&all=true&limit=500&rig=foo'),
+      false,
+    );
+  });
+
+  test('does NOT match a molecule read missing the expected limit', () => {
+    assert.equal(matches('/v0/city/ds-research/beads?type=molecule&all=true'), false);
+  });
+
+  test('does NOT match a feed carrying an EXTRA param', () => {
+    assert.equal(
+      matches('/v0/city/ds-research/formulas/feed?scope_kind=city&scope_ref=ds-research&rig=foo'),
+      false,
+    );
+  });
+
+  test('does NOT match an unrelated path', () => {
+    assert.equal(matches('/v0/city/ds-research/sessions'), false);
+  });
+});
+
+describe('supervisorTransportProxy — single-flight coalescing for the cacheable read', () => {
+  let upstream: Server;
+  let upstreamUrl: string;
+  let proxy: Server;
+  let proxyUrl: string;
+  let upstreamCalls = 0;
+
+  before(async () => {
+    const upstreamApp = express();
+    upstreamApp.get('/v0/city/:city/beads', (_req, res) => {
+      upstreamCalls += 1;
+      // Slow enough that two near-simultaneous proxy requests overlap.
+      setTimeout(() => {
+        // A stray upstream set-cookie must NOT be captured into the cached body
+        // (it would be replayed to every coalesced/within-TTL caller).
+        res
+          .status(200)
+          .type('application/json')
+          .setHeader('set-cookie', 'gc_session=secret; Path=/')
+          .send(JSON.stringify({ items: [], call: upstreamCalls }));
+      }, 50);
+    });
+    upstream = upstreamApp.listen(0);
+    await new Promise((r) => upstream.once('listening', r));
+    upstreamUrl = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+
+    const proxyApp = express();
+    proxyApp.use('/gc-supervisor', supervisorTransportProxy(upstreamUrl, true));
+    proxy = proxyApp.listen(0);
+    await new Promise((r) => proxy.once('listening', r));
+    proxyUrl = `http://127.0.0.1:${(proxy.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise((r) => proxy.close(r));
+    await new Promise((r) => upstream.close(r));
+  });
+
+  test('two concurrent identical molecule reads hit upstream once', async () => {
+    upstreamCalls = 0;
+    const path = '/gc-supervisor/v0/city/ds-research/beads?type=molecule&all=true&limit=500';
+    const [a, b] = await Promise.all([
+      fetch(proxyUrl + path).then((r) => r.json()),
+      fetch(proxyUrl + path).then((r) => r.json()),
+    ]);
+    assert.equal(upstreamCalls, 1, 'single-flight collapses the duplicate into one upstream call');
+    assert.deepEqual(a, b);
+  });
+
+  test('strips upstream set-cookie from the cached response', async () => {
+    upstreamCalls = 0;
+    const path = '/gc-supervisor/v0/city/ds-research/beads?type=molecule&all=true&limit=500';
+    const res = await fetch(proxyUrl + path);
+    await res.text();
+    assert.equal(
+      res.headers.get('set-cookie'),
+      null,
+      'cached response must not replay a set-cookie',
+    );
+  });
+});

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 import { HTTP_STATUS } from '../lib/http-status.js';
+import { createTtlSingleFlightCache, type CachedResponse } from '../lib/ttl-single-flight-cache.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
 import { isAllowedReadPath } from './supervisor-read-allowlist.js';
 
@@ -36,9 +37,118 @@ const READONLY_STRIPPED_REQUEST_HEADERS = new Set([
   'content-type',
 ]);
 
+// gascity-dashboard: short-TTL + single-flight cache for the two expensive
+// city-wide GET reads (the always-mounted run-summary subscription re-fires both
+// on every SSE bead-event burst). The molecule(all=true) history scan (~7s,
+// 340k-row) and the city formula feed (~10s) are city-wide, carry no
+// auth-varying headers, and are pure GETs — safe to coalesce + briefly cache so
+// the browser connection pool stays free for the run-detail's fast workflowRun
+// read. NOTHING scoped/per-rig/per-run/mutating is cached: the active-bead list
+// (no all=true), per-rig task reads (type=task&rig=...), and any query carrying
+// an extra param (rig/status/label/assignee/cursor/...) all fail the EXACT
+// param-set match below and go straight upstream.
+const CACHEABLE_CITY_WIDE_READS: readonly RegExp[] = [
+  /^\/v0\/city\/[^/]+\/formulas\/feed$/,
+  /^\/v0\/city\/[^/]+\/beads$/,
+];
+
+// The exact param sets the run-summary subscription sends for the two cacheable
+// reads (frontend/src/supervisor/runSummary.ts + discoverFromFeed). The match is
+// EXACT: any param outside the expected set (a scoped/per-rig/filtered read)
+// disqualifies the request, so a broader query can never be served a cached
+// city-wide body.
+const MOLECULE_HISTORY_FETCH_LIMIT = '500';
+const MOLECULE_HISTORY_PARAMS: ReadonlyArray<readonly [string, string]> = [
+  ['type', 'molecule'],
+  ['all', 'true'],
+  ['limit', MOLECULE_HISTORY_FETCH_LIMIT],
+];
+
+function paramsMatchExactly(
+  q: URLSearchParams,
+  expected: ReadonlyArray<readonly [string, string]>,
+): boolean {
+  if ([...q.keys()].length !== expected.length) return false;
+  return expected.every(([key, value]) => q.get(key) === value);
+}
+
+// 3s: single-flight collapses the SIMULTANEOUS duplicate reads within one SSE
+// burst; the short ready-window absorbs the closely-spaced re-fires that arrive
+// just after the first ~7-10s scan resolves. Kept well under the SPA's own
+// enrichment budgets (MOLECULE_HISTORY_TIMEOUT_MS=3s,
+// REQUIRED_RUN_SUMMARY_TIMEOUT_MS=15s) and far below the 60s status sampler, so
+// the historical-root discovery never visibly trails the live SSE-driven active
+// view (which is not cached). Do not exceed 5s.
+const CITY_WIDE_READ_TTL_MS = 3_000;
+
+export function cacheableCityWideRead(target: URL): boolean {
+  if (!CACHEABLE_CITY_WIDE_READS.some((p) => p.test(target.pathname))) return false;
+  const q = target.searchParams;
+  if (target.pathname.endsWith('/formulas/feed')) {
+    // The city feed sends EXACTLY scope_kind=city + scope_ref=<city>. scope_ref
+    // is the (dynamic) city name, so only its presence + the fixed scope_kind
+    // are matched; any extra param disqualifies the read.
+    return [...q.keys()].length === 2 && q.get('scope_kind') === 'city' && q.has('scope_ref');
+  }
+  // beads: ONLY the wide molecule history scan with its exact param set — a read
+  // carrying any extra param (rig/status/label/assignee/cursor) is a different,
+  // narrower query and must go straight upstream, never served a city-wide body.
+  return paramsMatchExactly(q, MOLECULE_HISTORY_PARAMS);
+}
+
+// searchParams.toString() PRESERVES insertion order (it does not sort), so two
+// requests with the same params in a different order would key differently. In
+// practice that never happens: each cacheable read is built from a fixed object
+// literal (runSummary.ts), so its param order is stable — a hypothetical reorder
+// is only a cache miss (a redundant upstream read), never a correctness or
+// security issue, because cacheableCityWideRead already pins the exact param set
+// and a different scope_ref / type / all value is a distinct key.
+function cacheKey(target: URL): string {
+  return `${target.pathname}?${target.searchParams.toString()}`;
+}
+
+// A non-2xx upstream must surface to the caller but NOT be pinned in the cache.
+// The cache loader throws this so getOrFetch deletes the inflight entry; the
+// proxy catch re-materializes the response from it.
+class UpstreamNon2xx extends Error {
+  constructor(private readonly cached: CachedResponse) {
+    super(`upstream responded ${cached.status}`);
+    this.name = 'UpstreamNon2xx';
+  }
+  toCached(): CachedResponse {
+    return this.cached;
+  }
+}
+
+// Headers that must never be captured into a CACHED response: a cached body is
+// replayed to every coalesced + every within-TTL caller, so a per-response
+// set-cookie from upstream would be broadcast to callers it was never issued
+// for. The cacheable reads are city-wide, auth-invariant GETs that should carry
+// no set-cookie at all — strip it defensively so a stray one can't be replayed.
+const STRIPPED_CACHED_RESPONSE_HEADERS = new Set([...HOP_BY_HOP_HEADERS, 'set-cookie']);
+
+function headerPairs(upstream: Response): Array<[string, string]> {
+  const pairs: Array<[string, string]> = [];
+  upstream.headers.forEach((value, name) => {
+    if (!STRIPPED_CACHED_RESPONSE_HEADERS.has(name.toLowerCase())) {
+      pairs.push([name, value]);
+    }
+  });
+  return pairs;
+}
+
+function writeCachedResponse(cached: CachedResponse, res: ExpressResponse): void {
+  res.status(cached.status);
+  for (const [name, value] of cached.headers) {
+    res.setHeader(name, value);
+  }
+  res.end(cached.body);
+}
+
 export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = false): Router {
   const router = Router();
   const baseUrl = new URL(supervisorBaseUrl);
+  const cityWideReadCache = createTtlSingleFlightCache({ ttlMs: CITY_WIDE_READ_TTL_MS });
 
   router.use(async (req, res) => {
     if (readOnly && req.method !== 'GET' && req.method !== 'HEAD') {
@@ -64,9 +174,33 @@ export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = f
     }
 
     try {
+      if (req.method === 'GET' && cacheableCityWideRead(target)) {
+        const cached = await cityWideReadCache.getOrFetch(cacheKey(target), async () => {
+          const upstream = await fetch(target, requestInit(req, readOnly));
+          const body = Buffer.from(await upstream.arrayBuffer());
+          const response: CachedResponse = {
+            status: upstream.status,
+            headers: headerPairs(upstream),
+            body,
+          };
+          if (upstream.status < 200 || upstream.status >= 300) {
+            // Surface non-2xx to the caller but don't pin it: throw so the
+            // single-flight cache drops the entry, then re-materialize below.
+            throw new UpstreamNon2xx(response);
+          }
+          return response;
+        });
+        writeCachedResponse(cached, res);
+        return;
+      }
+
       const upstream = await fetch(target, requestInit(req, readOnly));
       await writeUpstreamResponse(upstream, res);
     } catch (err) {
+      if (err instanceof UpstreamNon2xx) {
+        writeCachedResponse(err.toCached(), res);
+        return;
+      }
       logWarn(LOG_COMPONENT.admin, `gc supervisor transport proxy failed: ${errorMessage(err)}`);
       if (!res.headersSent) {
         res.status(HTTP_STATUS.badGateway).json({

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
-import { emptyRunSummary } from 'gas-city-dashboard-shared';
+import { emptyRunSummary, MAX_VISIBLE_ACTIVE_LANES } from 'gas-city-dashboard-shared';
 import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { RunMap } from './RunMap';
 
@@ -100,6 +100,116 @@ describe('RunMap historical expand-in-place (gascity-dashboard-l9q9)', () => {
     const section = screen.getByRole('region', { name: /historical runs/i });
     expect(within(section).getAllByRole('listitem')).toHaveLength(5);
     expect(within(section).queryByRole('button')).toBeNull();
+  });
+});
+
+function activeLane(id: string): RunLane {
+  return {
+    id,
+    title: `Active run ${id}`,
+    formula: { status: 'known', name: 'mol-adopt-pr-v2' },
+    scope: {
+      status: 'available',
+      kind: 'city',
+      ref: 'racoon-city',
+      rootStoreRef: 'city:racoon-city',
+    },
+    external: { status: 'unavailable', error: 'external unavailable in test' },
+    phase: 'implementation',
+    phaseLabel: 'implementation',
+    statusCounts: { in_progress: 1 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-05-24T12:00:00Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable in test' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+  };
+}
+
+function makeActiveLanes(count: number): RunLane[] {
+  return Array.from({ length: count }, (_, i) => activeLane(`gc-active-${i}`));
+}
+
+function renderActive(lanes: RunLane[]) {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <RunMap
+        source={{
+          source: 'runs',
+          status: 'fresh',
+          fetchedAt: '2026-05-24T12:00:00Z',
+          staleAt: '2026-05-24T12:01:00Z',
+          error: { kind: 'none' },
+          data: { ...emptyRunSummary(), totalActive: lanes.length, lanes },
+        }}
+        now={Date.parse('2026-05-24T12:01:00Z')}
+        showHistory={false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('RunMap active expand-in-place (lane-cap expander)', () => {
+  it('collapses to MAX_VISIBLE_ACTIVE_LANES with a Show-more toggle, no static footnote', () => {
+    const lanes = makeActiveLanes(MAX_VISIBLE_ACTIVE_LANES + 1);
+    renderActive(lanes);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(MAX_VISIBLE_ACTIVE_LANES);
+    expect(screen.queryByText(/more not shown/i)).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: /show 1 more runs/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('expands to all active lanes in place and collapses back', () => {
+    const total = MAX_VISIBLE_ACTIVE_LANES + 1;
+    const lanes = makeActiveLanes(total);
+    renderActive(lanes);
+
+    fireEvent.click(screen.getByRole('button', { name: /show 1 more runs/i }));
+    expect(screen.getAllByRole('listitem')).toHaveLength(total);
+
+    const collapse = screen.getByRole('button', { name: /show fewer/i });
+    expect(collapse.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(collapse);
+    expect(screen.getAllByRole('listitem')).toHaveLength(MAX_VISIBLE_ACTIVE_LANES);
+  });
+
+  it('renders no toggle when the active set fits the collapsed window', () => {
+    renderActive(makeActiveLanes(MAX_VISIBLE_ACTIVE_LANES));
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(MAX_VISIBLE_ACTIVE_LANES);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('drives the expander off the RENDERED lane count, not totalActive', () => {
+    // Self-consistency guard (mirrors the Historical section): the toggle's
+    // visibility AND its "N more" label both derive from summary.lanes.length —
+    // the collection actually rendered — not from totalActive. Feed a totalActive
+    // that disagrees with the lane count to prove the dependency is gone.
+    const lanes = makeActiveLanes(MAX_VISIBLE_ACTIVE_LANES + 2);
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <RunMap
+          source={{
+            source: 'runs',
+            status: 'fresh',
+            fetchedAt: '2026-05-24T12:00:00Z',
+            staleAt: '2026-05-24T12:01:00Z',
+            error: { kind: 'none' },
+            // totalActive deliberately disagrees with lanes.length.
+            data: { ...emptyRunSummary(), totalActive: 999, lanes },
+          }}
+          now={Date.parse('2026-05-24T12:01:00Z')}
+          showHistory={false}
+        />
+      </MemoryRouter>,
+    );
+
+    // Label reads lanes.length - MAX_VISIBLE (2), NOT totalActive - MAX_VISIBLE.
+    expect(screen.getByRole('button', { name: /show 2 more runs/i })).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  MAX_VISIBLE_ACTIVE_LANES,
   selectBlockedRuns,
   type RunLane,
   type RunSummary,
@@ -36,6 +37,7 @@ const COUNT_LABELS: Array<[keyof RunSummary['runCounts'], string]> = [
 
 const HISTORICAL_SECTION_ID = 'runs-historical-section';
 const HISTORICAL_LIST_ID = 'runs-historical-list';
+const ACTIVE_LIST_ID = 'runs-active-list';
 // How many completed runs show before the operator opts into the rest.
 // The wire carries up to MAX_HISTORICAL_LANES most-recent historical lanes
 // (gascity-dashboard-l9q9, recency-bounded in gascity-dashboard-9w3k); this
@@ -89,6 +91,13 @@ function ActiveSection({
   now: number;
   attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
+  // gascity-dashboard: `lanes` now carries the FULL active set; the collapsed
+  // window (MAX_VISIBLE_ACTIVE_LANES) and its "Show N more runs" expander live
+  // here, mirroring HistoricalSection. Collapsed by default keeps the calm
+  // density; expansion is opt-in. The hook precedes the empty-state early
+  // returns so hook order stays stable across renders.
+  const [expanded, setExpanded] = useState(false);
+
   if (summary.lanes.length === 0) {
     // gascity-dashboard-4xcv: a partial fetch with zero lanes is "we could
     // not see the runs", not "there are no runs". Never present a degraded
@@ -106,28 +115,39 @@ function ActiveSection({
       <p className="mt-8 text-body text-fg-muted italic">{`No active formula runs.${trailer}`}</p>
     );
   }
+  const shown = expanded ? summary.lanes : summary.lanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
   // gascity-dashboard-7hek: organize active lanes by rig (the run-root store).
   // A flat list of same-named molecule runs is indistinguishable; grouping
   // under the rig — a section head, no card, per the Flat Page Rule — gives
   // the operator the store context they navigate by. Within a group, lanes
   // keep their pre-sorted (recency/priority) order.
-  const groups = groupLanesByRig(summary.lanes);
+  const groups = groupLanesByRig(shown);
   return (
     <>
-      {groups.map(({ rig, lanes }) => (
-        <div key={rig} className="mt-6">
-          <h3 className="text-label uppercase tracking-wider text-fg-faint">{rigLabel(rig)}</h3>
-          <LaneList
-            lanes={lanes}
-            now={now}
-            {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
-          />
-        </div>
-      ))}
-      {summary.totalActive > summary.lanes.length && (
-        <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
-          {summary.totalActive - summary.lanes.length} more not shown
-        </p>
+      <div id={ACTIVE_LIST_ID}>
+        {groups.map(({ rig, lanes }) => (
+          <div key={rig} className="mt-6">
+            <h3 className="text-label uppercase tracking-wider text-fg-faint">{rigLabel(rig)}</h3>
+            <LaneList
+              lanes={lanes}
+              now={now}
+              {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+            />
+          </div>
+        ))}
+      </div>
+      {summary.lanes.length > MAX_VISIBLE_ACTIVE_LANES && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          aria-controls={ACTIVE_LIST_ID}
+          className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum hover:text-fg focus-mark"
+        >
+          {expanded
+            ? 'Show fewer'
+            : `Show ${summary.lanes.length - MAX_VISIBLE_ACTIVE_LANES} more runs`}
+        </button>
       )}
     </>
   );

--- a/frontend/src/hooks/useCachedData.test.tsx
+++ b/frontend/src/hooks/useCachedData.test.tsx
@@ -171,6 +171,58 @@ describe('useCachedData', () => {
     expect(second.result.current.fetchedAt).toBe(landedAt);
   });
 
+  it('cheapRefresh routes through sseRefreshFetcher when present', async () => {
+    const primary = vi.fn(() => Promise.resolve('primary'));
+    const wide = vi.fn(() => Promise.resolve('wide'));
+    const cheap = vi.fn(() => Promise.resolve('cheap'));
+
+    const { result } = renderHook(() =>
+      useCachedData('runs:cheap', primary, {
+        refreshFetcher: wide,
+        sseRefreshFetcher: cheap,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBe('primary');
+
+    await act(async () => {
+      await result.current.cheapRefresh();
+    });
+    expect(cheap).toHaveBeenCalledTimes(1);
+    expect(wide).not.toHaveBeenCalled();
+    expect(result.current.data).toBe('cheap');
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(wide).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toBe('wide');
+  });
+
+  it('cheapRefresh falls back to refreshFetcher then the primary fetcher', async () => {
+    const primary = vi.fn(() => Promise.resolve('primary'));
+    const wide = vi.fn(() => Promise.resolve('wide'));
+
+    const withWide = renderHook(() =>
+      useCachedData('runs:cheap-fallback-wide', primary, { refreshFetcher: wide }),
+    );
+    await waitFor(() => expect(withWide.result.current.loading).toBe(false));
+    await act(async () => {
+      await withWide.result.current.cheapRefresh();
+    });
+    expect(wide).toHaveBeenCalledTimes(1);
+
+    const primaryOnly = vi.fn(() => Promise.resolve('primary-only'));
+    const noOpts = renderHook(() => useCachedData('runs:cheap-fallback-primary', primaryOnly));
+    await waitFor(() => expect(noOpts.result.current.loading).toBe(false));
+    primaryOnly.mockClear();
+    await act(async () => {
+      await noOpts.result.current.cheapRefresh();
+    });
+    expect(primaryOnly).toHaveBeenCalledTimes(1);
+  });
+
   it('reports the latest fetch failure through onError', async () => {
     const onError = vi.fn();
     const failure = new Error('network down');

--- a/frontend/src/hooks/useCachedData.ts
+++ b/frontend/src/hooks/useCachedData.ts
@@ -8,6 +8,12 @@ interface UseCachedDataResult<T> {
   /** ISO timestamp of the cache read backing `data`, or undefined before any lands. */
   fetchedAt: string | undefined;
   refresh: () => Promise<void>;
+  /**
+   * Routes through `sseRefreshFetcher` when configured, else falls back to the
+   * primary refresh. A second, cheaper refresh path for high-frequency triggers
+   * (e.g. SSE bursts) that should not pay the full refresh cost.
+   */
+  cheapRefresh: () => Promise<void>;
 }
 
 export interface UseCachedDataOptions<T> {
@@ -19,6 +25,14 @@ export interface UseCachedDataOptions<T> {
    * the GET as `fetcher` and the POST as `refreshFetcher`.
    */
   refreshFetcher?: () => Promise<T>;
+  /**
+   * When provided, `cheapRefresh()` routes through this fetcher instead of the
+   * primary refresh path. Use for a cheaper variant of the same source that
+   * high-frequency triggers (SSE bursts) prefer, while the manual/explicit
+   * refresh stays on `refreshFetcher`. Falls back to `refreshFetcher` (or the
+   * primary `fetcher`) when undefined, so existing callers are unaffected.
+   */
+  sseRefreshFetcher?: () => Promise<T>;
   onError?: (error: unknown) => void;
 }
 
@@ -42,6 +56,8 @@ export function useCachedData<T>(
   fetcherRef.current = fetcher;
   const refreshFetcherRef = useRef(options?.refreshFetcher);
   refreshFetcherRef.current = options?.refreshFetcher;
+  const sseRefreshFetcherRef = useRef(options?.sseRefreshFetcher);
+  sseRefreshFetcherRef.current = options?.sseRefreshFetcher;
   const onErrorRef = useRef(options?.onError);
   onErrorRef.current = options?.onError;
   const currentKeyRef = useRef(key);
@@ -105,6 +121,13 @@ export function useCachedData<T>(
     () => runFetcher(refreshFetcherRef.current ?? fetcherRef.current),
     [runFetcher],
   );
+  // Cheap refresh prefers the SSE fetcher, then the primary refresh fetcher,
+  // then the cheap primary fetcher — so it is always a no-config superset.
+  const cheapRefresh = useCallback(
+    () =>
+      runFetcher(sseRefreshFetcherRef.current ?? refreshFetcherRef.current ?? fetcherRef.current),
+    [runFetcher],
+  );
 
   useEffect(() => {
     const cached = getCached<T>(key);
@@ -117,5 +140,5 @@ export function useCachedData<T>(
     };
   }, [key, runFetcher]);
 
-  return { data, loading, error, fetchedAt, refresh };
+  return { data, loading, error, fetchedAt, refresh, cheapRefresh };
 }

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -16,6 +16,7 @@ import { RunSummaryProvider } from '../runs/runSummarySubscription';
 import { MemoryRouter } from 'react-router-dom';
 import { NowProvider } from '../contexts/NowContext';
 import {
+  loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
 } from '../supervisor/runSummary';
@@ -40,6 +41,7 @@ import {
 vi.mock('../supervisor/runSummary', () => ({
   loadSupervisorRunSummaryPreviewSource: vi.fn(),
   loadSupervisorRunSummarySource: vi.fn(),
+  loadSupervisorRunSummaryActiveSource: vi.fn(),
 }));
 
 // Capture the prefixes + onMatch passed to useGcEventRefresh so each
@@ -60,6 +62,9 @@ vi.mock('../hooks/useGcEvents', () => ({
 
 const mockLoadRunSummaryPreview = loadSupervisorRunSummaryPreviewSource as Mock;
 const mockLoadRunSummary = loadSupervisorRunSummarySource as Mock;
+// gascity-dashboard: SSE-driven refreshes route through the CHEAP active source;
+// only the manual Refresh button + one-time first upgrade use the wide source.
+const mockLoadRunSummaryActive = loadSupervisorRunSummaryActiveSource as Mock;
 
 function buildRunSource(
   runsStatus: Exclude<SourceStatus, 'error'> = 'fresh',
@@ -178,11 +183,13 @@ beforeEach(() => {
   setActiveCity('racoon-city');
   mockLoadRunSummaryPreview.mockReset();
   mockLoadRunSummary.mockReset();
+  mockLoadRunSummaryActive.mockReset();
   lastHookCall.prefixes = null;
   lastHookCall.onMatch = null;
   invalidateKey('runs:summary:racoon-city');
   mockLoadRunSummaryPreview.mockResolvedValue(buildRunSource('fresh'));
   mockLoadRunSummary.mockResolvedValue(buildRunSource('fresh'));
+  mockLoadRunSummaryActive.mockResolvedValue(buildRunSource('fresh'));
 });
 
 afterEach(() => {
@@ -486,13 +493,14 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mount();
     await waitForMount();
-    mockLoadRunSummary.mockClear();
+    mockLoadRunSummaryActive.mockClear();
 
     // Simulate a busy slung pipeline: 5 onMatch calls within 1s. The
     // 10s in-component debounce floor must collapse this to a single
-    // upstream POST. (useGcEventRefresh's own 2.5s coalesce sits in
-    // front of onMatch in production; this test exercises ONLY the
-    // Runs-side debounce we added per architect H2.)
+    // upstream read. SSE bursts take the CHEAP active source.
+    // (useGcEventRefresh's own 2.5s coalesce sits in front of onMatch in
+    // production; this test exercises ONLY the Runs-side debounce per
+    // architect H2.)
     await act(async () => {
       for (let i = 0; i < 5; i++) {
         lastHookCall.onMatch?.();
@@ -504,7 +512,7 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     // `toBe(1)` rather than `toBeLessThanOrEqual(1)` so a regression
     // that suppresses the leading edge entirely (count would be 0) is
     // caught loudly.
-    expect(mockLoadRunSummary.mock.calls.length).toBe(1);
+    expect(mockLoadRunSummaryActive.mock.calls.length).toBe(1);
   });
 
   it('fires a second run-summary refresh once the debounce window elapses', async () => {
@@ -518,25 +526,25 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mount();
     await waitForMount();
-    mockLoadRunSummary.mockClear();
+    mockLoadRunSummaryActive.mockClear();
 
-    // Leading edge: one event, one POST.
+    // Leading edge: one event, one CHEAP read.
     await act(async () => {
       lastHookCall.onMatch?.();
     });
-    expect(mockLoadRunSummary.mock.calls.length).toBe(1);
+    expect(mockLoadRunSummaryActive.mock.calls.length).toBe(1);
 
     // Advance past the 10s debounce floor (REFRESH_DEBOUNCE_MS = 10_000
-    // in Runs.tsx; +100ms cushion so we're unambiguously past it).
+    // in the subscription; +100ms cushion so we're unambiguously past it).
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_100);
     });
 
-    // Second event after the window must fire a second POST.
+    // Second event after the window must fire a second CHEAP read.
     await act(async () => {
       lastHookCall.onMatch?.();
     });
-    expect(mockLoadRunSummary.mock.calls.length).toBe(2);
+    expect(mockLoadRunSummaryActive.mock.calls.length).toBe(2);
   });
 
   it('SSE callback no-ops when runs source status is not fresh', async () => {
@@ -548,12 +556,15 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     mount();
     await waitForMount();
     mockLoadRunSummary.mockClear();
+    mockLoadRunSummaryActive.mockClear();
 
     await act(async () => {
       lastHookCall.onMatch?.();
     });
 
+    // Fixture status short-circuits before any refresh — neither path fires.
     expect(mockLoadRunSummary).not.toHaveBeenCalled();
+    expect(mockLoadRunSummaryActive).not.toHaveBeenCalled();
   });
 });
 
@@ -764,19 +775,20 @@ describe('RunsPage — degraded first load recovery (gascity-dashboard-4xcv)', (
   it('SSE callback refreshes when the runs source is in error state', async () => {
     // The old guard skipped every non-fresh status, so an error first
     // load latched the page dead until a manual refresh. A bead event is
-    // exactly the cue to try live data again.
+    // exactly the cue to try live data again — via the CHEAP active source.
     mockLoadRunSummaryPreview.mockResolvedValue(errorSource);
     mockLoadRunSummary.mockResolvedValue(errorSource);
+    mockLoadRunSummaryActive.mockResolvedValue(errorSource);
 
     mount();
     await waitForMount();
-    mockLoadRunSummary.mockClear();
+    mockLoadRunSummaryActive.mockClear();
 
     await act(async () => {
       lastHookCall.onMatch?.();
     });
 
-    expect(mockLoadRunSummary).toHaveBeenCalledTimes(1);
+    expect(mockLoadRunSummaryActive).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -1,9 +1,15 @@
 import { act, cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { type RunSummary, type SourceState, type SourceStatus } from 'gas-city-dashboard-shared';
+import {
+  type RunLane,
+  type RunSummary,
+  type SourceState,
+  type SourceStatus,
+} from 'gas-city-dashboard-shared';
 import { invalidateKey } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
 import {
+  loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
 } from '../supervisor/runSummary';
@@ -19,6 +25,7 @@ import { RunSummaryProvider, useRunSummary } from './runSummarySubscription';
 vi.mock('../supervisor/runSummary', () => ({
   loadSupervisorRunSummaryPreviewSource: vi.fn(),
   loadSupervisorRunSummarySource: vi.fn(),
+  loadSupervisorRunSummaryActiveSource: vi.fn(),
 }));
 
 const lastHookCall: { prefixes: ReadonlyArray<string> | null; onMatch: (() => void) | null } = {
@@ -35,6 +42,9 @@ vi.mock('../hooks/useGcEvents', () => ({
 
 const mockPreview = loadSupervisorRunSummaryPreviewSource as Mock;
 const mockFull = loadSupervisorRunSummarySource as Mock;
+// gascity-dashboard: SSE-driven refreshes route through the CHEAP active source,
+// not the wide one — only the manual button + one-time first upgrade are wide.
+const mockActive = loadSupervisorRunSummaryActiveSource as Mock;
 
 function buildRunSource(
   status: Exclude<SourceStatus, 'error'>,
@@ -67,6 +77,54 @@ function buildRunSource(
   };
 }
 
+function lane(id: string): RunLane {
+  return {
+    id,
+    title: `Run ${id}`,
+    formula: { status: 'known', name: 'mol-focus-review' },
+    scope: {
+      status: 'available',
+      kind: 'city',
+      ref: 'racoon-city',
+      rootStoreRef: 'city:racoon-city',
+    },
+    external: { status: 'unavailable', error: 'external unavailable in test' },
+    phase: 'implementation',
+    phaseLabel: 'implementation',
+    statusCounts: { in_progress: 1 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-06-01T00:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable in test' },
+    formulaStageResolved: false,
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+  };
+}
+
+// Build a source carrying explicit active / blocked / historical lane sets, so a
+// test can assert WHICH run ids land in WHICH section after a cheap merge.
+function buildLaneSource(opts: {
+  status?: Exclude<SourceStatus, 'error'>;
+  active?: string[];
+  blocked?: string[];
+  historical?: string[];
+  totalHistorical?: number;
+}): SourceState<RunSummary> {
+  const base = buildRunSource(opts.status ?? 'fresh');
+  if (base.status === 'error') throw new Error('unreachable');
+  const historical = (opts.historical ?? []).map(lane);
+  return {
+    ...base,
+    data: {
+      ...base.data,
+      lanes: (opts.active ?? []).map(lane),
+      blockedLanes: (opts.blocked ?? []).map(lane),
+      historicalLanes: historical,
+      totalHistorical: opts.totalHistorical ?? historical.length,
+    },
+  };
+}
+
 // A stand-in for the two real consumers — the nav badge and the /runs page —
 // rendering the status + blocked count of the source it reads.
 function Consumer({ label }: { label: string }) {
@@ -75,15 +133,31 @@ function Consumer({ label }: { label: string }) {
   return <div data-testid={label}>{`${source?.status ?? 'pending'}:${blocked}`}</div>;
 }
 
+// A consumer that renders the active+blocked lane ids, the historical lane ids,
+// and totalHistorical — for asserting cheap-refresh history reconciliation.
+function LaneConsumer({ label }: { label: string }) {
+  const { source } = useRunSummary();
+  if (!source || source.status === 'error') return <div data-testid={label}>none</div>;
+  const live = [...source.data.lanes, ...source.data.blockedLanes].map((l) => l.id).join(',');
+  const hist = source.data.historicalLanes.map((l) => l.id).join(',');
+  return (
+    <div
+      data-testid={label}
+    >{`live=[${live}] hist=[${hist}] totalHist=${source.data.totalHistorical}`}</div>
+  );
+}
+
 beforeEach(() => {
   setActiveCity('racoon-city');
   mockPreview.mockReset();
   mockFull.mockReset();
+  mockActive.mockReset();
   lastHookCall.prefixes = null;
   lastHookCall.onMatch = null;
   invalidateKey('runs:summary:racoon-city');
   mockPreview.mockResolvedValue(buildRunSource('fresh'));
   mockFull.mockResolvedValue(buildRunSource('fresh'));
+  mockActive.mockResolvedValue(buildRunSource('fresh'));
 });
 
 afterEach(() => {
@@ -131,8 +205,8 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
     expect(screen.getByTestId('badge').textContent).toBe('fresh:0');
 
-    // A bead event lands and the next load carries a newly-blocked run.
-    mockFull.mockResolvedValue(buildRunSource('fresh', 1));
+    // A bead event lands and the next CHEAP load carries a newly-blocked run.
+    mockActive.mockResolvedValue(buildRunSource('fresh', 1));
     await act(async () => {
       lastHookCall.onMatch?.();
     });
@@ -166,9 +240,9 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     // The full upgrade has been kicked off and is parked, mid-flight.
     await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
 
-    // A bead event lands while the load is in flight; the next load must carry
-    // the newly-blocked run.
-    mockFull.mockResolvedValue(buildRunSource('fresh', 1));
+    // A bead event lands while the load is in flight; the queued trailing CHEAP
+    // refresh must carry the newly-blocked run.
+    mockActive.mockResolvedValue(buildRunSource('fresh', 1));
     await act(async () => {
       lastHookCall.onMatch?.();
     });
@@ -202,10 +276,10 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     // First good load lands.
     await waitFor(() => expect(screen.getByTestId('badge').textContent).toBe('fresh:2'));
 
-    // A bead event triggers a refresh that resolves to an error source (the
-    // supervisor list timed out). Prior good data exists, so the published
+    // A bead event triggers a CHEAP refresh that resolves to an error source
+    // (the supervisor list timed out). Prior good data exists, so the published
     // state must keep that data as 'stale', not flip to 'error'.
-    mockFull.mockResolvedValue({
+    mockActive.mockResolvedValue({
       source: 'runs',
       status: 'error',
       error: 'gc supervisor request timed out after 5000ms',
@@ -228,9 +302,9 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     );
     await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('fresh:3'));
 
-    // A refresh that rejects (rather than resolving to an error source) must
-    // also retain the last-good snapshot rather than latching the view dead.
-    mockFull.mockRejectedValue(new Error('gc supervisor request timed out after 5000ms'));
+    // A CHEAP refresh that rejects (rather than resolving to an error source)
+    // must also retain the last-good snapshot rather than latching the view dead.
+    mockActive.mockRejectedValue(new Error('gc supervisor request timed out after 5000ms'));
     await act(async () => {
       lastHookCall.onMatch?.();
     });
@@ -326,6 +400,79 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     );
 
     await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('error:-1'));
+  });
+
+  it('reconciles merged history against the fresh active set on a cheap refresh (no double-display)', async () => {
+    // MAJOR 1: the cheap refresh borrows historicalLanes from the last wide
+    // snapshot. If a run that WAS historical is now active/blocked again, it must
+    // appear ONLY in the live set, not in both. The wide upgrade seeds history
+    // with gc-1 (historical); the cheap refresh then reports gc-1 as active again.
+    mockFull.mockResolvedValue(buildLaneSource({ active: [], historical: ['gc-1', 'gc-2'] }));
+
+    render(
+      <RunSummaryProvider>
+        <LaneConsumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // Wide upgrade landed: gc-1 + gc-2 are historical, nothing live.
+    await waitFor(() =>
+      expect(screen.getByTestId('page').textContent).toBe('live=[] hist=[gc-1,gc-2] totalHist=2'),
+    );
+
+    // A bead event lands and the cheap active read now reports gc-1 active again.
+    mockActive.mockResolvedValue(buildLaneSource({ active: ['gc-1'], historical: [] }));
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+
+    // gc-1 appears ONLY in the live set; the borrowed history drops it and the
+    // count is recomputed. gc-2 (still only historical) stays in history.
+    await waitFor(() =>
+      expect(screen.getByTestId('page').textContent).toBe('live=[gc-1] hist=[gc-2] totalHist=1'),
+    );
+  });
+
+  it('does not let a cheap SSE success cancel the bounded wide-failure retry', async () => {
+    // MAJOR 2: a failed WIDE upgrade arms the bounded wide retry (off
+    // staleDueToFailureRef). A cheap SSE success must NOT clear that flag, so the
+    // wide retry still fires; only a successful WIDE refresh marks recovery.
+    vi.useFakeTimers();
+    mockPreview.mockResolvedValue(buildRunSource('fresh', 4));
+    // The one-time wide upgrade fails the first time, arming the retry...
+    mockFull.mockRejectedValueOnce(new Error('gc supervisor request timed out after 5000ms'));
+    // ...and the retried wide refresh succeeds.
+    mockFull.mockResolvedValue(buildRunSource('fresh', 7));
+    // A cheap SSE refresh in between succeeds — it must not be treated as recovery.
+    mockActive.mockResolvedValue(buildRunSource('fresh', 4));
+
+    render(
+      <RunSummaryProvider>
+        <Consumer label="page" />
+      </RunSummaryProvider>,
+    );
+
+    // Preview lands, wide upgrade fails and is retained as stale.
+    await vi.waitFor(() => expect(screen.getByTestId('page').textContent).toBe('stale:4'));
+    const wideCallsAfterFirstFail = mockFull.mock.calls.length;
+
+    // A cheap SSE refresh succeeds before the wide retry timer fires.
+    await act(async () => {
+      lastHookCall.onMatch?.();
+    });
+    // The cheap success did NOT add a wide call and (critically) did not cancel
+    // the armed wide retry — the published view is still stale-due-to-failure.
+    expect(mockFull.mock.calls.length).toBe(wideCallsAfterFirstFail);
+
+    // Advance through the backoff budget: the WIDE retry must still fire (the
+    // cheap success did not cancel it) and recover the view to the full snapshot.
+    // The intervening cheap-success render re-arms the retry timer at the next
+    // backoff slot, so drain the whole budget rather than just the first delay.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    expect(mockFull.mock.calls.length).toBeGreaterThan(wideCallsAfterFirstFail);
+    await vi.waitFor(() => expect(screen.getByTestId('page').textContent).toBe('fresh:7'));
   });
 
   it('throws when used outside a RunSummaryProvider', () => {

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -10,6 +10,7 @@ import { getActiveCity } from '../api/cityBase';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh, type GcEventConnState } from '../hooks/useGcEvents';
 import {
+  loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
 } from '../supervisor/runSummary';
@@ -27,12 +28,15 @@ import {
 // both. The page reads it through useRunSummary(); the badge reads its `source`
 // through the attention layer (liveContributors `runsFactsFromSource`).
 //
-// The fetch contract is unchanged from the page's prior implementation: the
-// cheap preview (2.5s budget) paints first, a one-time full refresh (30s,
-// session-enriched) upgrades the snapshot to the page-complete one, a bounded
-// backoff recovers a degraded first load, and SSE-driven refetches are gated by
-// an in-component debounce floor on top of useGcEventRefresh's own coalescing
-// (architect H1/H2 upstream-load protection during slung-pipeline bursts).
+// The fetch contract: the cheap preview (2.5s budget) paints first, a one-time
+// full refresh (30s, session-enriched, WIDE) upgrades the snapshot to the
+// page-complete one and populates the historical lanes, a bounded backoff
+// recovers a degraded first load (WIDE), and SSE-driven refetches take the CHEAP
+// active-only path (skips the molecule(all=true) + city feed + per-rig reads,
+// merging historical lanes from the last wide snapshot) gated by an in-component
+// debounce floor on top of useGcEventRefresh's own coalescing (architect H1/H2
+// upstream-load protection during slung-pipeline bursts). The manual Refresh
+// button still triggers a WIDE scan on demand.
 
 const REFRESH_DEBOUNCE_MS = 10_000;
 // gascity-dashboard-4xcv: bounded retry backoff for a degraded first load (error
@@ -94,10 +98,63 @@ export function useRunSummarySubscription(): RunSummarySubscription {
     return { ...lastGood, status: 'stale' };
   }, []);
 
-  const { data, loading, error, refresh } = useCachedData(
+  // gascity-dashboard: the CHEAP SSE-burst refresh. loadSupervisorRunSummaryActiveSource
+  // skips the molecule(all=true) + city feed + per-rig task reads, so a routine
+  // bead burst no longer saturates the browser connection pool and queues the
+  // run-detail's fast workflowRun read behind it. The active/blocked set is fully
+  // correct (scope/health/counts/census); only HISTORICAL lanes come from the
+  // recent reads, so we merge those back from the last wide snapshot to keep the
+  // History section populated. Failure handling mirrors the wide wrapper.
+  const refreshActiveWithMerge = useCallback(async (): Promise<SourceState<RunSummary>> => {
+    const result = await loadSupervisorRunSummaryActiveSource().catch(
+      (err): SourceState<RunSummary> => ({
+        source: 'runs',
+        status: 'error',
+        error: err instanceof Error ? err.message : 'formula runs unavailable',
+      }),
+    );
+    if (result.status !== 'error') {
+      // A cheap (active-only) success does NOT prove the WIDE failure recovered:
+      // the wide retry loop must keep driving off staleDueToFailureRef until a
+      // wide refresh actually lands (refreshWithLastGoodRetention clears it). So
+      // we deliberately do NOT clear the flag here.
+      const lastGood = lastGoodRef.current;
+      const borrowedHistorical = lastGood?.data.historicalLanes ?? [];
+      // Reconcile the borrowed history against the CURRENT active/blocked set: a
+      // run that was historical in last-good but is active or blocked again in
+      // this fresh snapshot would otherwise appear in BOTH sets (double-display).
+      // Drop any historical lane whose run is now live; recompute the count to
+      // match. (A run that completes between wide refreshes still lags into
+      // History on the next wide scan — accepted; this only kills the overlap.)
+      const liveIds = new Set<string>([
+        ...result.data.lanes.map((lane) => lane.id),
+        ...result.data.blockedLanes.map((lane) => lane.id),
+      ]);
+      const historicalLanes = borrowedHistorical.filter((lane) => !liveIds.has(lane.id));
+      const dropped = borrowedHistorical.length - historicalLanes.length;
+      const totalHistorical = Math.max(0, (lastGood?.data.totalHistorical ?? 0) - dropped);
+      return {
+        ...result,
+        data: {
+          ...result.data,
+          historicalLanes,
+          totalHistorical,
+        },
+      };
+    }
+    const lastGood = lastGoodRef.current;
+    if (lastGood === null) return result;
+    staleDueToFailureRef.current = true;
+    return { ...lastGood, status: 'stale' };
+  }, []);
+
+  const { data, loading, error, refresh, cheapRefresh } = useCachedData(
     `runs:summary:${cityName ?? 'no-city'}`,
     loadSupervisorRunSummaryPreviewSource,
-    { refreshFetcher: refreshWithLastGoodRetention },
+    {
+      refreshFetcher: refreshWithLastGoodRetention,
+      sseRefreshFetcher: refreshActiveWithMerge,
+    },
   );
   // Capture the latest available snapshot so the next failed refresh can fall
   // back to it. A re-published 'stale' snapshot stays good data, so it keeps
@@ -176,12 +233,15 @@ export function useRunSummarySubscription(): RunSummarySubscription {
       trailingTimerRef.current = null;
     }
     lastRefreshAtRef.current = Date.now();
-    void refresh().catch(() => {
+    // SSE-driven bursts take the CHEAP path (active-only + merged history); the
+    // wide scan is reserved for the manual Refresh button and the one-time
+    // first-upgrade.
+    void cheapRefresh().catch(() => {
       // Reset on error so the next event retries instead of being silently
       // dropped for the rest of the debounce window.
       lastRefreshAtRef.current = 0;
     });
-  }, [refresh]);
+  }, [cheapRefresh]);
 
   const onSseMatch = useCallback(() => {
     // Skip when fixtures are serving (supervisor down) — every forced refresh

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -11,6 +11,7 @@ import { resetSupervisorApiForTests, setSupervisorApiForTests, type SupervisorAp
 import { SupervisorApiError } from './errors';
 import {
   CORE_RUN_SUMMARY_TIMEOUT_MS,
+  loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryMountSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
@@ -488,10 +489,14 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(9);
-    expect(source.data.lanes).toHaveLength(8); // visible window still capped
+    // gascity-dashboard: `lanes` carries the FULL active set now — the rendered
+    // 8-lane collapse is applied by RunMap, not the wire.
+    expect(source.data.lanes).toHaveLength(9);
     expect(source.data.lanes.map((lane) => lane.id)).not.toContain('gc-1920');
+    // The phantom (the 10th, session-less latch) is demoted; all 9 live runs survive.
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(liveRuns.map((_, i) => `live-${i}`));
     expect(source.data.runCounts.total).toBe(9);
-    expect(source.data.runCounts.visible).toBe(8);
+    expect(source.data.runCounts.visible).toBe(9);
   });
 
   it('keeps available lanes while marking the summary partial when a recent rig read fails', async () => {
@@ -820,6 +825,66 @@ describe('loadSupervisorRunSummarySource', () => {
     // spike; it must stay well above the old 5s budget to absorb a burst.
     expect(CORE_RUN_SUMMARY_TIMEOUT_MS).toBe(15_000);
     expect(CORE_RUN_SUMMARY_TIMEOUT_MS).toBeGreaterThan(5_000);
+  });
+});
+
+describe('loadSupervisorRunSummaryActiveSource — cheap SSE-burst path', () => {
+  beforeEach(() => {
+    setActiveCity('test-city');
+    resetSupervisorRunSummaryStateForTests();
+  });
+  afterEach(() => {
+    resetSupervisorApiForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('skips the molecule history scan, city feed, and per-rig task reads', async () => {
+    // The core active read returns ONLY the no-query (active) listBeads call —
+    // any molecule/per-rig listBeads call or formulaFeed call would mean the
+    // cheap path is still firing the expensive reads. The run carries an
+    // in-progress step in the SAME core read (no per-rig fetch on the cheap
+    // path), so the lane stays active without session enrichment.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query && (query.type !== undefined || query.rig !== undefined)) {
+        throw new Error(`cheap path must not call listBeads with ${JSON.stringify(query)}`);
+      }
+      return beadList([
+        runRoot(),
+        bead({
+          id: 'run-1-step-1',
+          title: 'Implementation patch',
+          status: 'in_progress',
+          metadata: {
+            'gc.kind': 'step',
+            'gc.root_bead_id': 'run-1',
+            'gc.parent_bead_id': 'run-1',
+            'gc.step_id': 'implementation.patch',
+          },
+        }),
+      ]);
+    });
+    const formulaFeed = vi.fn(async () => feed([]));
+    const listSessions = vi.fn(async () => sessionList());
+    setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed, listSessions });
+
+    const source = await loadSupervisorRunSummaryActiveSource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    // The active lane is present, and its rig scope resolves from the bead's own
+    // gc.root_store_ref metadata — no feed needed.
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
+    expect(source.data.lanes[0]?.scope).toMatchObject({ status: 'available', kind: 'rig' });
+    // No history reads on the cheap path.
+    expect(source.data.historicalLanes).toEqual([]);
+    expect(source.data.totalHistorical).toBe(0);
+    // The expensive reads were never issued.
+    expect(formulaFeed).not.toHaveBeenCalled();
+    expect(
+      listBeads.mock.calls.every(([, query]) => query === undefined || query.limit !== undefined),
+    ).toBe(true);
+    expect(listBeads.mock.calls.some(([, query]) => query?.type === 'molecule')).toBe(false);
+    expect(listBeads.mock.calls.some(([, query]) => query?.rig !== undefined)).toBe(false);
   });
 });
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -17,7 +17,6 @@ import {
   fromRootMetadataScope,
   fromStoreRef,
   isStaleSessionlessLatch,
-  MAX_VISIBLE_ACTIVE_LANES,
   runBeadFilter,
   runCounts,
   SCOPE_REF_RE,
@@ -160,6 +159,66 @@ async function loadRunSummarySource(enrichmentBudgetMs: number): Promise<SourceS
   }
 }
 
+// gascity-dashboard: the CHEAP SSE-refresh source. The wide source's loadRunBeads
+// fires the two expensive HISTORICAL/discovery reads (molecule(all=true) ~6.8s,
+// city formulaFeed ~10s) plus per-rig task reads on every SSE burst, saturating
+// the browser ~6-conn/host cap so the run-detail's fast workflowRun read queues
+// behind them. The active/blocked set and its scope/health/counts/census do NOT
+// need those reads: runScope takes the bead's own gc.root_store_ref/gc.scope_ref
+// metadata first (feedScopes is only a fallback), and runRigNames derives the
+// active rig set from that same per-bead metadata. So this fetches only the core
+// active read + sessions, skipping molecule + city feed + per-rig task reads.
+// historicalLanes/totalHistorical come back empty here; the subscription merges
+// them from the last wide snapshot so History is never blanked.
+export async function loadSupervisorRunSummaryActiveSource(): Promise<SourceState<RunSummary>> {
+  const cityName = activeCityOrThrow('load supervisor run summary active');
+  const fetchedAt = new Date().toISOString();
+  try {
+    const [loaded, sessions] = await Promise.all([
+      loadActiveRunBeads(cityName, RUNS_FETCH_LIMIT),
+      loadRunSessions(cityName, PREVIEW_ENRICHMENT_TIMEOUT_MS),
+    ]);
+    const summary = buildRunSummary(
+      loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
+      loaded.feedScopes,
+      loaded.partial,
+    );
+    const source: SourceAvailableState<RunSummary> = {
+      source: 'runs',
+      status: 'fresh',
+      fetchedAt,
+      staleAt: new Date(Date.parse(fetchedAt) + RUNS_STALE_AFTER_MS).toISOString(),
+      error: { kind: 'none' },
+      data: summary,
+    };
+    return {
+      ...source,
+      data: enrichRunSummary(cityName, source, sessions),
+    };
+  } catch (err) {
+    return {
+      source: 'runs',
+      status: 'error',
+      error: errorMessage(err, 'formula runs unavailable'),
+    };
+  }
+}
+
+// Core active read only — no molecule history scan, no city formula feed, no
+// per-rig task reads. Truncation still reads as partial lanes. feedScopes is
+// empty: a run root whose OWN bead carries no scope metadata falls back to
+// 'unavailable' scope until the next wide refresh repairs it (minority path —
+// runScope prefers per-bead metadata).
+async function loadActiveRunBeads(cityName: string, limit: number): Promise<LoadedRunBeads> {
+  const activeList = await fetchCoreActiveBeads(cityName, limit);
+  const active = normalizeBeads(activeList.items ?? []);
+  return {
+    beads: active,
+    feedScopes: new Map(),
+    partial: listIsIncomplete(activeList, active.length),
+  };
+}
+
 export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceState<RunSummary>> {
   const cityName = activeCityOrThrow('load supervisor run summary preview');
   const fetchedAt = new Date().toISOString();
@@ -176,9 +235,9 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
       fetchedAt,
       staleAt: new Date(Date.parse(fetchedAt) + RUNS_STALE_AFTER_MS).toISOString(),
       error: { kind: 'none' },
-      // First paint has no sessions yet, so no latch demotion — just apply the
-      // visible cap that buildRunSummary now defers to its consumers (s4rp).
-      data: { ...summary, lanes: summary.lanes.slice(0, MAX_VISIBLE_ACTIVE_LANES) },
+      // First paint has no sessions yet, so no latch demotion. `lanes` carries
+      // the full active set; RunMap applies the collapsed window.
+      data: summary,
     };
   } catch (err) {
     return {
@@ -405,15 +464,17 @@ function enrichRunSummary(
   const liveActive = activeEnriched.filter(
     (lane) => !isStaleSessionlessLatch(lane, generationMs, sessionsAvailable),
   );
-  const visibleActive = liveActive.slice(0, MAX_VISIBLE_ACTIVE_LANES);
   const census = buildCensus([...liveActive, ...blockedLanes]);
 
+  // gascity-dashboard: `lanes` carries the FULL active set; RunMap owns the
+  // collapsed window (MAX_VISIBLE_ACTIVE_LANES) and its "Show N more runs"
+  // expander, mirroring the historical section.
   return {
     ...source.data,
     totalActive: liveActive.length,
-    lanes: visibleActive,
+    lanes: liveActive,
     blockedLanes,
-    runCounts: runCounts(liveActive, visibleActive.length, blockedLanes.length),
+    runCounts: runCounts(liveActive, liveActive.length, blockedLanes.length),
     census: { status: 'available', data: census },
   };
 }

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -1,7 +1,13 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildRunSummary, emptyRunSummary, runLane, MAX_HISTORICAL_LANES } from './summary.js';
+import {
+  buildRunSummary,
+  emptyRunSummary,
+  runLane,
+  MAX_HISTORICAL_LANES,
+  MAX_VISIBLE_ACTIVE_LANES,
+} from './summary.js';
 import type { RunFeedScope } from './summary.js';
 import type { RunIssue } from './phaseMapping.js';
 
@@ -301,6 +307,22 @@ describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard
     assert.deepEqual(summary.blockedLanes, []);
     assert.equal(summary.totalActive, 0);
     assert.equal(summary.totalHistorical, 0);
+  });
+});
+
+// gascity-dashboard: the builder carries the FULL active set on the wire — the
+// rendered 8-lane collapse is applied by the consumer (RunMap), mirroring the
+// historical section. The builder must NOT pre-cap `lanes`.
+describe('buildRunSummary — active lanes carry the full set (component-collapsed)', () => {
+  test('lanes carries every active run when there are more than MAX_VISIBLE_ACTIVE_LANES', () => {
+    const count = MAX_VISIBLE_ACTIVE_LANES + 3;
+    const issues = Array.from({ length: count }, (_, i) => activeRun(`run-${i}`)).flat();
+    const summary = buildRunSummary(issues);
+
+    assert.equal(summary.totalActive, count);
+    assert.equal(summary.lanes.length, count);
+    assert.equal(summary.runCounts.total, count);
+    assert.equal(summary.runCounts.visible, count);
   });
 });
 

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -15,6 +15,9 @@ import {
   type RunIssue,
 } from './phaseMapping.js';
 
+// Default collapsed active-lane count (component-controlled). The wire carries
+// the FULL active set in `lanes`; RunMap renders this many by default and offers
+// a "Show N more runs" expander (mirroring historicalLanes/MAX_HISTORICAL_LANES).
 export const MAX_VISIBLE_ACTIVE_LANES = 8;
 export const RECENT_CHANGES_CAP = 12;
 // gascity-dashboard-9w3k: once v1 history is surfaced the completed set can grow
@@ -79,19 +82,18 @@ export function buildRunSummary(
   const totalHistorical = completedLanes.length;
   const historicalLanes = completedLanes.slice(0, MAX_HISTORICAL_LANES);
   const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
-  const visibleActive = activeLanes.slice(0, MAX_VISIBLE_ACTIVE_LANES);
 
-  // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not the capped
+  // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not a capped
   // window. Session-less-latch demotion (enrichRunSummary) is session-aware and
   // can only run downstream of this builder, so it must see every active lane to
   // recompute totalActive exactly — capping here would hide phantoms beyond the
-  // 8th slot from demotion and leave them in the count. Both consumers
-  // (preview and enriched loaders) apply MAX_VISIBLE_ACTIVE_LANES to `lanes`
-  // before it reaches the DTO, so the rendered window stays capped.
+  // 8th slot from demotion and leave them in the count. RunMap owns the rendered
+  // collapse (default MAX_VISIBLE_ACTIVE_LANES) and its "Show N more" expander,
+  // mirroring the historical section — so the wire is never pre-capped.
   const summary: RunSummary = {
     totalActive: activeLanes.length,
     totalHistorical,
-    runCounts: runCounts(activeLanes, visibleActive.length, blockedLanes.length),
+    runCounts: runCounts(activeLanes, activeLanes.length, blockedLanes.length),
     lanes: activeLanes,
     historicalLanes,
     blockedLanes,

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -316,7 +316,10 @@ export interface RunSummary {
    *  so the operator sees the real number behind the recency window. */
   totalHistorical: number;
   runCounts: RunCounts;
-  /** Active lanes, sorted by compareLanes, capped at MAX_VISIBLE_ACTIVE_LANES. */
+  /** Active lanes, sorted by compareLanes (newest-first). The FULL active set —
+   *  `totalActive === lanes.length`. The rendered collapsed window
+   *  (MAX_VISIBLE_ACTIVE_LANES) and its "Show N more runs" expander are applied
+   *  by the consumer (RunMap), mirroring historicalLanes/MAX_HISTORICAL_LANES. */
   lanes: RunLane[];
   /** Historical (phase === 'complete') lanes, sorted by compareLanes, capped at
    *  MAX_HISTORICAL_LANES (most-recent-first). Frontend renders these only when
@@ -449,6 +452,11 @@ export type RunLaneHealthState = Avail<{
 
 export interface RunCounts {
   total: number;
+  /** @deprecated use total — RunMap owns the rendered collapse; always equals total.
+   *
+   *  Count of active lanes carried on the wire. Now equal to `total` (the full
+   *  active set), since RunMap owns the rendered collapse rather than the wire
+   *  pre-capping at MAX_VISIBLE_ACTIVE_LANES. */
   visible: number;
   prReview: number;
   designReview: number;


### PR DESCRIPTION
## Summary

Fixes the `/runs` 20–30s click-into-a-run slowness. Root cause (measured): the always-mounted run-summary subscription re-fired its **wide** fan-out — `formulas/feed` (~10s) + `beads?type=molecule&all=true` (~7s, full-history scan) + per-rig task reads — on *every* SSE bead-event burst. ~8 parallel requests saturated the browser's ~6-connection-per-host cap, so the detail's fast `workflowRun` (~0.23s) queued behind them. (Complements the merged #108 detail-resilience + rig-scope fix and the server-side follow-up filed as #3253.)

### Fix B — cheap SSE refresh
New `loadSupervisorRunSummaryActiveSource` fetches only the core active beads + sessions, skipping `molecule(all=true)` + the city `formulas/feed` + per-rig task reads. Routine SSE-burst refreshes use it; the wide scan is reserved for the manual Refresh button and the one-time first upgrade. Active/blocked lane scope comes from each bead's own `gc.root_store_ref` metadata (not the feed), so the cheap path keeps active lanes, scope, health, counts, and census correct. Borrowed historical lanes are reconciled against the live active+blocked ids (no double-display of a re-opened run); a failed wide refresh still recovers via the bounded wide retry (a cheap success no longer cancels it).

### Fix C — short-TTL + single-flight backend proxy cache
`ttl-single-flight-cache.ts` caches **only** the two expensive city-wide reads (exact param-set match: `formulas/feed?scope_kind=city&scope_ref=…` and `beads?type=molecule&all=true&limit=500`). Concurrent identical misses coalesce to one upstream call; entries expire on a short TTL and are swept on access; non-2xx is never cached; `set-cookie` is stripped from cached headers; scoped/per-run/mutating/SSE paths are never cached.

### Fix A — active-lane expander
The active list was hard-capped at 8 with a dead "N more not shown". `RunSummary` now carries the full active set; `RunMap` shows 8 collapsed with a quiet "Show N more runs" / "Show fewer" expander (same register as the Historical toggle; `DESIGN.md` updated).

## Verification (measured)
- **Proxy cache, live against the slow supervisor:** feed cold→cached **6.71s → 0.001s**; molecule **6.91s → 0.0008s** (byte-identical bodies); TTL expiry honored; **single-flight** — 5 concurrent identical reads → one upstream call, all return together; scoped/non-city-wide reads correctly NOT cached.
- Cheap SSE refresh verified by tests (the loader test fails if an expensive read fires); expander verified by component tests.
- Local CI parity green: build, typecheck (src+test), eslint `--max-warnings=0`, prettier, openapi drift; tests shared 173 / backend 575 / frontend 913 (regression tests added per fix).
- Multi-reviewer review (code + security + typescript + Codex cross-provider, 2 iterations) converged clean; Codex caught 3 real majors in iteration 1 (history double-display, wide-recovery cancellation, cache overmatch) — all fixed + re-verified.

## Known tradeoff
Cheap SSE refresh cannot promote a newly-completed run into the Historical section until the next wide/manual refresh — the History list can lag on completions between wide scans (active set + counts stay correct). The durable server-side fix is tracked in #3253.
