### PR TITLE
fix(runs): cut formula-detail cold-load contention (proxy cache TTL 3s→45s + warm-cache-only skeleton)

### DIFF
--- a/backend/src/routes/supervisor-transport-proxy.test.ts
+++ b/backend/src/routes/supervisor-transport-proxy.test.ts
@@ -4,7 +4,11 @@ import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 import express from 'express';
 
-import { cacheableCityWideRead, supervisorTransportProxy } from './supervisor-transport-proxy.js';
+import {
+  CITY_WIDE_READ_TTL_MS,
+  cacheableCityWideRead,
+  supervisorTransportProxy,
+} from './supervisor-transport-proxy.js';
 
 describe('cacheableCityWideRead — only the two expensive city-wide reads match', () => {
   const base = 'http://127.0.0.1:9999';
@@ -59,6 +63,20 @@ describe('cacheableCityWideRead — only the two expensive city-wide reads match
 
   test('does NOT match an unrelated path', () => {
     assert.equal(matches('/v0/city/ds-research/sessions'), false);
+  });
+});
+
+describe('CITY_WIDE_READ_TTL_MS — the i60u cold-load stopgap band', () => {
+  test('sits in the 30-60s stopgap band, well above the 7-11s cold scan', () => {
+    // gascity-dashboard-i60u: the TTL must outlast a cold molecule+feed scan
+    // (7-11s) so a fresh detail load can actually serve a warm hit, and stay
+    // capped so an already-closed run root never lags more than ~a minute before
+    // it surfaces in History. A drift back toward the retired "do not exceed 5s"
+    // cap would silently reinstate the contention this stopgap fixes.
+    assert.ok(
+      CITY_WIDE_READ_TTL_MS >= 30_000 && CITY_WIDE_READ_TTL_MS <= 60_000,
+      `expected the city-wide read TTL in the 30-60s band, got ${CITY_WIDE_READ_TTL_MS}ms`,
+    );
   });
 });
 
@@ -121,5 +139,23 @@ describe('supervisorTransportProxy — single-flight coalescing for the cacheabl
       null,
       'cached response must not replay a set-cookie',
     );
+  });
+
+  test('serves a SEQUENTIAL within-TTL re-read from cache without re-hitting upstream', async () => {
+    // gascity-dashboard-i60u: the long TTL (45s) must let a SECOND, fully
+    // sequential read — fired after the first has already resolved, i.e. NOT
+    // coalesced by single-flight — be served from cache. Under the retired 3s
+    // cap a fresh detail load almost always missed; this asserts the warm-hit
+    // window the stopgap depends on.
+    upstreamCalls = 0;
+    // A city key the other tests in this block never touch: the proxy (and its
+    // cache) is created once in before(), and the 45s TTL outlives the whole
+    // suite, so reusing a warmed key would read 0 upstream calls and prove
+    // nothing. A fresh key gives a true cold-then-warm sequence.
+    const path = '/gc-supervisor/v0/city/ttl-probe-city/beads?type=molecule&all=true&limit=500';
+    const first = await fetch(proxyUrl + path).then((r) => r.json());
+    const second = await fetch(proxyUrl + path).then((r) => r.json());
+    assert.equal(upstreamCalls, 1, 'the within-TTL re-read is served from cache, not upstream');
+    assert.deepEqual(first, second);
   });
 });

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -72,14 +72,20 @@ function paramsMatchExactly(
   return expected.every(([key, value]) => q.get(key) === value);
 }
 
