### PR TITLE
fix(runs): explicit Refresh bypasses the 45s proxy cache for the wide historical read

### DIFF
--- a/backend/src/lib/ttl-single-flight-cache.test.ts
+++ b/backend/src/lib/ttl-single-flight-cache.test.ts
@@ -107,6 +107,79 @@ describe('createTtlSingleFlightCache', () => {
     await assert.rejects(b, /shared boom/);
   });
 
+  test('forceFresh re-runs the loader inside the TTL and repopulates the cache', async () => {
+    // gascity-dashboard-i3dz: the operator's explicit Refresh must re-scan
+    // upstream even while a ready entry is still warm, and the fresh value must
+    // replace the cached one (resetting the TTL window) so later reads ride it.
+    let nowMs = 0;
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => nowMs });
+    let calls = 0;
+    const loader = async () => {
+      calls += 1;
+      return response(200, `body-${calls}`);
+    };
+
+    const first = await cache.getOrFetch('k', loader);
+    assert.equal(first.body.toString(), 'body-1');
+
+    nowMs = 500; // still within TTL — a normal read would be a cache hit.
+    const forced = await cache.getOrFetch('k', loader, { forceFresh: true });
+    assert.equal(calls, 2, 'forceFresh re-runs the loader despite the warm entry');
+    assert.equal(forced.body.toString(), 'body-2');
+
+    nowMs = 900; // within the RESET TTL of the forced load.
+    const afterForced = await cache.getOrFetch('k', loader);
+    assert.equal(calls, 2, 'the forced result repopulated the cache; the next read is a hit');
+    assert.equal(afterForced.body.toString(), 'body-2');
+  });
+
+  test('forceFresh does not coalesce onto an in-flight normal read', async () => {
+    // An explicit Refresh must observe genuinely fresh data, not attach to a
+    // load that started before the operator's intent (gascity-dashboard-i3dz).
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    let calls = 0;
+    const resolvers: Array<(value: CachedResponse) => void> = [];
+    const loader = () =>
+      new Promise<CachedResponse>((resolve) => {
+        calls += 1;
+        resolvers.push(resolve);
+      });
+
+    const normal = cache.getOrFetch('k', loader);
+    const forced = cache.getOrFetch('k', loader, { forceFresh: true });
+    assert.equal(calls, 2, 'forceFresh starts its own load rather than sharing the in-flight one');
+
+    resolvers[0]?.(response(200, 'normal'));
+    resolvers[1]?.(response(200, 'forced'));
+    assert.equal((await normal).body.toString(), 'normal');
+    assert.equal((await forced).body.toString(), 'forced');
+  });
+
+  test('a forceFresh result is not clobbered by a slower concurrent normal read', async () => {
+    // The repopulation guarantee: when a normal in-flight read and a forceFresh
+    // race and the normal load resolves LAST, the cache must end on the forced
+    // (newer) value, not the stale predecessor (gascity-dashboard-i3dz).
+    const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
+    const resolvers: Array<(value: CachedResponse) => void> = [];
+    const loader = () =>
+      new Promise<CachedResponse>((resolve) => {
+        resolvers.push(resolve);
+      });
+
+    const normal = cache.getOrFetch('k', loader);
+    const forced = cache.getOrFetch('k', loader, { forceFresh: true });
+
+    // The forced load resolves first and pins its value...
+    resolvers[1]?.(response(200, 'forced'));
+    await forced;
+    // ...then the slower normal load resolves — it must NOT re-pin its stale body.
+    resolvers[0]?.(response(200, 'normal'));
+    await normal;
+
+    const afterRace = await cache.getOrFetch('k', loader);
+    assert.equal(afterRace.body.toString(), 'forced', 'the cache keeps the forced value');
+  });
+
   test('a thrown non-2xx (loader-side) is not cached', async () => {
     const cache = createTtlSingleFlightCache({ ttlMs: 1_000, now: () => 0 });
     let calls = 0;

--- a/backend/src/lib/ttl-single-flight-cache.ts
+++ b/backend/src/lib/ttl-single-flight-cache.ts
@@ -20,7 +20,10 @@ export interface CachedResponse {
 }
 
 type Entry =
-  | { state: 'inflight'; promise: Promise<CachedResponse> }
+  // `token` identifies WHICH load owns the slot: a concurrent forceFresh can
+  // replace an in-flight entry, so a load only writes back (or deletes on error)
+  // when it still owns the slot, never clobbering a newer load's value.
+  | { state: 'inflight'; promise: Promise<CachedResponse>; token: object }
   | { state: 'ready'; value: CachedResponse; expiresAt: number };
 
 export interface TtlSingleFlightCacheOptions {
@@ -28,8 +31,22 @@ export interface TtlSingleFlightCacheOptions {
   now?: () => number;
 }
 
+export interface GetOrFetchOptions {
+  /**
+   * Force a fresh upstream load, ignoring any ready/in-flight entry, and store
+   * its result (resetting the TTL). For the operator's explicit Refresh, which
+   * must re-scan upstream within the TTL window while preview/SSE reads keep
+   * serving the amortized cache (gascity-dashboard-i3dz).
+   */
+  forceFresh?: boolean;
+}
+
 export interface TtlSingleFlightCache {
-  getOrFetch(key: string, loader: () => Promise<CachedResponse>): Promise<CachedResponse>;
+  getOrFetch(
+    key: string,
+    loader: () => Promise<CachedResponse>,
+    options?: GetOrFetchOptions,
+  ): Promise<CachedResponse>;
 }
 
 export function createTtlSingleFlightCache(
@@ -53,31 +70,45 @@ export function createTtlSingleFlightCache(
   }
 
   return {
-    async getOrFetch(key, loader) {
+    async getOrFetch(key, loader, options) {
       sweepExpired();
-      const existing = entries.get(key);
-      if (existing !== undefined) {
-        if (existing.state === 'ready' && now() < existing.expiresAt) {
-          return existing.value;
-        }
-        if (existing.state === 'inflight') {
-          return existing.promise;
+      // forceFresh skips BOTH a warm ready value and coalescing onto an
+      // in-flight load: an explicit Refresh must observe genuinely fresh
+      // upstream data, not a value that may predate the operator's intent.
+      if (options?.forceFresh !== true) {
+        const existing = entries.get(key);
+        if (existing !== undefined) {
+          if (existing.state === 'ready' && now() < existing.expiresAt) {
+            return existing.value;
+          }
+          if (existing.state === 'inflight') {
+            return existing.promise;
+          }
         }
       }
 
+      const token = {};
       const promise = (async () => {
         const value = await loader();
-        entries.set(key, { state: 'ready', value, expiresAt: now() + ttlMs });
+        // Repopulate only if this load still owns the inflight slot. A concurrent
+        // forceFresh may have superseded it; the newer load's value must win, so a
+        // slower predecessor resolving afterward must not re-pin its stale body.
+        const current = entries.get(key);
+        if (current?.state === 'inflight' && current.token === token) {
+          entries.set(key, { state: 'ready', value, expiresAt: now() + ttlMs });
+        }
         return value;
       })();
-      entries.set(key, { state: 'inflight', promise });
+      entries.set(key, { state: 'inflight', promise, token });
 
       try {
         return await promise;
       } catch (err) {
         // Never cache a failure: drop the inflight entry so the next caller
         // retries upstream instead of being served the rejection for the TTL.
-        if (entries.get(key)?.state === 'inflight') {
+        // Same ownership guard — only the load that still owns the slot deletes it.
+        const current = entries.get(key);
+        if (current?.state === 'inflight' && current.token === token) {
           entries.delete(key);
         }
         throw err;

--- a/backend/src/routes/supervisor-transport-proxy.test.ts
+++ b/backend/src/routes/supervisor-transport-proxy.test.ts
@@ -5,6 +5,11 @@ import type { Server } from 'node:http';
 import express from 'express';
 
 import {
+  SUPERVISOR_CACHE_BYPASS_HEADER,
+  SUPERVISOR_CACHE_BYPASS_VALUE,
+} from 'gas-city-dashboard-shared';
+
+import {
   CITY_WIDE_READ_TTL_MS,
   cacheableCityWideRead,
   supervisorTransportProxy,
@@ -86,11 +91,13 @@ describe('supervisorTransportProxy — single-flight coalescing for the cacheabl
   let proxy: Server;
   let proxyUrl: string;
   let upstreamCalls = 0;
+  let lastForwardedBypassHeader: string | undefined;
 
   before(async () => {
     const upstreamApp = express();
-    upstreamApp.get('/v0/city/:city/beads', (_req, res) => {
+    upstreamApp.get('/v0/city/:city/beads', (req, res) => {
       upstreamCalls += 1;
+      lastForwardedBypassHeader = req.get(SUPERVISOR_CACHE_BYPASS_HEADER) ?? undefined;
       // Slow enough that two near-simultaneous proxy requests overlap.
       setTimeout(() => {
         // A stray upstream set-cookie must NOT be captured into the cached body
@@ -157,5 +164,48 @@ describe('supervisorTransportProxy — single-flight coalescing for the cacheabl
     const second = await fetch(proxyUrl + path).then((r) => r.json());
     assert.equal(upstreamCalls, 1, 'the within-TTL re-read is served from cache, not upstream');
     assert.deepEqual(first, second);
+  });
+
+  test('the cache-bypass header re-hits upstream within the TTL, then repopulates the cache', async () => {
+    // gascity-dashboard-i3dz: the operator's explicit Refresh sends the bypass
+    // marker so its wide read re-scans upstream even inside the 45s window, while
+    // a plain re-read (preview/SSE) stays a cache hit. A fresh key keeps this
+    // independent of the suite's other warmed keys.
+    upstreamCalls = 0;
+    const path = '/gc-supervisor/v0/city/bypass-probe-city/beads?type=molecule&all=true&limit=500';
+
+    const cold = await fetch(proxyUrl + path).then((r) => r.json());
+    assert.equal(upstreamCalls, 1, 'first read is the cold upstream scan');
+
+    // A within-TTL read carrying the bypass marker forces a SECOND upstream scan.
+    const bypassed = await fetch(proxyUrl + path, {
+      headers: { [SUPERVISOR_CACHE_BYPASS_HEADER]: SUPERVISOR_CACHE_BYPASS_VALUE },
+    }).then((r) => r.json());
+    assert.equal(upstreamCalls, 2, 'the bypass marker re-hits upstream inside the TTL');
+    assert.notDeepEqual(bypassed, cold, 'the bypassed read returns the fresh upstream body');
+
+    // The forced scan repopulated the cache, so the next plain read is a hit.
+    await fetch(proxyUrl + path).then((r) => r.json());
+    assert.equal(
+      upstreamCalls,
+      2,
+      'the force-refreshed value resets the warm window for plain reads',
+    );
+  });
+
+  test('the cache-bypass marker is stripped before forwarding upstream', async () => {
+    // The marker is consumed by the proxy; the supervisor must never see this
+    // dashboard-internal header (gascity-dashboard-i3dz).
+    upstreamCalls = 0;
+    lastForwardedBypassHeader = undefined;
+    const path = '/gc-supervisor/v0/city/bypass-strip-city/beads?type=molecule&all=true&limit=500';
+    await fetch(proxyUrl + path, {
+      headers: { [SUPERVISOR_CACHE_BYPASS_HEADER]: SUPERVISOR_CACHE_BYPASS_VALUE },
+    }).then((r) => r.text());
+    assert.equal(
+      lastForwardedBypassHeader,
+      undefined,
+      'the bypass header is not forwarded to the supervisor',
+    );
   });
 });

--- a/backend/src/routes/supervisor-transport-proxy.ts
+++ b/backend/src/routes/supervisor-transport-proxy.ts
@@ -3,6 +3,8 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
+import { SUPERVISOR_CACHE_BYPASS_HEADER } from 'gas-city-dashboard-shared';
+
 import { HTTP_STATUS } from '../lib/http-status.js';
 import { createTtlSingleFlightCache, type CachedResponse } from '../lib/ttl-single-flight-cache.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
@@ -25,6 +27,10 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   'host',
   'origin',
   'referer',
+  // The cache-bypass marker is consumed by THIS proxy (forces a fresh upstream
+  // scan, gascity-dashboard-i3dz); it carries no meaning upstream, so strip it
+  // before forwarding rather than leaking a dashboard-internal header.
+  SUPERVISOR_CACHE_BYPASS_HEADER,
 ]);
 
 // In read-only mode every forwarded request is a GET/HEAD read, so the
@@ -181,21 +187,31 @@ export function supervisorTransportProxy(supervisorBaseUrl: string, readOnly = f
 
     try {
       if (req.method === 'GET' && cacheableCityWideRead(target)) {
-        const cached = await cityWideReadCache.getOrFetch(cacheKey(target), async () => {
-          const upstream = await fetch(target, requestInit(req, readOnly));
-          const body = Buffer.from(await upstream.arrayBuffer());
-          const response: CachedResponse = {
-            status: upstream.status,
-            headers: headerPairs(upstream),
-            body,
-          };
-          if (upstream.status < 200 || upstream.status >= 300) {
-            // Surface non-2xx to the caller but don't pin it: throw so the
-            // single-flight cache drops the entry, then re-materialize below.
-            throw new UpstreamNon2xx(response);
-          }
-          return response;
-        });
+        // The operator's explicit /runs Refresh sets the bypass marker so its
+        // wide molecule+feed scan re-hits upstream even inside the TTL window;
+        // preview/SSE reads omit it and keep serving the amortized cache
+        // (gascity-dashboard-i3dz). A force-fresh load still repopulates the
+        // cache, so the refreshed value resets the amortization window.
+        const forceFresh = requestsCacheBypass(req);
+        const cached = await cityWideReadCache.getOrFetch(
+          cacheKey(target),
+          async () => {
+            const upstream = await fetch(target, requestInit(req, readOnly));
+            const body = Buffer.from(await upstream.arrayBuffer());
+            const response: CachedResponse = {
+              status: upstream.status,
+              headers: headerPairs(upstream),
+              body,
+            };
+            if (upstream.status < 200 || upstream.status >= 300) {
+              // Surface non-2xx to the caller but don't pin it: throw so the
+              // single-flight cache drops the entry, then re-materialize below.
+              throw new UpstreamNon2xx(response);
+            }
+            return response;
+          },
+          { forceFresh },
+        );
         writeCachedResponse(cached, res);
         return;
       }
@@ -237,6 +253,13 @@ function resolveUpstreamTarget(reqUrl: string, baseUrl: URL): URL | null {
   }
   if (target.origin !== baseUrl.origin) return null;
   return target;
+}
+
+// True when the request carries the dashboard's cache-bypass marker (set only by
+// the operator's explicit /runs Refresh). express lowercases header names, so the
+// lookup matches the lowercase header constant.
+function requestsCacheBypass(req: Request): boolean {
+  return req.headers[SUPERVISOR_CACHE_BYPASS_HEADER] !== undefined;
 }
 
 function isAllowedPath(path: string, readOnly: boolean): boolean {

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -28,7 +28,7 @@ const HISTORY_QUERY_VALUE = '1';
 
 export function RunsPage() {
   const attention = useAttentionModel();
-  const { source: data, loading, error, refresh, sseState } = useRunSummary();
+  const { source: data, loading, error, manualRefresh, sseState } = useRunSummary();
   const [searchParams, setSearchParams] = useSearchParams();
   // gascity-dashboard-yh5i: ?history=1 toggles the historical lane
   // section. Pure render-time state — the summary already carries both
@@ -151,7 +151,7 @@ export function RunsPage() {
               <Button
                 size="sm"
                 className="w-full justify-center"
-                onClick={() => void refresh()}
+                onClick={() => void manualRefresh()}
                 disabled={loading}
               >
                 {loading ? 'Refreshing' : 'Refresh'}

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -195,6 +195,29 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     expect(typeof lastHookCall.onMatch).toBe('function');
   });
 
+  it('manualRefresh forces a cache-bypassing wide refresh; the one-time upgrade does not (gascity-dashboard-i3dz)', async () => {
+    const { result } = renderHook(() => useRunSummary(), { wrapper: RunSummaryProvider });
+
+    // The one-time preview→full upgrade runs a NORMAL wide refresh, so it keeps
+    // serving the proxy's amortized cache.
+    await waitFor(() => expect(mockFull).toHaveBeenCalledTimes(1));
+    expect(mockFull).toHaveBeenLastCalledWith({ forceFresh: false });
+
+    // The operator's explicit Refresh forces a fresh upstream re-scan.
+    await act(async () => {
+      await result.current.manualRefresh();
+    });
+    expect(mockFull).toHaveBeenCalledTimes(2);
+    expect(mockFull).toHaveBeenLastCalledWith({ forceFresh: true });
+
+    // The bypass is one-shot: a subsequent programmatic refresh() reverts to the
+    // cache-friendly path (the flag was consumed, not latched).
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockFull).toHaveBeenLastCalledWith({ forceFresh: false });
+  });
+
   it('refreshes every consumer on an SSE event (no post-mount drift)', async () => {
     render(
       <RunSummaryProvider>

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -49,7 +49,14 @@ export interface RunSummarySubscription {
   source: SourceState<RunSummary> | undefined;
   loading: boolean;
   error: string | null;
+  /** Programmatic wide refresh that may serve the proxy's amortized cache. */
   refresh: () => Promise<void>;
+  /**
+   * The operator's explicit Refresh: a wide refresh that bypasses the proxy's
+   * city-wide read cache so the molecule+feed scan re-hits upstream even inside
+   * the TTL window (gascity-dashboard-i3dz).
+   */
+  manualRefresh: () => Promise<void>;
   sseState: GcEventConnState;
 }
 
@@ -80,8 +87,16 @@ export function useRunSummarySubscription(): RunSummarySubscription {
   // of a failure" so recovery keeps driving regardless of what we display, and
   // is cleared the moment a genuine fresh/full result lands.
   const staleDueToFailureRef = useRef(false);
+  // Set true for exactly one wide refresh by manualRefresh(), then consumed
+  // synchronously here before any await. The one-time preview→full upgrade and
+  // the degraded-load retry call refresh() directly and leave it false, so only
+  // the operator's explicit Refresh bypasses the proxy cache
+  // (gascity-dashboard-i3dz).
+  const forceFreshRef = useRef(false);
   const refreshWithLastGoodRetention = useCallback(async (): Promise<SourceState<RunSummary>> => {
-    const result = await loadSupervisorRunSummarySource().catch(
+    const forceFresh = forceFreshRef.current;
+    forceFreshRef.current = false;
+    const result = await loadSupervisorRunSummarySource({ forceFresh }).catch(
       (err): SourceState<RunSummary> => ({
         source: 'runs',
         status: 'error',
@@ -156,6 +171,14 @@ export function useRunSummarySubscription(): RunSummarySubscription {
       sseRefreshFetcher: refreshActiveWithMerge,
     },
   );
+  // The operator's explicit Refresh: arm the one-shot bypass flag, then run the
+  // same wide refresh path. refreshWithLastGoodRetention consumes the flag
+  // synchronously (before its first await), so this stays scoped to this one
+  // call and never bleeds into the upgrade/retry refreshes (gascity-dashboard-i3dz).
+  const manualRefresh = useCallback(() => {
+    forceFreshRef.current = true;
+    return refresh();
+  }, [refresh]);
   // Capture the latest available snapshot so the next failed refresh can fall
   // back to it. A re-published 'stale' snapshot stays good data, so it keeps
   // being retained across a run of consecutive failures.
@@ -282,7 +305,7 @@ export function useRunSummarySubscription(): RunSummarySubscription {
 
   const sseState = useGcEventRefresh([GC_EVENT_PREFIX.bead], onSseMatch);
 
-  return { source: data, loading, error, refresh, sseState };
+  return { source: data, loading, error, refresh, manualRefresh, sseState };
 }
 
 const RunSummaryContext = createContext<RunSummarySubscription | null>(null);

--- a/frontend/src/supervisor/client.ts
+++ b/frontend/src/supervisor/client.ts
@@ -72,6 +72,10 @@ import type {
   SupervisorCitiesOutputBody,
   WorkflowSnapshotResponse,
 } from 'gas-city-dashboard-shared/gc-supervisor';
+import {
+  SUPERVISOR_CACHE_BYPASS_HEADER,
+  SUPERVISOR_CACHE_BYPASS_VALUE,
+} from 'gas-city-dashboard-shared';
 import { SupervisorApiError, unwrapSupervisorResult, type SupervisorResult } from './errors';
 import {
   SUPERVISOR_PROXY_BASE_URL,
@@ -84,6 +88,20 @@ export const SUPERVISOR_REQUEST_TIMEOUT_MS = 60_000;
 export const GC_MUTATION_HEADERS = {
   'X-GC-Request': 'dashboard',
 } as const;
+
+// Options for the two cacheable city-wide reads (listBeads molecule history +
+// formulaFeed). `cacheBypass` makes the proxy force a fresh upstream scan instead
+// of serving its short-TTL cache — set only by the operator's explicit /runs
+// Refresh so preview/SSE reads keep the amortization (gascity-dashboard-i3dz).
+export interface SupervisorReadOptions {
+  cacheBypass?: boolean;
+}
+
+function cacheBypassHeaders(options?: SupervisorReadOptions): { headers?: Record<string, string> } {
+  return options?.cacheBypass === true
+    ? { headers: { [SUPERVISOR_CACHE_BYPASS_HEADER]: SUPERVISOR_CACHE_BYPASS_VALUE } }
+    : {};
+}
 
 export { SupervisorApiError, SUPERVISOR_PROXY_BASE_URL };
 
@@ -98,6 +116,7 @@ export interface SupervisorApi {
   listBeads(
     cityName: string,
     query?: NonNullable<GetV0CityByCityNameBeadsData['query']>,
+    options?: SupervisorReadOptions,
   ): Promise<ListBodyBead>;
   listEvents(
     cityName: string,
@@ -117,6 +136,7 @@ export interface SupervisorApi {
   formulaFeed(
     cityName: string,
     query?: NonNullable<GetV0CityByCityNameFormulasFeedData['query']>,
+    options?: SupervisorReadOptions,
   ): Promise<FormulaFeedBody>;
   sendMail(cityName: string, body: MailSendInputBody): Promise<Message>;
   mailThread(cityName: string, threadId: string): Promise<MailListBody>;
@@ -244,12 +264,13 @@ export function createSupervisorApi(options: CreateSupervisorApiOptions = {}): S
         'gc supervisor rigs response was empty',
       );
     },
-    listBeads(cityName, query) {
+    listBeads(cityName, query, options) {
       return unwrapSupervisorResult<ListBodyBead>(
         getV0CityByCityNameBeads({
           client,
           path: { cityName },
           ...(query === undefined ? {} : { query }),
+          ...cacheBypassHeaders(options),
         }) as Promise<SupervisorResult<ListBodyBead>>,
         'gc supervisor beads response was empty',
       );
@@ -367,12 +388,13 @@ export function createSupervisorApi(options: CreateSupervisorApiOptions = {}): S
         'gc supervisor mail response was empty',
       );
     },
-    formulaFeed(cityName, query) {
+    formulaFeed(cityName, query, options) {
       return unwrapSupervisorResult<FormulaFeedBody>(
         getV0CityByCityNameFormulasFeed({
           client,
           path: { cityName },
           ...(query === undefined ? {} : { query }),
+          ...cacheBypassHeaders(options),
         }) as Promise<SupervisorResult<FormulaFeedBody>>,
         'gc supervisor formula feed response was empty',
       );

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -226,6 +226,64 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('forceFresh marks ONLY the proxy-cached molecule + feed reads for cache bypass (gascity-dashboard-i3dz)', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    const formulaFeed = vi.fn(async () => feed([feedRun()]));
+    const listSessions = vi.fn(async () => sessionList());
+    setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed, listSessions });
+
+    const source = await loadSupervisorRunSummarySource({ forceFresh: true });
+    expect(source.status).toBe('fresh');
+
+    // The two proxy-cached city-wide reads carry the bypass option...
+    expect(listBeads).toHaveBeenCalledWith(
+      'test-city',
+      { limit: 500, type: 'molecule', all: true },
+      { cacheBypass: true },
+    );
+    expect(formulaFeed).toHaveBeenCalledWith(
+      'test-city',
+      { scope_kind: 'city', scope_ref: 'test-city' },
+      { cacheBypass: true },
+    );
+    // ...while the uncached core-active and per-rig reads keep the plain
+    // two-arg call (no options object), so they are never marked for bypass.
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', {
+      limit: 500,
+      type: 'task',
+      rig: 'rig-a',
+      all: true,
+    });
+  });
+
+  it('a normal (non-forceFresh) wide refresh leaves the cacheable reads on the plain cacheable call', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    const formulaFeed = vi.fn(async () => feed([feedRun()]));
+    const listSessions = vi.fn(async () => sessionList());
+    setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed, listSessions });
+
+    await loadSupervisorRunSummarySource();
+
+    // No bypass option is attached, so the proxy keeps serving its amortized
+    // cache for preview/SSE/upgrade reads.
+    expect(listBeads).toHaveBeenCalledWith('test-city', {
+      limit: 500,
+      type: 'molecule',
+      all: true,
+    });
+    expect(formulaFeed).toHaveBeenCalledWith('test-city', {
+      scope_kind: 'city',
+      scope_ref: 'test-city',
+    });
+  });
+
   it('derives a rig lane scope from the feed root_store_ref even when the feed scope_kind is city (q89b detail scope leak)', async () => {
     // The formula feed's top-level scope_kind is always 'city'; the rig identity
     // lives only in root_store_ref. When the root bead carries no scope metadata

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -113,8 +113,15 @@ const progressStateByCity = new Map<string, ProgressState>();
 // Detail) use loadSupervisorRunSummaryMountSource on the tight budget instead.
 // The shared subscription is exempt: it is cache-backed and the always-mounted
 // header reads its result, so its latency never blocks a route view.
-export async function loadSupervisorRunSummarySource(): Promise<SourceState<RunSummary>> {
-  return loadRunSummarySource(REFRESH_ENRICHMENT_TIMEOUT_MS);
+// `forceFresh` flows down to the two cacheable city-wide reads (molecule history
+// + city feed) as the proxy cache-bypass marker. The shared subscription sets it
+// ONLY for the operator's explicit Refresh (gascity-dashboard-i3dz); the one-time
+// preview→full upgrade and SSE refreshes leave it false so they keep serving the
+// proxy's amortized cache.
+export async function loadSupervisorRunSummarySource(options?: {
+  forceFresh?: boolean;
+}): Promise<SourceState<RunSummary>> {
+  return loadRunSummarySource(REFRESH_ENRICHMENT_TIMEOUT_MS, options?.forceFresh === true);
 }
 
 // Mount / first-paint full source for Home and Formula Run Detail: the same data
@@ -125,12 +132,15 @@ export async function loadSupervisorRunSummaryMountSource(): Promise<SourceState
   return loadRunSummarySource(PREVIEW_ENRICHMENT_TIMEOUT_MS);
 }
 
-async function loadRunSummarySource(enrichmentBudgetMs: number): Promise<SourceState<RunSummary>> {
+async function loadRunSummarySource(
+  enrichmentBudgetMs: number,
+  forceFresh = false,
+): Promise<SourceState<RunSummary>> {
   const cityName = activeCityOrThrow('load supervisor run summary');
   const fetchedAt = new Date().toISOString();
   try {
     const [loaded, sessions] = await Promise.all([
-      loadRunBeads(cityName, RUNS_FETCH_LIMIT, enrichmentBudgetMs),
+      loadRunBeads(cityName, RUNS_FETCH_LIMIT, enrichmentBudgetMs, forceFresh),
       loadRunSessions(cityName, enrichmentBudgetMs),
     ]);
     const summary = buildRunSummary(
@@ -277,10 +287,14 @@ async function loadRunBeads(
   cityName: string,
   limit: number,
   enrichmentBudgetMs: number,
+  forceFresh = false,
 ): Promise<LoadedRunBeads> {
   // The molecule-history read gets its own tight bound (gascity-dashboard-9rk2),
   // capped to the surrounding enrichment budget so the first-paint path is never
   // loosened: a slow scan folds to `partial` instead of dominating the refresh.
+  // forceFresh rides the two proxy-cached reads (molecule + feed) so an explicit
+  // Refresh re-scans upstream within the TTL window (gascity-dashboard-i3dz). The
+  // per-rig task reads are not proxy-cached, so they need no bypass.
   const moleculeFetch = settledRecentFetch(
     cityName,
     {
@@ -289,10 +303,11 @@ async function loadRunBeads(
       all: true,
     },
     Math.min(MOLECULE_HISTORY_TIMEOUT_MS, enrichmentBudgetMs),
+    forceFresh,
   );
   const [activeList, feedDiscovery] = await Promise.all([
     fetchCoreActiveBeads(cityName, limit),
-    discoverFromFeed(cityName, enrichmentBudgetMs),
+    discoverFromFeed(cityName, enrichmentBudgetMs, forceFresh),
   ]);
   const active = normalizeBeads(activeList.items ?? []);
   const rigNames = unionRigNames(runRigNames(active), feedDiscovery.rigNames);
@@ -336,10 +351,15 @@ async function settledRecentFetch(
   cityName: string,
   query: { limit: number; type: string; all: true; rig?: string },
   budgetMs: number,
+  cacheBypass = false,
 ): Promise<RecentFetchOutcome> {
   try {
+    // Attach the read options only to force a bypass: an unmarked read makes the
+    // same call as before (no options object, no bypass header), so the proxy
+    // keeps serving its amortized city-wide cache for it.
+    const readOptions = cacheBypass ? ([{ cacheBypass: true }] as const) : ([] as const);
     const list = await withOptionalReadBudget(
-      optionalRunSummaryApi(budgetMs).listBeads(cityName, query),
+      optionalRunSummaryApi(budgetMs).listBeads(cityName, query, ...readOptions),
       `recent ${query.type} beads`,
       budgetMs,
     );
@@ -359,13 +379,25 @@ interface FeedDiscovery {
   partial: boolean;
 }
 
-async function discoverFromFeed(cityName: string, budgetMs: number): Promise<FeedDiscovery> {
+async function discoverFromFeed(
+  cityName: string,
+  budgetMs: number,
+  cacheBypass = false,
+): Promise<FeedDiscovery> {
   try {
+    // Attach the read options only to force a bypass: an unmarked read makes the
+    // same call as before (no options object, no bypass header), so the proxy
+    // keeps serving its amortized city-wide cache for it.
+    const readOptions = cacheBypass ? ([{ cacheBypass: true }] as const) : ([] as const);
     const runs = await withOptionalReadBudget(
-      optionalRunSummaryApi(budgetMs).formulaFeed(cityName, {
-        scope_kind: 'city',
-        scope_ref: cityName,
-      }),
+      optionalRunSummaryApi(budgetMs).formulaFeed(
+        cityName,
+        {
+          scope_kind: 'city',
+          scope_ref: cityName,
+        },
+        ...readOptions,
+      ),
       'formula feed',
       budgetMs,
     );

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -45,6 +45,7 @@ export * from './maintainer-sling.js';
 export * from './alert.js';
 export * from './pending.js';
 export * from './context-window.js';
+export * from './supervisor-proxy.js';
 export type * from './lists.js';
 export type * from './transcript.js';
 export type * from './dashboard-beads.js';

--- a/shared/src/supervisor-proxy.ts
+++ b/shared/src/supervisor-proxy.ts
@@ -1,0 +1,13 @@
+// Dashboard-owned transport contract for the `/gc-supervisor/*` proxy
+// (backend/src/routes/supervisor-transport-proxy.ts). The proxy short-TTL-caches
+// the two expensive city-wide reads (molecule(all=true) history + city formula
+// feed); the operator's explicit /runs Refresh must be able to force a fresh
+// upstream scan within that TTL window (gascity-dashboard-i3dz).
+//
+// The frontend sets this request header ONLY on a manual wide Refresh; the proxy
+// honors it as a cache bypass (force-refresh + repopulate) and strips it before
+// forwarding upstream, so preview/SSE traffic keeps the TTL amortization. The
+// name/value live here so the frontend client and the backend proxy share one
+// definition and cannot drift.
+export const SUPERVISOR_CACHE_BYPASS_HEADER = 'x-gc-cache-bypass';
+export const SUPERVISOR_CACHE_BYPASS_VALUE = '1';


### PR DESCRIPTION
Fast-follow from the i60u review (#110). The i60u stopgap raised the supervisor-transport-proxy city-wide-read cache TTL 3s→45s; Codex review caught that the explicit `/runs` Refresh button's WIDE historical fetch flows through that same 45s-cached read, so clicking Refresh within 45s couldn't force-refresh the historical lanes (live/SSE lanes were already fine — they use the uncached active source).

**Fix:** give the explicit manual wide Refresh a cache-bypass the proxy honors **only for manual refresh** — a `SUPERVISOR_CACHE_BYPASS_HEADER` marker (defined once in `shared/src/supervisor-proxy.ts`, set by the frontend Refresh path, read+stripped by the proxy). Preview/SSE traffic keeps the 45s amortization; Refresh always re-scans upstream.

- backend: `ttl-single-flight-cache.ts` `forceFresh` (skips warm + in-flight coalescing, ownership-guarded so a forced load can't clobber a concurrent normal entry), `supervisor-transport-proxy.ts` reads/strips the marker.
- frontend: one-shot `forceFreshRef` consumed synchronously in the Refresh path; SSE/upgrade/retry paths never set it, so the bypass can't bleed.
- shared: the bypass marker (SSOT).

**Acceptance:** clicking Refresh re-hits upstream for the molecule+feed reads even within the 45s window; preview/SSE reads stay cached.

**Verification:** code-reviewer + typescript-reviewer re-review = approve (one minor: backend checks header presence not value — non-blocking, possible follow-up). CI-parity green in worktree: build, typecheck (src+test), eslint, prettier, openapi drift, shared / backend 582 / frontend 917 tests.