### PR TITLE
fix(attention): dedup mayor-decision items on decision.slug

### DIFF
--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -760,6 +760,102 @@ describe('createAttentionContributors', () => {
     ]);
   });
 
+  it('dedups mayor-decisions sharing a decision.slug, keeping the most recently moved bead', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: {
+          decisionLabel: NEEDS_STEPHANIE_LABEL,
+          // The same decision identity re-filed as a second marker bead: one
+          // decision = one attention row, and the most recent movement wins.
+          decisions: [
+            bead({
+              id: 'dec-old',
+              title: 'Decide: merge-queue protocol',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              updated_at: '2026-06-03T10:00:00.000Z',
+              metadata: { 'decision.slug': 'merge-queue-protocol' },
+            }),
+            bead({
+              id: 'dec-new',
+              title: 'Decide: merge-queue protocol (re-filed)',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              updated_at: '2026-06-04T10:00:00.000Z',
+              metadata: { 'decision.slug': 'merge-queue-protocol' },
+            }),
+          ],
+        },
+      }),
+    );
+
+    expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
+      'beads:dec-new:mayor-decision',
+    ]);
+  });
+
+  it('keeps mayor-decisions with distinct or absent decision.slug as separate items', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: {
+          decisionLabel: NEEDS_STEPHANIE_LABEL,
+          decisions: [
+            bead({
+              id: 'dec-a',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              metadata: { 'decision.slug': 'slug-a' },
+            }),
+            bead({
+              id: 'dec-b',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              metadata: { 'decision.slug': 'slug-b' },
+            }),
+            // No slug (and a blank slug) — no shared identity to dedup on.
+            bead({ id: 'dec-c', labels: [NEEDS_STEPHANIE_LABEL] }),
+            bead({
+              id: 'dec-d',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              metadata: { 'decision.slug': '   ' },
+            }),
+          ],
+        },
+      }),
+    );
+
+    expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
+      'beads:dec-a:mayor-decision',
+      'beads:dec-b:mayor-decision',
+      'beads:dec-c:mayor-decision',
+      'beads:dec-d:mayor-decision',
+    ]);
+  });
+
+  it('breaks a decision.slug recency tie deterministically by bead id', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: {
+          decisionLabel: NEEDS_STEPHANIE_LABEL,
+          decisions: [
+            bead({
+              id: 'dec-b',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              updated_at: '2026-06-04T10:00:00.000Z',
+              metadata: { 'decision.slug': 'tied' },
+            }),
+            bead({
+              id: 'dec-a',
+              labels: [NEEDS_STEPHANIE_LABEL],
+              updated_at: '2026-06-04T10:00:00.000Z',
+              metadata: { 'decision.slug': 'tied' },
+            }),
+          ],
+        },
+      }),
+    );
+
+    expect(model.byDomain.beads.items.map((item) => item.id)).toEqual([
+      'beads:dec-a:mayor-decision',
+    ]);
+  });
+
   it('surfaces a decision-queue fetch failure without blanking generic bead alerts', () => {
     const model = composeAttention(
       createAttentionContributors({

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -167,6 +167,14 @@ export const GC_ESCALATION_LABEL = 'gc:escalation';
  */
 const DECISION_DECIDE_META_KEY = 'decision.decide';
 
+/**
+ * Flat metadata key for the decision's stable identity (the spec's
+ * `metadata.decision.slug`). Two open marker beads sharing a slug are the SAME
+ * decision (re-filed or mirrored) and must surface as one attention row.
+ * Optional: a bead without it has no shared identity and is never deduped.
+ */
+const DECISION_SLUG_META_KEY = 'decision.slug';
+
 export function createAttentionContributors(
   facts: AttentionContributorFacts = {},
 ): readonly AttentionContributor[] {
@@ -431,7 +439,7 @@ function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly 
       }),
     );
   }
-  for (const decision of facts.decisions ?? []) {
+  for (const decision of dedupeDecisionsBySlug(facts.decisions ?? [])) {
     items.push(mayorDecisionAttention(decision));
   }
   const nowMs = facts.nowMs ?? Date.now();
@@ -481,6 +489,46 @@ function beadHref(beadId: string): string {
  */
 function isMayorDecision(bead: Bead, decisionLabel: string): boolean {
   return (bead.labels ?? []).includes(decisionLabel);
+}
+
+/**
+ * Collapse the decision queue onto distinct decision identities
+ * (`metadata['decision.slug']`). Among beads sharing a non-empty slug only the
+ * most recently moved bead surfaces; on a timestamp tie the lowest bead id
+ * wins. Mechanical duplicate detection with explicit deterministic tiebreakers
+ * (the sanctioned ZFC exception), not a semantic judgment — bodies are never
+ * read. Beads without a slug pass through untouched, in queue order.
+ */
+function dedupeDecisionsBySlug(decisions: readonly Bead[]): readonly Bead[] {
+  const winners = new Map<string, Bead>();
+  for (const bead of decisions) {
+    const slug = decisionSlug(bead);
+    if (slug === null) continue;
+    const held = winners.get(slug);
+    if (held === undefined || displacesHeldDecision(bead, held)) winners.set(slug, bead);
+  }
+  return decisions.filter((bead) => {
+    const slug = decisionSlug(bead);
+    return slug === null || winners.get(slug) === bead;
+  });
+}
+
+function decisionSlug(bead: Bead): string | null {
+  const slug = bead.metadata?.[DECISION_SLUG_META_KEY]?.trim();
+  return slug === undefined || slug.length === 0 ? null : slug;
+}
+
+function displacesHeldDecision(candidate: Bead, held: Bead): boolean {
+  const candidateMs = decisionMovementMs(candidate);
+  const heldMs = decisionMovementMs(held);
+  if (candidateMs !== heldMs) return candidateMs > heldMs;
+  return candidate.id < held.id;
+}
+
+/** Movement timestamp for recency ranking; an unparsable timestamp sorts oldest. */
+function decisionMovementMs(bead: Bead): number {
+  const ms = Date.parse(bead.updated_at ?? bead.created_at);
+  return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms;
 }
 
 /**


### PR DESCRIPTION
Closes the remaining gap in the mayor-decision attention tier: dedup mayor-decision attention items on `metadata['decision.slug']` in `deriveBeadsAttention`.

Among open marker beads sharing a non-empty slug, keep the most recently updated (`updated_at ?? created_at`) with a deterministic id tiebreak; beads without a slug pass through undeduped. Pure projection (no local state) — the slug is a Map key only, never reaches an href/DOM. Sanctioned ZFC exception (mechanical dedup with explicit tiebreakers).

**Shape decision:** registry-native AttentionItem — shared AlertItem stays dead (yt5m removes it). The core consumer (decision-queue fetch, per-bead attention identity, self-clear, config label) already landed via #53/#96/#100/#102; this is the dedup increment.

Only `frontend/src/attention/registry.ts` (+50) and `registry.test.ts` (+96).

**Verification:** code-reviewer (re-review) = approve; prior code+security+typescript = approve. Tests discriminate (1+3 fail without the fix). CI-parity green: build, typecheck (src+test), eslint, prettier, openapi, 917 frontend tests.