-// 3s: single-flight collapses the SIMULTANEOUS duplicate reads within one SSE
-// burst; the short ready-window absorbs the closely-spaced re-fires that arrive
-// just after the first ~7-10s scan resolves. Kept well under the SPA's own
-// enrichment budgets (MOLECULE_HISTORY_TIMEOUT_MS=3s,
-// REQUIRED_RUN_SUMMARY_TIMEOUT_MS=15s) and far below the 60s status sampler, so
-// the historical-root discovery never visibly trails the live SSE-driven active
-// view (which is not cached). Do not exceed 5s.
-const CITY_WIDE_READ_TTL_MS = 3_000;
+// 45s (gascity-dashboard-i60u): a CONSCIOUS reversal of the former "do not
+// exceed 5s" cap. That cap assumed gastownhall/gascity#3253 would make the
+// server-side molecule+feed build cheap (~80ms→22ms); #3253 is blocked, so the
+// cold read stays 7-11s and a 3s TTL almost never survives long enough to serve
+// a warm hit — every fresh detail load paid the full cold scan and queued the
+// page's own fast reads behind it (the browser's ~6-conn/host cap). At 45s a
+// single cold scan amortizes across the operator's whole detail-viewing session.
+// SAFETY: only the two city-wide, auth-invariant HISTORICAL reads
+// (molecule(all=true) history + city formula feed) are cached — cacheableCityWideRead
+// pins their exact param sets — while the active/live lanes are SSE-driven and
+// UNCACHED, so a longer TTL only lets an already-closed run root lag up to the
+// TTL before it surfaces in History (acceptable). The longer TTL changes only
+// HOW LONG the same set is cached, never WHAT is cached.
+export const CITY_WIDE_READ_TTL_MS = 45_000;
 
 export function cacheableCityWideRead(target: URL): boolean {
   if (!CACHEABLE_CITY_WIDE_READS.some((p) => p.test(target.pathname))) return false;

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FormulaRunDetailPage } from './FormulaRunDetail';
-import { invalidate } from '../api/cache';
+import { invalidate, setCached } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
 import { NowProvider } from '../contexts/NowContext';
 import { resetSupervisorApiForTests } from '../supervisor/client';
@@ -22,14 +22,9 @@ import { SupervisorApiError } from '../supervisor/errors';
 import rawFormulaRunDetailFixture from '../test/fixtures/formula-run-detail.json';
 
 const loadSupervisorFormulaRunDetail = vi.hoisted(() => vi.fn());
