### PR TITLE
test(runs): cover runs:partial live-path reachability

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildRunSummary } from 'gas-city-dashboard-shared';
 import type { RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { invalidate } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
@@ -377,6 +378,40 @@ describe('useLiveAttentionContributors', () => {
     expect(freshFacts?.summary).toBe(fresh.status === 'error' ? undefined : fresh.data);
     expect(freshFacts?.provenance).toBe('fresh');
     expect(freshFacts?.fetchedAt).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('emits runs:partial through the live wiring when the run-summary source is partial (gascity-dashboard-0gww)', async () => {
+    // PR #91 MAJOR-2: the runs:partial emitter was dead in the live pipeline —
+    // it could only fire in synthetic registry tests because the live hook never
+    // carried `summary`. Post-#101/#108 the shared run-summary subscription IS
+    // the badge's source and runsFactsFromSource carries summary.lanesPartial
+    // through, so a partial live read now reaches the emitter. Drive the REAL
+    // production builder (buildRunSummary's `partial` flag, set live on a
+    // truncated/timed-out read) through the REAL projection so this path cannot
+    // silently go dead again.
+    const summary = buildRunSummary([], new Map(), true);
+    expect(summary.lanesPartial).toBe(true);
+    const partialSource: SourceState<RunSummary> = {
+      source: 'runs',
+      status: 'fresh',
+      fetchedAt: '2026-06-01T00:00:00.000Z',
+      staleAt: '2026-06-01T00:01:00.000Z',
+      error: { kind: 'none' },
+      data: summary,
+    };
+
+    const { result } = renderHook(() =>
+      useLiveAttentionContributors([], testOperator, partialSource),
+    );
+
+    await waitFor(() => {
+      const runs = composeAttention(result.current).byDomain.runs;
+      // A partial read is data degradation, not an operator-actionable signal: it
+      // lands in the unavailable tier and never inflates the badge count.
+      expect(runs.attention).toBe(0);
+      expect(runs.unavailable).toBeGreaterThanOrEqual(1);
+      expect(runs.items.map((item) => item.id)).toContain('runs:partial');
+    });
   });
 
   it('does not fetch maintainer triage before the enabled module config is loaded', async () => {


### PR DESCRIPTION
Adds the missing live-path regression test for the `runs:partial` attention emitter (fast-follow from PR #91 review, MAJOR-2).

**Context:** PR #91's review flagged `runs:partial` + `health-unavailable` emitters as potentially dead (only firable in synthetic registry tests = validation-theater). Verified against current main (@#110): the health-unavailable half is already fixed on main (#108); and **`runs:partial` IS reachable + correct live** — the 2j8e.7/#101/#108 runs rework wired the shared run-summary subscription as the badge source (`runSummary.ts` passes `loaded.partial` → `buildRunSummary` sets `lanesPartial`; `runsFactsFromSource` carries summary through; `registry.ts` emits `runs:partial` into the non-counting 'unavailable' tier).

**This PR:** no production code change needed — adds the live-path regression test (`liveContributors.test.tsx`) driving real `buildRunSummary(partial=true)` → real projection → asserts `runs:partial` in the unavailable tier without inflating the badge. Tests 62/62, typecheck (src+test), eslint, prettier green.