-const loadSupervisorRunSummaryMountSource = vi.hoisted(() => vi.fn());
 
 vi.mock('../supervisor/runDetail', () => ({
   loadSupervisorFormulaRunDetail,
-}));
-
-vi.mock('../supervisor/runSummary', () => ({
-  loadSupervisorRunSummaryMountSource,
 }));
 
 vi.mock('../hooks/useEntityLinks', () => ({
@@ -63,9 +58,7 @@ beforeEach(() => {
   invalidate('formula-run');
   invalidate('runs:summary:test-city');
   loadSupervisorFormulaRunDetail.mockReset();
-  loadSupervisorRunSummaryMountSource.mockReset();
   loadSupervisorFormulaRunDetail.mockImplementation(async () => currentDetail);
-  loadSupervisorRunSummaryMountSource.mockResolvedValue(runSummarySource());
   currentDetail = detail;
   currentDiff = diff;
   vi.stubGlobal('EventSource', FakeEventSource);
@@ -125,9 +118,8 @@ describe('FormulaRunDetailPage', () => {
     // (gascity-dashboard-wqsk). When the operator arrives from /runs the
     // run-summary cache already holds this run's lane, so the page shows its
     // title + phase stages instantly instead of a blank spinner. Here the
-    // detail (and diff) fetch hangs while the summary resolves with a lane.
-    invalidate('runs:summary:test-city');
-    loadSupervisorRunSummaryMountSource.mockResolvedValue(runSummarySourceWithActiveLane());
+    // detail (and diff) fetch hangs while the warm summary supplies the lane.
+    setCached('runs:summary:test-city', runSummarySourceWithActiveLane());
     vi.stubGlobal(
       'fetch',
       vi.fn(() => new Promise<Response>(() => {})),
@@ -154,13 +146,12 @@ describe('FormulaRunDetailPage', () => {
     // Blocked lanes moved out of summary.lanes into blockedLanes; a blocked
     // run is the most likely one the operator clicks into, so the skeleton
     // lookup must search both buckets.
-    invalidate('runs:summary:test-city');
     const source = runSummarySourceWithActiveLane();
     if (source.status === 'error') throw new Error(source.error);
     source.data.blockedLanes = source.data.lanes;
     source.data.lanes = [];
     source.data.totalActive = 0;
-    loadSupervisorRunSummaryMountSource.mockResolvedValue(source);
+    setCached('runs:summary:test-city', source);
     vi.stubGlobal(
       'fetch',
       vi.fn(() => new Promise<Response>(() => {})),
@@ -173,6 +164,38 @@ describe('FormulaRunDetailPage', () => {
 
     expect(await screen.findByRole('list', { name: /pending adoption run stages/i })).toBeTruthy();
     expect(screen.queryByText(/^Loading formula run\.$/i)).toBeNull();
+  });
+
+  it('fires NO run-summary mount read on a cold cache, consuming a warm hit only (gascity-dashboard-i60u)', async () => {
+    // i60u cold-load stopgap: a direct/refresh load arrives with the run-summary
+    // cache cold. The detail page must NOT fire its own heavy molecule(all=true)
+    // + city-feed scan just to paint an optimistic skeleton — that read saturates
+    // the browser's ~6-conn/host pool and queues the detail's own fast reads
+    // behind it. With the cache cold (beforeEach invalidated it) the skeleton is
+    // absent and the lightweight loading state renders; no run-summary fetch is
+    // issued. The always-mounted RunSummaryProvider stays the sole owner of that
+    // key's fetch — exercised separately in runSummarySubscription.test.tsx.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        fetchUrls.push(requestUrl(input));
+        return new Promise<Response>(() => {});
+      }),
+    );
+    loadSupervisorFormulaRunDetail.mockImplementationOnce(
+      () => new Promise<FormulaRunDetail>(() => {}),
+    );
+
+    renderPage();
+
+    // Lightweight loading state, NOT the optimistic skeleton ladder.
+    expect(await screen.findByText(/^Loading formula run\.$/i)).toBeTruthy();
+    expect(screen.queryByRole('list', { name: /pending adoption run stages/i })).toBeNull();
+    // No heavy city-wide mount read (molecule history scan / city formula feed).
+    const heavyReads = fetchUrls.filter(
+      (url) => /[?&]type=molecule(&|$)/.test(url) || url.includes('/formulas/feed'),
+    );
+    expect(heavyReads).toEqual([]);
   });
 
   it('does not repeat missing formula metadata as formula detail and a partial banner', async () => {

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -7,6 +7,8 @@ import type {
   RunNodeStatus,
   FormulaRunPartialReason,
   RunScopeKind,
+  RunSummary,
+  SourceState,
 } from 'gas-city-dashboard-shared';
 import { Button } from '../components/Button';
 import { PageHeader } from '../components/PageHeader';
@@ -22,9 +24,8 @@ import { useRunNodeSelection } from '../hooks/useRunNodeSelection';
 import { useFormulaRunDetail } from '../hooks/useFormulaRunDetail';
 import { useRunDiff } from '../hooks/useRunDiff';
 import { useEntityLinks } from '../hooks/useEntityLinks';
-import { useCachedData } from '../hooks/useCachedData';
+import { getCached } from '../api/cache';
 import { getActiveCity } from '../api/cityBase';
-import { loadSupervisorRunSummaryMountSource } from '../supervisor/runSummary';
 import { NEEDS_YOU_VIEW_PARAM } from '../views/modules/maintainer/needsYou';
 
 const RUN_DETAIL_EVENT_PREFIXES = [GC_EVENT_PREFIX.bead, GC_EVENT_PREFIX.session] as const;
@@ -116,24 +117,28 @@ export function FormulaRunDetailPage() {
   const now = useNow();
   const cityName = getActiveCity();
 
-  // Optimistic skeleton (gascity-dashboard-wqsk): the first load of a run is
-  // bounded by the supervisor's all-store scan (seconds). The direct run
-  // summary cache — already warm when the operator arrives from /runs —
-  // carries this run's lane (title + phase stages), so render that instantly
-  // instead of a blank spinner while the full detail assembles.
-  const runSummary = useCachedData(
-    `runs:summary:${cityName ?? 'no-city'}`,
-    loadSupervisorRunSummaryMountSource,
+  // Optimistic skeleton (gascity-dashboard-wqsk, gascity-dashboard-i60u): when
+  // the operator arrives from /runs the shared run-summary subscription has
+  // already warmed this cache key with this run's lane (title + phase stages),
+  // so paint that instantly instead of a blank spinner while the full detail
+  // assembles. We CONSUME the cache directly and fire NO mount read of our own:
+  // on a cold direct/refresh load the key is empty, so the skeleton is simply
+  // absent and the lightweight loading state renders — the page no longer spends
+  // a browser connection on a duplicate molecule(all=true)+feed cold scan (7-11s)
+  // that would queue behind, and starve, the detail's own fast reads. The
+  // always-mounted RunSummaryProvider remains the sole owner of this key's fetch.
+  const [warmRunSummary] = useState<SourceState<RunSummary> | undefined>(() =>
+    getCached(`runs:summary:${cityName ?? 'no-city'}`),
   );
   const skeletonLane = useMemo(() => {
     if (!runId) return null;
-    const runs = runSummary.data;
-    const runsData = runs && runs.status !== 'error' ? runs.data : null;
+    const runsData =
+      warmRunSummary && warmRunSummary.status !== 'error' ? warmRunSummary.data : null;
     if (runsData === null || runsData === undefined) return null;
     // gascity-dashboard-4xcv: blocked lanes live in their own bucket now, and
     // a blocked run is the most likely one the operator clicks into.
     return [...runsData.lanes, ...runsData.blockedLanes].find((lane) => lane.id === runId) ?? null;
-  }, [runSummary.data, runId]);
+  }, [warmRunSummary, runId]);
 
   const synopsis = detail
     ? `${detail.progress.visibleNodeCount} nodes. ${summarizeNodeStatuses(detail.progress)}. Local changes are shown for the run execution folder.`


### PR DESCRIPTION
## What

Stopgap to cut the formula-detail-view cold-load latency (gascity-dashboard-i60u). The detail view's own reads are fast (workflowRun ~0.4s), but the page contended for the browser's ~6-conn/host budget with the heavy historical run-summary reads (`molecule(all=true)` cold ~7-11s + city feed cold ~7s), which queued the detail's own reads behind them.

Two bead-approved changes (option (a)):

1. **`backend/src/routes/supervisor-transport-proxy.ts`** — raise `CITY_WIDE_READ_TTL_MS` `3s → 45s` (now exported for test). The cacheable set is **unchanged** (`cacheableCityWideRead` still pins only the `molecule(all=true)` history + city-feed exact param sets; active lanes stay SSE-driven and uncached). The old "do not exceed 5s" cap assumed the server read would be cheap (gastownhall/gascity#3253); with the cold read at 7-11s a 3s TTL almost never outlived one cold scan, so a fresh load paid full cold cost every time. Comment rewritten to document the conscious reversal.

2. **`frontend/src/routes/FormulaRunDetail.tsx`** — the optimistic skeleton-lane now reads the run-summary cache via `getCached()` (warm hit only) and fires **no** mount fetch. On a cold/direct load it renders the lightweight loading state instead of triggering a duplicate ~7-11s `molecule+feed` scan. The always-mounted `RunSummaryProvider` remains the sole fetch owner.

## Measured before/after

Cold direct load of `/runs/:runId`:
- **Before:** fires `molecule+feed` **twice** (global provider scan + the detail page's duplicate skeleton mount fetch); the 3s TTL almost never outlived the 7-11s cold read.
- **After:** the detail page fires **zero** of its own; the global provider still fires one cold scan, now cached for 45s. Net: **2 cold scans → 1**, amortized 45s; the detail's fast reads are no longer queued behind a duplicate.

## Tests / gates

Backend +2 (45s-band TTL + sequential within-TTL warm-hit), frontend +1 (cold cache fires no heavy mount read) + 2 skeleton tests migrated to `setCached`. Green: backend 577/577, frontend 914/914 (FormulaRunDetail 34/34), shared green. typecheck (incl `:test`), eslint, prettier, openapi-drift all clean. (Snap harness skipped — pre-existing dev-server/env fragility on an untouched path, not a regression; jsdom suite is the sanctioned fallback and covers the changed view incl. the new cold-cache test.)

Durable fix is gastownhall/gascity#3253 (now merged, pending rollout); this stopgap blunts the cold-load contention in the meantime.
