### PR TITLE
fix(runs): render orphaned molecules as stranded, never as a live stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 #   - generated gc supervisor OpenAPI client drift check
 #   - shared tests (node --test via tsx)
 #   - backend tests (node --test via tsx loader)
-#   - frontend tests (vitest in jsdom)
+#   - frontend tests (vitest in jsdom, with v8 coverage ratchet thresholds)
 #
 # Not yet in CI (file a separate bead if you want to change this):
 #   - scripts/snap.mjs (Playwright visual snaps — too heavy, no golden source)
@@ -105,5 +105,9 @@ jobs:
       - name: Backend tests
         run: npm --workspace backend test
 
-      - name: Frontend tests
-        run: npm --workspace frontend test
+      # Coverage variant of `vitest run`: same tests, plus the v8 coverage
+      # ratchet thresholds in frontend/vitest.config.ts (set ~5 points below
+      # the measured baseline, so they catch regressions without blocking
+      # normal work). Raise the thresholds as real coverage rises.
+      - name: Frontend tests (with coverage)
+        run: npm --workspace frontend run test:coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist
 *.log
 scripts/node_modules
 
+# Vitest coverage output (npm --workspace frontend run test:coverage)
+coverage/
+
 # Beads / Dolt internal files. The .beads/ store itself is local-only — bd
 # state lives in each operator's Dolt working copy, not in the GitHub tree.
 # Falls under the hidden-path deny-all below; no allow-list entry on purpose.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "pretest": "npm --workspace gas-city-dashboard-shared run build",
     "test": "vitest run",
+    "pretest:coverage": "npm --workspace gas-city-dashboard-shared run build",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -30,6 +32,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.4.20",
     "jsdom": "^29.1.1",
     "postcss": "^8.4.47",

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -1072,7 +1072,7 @@ function runLane({
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: {
       status: 'available',
       data: {

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -1072,6 +1072,7 @@ function runLane({
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: {
       status: 'available',
       data: {

--- a/frontend/src/components/run/LaneCard.test.tsx
+++ b/frontend/src/components/run/LaneCard.test.tsx
@@ -33,6 +33,7 @@ describe('LaneCard navigation', () => {
         error: 'run progress unavailable in test',
       },
       formulaStageResolved: false,
+      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
       health: { status: 'unavailable', error: 'run health has not been derived' },
     };
 
@@ -67,6 +68,7 @@ describe('LaneCard navigation', () => {
         error: 'run progress unavailable in test',
       },
       formulaStageResolved: false,
+      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
       health: { status: 'unavailable', error: 'run health has not been derived' },
     };
 
@@ -113,6 +115,7 @@ describe('LaneCard historical-lane render', () => {
         error: 'workflow progress unavailable in test',
       },
       formulaStageResolved: false,
+      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
       health: {
         status: 'unavailable',
         error: 'workflow health has not been derived',
@@ -169,5 +172,81 @@ describe('LaneCard historical-lane render', () => {
     const label = screen.getByText('complete');
     expect(label.className).toContain('text-fg-muted');
     expect(label.className).not.toContain('text-accent');
+  });
+});
+
+// gascity-dashboard-uxvk: an orphaned molecule (no supervisor workflow record,
+// zero step progress) used to render as a LIVE run with a stage ladder and a
+// phase label — a false-alive signal the operator cannot distinguish from a
+// working run. A lane whose registration is 'stranded' must read as stranded:
+// glyph + word per DESIGN.md, an explanation, and no live stage ladder.
+describe('LaneCard stranded runs (gascity-dashboard-uxvk)', () => {
+  function strandedLane(overrides: Partial<RunLane> = {}): RunLane {
+    return {
+      id: 'gc-odssky',
+      title: 'mol-pr-start: gascity issue #3192',
+      formula: { status: 'known', name: 'mol-pr-start' },
+      scope: { status: 'available', kind: 'rig', ref: 'gascity', rootStoreRef: 'rig:gascity' },
+      external: { status: 'unavailable', error: 'external unavailable in test' },
+      phase: 'intake',
+      phaseLabel: 'intake',
+      statusCounts: { open: 7 },
+      activeAssignees: [],
+      updatedAt: { status: 'available', at: '2026-06-12T01:20:05Z' },
+      stages: [
+        { key: 'intake', label: 'Intake', status: 'active' },
+        { key: 'implementation', label: 'Implementation', status: 'pending' },
+      ],
+      progress: {
+        status: 'stage_only',
+        stage: { status: 'available', index: 0, key: 'intake', label: 'Intake' },
+        error: 'active run step unavailable',
+      },
+      formulaStageResolved: false,
+      health: { status: 'unavailable', error: 'run health has not been derived' },
+      registration: { status: 'stranded' },
+      ...overrides,
+    };
+  }
+
+  function renderLane(lane: RunLane) {
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <LaneCard lane={lane} now={Date.parse('2026-06-12T08:20:00Z')} />
+      </MemoryRouter>,
+    );
+  }
+
+  it('renders the stranded glyph + word in place of the phase label', () => {
+    renderLane(strandedLane());
+    const label = screen.getByText(/stranded/i);
+    expect(label.textContent).toMatch(/\(!\)\s*stranded/i);
+    // The live phase label must NOT render alongside it.
+    expect(screen.queryByText(/^intake$/i)).toBeNull();
+  });
+
+  it('explains the stranded state instead of rendering a live stage ladder', () => {
+    renderLane(strandedLane());
+    expect(screen.getByText(/never registered with the supervisor/i)).toBeTruthy();
+    // No stage ladder: a run that never executed has no live stage.
+    expect(screen.queryByLabelText(/stages$/i)).toBeNull();
+  });
+
+  it('keeps the stage ladder and phase label for a non-stranded lane', () => {
+    renderLane(strandedLane({ registration: { status: 'registered' } }));
+    // Matches both the phase label and the ladder's Intake stage word.
+    expect(screen.getAllByText(/^intake$/i).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/stages$/i)).toBeTruthy();
+    expect(screen.queryByText(/never registered with the supervisor/i)).toBeNull();
+  });
+
+  it('an unknown registration renders exactly like a registered lane (no stranded claim)', () => {
+    renderLane(
+      strandedLane({
+        registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+      }),
+    );
+    expect(screen.queryByText(/stranded/i)).toBeNull();
+    expect(screen.getByLabelText(/stages$/i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/run/LaneCard.test.tsx
+++ b/frontend/src/components/run/LaneCard.test.tsx
@@ -33,7 +33,7 @@ describe('LaneCard navigation', () => {
         error: 'run progress unavailable in test',
       },
       formulaStageResolved: false,
-      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+      registration: 'unknown',
       health: { status: 'unavailable', error: 'run health has not been derived' },
     };
 
@@ -68,7 +68,7 @@ describe('LaneCard navigation', () => {
         error: 'run progress unavailable in test',
       },
       formulaStageResolved: false,
-      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+      registration: 'unknown',
       health: { status: 'unavailable', error: 'run health has not been derived' },
     };
 
@@ -115,7 +115,7 @@ describe('LaneCard historical-lane render', () => {
         error: 'workflow progress unavailable in test',
       },
       formulaStageResolved: false,
-      registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+      registration: 'unknown',
       health: {
         status: 'unavailable',
         error: 'workflow health has not been derived',
@@ -204,7 +204,7 @@ describe('LaneCard stranded runs (gascity-dashboard-uxvk)', () => {
       },
       formulaStageResolved: false,
       health: { status: 'unavailable', error: 'run health has not been derived' },
-      registration: { status: 'stranded' },
+      registration: 'stranded',
       ...overrides,
     };
   }
@@ -233,7 +233,7 @@ describe('LaneCard stranded runs (gascity-dashboard-uxvk)', () => {
   });
 
   it('keeps the stage ladder and phase label for a non-stranded lane', () => {
-    renderLane(strandedLane({ registration: { status: 'registered' } }));
+    renderLane(strandedLane({ registration: 'registered' }));
     // Matches both the phase label and the ladder's Intake stage word.
     expect(screen.getAllByText(/^intake$/i).length).toBeGreaterThan(0);
     expect(screen.getByLabelText(/stages$/i)).toBeTruthy();
@@ -243,7 +243,7 @@ describe('LaneCard stranded runs (gascity-dashboard-uxvk)', () => {
   it('an unknown registration renders exactly like a registered lane (no stranded claim)', () => {
     renderLane(
       strandedLane({
-        registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+        registration: 'unknown',
       }),
     );
     expect(screen.queryByText(/stranded/i)).toBeNull();

--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -49,7 +49,7 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
   // record, never executed) must not read as a live run. Stranded lanes swap
   // the phase label for a glyph + word and the stage ladder for an
   // explanation — a run that never started has no live stage to show.
-  const stranded = lane.registration.status === 'stranded';
+  const stranded = lane.registration === 'stranded';
   const statusEntries = Object.entries(lane.statusCounts).sort((a, b) =>
     statusSortKey(a[0]).localeCompare(statusSortKey(b[0])),
   );

--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -45,6 +45,11 @@ function phaseLabelTone(phase: RunLane['phase']): 'text-accent' | 'text-fg-muted
 }
 
 export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneCardProps) {
+  // gascity-dashboard-uxvk: an orphaned molecule (no supervisor workflow
+  // record, never executed) must not read as a live run. Stranded lanes swap
+  // the phase label for a glyph + word and the stage ladder for an
+  // explanation — a run that never started has no live stage to show.
+  const stranded = lane.registration.status === 'stranded';
   const statusEntries = Object.entries(lane.statusCounts).sort((a, b) =>
     statusSortKey(a[0]).localeCompare(statusSortKey(b[0])),
   );
@@ -58,7 +63,13 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
     >
       <div className="flex items-baseline justify-between gap-4">
         <span className={`text-label uppercase tracking-wider ${phaseLabelTone(lane.phase)}`}>
-          {lane.phaseLabel}
+          {stranded ? (
+            <>
+              <span aria-hidden="true">(!)</span> stranded
+            </>
+          ) : (
+            lane.phaseLabel
+          )}
         </span>
         <span
           className="text-label uppercase tracking-wider text-fg-faint tnum tabular-nums"
@@ -96,7 +107,14 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
         </div>
       )}
 
-      <StageLadder stages={lane.stages} label={lane.title} />
+      {stranded ? (
+        <p className="mt-2 text-body text-fg-muted leading-snug">
+          Dispatched but never registered with the supervisor, likely a supervisor restart or crash
+          at dispatch time. This run never executed.
+        </p>
+      ) : (
+        <StageLadder stages={lane.stages} label={lane.title} />
+      )}
 
       <div className="mt-2 flex items-baseline gap-x-4 gap-y-1 flex-wrap text-label">
         <span className="text-fg-faint tnum" title="run root bead">

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -27,6 +27,7 @@ function historicalLane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }
@@ -143,6 +144,7 @@ function activeLane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -27,7 +27,7 @@ function historicalLane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }
@@ -144,7 +144,7 @@ function activeLane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }

--- a/frontend/src/hooks/useStaleness.test.tsx
+++ b/frontend/src/hooks/useStaleness.test.tsx
@@ -48,6 +48,7 @@ function laneFixture(overrides: {
     stages: [],
     progress: { status: 'unavailable', error: 'unused' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health,
   };
 }

--- a/frontend/src/hooks/useStaleness.test.tsx
+++ b/frontend/src/hooks/useStaleness.test.tsx
@@ -48,7 +48,7 @@ function laneFixture(overrides: {
     stages: [],
     progress: { status: 'unavailable', error: 'unused' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health,
   };
 }

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -133,7 +133,7 @@ function lane(f: LaneFixture): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'unused' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health,
   };
 }

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -133,6 +133,7 @@ function lane(f: LaneFixture): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'unused' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health,
   };
 }

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -716,6 +716,9 @@ describe('FormulaRunDetailPage', () => {
     renderPage();
 
     await screen.findByText(/this run’s detail snapshot was not found/i);
+    // gascity-dashboard-uxvk: the copy must name the orphaned-molecule cause —
+    // dispatched but never registered with the supervisor — alongside v1/wisp.
+    expect(screen.getByText(/never registered with the supervisor/i)).toBeTruthy();
     // Does not over-claim v1.
     expect(screen.queryByText(/v1\/wisp runs are list-only/i)).toBeNull();
     // Not the generic dead-end, and not an error alert.
@@ -875,6 +878,7 @@ function runSummarySourceWithActiveLane(): SourceState<RunSummary> {
     ],
     progress: { status: 'unavailable', error: 'active run step unavailable' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: {
       status: 'available',
       data: {

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -166,6 +166,32 @@ describe('FormulaRunDetailPage', () => {
     expect(screen.queryByText(/^Loading formula run\.$/i)).toBeNull();
   });
 
+  it('the optimistic skeleton for a STRANDED lane shows the stranded notice, not a live ladder', async () => {
+    // A stranded lane must not flash a live stage ladder while the detail
+    // loads — the false-alive cue the run list suppresses would otherwise
+    // reappear on the detail route during the optimistic loading window.
+    const source = runSummarySourceWithActiveLane();
+    if (source.status === 'error') throw new Error(source.error);
+    source.data.lanes = source.data.lanes.map((lane) => ({
+      ...lane,
+      registration: 'stranded' as const,
+    }));
+    setCached('runs:summary:test-city', source);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    loadSupervisorFormulaRunDetail.mockImplementationOnce(
+      () => new Promise<FormulaRunDetail>(() => {}),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText(/never registered with the supervisor/i)).toBeTruthy();
+    expect(screen.getByText(/^Loading run detail\.$/i)).toBeTruthy();
+    expect(screen.queryByRole('list', { name: /pending adoption run stages/i })).toBeNull();
+  });
+
   it('fires NO run-summary mount read on a cold cache, consuming a warm hit only (gascity-dashboard-i60u)', async () => {
     // i60u cold-load stopgap: a direct/refresh load arrives with the run-summary
     // cache cold. The detail page must NOT fire its own heavy molecule(all=true)

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -878,7 +878,7 @@ function runSummarySourceWithActiveLane(): SourceState<RunSummary> {
     ],
     progress: { status: 'unavailable', error: 'active run step unavailable' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: {
       status: 'available',
       data: {

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -205,8 +205,8 @@ export function FormulaRunDetailPage() {
         )
       ) : unsupported ? (
         <p className="text-body text-fg-muted" role="status">
-          Detailed step view isn&rsquo;t available for this run (v1/wisp runs are list-only) — this
-          run appears in the run list only.
+          Detailed step view isn&rsquo;t available for this run (v1/wisp runs are list-only); it
+          appears in the run list only.
         </p>
       ) : notFound ? (
         <p className="text-body text-fg-muted" role="status">

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -211,7 +211,9 @@ export function FormulaRunDetailPage() {
       ) : notFound ? (
         <p className="text-body text-fg-muted" role="status">
           This run&rsquo;s detail snapshot was not found. It may be a v1/wisp run, a completed run
-          whose snapshot wasn&rsquo;t retained, or no longer available.
+          whose snapshot wasn&rsquo;t retained, no longer available, or a run that was dispatched
+          but never registered with the supervisor (a supervisor restart or crash at dispatch time
+          strands a run before it executes).
         </p>
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -197,7 +197,17 @@ export function FormulaRunDetailPage() {
       {loading && !routeError && !detail ? (
         skeletonLane ? (
           <>
-            <StageLadder stages={skeletonLane.stages} label={skeletonLane.title} />
+            {/* A stranded lane must not flash a live stage ladder while the
+                detail loads — mirror the LaneCard stranded treatment. */}
+            {skeletonLane.registration === 'stranded' ? (
+              <p className="text-body text-fg-muted leading-snug" role="status">
+                <span aria-hidden="true">(!)</span> stranded: dispatched but never registered with
+                the supervisor, likely a supervisor restart or crash at dispatch time. This run
+                never executed.
+              </p>
+            ) : (
+              <StageLadder stages={skeletonLane.stages} label={skeletonLane.title} />
+            )}
             <p className="text-body text-fg-muted italic mt-8">Loading run detail.</p>
           </>
         ) : (

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -145,6 +145,7 @@ function completedLane(): RunLane {
       error: 'active run step unavailable',
     },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: {
       status: 'available',
       data: {

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -145,7 +145,7 @@ function completedLane(): RunLane {
       error: 'active run step unavailable',
     },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: {
       status: 'available',
       data: {

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -95,7 +95,7 @@ function lane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -95,6 +95,7 @@ function lane(id: string): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable in test' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: { status: 'unavailable', error: 'run health has not been derived' },
   };
 }

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1222,6 +1222,25 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('registered');
   });
 
+  it('a workflow_id-only row never recovers a stranded lane (non-authoritative key)', async () => {
+    // The presence overlay trusts only run.root_bead_id. A rootless row whose
+    // workflow_id happens to equal the stranded root proves nothing about the
+    // bead root — the lane must stay stranded off the cached observation.
+    wideApi(feed([]));
+    const first = await loadSupervisorRunSummarySource();
+    if (first.status === 'error') throw new Error(first.error);
+    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+
+    const { root_bead_id: _omitted, ...rootless } = feedRun({
+      id: 'gc-odssky',
+      workflow_id: 'gc-odssky',
+    });
+    wideApi(feed([rootless]));
+    const second = await loadSupervisorRunSummarySource();
+    if (second.status === 'error') throw new Error(second.error);
+    expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+  });
+
   it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
     wideApi(feed([]));
     const wide = await loadSupervisorRunSummarySource();

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1153,6 +1153,35 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     expect(lane?.registration).toBe('unknown');
   });
 
+  it('a feed item missing root_bead_id never strands a lane (absence unprovable)', async () => {
+    // A run item keyed only by workflow_id may cover a root under a key the
+    // bead store never sees, so the root-id set cannot prove gc-odssky absent.
+    const { root_bead_id: _omitted, ...rootless } = feedRun({
+      id: 'other-run',
+      workflow_id: 'wf-other',
+    });
+    wideApi(feed([rootless]));
+
+    const source = await loadSupervisorRunSummarySource();
+
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('unknown');
+  });
+
+  it('a later complete feed read that lists the root recovers stranded to registered', async () => {
+    wideApi(feed([]));
+    const first = await loadSupervisorRunSummarySource();
+    if (first.status === 'error') throw new Error(first.error);
+    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+
+    wideApi(
+      feed([feedRun({ id: 'gc-odssky', root_bead_id: 'gc-odssky', workflow_id: 'gc-odssky' })]),
+    );
+    const second = await loadSupervisorRunSummarySource();
+    if (second.status === 'error') throw new Error(second.error);
+    expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('registered');
+  });
+
   it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
     wideApi(feed([]));
     const wide = await loadSupervisorRunSummarySource();

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1182,6 +1182,46 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('registered');
   });
 
+  it('a partial feed read that lists the root recovers stranded to registered', async () => {
+    // A partial read cannot prove absence, but it proves presence: the listed
+    // root must not stay stranded off the older cached observation.
+    wideApi(feed([]));
+    const first = await loadSupervisorRunSummarySource();
+    if (first.status === 'error') throw new Error(first.error);
+    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+
+    wideApi(
+      feed(
+        [feedRun({ id: 'gc-odssky', root_bead_id: 'gc-odssky', workflow_id: 'gc-odssky' })],
+        true,
+      ),
+    );
+    const second = await loadSupervisorRunSummarySource();
+    if (second.status === 'error') throw new Error(second.error);
+    expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('registered');
+  });
+
+  it('a root-incomplete feed read that lists the root recovers stranded to registered', async () => {
+    wideApi(feed([]));
+    const first = await loadSupervisorRunSummarySource();
+    if (first.status === 'error') throw new Error(first.error);
+    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+
+    const { root_bead_id: _omitted, ...rootless } = feedRun({
+      id: 'other-run',
+      workflow_id: 'wf-other',
+    });
+    wideApi(
+      feed([
+        feedRun({ id: 'gc-odssky', root_bead_id: 'gc-odssky', workflow_id: 'gc-odssky' }),
+        rootless,
+      ]),
+    );
+    const second = await loadSupervisorRunSummarySource();
+    if (second.status === 'error') throw new Error(second.error);
+    expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('registered');
+  });
+
   it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
     wideApi(feed([]));
     const wide = await loadSupervisorRunSummarySource();

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1065,3 +1065,130 @@ function sessionList(): ListBodySessionResponse {
     total: 0,
   };
 }
+
+// gascity-dashboard-uxvk: orphaned-molecule registration. The wide sources
+// observe the supervisor formula feed; a COMPLETE read is cached per city so
+// the cheap SSE-burst source (which deliberately skips the feed) judges lanes
+// off the same observation instead of flapping every stranded lane back to
+// unknown on each burst.
+describe('run registration (gascity-dashboard-uxvk)', () => {
+  beforeEach(() => {
+    setActiveCity('test-city');
+    resetSupervisorRunSummaryStateForTests();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    resetSupervisorApiForTests();
+    resetSupervisorRunSummaryStateForTests();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function orphanBeads(): Bead[] {
+    // The gc-odssky shape: a molecule root with an all-open step graph,
+    // dispatched an hour ago (well past the dispatch grace).
+    return [
+      runRoot({ id: 'gc-odssky', title: 'mol-pr-start: gascity issue #3192' }),
+      bead({
+        id: 'gc-odssky-s1',
+        title: 'read issue',
+        status: 'open',
+        metadata: {
+          'gc.kind': 'step',
+          'gc.root_bead_id': 'gc-odssky',
+          'gc.step_id': 'read-issue',
+        },
+      }),
+    ];
+  }
+
+  function wideApi(feedBody: FormulaFeedBody) {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      if (query?.rig !== undefined) return beadList([]);
+      return beadList(orphanBeads());
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feedBody),
+      listSessions: vi.fn(async () => sessionList()),
+    });
+  }
+
+  it('marks an orphaned molecule stranded off a complete feed read', async () => {
+    wideApi(feed([]));
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
+    expect(lane?.registration).toEqual({ status: 'stranded' });
+    expect(lane?.phase).toBe('intake');
+  });
+
+  it('a run listed by the feed is registered', async () => {
+    wideApi(
+      feed([feedRun({ id: 'gc-odssky', root_bead_id: 'gc-odssky', workflow_id: 'gc-odssky' })]),
+    );
+
+    const source = await loadSupervisorRunSummarySource();
+
+    if (source.status === 'error') throw new Error(source.error);
+    const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
+    expect(lane?.registration).toEqual({ status: 'registered' });
+  });
+
+  it('a partial feed read never strands a lane', async () => {
+    wideApi(feed([], true));
+
+    const source = await loadSupervisorRunSummarySource();
+
+    if (source.status === 'error') throw new Error(source.error);
+    const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
+    expect(lane?.registration.status).toBe('unknown');
+  });
+
+  it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
+    wideApi(feed([]));
+    const wide = await loadSupervisorRunSummarySource();
+    if (wide.status === 'error') throw new Error(wide.error);
+    expect(wide.data.lanes.find((l) => l.id === 'gc-odssky')?.registration.status).toBe('stranded');
+
+    // The cheap source: core active read + sessions only, NO feed read.
+    const listBeads = vi.fn(async () => beadList(orphanBeads()));
+    const formulaFeed = vi.fn();
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed,
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const cheap = await loadSupervisorRunSummaryActiveSource();
+
+    if (cheap.status === 'error') throw new Error(cheap.error);
+    expect(formulaFeed).not.toHaveBeenCalled();
+    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toEqual({
+      status: 'stranded',
+    });
+  });
+
+  it('without any complete feed observation the cheap source reports unknown', async () => {
+    const listBeads = vi.fn(async () => beadList(orphanBeads()));
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      listSessions: vi.fn(async () => sessionList()),
+    });
+
+    const cheap = await loadSupervisorRunSummaryActiveSource();
+
+    if (cheap.status === 'error') throw new Error(cheap.error);
+    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration.status).toBe('unknown');
+  });
+});

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1127,7 +1127,7 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
     const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
-    expect(lane?.registration).toEqual({ status: 'stranded' });
+    expect(lane?.registration).toBe('stranded');
     expect(lane?.phase).toBe('intake');
   });
 
@@ -1140,7 +1140,7 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
 
     if (source.status === 'error') throw new Error(source.error);
     const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
-    expect(lane?.registration).toEqual({ status: 'registered' });
+    expect(lane?.registration).toBe('registered');
   });
 
   it('a partial feed read never strands a lane', async () => {
@@ -1150,14 +1150,14 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
 
     if (source.status === 'error') throw new Error(source.error);
     const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
-    expect(lane?.registration.status).toBe('unknown');
+    expect(lane?.registration).toBe('unknown');
   });
 
   it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
     wideApi(feed([]));
     const wide = await loadSupervisorRunSummarySource();
     if (wide.status === 'error') throw new Error(wide.error);
-    expect(wide.data.lanes.find((l) => l.id === 'gc-odssky')?.registration.status).toBe('stranded');
+    expect(wide.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
 
     // The cheap source: core active read + sessions only, NO feed read.
     const listBeads = vi.fn(async () => beadList(orphanBeads()));
@@ -1173,9 +1173,7 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
 
     if (cheap.status === 'error') throw new Error(cheap.error);
     expect(formulaFeed).not.toHaveBeenCalled();
-    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toEqual({
-      status: 'stranded',
-    });
+    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
   });
 
   it('without any complete feed observation the cheap source reports unknown', async () => {
@@ -1189,6 +1187,6 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     const cheap = await loadSupervisorRunSummaryActiveSource();
 
     if (cheap.status === 'error') throw new Error(cheap.error);
-    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration.status).toBe('unknown');
+    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('unknown');
   });
 });

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -168,6 +168,11 @@ function citySummary(cityName: string, loaded: LoadedRunBeads): RunSummary {
   // partial or root-incomplete — proves PRESENCE for the roots it lists. Merge
   // them in so a stranded lane recovers the moment any read shows the
   // supervisor knows its root, instead of waiting for the next complete read.
+  // When there is no cached complete observation yet (preview/cheap source
+  // before any complete feed read), the overlay is useless without the cached
+  // observedAtMs anchor for the absence grace — so we pass `cached` (undefined)
+  // and every lane starts 'unknown'. A non-null feedRootIds only RECOVERS a
+  // stranded lane (presence), never strands one, so discarding it here is safe.
   const observation =
     cached !== undefined && loaded.feedRootIds !== null && loaded.feedRootIds.size > 0
       ? {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -375,6 +375,16 @@ async function loadRunBeads(
     fetchCoreActiveBeads(cityName, limit),
     discoverFromFeed(cityName, enrichmentBudgetMs, forceFresh),
   ]);
+  // gascity-dashboard-uxvk: the default header-first fan-out reads the feed too,
+  // so a COMPLETE read here is registration evidence — cache it (anchored to the
+  // observation time) exactly as the lazy history fan-out does, or the common
+  // /runs path would never strand an orphaned molecule.
+  if (!feedDiscovery.partial && feedDiscovery.rootIdsComplete) {
+    feedObservationByCity.set(cityName, {
+      rootIds: feedDiscovery.rootIds,
+      observedAtMs: Date.now(),
+    });
+  }
   const active = normalizeBeads(activeList.items ?? []);
   // Truncation at the bounded fetch reads as partial lanes, not complete
   // (gascity-dashboard-q89b). A failed/slow feed also reads as partial: the lane
@@ -384,6 +394,10 @@ async function loadRunBeads(
   return {
     beads: active,
     feedScopes: feedDiscovery.scopes,
+    // The default fan-out reads the feed, so its root-id presence observation is
+    // available for the stranded/recovery overlay (gascity-dashboard-uxvk); only
+    // the feed-less cheap source carries a null (no observation) here.
+    feedRootIds: feedDiscovery.presenceRootIds,
     partial: feedDiscovery.partial || listIsIncomplete(activeList, active.length),
   };
 }

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -151,6 +151,18 @@ export async function loadSupervisorRunSummaryMountSource(): Promise<SourceState
   return loadRunSummarySource(PREVIEW_ENRICHMENT_TIMEOUT_MS);
 }
 
+// Single place the lane summary is built from a bead load, so every source
+// (wide refresh, cheap active, preview) derives registration from the same
+// per-city feed observation.
+function citySummary(cityName: string, loaded: LoadedRunBeads): RunSummary {
+  return buildRunSummary(
+    loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
+    loaded.feedScopes,
+    loaded.partial,
+    feedObservationByCity.get(cityName),
+  );
+}
+
 async function loadRunSummarySource(
   enrichmentBudgetMs: number,
   forceFresh = false,
@@ -162,12 +174,7 @@ async function loadRunSummarySource(
       loadRunBeads(cityName, RUNS_FETCH_LIMIT, enrichmentBudgetMs, forceFresh),
       loadRunSessions(cityName, enrichmentBudgetMs),
     ]);
-    const summary = buildRunSummary(
-      loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
-      loaded.feedScopes,
-      loaded.partial,
-      feedObservationByCity.get(cityName),
-    );
+    const summary = citySummary(cityName, loaded);
     const source: SourceAvailableState<RunSummary> = {
       source: 'runs',
       status: 'fresh',
@@ -207,12 +214,7 @@ export async function loadSupervisorRunSummaryActiveSource(): Promise<SourceStat
       loadActiveRunBeads(cityName, RUNS_FETCH_LIMIT),
       loadRunSessions(cityName, PREVIEW_ENRICHMENT_TIMEOUT_MS),
     ]);
-    const summary = buildRunSummary(
-      loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
-      loaded.feedScopes,
-      loaded.partial,
-      feedObservationByCity.get(cityName),
-    );
+    const summary = citySummary(cityName, loaded);
     const source: SourceAvailableState<RunSummary> = {
       source: 'runs',
       status: 'fresh',
@@ -254,12 +256,7 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
   const fetchedAt = new Date().toISOString();
   try {
     const loaded = await loadRunBeads(cityName, RUNS_FETCH_LIMIT, PREVIEW_ENRICHMENT_TIMEOUT_MS);
-    const summary = buildRunSummary(
-      loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
-      loaded.feedScopes,
-      loaded.partial,
-      feedObservationByCity.get(cityName),
-    );
+    const summary = citySummary(cityName, loaded);
     return {
       source: 'runs',
       status: 'fresh',
@@ -504,14 +501,13 @@ async function discoverFromFeed(
     const scopes = new Map<string, RunFeedScope>();
     const rootIds = new Set<string>();
     for (const run of runs.items ?? []) {
-      const feedRootId = run.root_bead_id ?? run.workflow_id ?? null;
-      if (feedRootId !== null) rootIds.add(feedRootId);
+      const rootId = run.root_bead_id ?? run.workflow_id ?? null;
+      if (rootId !== null) rootIds.add(rootId);
       if (run.type !== 'formula') continue;
       const storeScope = fromStoreRef(run.root_store_ref ?? null);
       if (storeScope?.scopeKind === 'rig') {
         rigNames.add(storeScope.scopeRef);
       }
-      const rootId = run.root_bead_id ?? run.workflow_id ?? null;
       // gascity-dashboard-q89b (detail scope leak): the feed's top-level
       // scope_kind is always 'city', so fromFeedScope alone makes a rig lane's
       // detail href drop to city scope — and a city-scoped workflow fetch hits

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -394,7 +394,7 @@ async function loadHistoryBeads(cityName: string, forceFresh: boolean): Promise<
   // gascity-dashboard-uxvk: a COMPLETE feed read is the registration evidence;
   // record when it was taken so the stranded judgment's dispatch grace is
   // anchored to the observation, never to a later clock read.
-  if (!feedDiscovery.partial) {
+  if (!feedDiscovery.partial && feedDiscovery.rootIdsComplete) {
     feedObservationByCity.set(cityName, {
       rootIds: feedDiscovery.rootIds,
       observedAtMs: Date.now(),
@@ -472,6 +472,13 @@ interface FeedDiscovery {
    * still proves the supervisor knows the run.
    */
   rootIds: ReadonlySet<string>;
+  /**
+   * False when any feed item lacked root_bead_id: such an item may cover a
+   * root under a key the bead store never sees (workflow_id), so this read can
+   * prove a root's presence but no longer prove any root's ABSENCE. A stranded
+   * judgment must not be cached from an incomplete root-id set.
+   */
+  rootIdsComplete: boolean;
   partial: boolean;
 }
 
@@ -500,9 +507,11 @@ async function discoverFromFeed(
     const rigNames = new Set<string>();
     const scopes = new Map<string, RunFeedScope>();
     const rootIds = new Set<string>();
+    let rootIdsComplete = true;
     for (const run of runs.items ?? []) {
       const rootId = run.root_bead_id ?? run.workflow_id ?? null;
       if (rootId !== null) rootIds.add(rootId);
+      if (run.root_bead_id == null) rootIdsComplete = false;
       if (run.type !== 'formula') continue;
       const storeScope = fromStoreRef(run.root_store_ref ?? null);
       if (storeScope?.scopeKind === 'rig') {
@@ -533,9 +542,21 @@ async function discoverFromFeed(
         });
       }
     }
-    return { rigNames: [...rigNames], scopes, rootIds, partial: feedIsPartial(runs) };
+    return {
+      rigNames: [...rigNames],
+      scopes,
+      rootIds,
+      rootIdsComplete,
+      partial: feedIsPartial(runs),
+    };
   } catch {
-    return { rigNames: [], scopes: new Map(), rootIds: new Set(), partial: true };
+    return {
+      rigNames: [],
+      scopes: new Map(),
+      rootIds: new Set(),
+      rootIdsComplete: false,
+      partial: true,
+    };
   }
 }
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -87,6 +87,13 @@ const HISTORY_ENRICHMENT_TIMEOUT_MS = 30_000;
 interface LoadedRunBeads {
   beads: DashboardBead[];
   feedScopes: RunFeedScopeMap;
+  /**
+   * Root ids the feed listed in THIS load, regardless of the read's
+   * completeness — a partial or root-incomplete read cannot prove absence,
+   * but it still proves presence for every root it lists. Null when the load
+   * never read the feed (the cheap active source).
+   */
+  feedRootIds: ReadonlySet<string> | null;
   partial: boolean;
 }
 
@@ -155,11 +162,24 @@ export async function loadSupervisorRunSummaryMountSource(): Promise<SourceState
 // (wide refresh, cheap active, preview) derives registration from the same
 // per-city feed observation.
 function citySummary(cityName: string, loaded: LoadedRunBeads): RunSummary {
+  const cached = feedObservationByCity.get(cityName);
+  // Presence overlay (review iter 2): the stranded judgment's ABSENCE evidence
+  // must come from the cached complete observation, but any feed read — even
+  // partial or root-incomplete — proves PRESENCE for the roots it lists. Merge
+  // them in so a stranded lane recovers the moment any read shows the
+  // supervisor knows its root, instead of waiting for the next complete read.
+  const observation =
+    cached !== undefined && loaded.feedRootIds !== null && loaded.feedRootIds.size > 0
+      ? {
+          rootIds: new Set([...cached.rootIds, ...loaded.feedRootIds]),
+          observedAtMs: cached.observedAtMs,
+        }
+      : cached;
   return buildRunSummary(
     loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
     loaded.feedScopes,
     loaded.partial,
-    feedObservationByCity.get(cityName),
+    observation,
   );
 }
 
@@ -247,6 +267,7 @@ async function loadActiveRunBeads(cityName: string, limit: number): Promise<Load
   return {
     beads: active,
     feedScopes: new Map(),
+    feedRootIds: null,
     partial: listIsIncomplete(activeList, active.length),
   };
 }
@@ -432,6 +453,7 @@ async function loadHistoryBeads(cityName: string, forceFresh: boolean): Promise<
   return {
     beads: uniqueBeads([...active, ...recentItems]),
     feedScopes: feedDiscovery.scopes,
+    feedRootIds: feedDiscovery.rootIds,
     partial,
   };
 }

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -4,6 +4,7 @@ import type {
   RunFeedScope,
   RunFeedScopeMap,
   RunHistory,
+  RunRegistryObservation,
   RunSummary,
   SourceAvailableState,
   SourceState,
@@ -102,6 +103,15 @@ interface ProgressState {
 
 const progressStateByCity = new Map<string, ProgressState>();
 
+// gascity-dashboard-uxvk: the last COMPLETE formula-feed observation per city,
+// the evidence behind the stranded-run judgment (orphaned molecule with no
+// supervisor workflow record). Only the wide sources read the feed; caching the
+// observation here lets the cheap SSE-burst source judge lanes off the same
+// evidence instead of flapping every stranded lane back to 'unknown' on each
+// burst. A partial or failed feed read never updates the cache — the last
+// known-good observation keeps serving until a complete read replaces it.
+const feedObservationByCity = new Map<string, RunRegistryObservation>();
+
 // The wide-budget run-summary source (gascity-dashboard-4bol): the wide
 // enrichment budget lets the slow-but-available city feed (measured 14.3s) land
 // and clear the spurious "runs partial" badge (upstream gascity-dashboard#88).
@@ -156,6 +166,7 @@ async function loadRunSummarySource(
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
       loaded.feedScopes,
       loaded.partial,
+      feedObservationByCity.get(cityName),
     );
     const source: SourceAvailableState<RunSummary> = {
       source: 'runs',
@@ -200,6 +211,7 @@ export async function loadSupervisorRunSummaryActiveSource(): Promise<SourceStat
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
       loaded.feedScopes,
       loaded.partial,
+      feedObservationByCity.get(cityName),
     );
     const source: SourceAvailableState<RunSummary> = {
       source: 'runs',
@@ -246,6 +258,7 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
       loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
       loaded.feedScopes,
       loaded.partial,
+      feedObservationByCity.get(cityName),
     );
     return {
       source: 'runs',
@@ -304,6 +317,7 @@ export async function loadSupervisorRunHistorySource(options?: {
 
 export function resetSupervisorRunSummaryStateForTests(): void {
   progressStateByCity.clear();
+  feedObservationByCity.clear();
 }
 
 // Exposed for tests: the raised core-read budget that absorbs a CPU-burst spike.
@@ -380,6 +394,15 @@ async function loadHistoryBeads(cityName: string, forceFresh: boolean): Promise<
     fetchCoreActiveBeads(cityName, RUNS_FETCH_LIMIT),
     discoverFromFeed(cityName, budgetMs, forceFresh),
   ]);
+  // gascity-dashboard-uxvk: a COMPLETE feed read is the registration evidence;
+  // record when it was taken so the stranded judgment's dispatch grace is
+  // anchored to the observation, never to a later clock read.
+  if (!feedDiscovery.partial) {
+    feedObservationByCity.set(cityName, {
+      rootIds: feedDiscovery.rootIds,
+      observedAtMs: Date.now(),
+    });
+  }
   const active = normalizeBeads(activeList.items ?? []);
   const rigNames = unionRigNames(runRigNames(active), feedDiscovery.rigNames);
 
@@ -445,6 +468,13 @@ async function settledRecentFetch(
 interface FeedDiscovery {
   rigNames: string[];
   scopes: RunFeedScopeMap;
+  /**
+   * Every run root id the feed listed, regardless of scope resolvability —
+   * the registration evidence (gascity-dashboard-uxvk). Deliberately a
+   * superset of `scopes` keys: a feed item whose scope cannot be resolved
+   * still proves the supervisor knows the run.
+   */
+  rootIds: ReadonlySet<string>;
   partial: boolean;
 }
 
@@ -472,7 +502,10 @@ async function discoverFromFeed(
     );
     const rigNames = new Set<string>();
     const scopes = new Map<string, RunFeedScope>();
+    const rootIds = new Set<string>();
     for (const run of runs.items ?? []) {
+      const feedRootId = run.root_bead_id ?? run.workflow_id ?? null;
+      if (feedRootId !== null) rootIds.add(feedRootId);
       if (run.type !== 'formula') continue;
       const storeScope = fromStoreRef(run.root_store_ref ?? null);
       if (storeScope?.scopeKind === 'rig') {
@@ -504,9 +537,9 @@ async function discoverFromFeed(
         });
       }
     }
-    return { rigNames: [...rigNames], scopes, partial: feedIsPartial(runs) };
+    return { rigNames: [...rigNames], scopes, rootIds, partial: feedIsPartial(runs) };
   } catch {
-    return { rigNames: [], scopes: new Map(), partial: true };
+    return { rigNames: [], scopes: new Map(), rootIds: new Set(), partial: true };
   }
 }
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -453,7 +453,7 @@ async function loadHistoryBeads(cityName: string, forceFresh: boolean): Promise<
   return {
     beads: uniqueBeads([...active, ...recentItems]),
     feedScopes: feedDiscovery.scopes,
-    feedRootIds: feedDiscovery.rootIds,
+    feedRootIds: feedDiscovery.presenceRootIds,
     partial,
   };
 }
@@ -495,6 +495,13 @@ interface FeedDiscovery {
    */
   rootIds: ReadonlySet<string>;
   /**
+   * Only the authoritative run.root_bead_id values — no workflow_id fallback.
+   * This is the set that may prove a bead root's PRESENCE (the overlay in
+   * citySummary); the broader `rootIds` set above is only ever conservative
+   * (extra ids prevent stranding) and stays confined to the absence evidence.
+   */
+  presenceRootIds: ReadonlySet<string>;
+  /**
    * False when any feed item lacked root_bead_id: such an item may cover a
    * root under a key the bead store never sees (workflow_id), so this read can
    * prove a root's presence but no longer prove any root's ABSENCE. A stranded
@@ -529,11 +536,13 @@ async function discoverFromFeed(
     const rigNames = new Set<string>();
     const scopes = new Map<string, RunFeedScope>();
     const rootIds = new Set<string>();
+    const presenceRootIds = new Set<string>();
     let rootIdsComplete = true;
     for (const run of runs.items ?? []) {
       const rootId = run.root_bead_id ?? run.workflow_id ?? null;
       if (rootId !== null) rootIds.add(rootId);
       if (run.root_bead_id == null) rootIdsComplete = false;
+      else presenceRootIds.add(run.root_bead_id);
       if (run.type !== 'formula') continue;
       const storeScope = fromStoreRef(run.root_store_ref ?? null);
       if (storeScope?.scopeKind === 'rig') {
@@ -568,6 +577,7 @@ async function discoverFromFeed(
       rigNames: [...rigNames],
       scopes,
       rootIds,
+      presenceRootIds,
       rootIdsComplete,
       partial: feedIsPartial(runs),
     };
@@ -576,6 +586,7 @@ async function discoverFromFeed(
       rigNames: [],
       scopes: new Map(),
       rootIds: new Set(),
+      presenceRootIds: new Set(),
       rootIdsComplete: false,
       partial: true,
     };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -16,5 +16,18 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     globals: false,
     setupFiles: ['src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      // Ratchet floor, not aspiration: thresholds sit ~5 points below the
+      // measured baseline (89.02 lines / 77.12 branches / 86.4 stmts /
+      // 87.1 funcs as of 2026-06). Raise them as real coverage rises;
+      // never lower them to admit a regression.
+      thresholds: {
+        lines: 84,
+        branches: 72,
+        statements: 81,
+        functions: 82,
+      },
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.8",
         "autoprefixer": "^10.4.20",
         "jsdom": "^29.1.1",
         "postcss": "^8.4.47",
@@ -312,7 +313,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -322,7 +323,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -356,7 +357,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -416,7 +417,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -424,6 +425,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -626,6 +637,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -643,6 +655,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -660,6 +673,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -677,6 +691,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -694,6 +709,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -711,6 +727,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -728,6 +745,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -745,6 +763,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -762,6 +781,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -779,6 +799,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -796,6 +817,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -813,6 +835,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -830,6 +853,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -847,6 +871,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -864,6 +889,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -881,6 +907,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -898,6 +925,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -915,6 +943,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -932,6 +961,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -949,6 +979,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -966,6 +997,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -983,6 +1015,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1000,6 +1033,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1017,6 +1051,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1034,6 +1069,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1051,6 +1087,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1657,9 +1694,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,9 +1711,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,9 +1728,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1717,9 +1745,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,9 +1762,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1757,9 +1779,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2372,6 +2391,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -2816,6 +2866,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -4913,6 +4982,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5497,6 +5573,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5823,9 +5938,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5847,9 +5959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5871,9 +5980,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5895,9 +6001,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6043,6 +6146,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7650,7 +7781,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/scripts/snap-formula-run-detail.mjs
+++ b/scripts/snap-formula-run-detail.mjs
@@ -275,7 +275,10 @@ async function runTheme(browser, theme) {
       waitUntil: 'domcontentloaded',
       timeout: 5_000,
     });
-    await page.getByText(/run is not a graph\.v2 run/i).waitFor({ timeout: 5_000 });
+    // gascity-dashboard-9w3k: a snapshot that loads but has no graph is the
+    // reliable v1/wisp signal; the page renders the honest list-only copy, not
+    // the raw UnsupportedRunError text.
+    await page.getByText(/v1\/wisp runs are list-only/i).waitFor({ timeout: 5_000 });
 
     await page.goto(`${CITY_BASE}/runs/gc-not-git`, {
       waitUntil: 'domcontentloaded',
@@ -813,6 +816,14 @@ function sessionListFixture() {
   };
 }
 
+// The lane root's recency is load-bearing, not cosmetic: the run-summary
+// pipeline demotes a session-less lane with no in_progress step once its last
+// write is older than STALE_LATCH_AFTER_MS (24h, gascity-dashboard-s4rp). A
+// pinned absolute date rots past that window and silently empties the Active
+// set, timing the whole journey out at the first click — so the fixture is
+// stamped relative to the run.
+const FIXTURE_LANE_UPDATED_AT = new Date(Date.now() - 5 * 60_000).toISOString();
+
 function runRootBeadFixture() {
   return {
     id: 'gc-adopt-pr-active',
@@ -820,8 +831,8 @@ function runRootBeadFixture() {
     status: 'in_progress',
     issue_type: 'molecule',
     priority: null,
-    created_at: '2026-05-25T00:00:00.000Z',
-    updated_at: '2026-05-25T00:00:00.000Z',
+    created_at: FIXTURE_LANE_UPDATED_AT,
+    updated_at: FIXTURE_LANE_UPDATED_AT,
     metadata: {
       'gc.kind': 'run',
       'gc.formula': 'mol-adopt-pr-v2',

--- a/shared/src/runs/blocked.test.ts
+++ b/shared/src/runs/blocked.test.ts
@@ -25,6 +25,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: { status: 'unavailable', error: 'run health has not been derived' },
     ...overrides,
   };

--- a/shared/src/runs/blocked.test.ts
+++ b/shared/src/runs/blocked.test.ts
@@ -25,7 +25,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: { status: 'unavailable', error: 'run health has not been derived' },
     ...overrides,
   };

--- a/shared/src/runs/health.test.ts
+++ b/shared/src/runs/health.test.ts
@@ -26,6 +26,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: { status: 'unavailable', error: 'run health has not been derived' },
     ...overrides,
   };

--- a/shared/src/runs/health.test.ts
+++ b/shared/src/runs/health.test.ts
@@ -26,7 +26,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: { status: 'unavailable', error: 'run health has not been derived' },
     ...overrides,
   };

--- a/shared/src/runs/liveness.test.ts
+++ b/shared/src/runs/liveness.test.ts
@@ -61,7 +61,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
-    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
+    registration: 'unknown',
     health: health('unresolved'),
     ...overrides,
   };

--- a/shared/src/runs/liveness.test.ts
+++ b/shared/src/runs/liveness.test.ts
@@ -272,6 +272,27 @@ describe('isStrandedRun — gascity-dashboard-uxvk', () => {
     assert.equal(isStrandedRun('gc-floor', groupInside, observation([])), false);
   });
 
+  test('cased/padded open step spellings still read as zero progress → stranded', () => {
+    // The supervisor wire is not case/trim-guaranteed (status.ts). A raw
+    // !== 'open' check would treat ' Open '/'OPEN' as advanced and wrongly clear
+    // the stranded judgment; isOpenStatus normalizes, so the orphan still strands.
+    const group = [
+      orphanRoot('gc-cased'),
+      orphanStep('gc-cased', 'read-issue', ' Open '),
+      orphanStep('gc-cased', 'plan-implementation', 'OPEN'),
+    ];
+    assert.equal(isStrandedRun('gc-cased', group, observation([])), true);
+  });
+
+  test('a cased/padded non-open step (advanced) still clears stranding', () => {
+    const group = [
+      orphanRoot('gc-adv'),
+      orphanStep('gc-adv', 'read-issue', ' Closed '),
+      orphanStep('gc-adv', 'plan-implementation', 'open'),
+    ];
+    assert.equal(isStrandedRun('gc-adv', group, observation([])), false);
+  });
+
   test('age is judged off the most recent bead write in the group', () => {
     // Root is old, but a step bead was written recently (e.g. a metadata
     // refresh): the group is not conclusively abandoned yet.

--- a/shared/src/runs/liveness.test.ts
+++ b/shared/src/runs/liveness.test.ts
@@ -1,7 +1,14 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isDanglingRootGroup, isStaleSessionlessLatch, STALE_LATCH_AFTER_MS } from './liveness.js';
+import {
+  isDanglingRootGroup,
+  isStaleSessionlessLatch,
+  isStrandedRun,
+  STALE_LATCH_AFTER_MS,
+  STRANDED_DISPATCH_GRACE_MS,
+  type RunRegistryObservation,
+} from './liveness.js';
 import type { RunIssue } from './phaseMapping.js';
 import type { RunLane, RunLaneHealth } from '../snapshot/types.js';
 
@@ -54,6 +61,7 @@ function lane(overrides: Partial<RunLane> = {}): RunLane {
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
+    registration: { status: 'unknown', error: 'supervisor formula feed not observed' },
     health: health('unresolved'),
     ...overrides,
   };
@@ -149,5 +157,130 @@ describe('isDanglingRootGroup — gascity-dashboard-s4rp', () => {
       isDanglingRootGroup('gc-1920', [issue('gc-1920'), issue('gc-1920-step-1')]),
       false,
     );
+  });
+});
+
+// gascity-dashboard-uxvk: an orphaned molecule — its bead graph persisted in
+// the rig store but the supervisor's workflow registry has NO entry (the
+// gc-odssky repro: dispatched during a supervisor orphan-PID crash-loop, every
+// step child still open, absent from a COMPLETE formula feed). Such a run never
+// executed and never will; it must read as stranded, not live. The predicate
+// must NOT strand: a run the feed knows, a run with any step progress (it
+// executed; feed absence just means it aged out of the feed window), a freshly
+// dispatched run racing the feed read, or a group with no step graph to judge.
+describe('isStrandedRun — gascity-dashboard-uxvk', () => {
+  const OBSERVED_AT_MS = Date.parse('2026-06-12T08:20:00.000Z');
+  // The repro dispatch time: ~7h before the feed observation.
+  const DISPATCHED_AT = '2026-06-12T01:20:05.000Z';
+
+  function orphanRoot(id: string, overrides: Partial<RunIssue> = {}): RunIssue {
+    return {
+      id,
+      title: 'mol-pr-start: gascity issue #3192',
+      status: 'open',
+      issue_type: 'molecule',
+      updated_at: DISPATCHED_AT,
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+      ...overrides,
+    };
+  }
+
+  function orphanStep(
+    rootId: string,
+    stepId: string,
+    status = 'open',
+    overrides: Partial<RunIssue> = {},
+  ): RunIssue {
+    return {
+      id: `${rootId}-${stepId}`,
+      title: stepId,
+      status,
+      issue_type: 'task',
+      updated_at: DISPATCHED_AT,
+      metadata: { 'gc.kind': 'step', 'gc.root_bead_id': rootId, 'gc.step_id': stepId },
+      ...overrides,
+    };
+  }
+
+  function observation(rootIds: string[]): RunRegistryObservation {
+    return { rootIds: new Set(rootIds), observedAtMs: OBSERVED_AT_MS };
+  }
+
+  function orphanGroup(id: string): RunIssue[] {
+    return [
+      orphanRoot(id),
+      orphanStep(id, 'read-issue'),
+      orphanStep(id, 'plan-implementation'),
+      orphanStep(id, 'conventions-audit'),
+    ];
+  }
+
+  test('zero step progress + absent from a complete feed + past the grace → stranded', () => {
+    assert.equal(isStrandedRun('gc-odssky', orphanGroup('gc-odssky'), observation([])), true);
+  });
+
+  test('a run present in the feed observation is never stranded', () => {
+    assert.equal(
+      isStrandedRun('gc-odssky', orphanGroup('gc-odssky'), observation(['gc-odssky'])),
+      false,
+    );
+  });
+
+  test('a freshly dispatched run inside the grace window is not stranded', () => {
+    const recent = new Date(OBSERVED_AT_MS - 60_000).toISOString();
+    const group = [
+      orphanRoot('gc-fresh', { updated_at: recent }),
+      orphanStep('gc-fresh', 'read-issue', 'open', { updated_at: recent }),
+    ];
+    assert.equal(isStrandedRun('gc-fresh', group, observation([])), false);
+  });
+
+  test('a run with a closed step executed; feed absence is not stranding', () => {
+    const group = [
+      orphanRoot('gc-old'),
+      orphanStep('gc-old', 'read-issue', 'closed'),
+      orphanStep('gc-old', 'plan-implementation', 'open'),
+    ];
+    assert.equal(isStrandedRun('gc-old', group, observation([])), false);
+  });
+
+  test('a run with an in_progress step is live, not stranded', () => {
+    const group = [
+      orphanRoot('gc-live'),
+      orphanStep('gc-live', 'read-issue', 'in_progress'),
+      orphanStep('gc-live', 'plan-implementation', 'open'),
+    ];
+    assert.equal(isStrandedRun('gc-live', group, observation([])), false);
+  });
+
+  test('a group with no step beads cannot be judged → not stranded', () => {
+    assert.equal(isStrandedRun('gc-bare', [orphanRoot('gc-bare')], observation([])), false);
+  });
+
+  test('the grace boundary is inclusive at the floor', () => {
+    const atFloor = new Date(OBSERVED_AT_MS - STRANDED_DISPATCH_GRACE_MS).toISOString();
+    const justInside = new Date(OBSERVED_AT_MS - STRANDED_DISPATCH_GRACE_MS + 1_000).toISOString();
+    const groupAt = [
+      orphanRoot('gc-floor', { updated_at: atFloor }),
+      orphanStep('gc-floor', 'read-issue', 'open', { updated_at: atFloor }),
+    ];
+    const groupInside = [
+      orphanRoot('gc-floor', { updated_at: justInside }),
+      orphanStep('gc-floor', 'read-issue', 'open', { updated_at: justInside }),
+    ];
+    assert.equal(isStrandedRun('gc-floor', groupAt, observation([])), true);
+    assert.equal(isStrandedRun('gc-floor', groupInside, observation([])), false);
+  });
+
+  test('age is judged off the most recent bead write in the group', () => {
+    // Root is old, but a step bead was written recently (e.g. a metadata
+    // refresh): the group is not conclusively abandoned yet.
+    const group = [
+      orphanRoot('gc-mixed'),
+      orphanStep('gc-mixed', 'read-issue', 'open', {
+        updated_at: new Date(OBSERVED_AT_MS - 60_000).toISOString(),
+      }),
+    ];
+    assert.equal(isStrandedRun('gc-mixed', group, observation([])), false);
   });
 });

--- a/shared/src/runs/liveness.ts
+++ b/shared/src/runs/liveness.ts
@@ -1,4 +1,4 @@
-import type { RunIssue } from './phaseMapping.js';
+import { isPrimaryStepIssue, stringValue, type RunIssue } from './phaseMapping.js';
 import type { RunLane } from '../snapshot/types.js';
 
 // gascity-dashboard-s4rp: a run can be echoed by the supervisor long after it
@@ -71,4 +71,67 @@ function laneSessionResolved(lane: RunLane): boolean {
  */
 export function isDanglingRootGroup(rootId: string, issues: readonly RunIssue[]): boolean {
   return !issues.some((issue) => issue.id === rootId);
+}
+
+// gascity-dashboard-uxvk: an orphaned molecule. The operator repro is
+// gc-odssky — dispatched during a supervisor orphan-PID crash-loop, so the
+// molecule bead graph persisted in the rig store but the supervisor's workflow
+// registry has NO entry (workflow detail 404, absent from a complete formula
+// feed) and every step child is still open: the run NEVER EXECUTED and never
+// will. Built from beads alone it rendered as a live lane with a stage and a
+// relative time — a false-alive signal the operator cannot distinguish from a
+// working run.
+
+/**
+ * The supervisor-registry side of the stranded judgment: the set of run root
+ * ids present in a COMPLETE formula-feed read, and when that read was taken.
+ * `observedAtMs` is the age reference for {@link STRANDED_DISPATCH_GRACE_MS} —
+ * judging a run's age against the observation that failed to list it (rather
+ * than a live clock) means a cached observation can never strand a run that
+ * was dispatched after it was taken.
+ */
+export interface RunRegistryObservation {
+  rootIds: ReadonlySet<string>;
+  observedAtMs: number;
+}
+
+/**
+ * Dispatch grace: a run is only judged stranded once its last bead write is at
+ * least this much older than the feed observation that lacks it. Registration
+ * normally follows bead creation within seconds; the race a grace must absorb
+ * is one refresh cycle (the bead read and the feed read run concurrently,
+ * ≤60s apart). Ten minutes is an order of magnitude above that race and far
+ * below the hours-old scale at which an operator meets a stranded run.
+ */
+export const STRANDED_DISPATCH_GRACE_MS = 10 * 60 * 1000;
+
+/**
+ * True when a run group is conclusively stranded: it has a structured step
+ * graph with ZERO progress (every primary gc.step_id carrier still open), the
+ * supervisor's formula feed — read completely — does not know its root, and
+ * its last bead write predates that observation by the dispatch grace. Any
+ * weaker evidence returns false: a run with step progress executed (feed
+ * absence just means it aged out of the feed window), and a group without a
+ * step graph offers no never-executed signal to judge.
+ */
+export function isStrandedRun(
+  rootId: string,
+  issues: readonly RunIssue[],
+  observation: RunRegistryObservation,
+): boolean {
+  if (observation.rootIds.has(rootId)) return false;
+
+  const stepCarriers = issues.filter(
+    (issue) => isPrimaryStepIssue(issue) && stringValue(issue.metadata?.['gc.step_id']) !== '',
+  );
+  if (stepCarriers.length === 0) return false;
+  if (stepCarriers.some((issue) => issue.status !== 'open')) return false;
+
+  const lastWriteMs = issues
+    .map((issue) => Date.parse(issue.updated_at))
+    .filter((ms) => Number.isFinite(ms))
+    .reduce((latest, ms) => Math.max(latest, ms), Number.NEGATIVE_INFINITY);
+  if (!Number.isFinite(lastWriteMs)) return false;
+
+  return observation.observedAtMs - lastWriteMs >= STRANDED_DISPATCH_GRACE_MS;
 }

--- a/shared/src/runs/liveness.ts
+++ b/shared/src/runs/liveness.ts
@@ -1,4 +1,5 @@
 import { stepIdCarriers, type RunIssue } from './phaseMapping.js';
+import { isOpenStatus } from './status.js';
 import type { RunLane } from '../snapshot/types.js';
 
 // gascity-dashboard-s4rp: a run can be echoed by the supervisor long after it
@@ -133,7 +134,12 @@ export function isStrandedRun(
 
   const stepCarriers = stepIdCarriers(issues);
   if (stepCarriers.length === 0) return false;
-  if (stepCarriers.some((issue) => issue.status !== 'open')) return false;
+  // isOpenStatus (not a raw !== 'open'): the supervisor wire is not
+  // case/trim-guaranteed (status.ts), so any advanced step — including a
+  // cased/padded non-open spelling — must disable stranding; a raw compare
+  // would wrongly read a ' Closed ' step as "still open" and strand a
+  // progressed run (gascity-dashboard-uxvk).
+  if (stepCarriers.some((issue) => !isOpenStatus(issue.status))) return false;
 
   const lastWriteMs = issues
     .map((issue) => Date.parse(issue.updated_at))

--- a/shared/src/runs/liveness.ts
+++ b/shared/src/runs/liveness.ts
@@ -1,4 +1,4 @@
-import { isPrimaryStepIssue, stringValue, type RunIssue } from './phaseMapping.js';
+import { stepIdCarriers, type RunIssue } from './phaseMapping.js';
 import type { RunLane } from '../snapshot/types.js';
 
 // gascity-dashboard-s4rp: a run can be echoed by the supervisor long after it
@@ -113,6 +113,13 @@ export const STRANDED_DISPATCH_GRACE_MS = 10 * 60 * 1000;
  * weaker evidence returns false: a run with step progress executed (feed
  * absence just means it aged out of the feed window), and a group without a
  * step graph offers no never-executed signal to judge.
+ *
+ * Precedence vs {@link isStaleSessionlessLatch}: a stranded lane is sessionless
+ * with no in_progress step, so once its last write ages past
+ * {@link STALE_LATCH_AFTER_MS} the latch demotes it out of the Active set like
+ * any other abandoned lane. Deliberate — the stranded card is an operator
+ * prompt while the orphan is recent; a day-old orphan leaves the board with
+ * the rest of the stale latches rather than accumulating forever.
  */
 export function isStrandedRun(
   rootId: string,
@@ -121,9 +128,7 @@ export function isStrandedRun(
 ): boolean {
   if (observation.rootIds.has(rootId)) return false;
 
-  const stepCarriers = issues.filter(
-    (issue) => isPrimaryStepIssue(issue) && stringValue(issue.metadata?.['gc.step_id']) !== '',
-  );
+  const stepCarriers = stepIdCarriers(issues);
   if (stepCarriers.length === 0) return false;
   if (stepCarriers.some((issue) => issue.status !== 'open')) return false;
 

--- a/shared/src/runs/liveness.ts
+++ b/shared/src/runs/liveness.ts
@@ -112,7 +112,10 @@ export const STRANDED_DISPATCH_GRACE_MS = 10 * 60 * 1000;
  * its last bead write predates that observation by the dispatch grace. Any
  * weaker evidence returns false: a run with step progress executed (feed
  * absence just means it aged out of the feed window), and a group without a
- * step graph offers no never-executed signal to judge.
+ * step graph offers no never-executed signal to judge. A group whose
+ * timestamps are all unparsable (e.g. the run-detail snapshot adapter blanks
+ * every updated_at) has no age to hold against the grace and is likewise
+ * unjudgeable — never stranded.
  *
  * Precedence vs {@link isStaleSessionlessLatch}: a stranded lane is sessionless
  * with no in_progress step, so once its last write ages past

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1199,10 +1199,13 @@ describe('mapRunPhase — zero step progress never invents a mid-run phase (gasc
       step('z3-s1', 'implement-change', 'closed'),
       step('z3-s2', 'code-review-loop', 'open'),
     ]);
-    // Not zero progress: the deterministic furthest pick stays as pinned by the
-    // Major 3 suite (review here, since the open review step outranks the
-    // closed implementation step).
-    assert.equal(phase.phase, 'review');
+    // Not zero progress (one step closed), so the intake clamp does NOT fire and
+    // the run falls through to the normal furthest-stage pick. Under the M2 audit
+    // only ADVANCED steps rank (hasAdvanced = in-flight | resolved), so the OPEN
+    // review step is not counted and the closed implementation step is the
+    // furthest advanced → implementation. The guard here is that the clamp does
+    // not hijack a progressed run to intake.
+    assert.equal(phase.phase, 'implementation');
   });
 
   test('an in_progress step always wins over the zero-progress clamp', () => {

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1172,6 +1172,18 @@ describe('mapRunPhase — zero step progress never invents a mid-run phase (gasc
     assert.equal(phase.phase, 'intake');
   });
 
+  test('a live run whose approval-vocabulary first step is untouched also reads intake', () => {
+    // The clamp is registration-agnostic by design: zero progress means intake
+    // for registered runs too, not only orphans — without it this graph read
+    // as 'approval' before any step was picked up.
+    const phase = mapRunPhase([
+      root({ id: 'z4' }),
+      step('z4-s1', 'approve-fix-plan', 'open'),
+      step('z4-s2', 'human-approval', 'open'),
+    ]);
+    assert.equal(phase.phase, 'intake');
+  });
+
   test('an in_progress root bead with all steps open is still zero step progress → intake', () => {
     const phase = mapRunPhase([
       root({ id: 'z2', status: 'in_progress' }),

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1193,6 +1193,18 @@ describe('mapRunPhase — zero step progress never invents a mid-run phase (gasc
     assert.equal(phase.phase, 'intake');
   });
 
+  test('cased/padded open step spellings still count as zero progress → intake', () => {
+    // The supervisor wire is not case/trim-guaranteed (status.ts). A raw
+    // === 'open' clamp would let a ' Open '/'OPEN' orphan slip into a
+    // live-looking phase; isOpenStatus normalizes, so it stays intake.
+    const phase = mapRunPhase([
+      root({ id: 'z5' }),
+      step('z5-s1', 'read-issue', ' Open '),
+      step('z5-s2', 'plan-implementation', 'OPEN'),
+    ]);
+    assert.equal(phase.phase, 'intake');
+  });
+
   test('a single closed step among open ones keeps the existing furthest-stage pick', () => {
     const phase = mapRunPhase([
       root({ id: 'z3' }),

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1148,3 +1148,57 @@ describe('isPrimaryStepIssue — control constructs are not primary steps', () =
     assert.equal(isPrimaryStepIssue(issueWithKind('run-finalize')), false);
   });
 });
+
+// gascity-dashboard-uxvk: an orphaned molecule (dispatched during a supervisor
+// crash-loop, never registered, never executed) carries a full graph of OPEN
+// step beads. The furthest-stage fallback ran over ALL step-id carriers — open
+// ones included — so a run with ZERO step progress read as a mid-run phase
+// (gc-odssky surfaced as "implementation" with every step still open). With no
+// in_progress step and no closed step there is no progress signal at all; the
+// run is at its start, so it must read as intake, never a later stage.
+describe('mapRunPhase — zero step progress never invents a mid-run phase (gascity-dashboard-uxvk)', () => {
+  test('all step beads open (never executed) → intake, not implementation or review', () => {
+    // The gc-odssky shape: a planning-phase step graph, entirely open.
+    const phase = mapRunPhase([
+      root({ id: 'z1' }),
+      step('z1-s1', 'read-issue', 'open'),
+      step('z1-s2', 'plan-implementation', 'open'),
+      step('z1-s3', 'conventions-audit', 'open'),
+      step('z1-s4', 'blast-radius', 'open'),
+      step('z1-s5', 'plan-gates', 'open'),
+    ]);
+    assert.notEqual(phase.phase, 'implementation');
+    assert.notEqual(phase.phase, 'review');
+    assert.equal(phase.phase, 'intake');
+  });
+
+  test('an in_progress root bead with all steps open is still zero step progress → intake', () => {
+    const phase = mapRunPhase([
+      root({ id: 'z2', status: 'in_progress' }),
+      step('z2-s1', 'plan-implementation', 'open'),
+      step('z2-s2', 'conventions-audit', 'open'),
+    ]);
+    assert.equal(phase.phase, 'intake');
+  });
+
+  test('a single closed step among open ones keeps the existing furthest-stage pick', () => {
+    const phase = mapRunPhase([
+      root({ id: 'z3' }),
+      step('z3-s1', 'implement-change', 'closed'),
+      step('z3-s2', 'code-review-loop', 'open'),
+    ]);
+    // Not zero progress: the deterministic furthest pick stays as pinned by the
+    // Major 3 suite (review here, since the open review step outranks the
+    // closed implementation step).
+    assert.equal(phase.phase, 'review');
+  });
+
+  test('an in_progress step always wins over the zero-progress clamp', () => {
+    const phase = mapRunPhase([
+      root({ id: 'z4' }),
+      step('z4-s1', 'implement-change', 'in_progress'),
+      step('z4-s2', 'code-review-loop', 'open'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+});

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -102,6 +102,20 @@ export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
 function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   const primary = issues.filter(isPrimaryStepIssue);
   const inProgressStep = latestStepId(primary.filter((i) => isInFlightStatus(i.status)));
+  // gascity-dashboard-uxvk: ZERO step progress — every gc.step_id carrier is
+  // still open (none in flight, none closed). The furthest-stage pick below
+  // runs over ALL carriers, open ones included, so a never-executed run (the
+  // orphaned-molecule repro gc-odssky, all six step children open) would read
+  // as whatever mid-run stage its step VOCABULARY ranks highest. With no
+  // progress signal at all the run is at its start: intake, never a later
+  // stage. Any non-open carrier (closed, blocked, unknown) disables the clamp
+  // and falls through to the existing pinned derivation.
+  if (inProgressStep === null) {
+    const carriers = primary.filter((i) => stringValue(i.metadata?.['gc.step_id']) !== '');
+    if (carriers.length > 0 && carriers.every((i) => i.status === 'open')) {
+      return { phase: 'intake', label: 'intake', reviewRound: null };
+    }
+  }
   // gascity-dashboard (Major 3): when no step is in flight, the current step
   // is the FURTHEST-ADVANCED step by stage rank — a deterministic, order- and
   // timestamp-independent signal. The run-detail snapshot adapter sets every

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -22,6 +22,7 @@ import {
   isClosedStatus,
   isFailedStatus,
   isInFlightStatus,
+  isOpenStatus,
   isResolvedStatus,
   isSkippedStatus,
 } from './status.js';
@@ -112,7 +113,11 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   // and falls through to the existing pinned derivation.
   if (inProgressStep === null) {
     const carriers = stepIdCarriers(primary);
-    if (carriers.length > 0 && carriers.every((i) => i.status === 'open')) {
+    // isOpenStatus (not a raw === 'open') so a cased/padded wire spelling
+    // ('Open', ' open ') still counts as zero progress — the supervisor wire is
+    // not case/trim-guaranteed (status.ts), and a raw compare would let such an
+    // orphan slip past the clamp into a live-looking phase (gascity-dashboard-uxvk).
+    if (carriers.length > 0 && carriers.every((i) => isOpenStatus(i.status))) {
       return { phase: 'intake', label: 'intake', reviewRound: null };
     }
   }

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -111,7 +111,7 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   // stage. Any non-open carrier (closed, blocked, unknown) disables the clamp
   // and falls through to the existing pinned derivation.
   if (inProgressStep === null) {
-    const carriers = primary.filter((i) => stringValue(i.metadata?.['gc.step_id']) !== '');
+    const carriers = stepIdCarriers(primary);
     if (carriers.length > 0 && carriers.every((i) => i.status === 'open')) {
       return { phase: 'intake', label: 'intake', reviewRound: null };
     }
@@ -942,5 +942,18 @@ export function isPrimaryStepIssue(issue: RunIssue): boolean {
     kind !== 'scope-check' &&
     kind !== 'workflow-finalize' &&
     kind !== 'run-finalize'
+  );
+}
+
+/**
+ * The run's structured step graph: primary step issues carrying a non-empty
+ * gc.step_id. This is the SINGLE definition of the carrier set behind the
+ * "zero step progress" fact (gascity-dashboard-uxvk) — the intake phase clamp
+ * and isStrandedRun must judge the same issues or a stranded lane could stop
+ * reading as intake (and vice versa).
+ */
+export function stepIdCarriers(issues: readonly RunIssue[]): RunIssue[] {
+  return issues.filter(
+    (issue) => isPrimaryStepIssue(issue) && stringValue(issue.metadata?.['gc.step_id']) !== '',
   );
 }

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -772,7 +772,7 @@ describe('buildRunSummary — orphaned molecules carry a stranded registration (
     const summary = buildRunSummary(orphanGroup('gc-odssky'), new Map(), false, observation([]));
     const lane = summary.lanes.find((l) => l.id === 'gc-odssky');
     assert.ok(lane);
-    assert.deepEqual(lane.registration, { status: 'stranded' });
+    assert.equal(lane.registration, 'stranded');
     // The false-alive part of the repro: the orphan must never read as a
     // mid-run stage.
     assert.equal(lane.phase, 'intake');
@@ -788,14 +788,14 @@ describe('buildRunSummary — orphaned molecules carry a stranded registration (
     );
     const lane = summary.lanes.find((l) => l.id === 'gc-known');
     assert.ok(lane);
-    assert.deepEqual(lane.registration, { status: 'registered' });
+    assert.equal(lane.registration, 'registered');
   });
 
   test('no feed observation → registration unknown, lane renders as before', () => {
     const summary = buildRunSummary(orphanGroup('gc-blind'));
     const lane = summary.lanes.find((l) => l.id === 'gc-blind');
     assert.ok(lane);
-    assert.equal(lane.registration.status, 'unknown');
+    assert.equal(lane.registration, 'unknown');
   });
 
   test('a progressed run absent from the observation is unknown, not stranded', () => {
@@ -804,6 +804,6 @@ describe('buildRunSummary — orphaned molecules carry a stranded registration (
     const summary = buildRunSummary(group, new Map(), false, observation([]));
     const lane = summary.lanes.find((l) => l.id === 'gc-aged');
     assert.ok(lane);
-    assert.equal(lane.registration.status, 'unknown');
+    assert.equal(lane.registration, 'unknown');
   });
 });

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -719,3 +719,91 @@ describe('statusCounts — canonical key normalization (PR #124)', () => {
     assert.equal(counts['Blocked'], undefined);
   });
 });
+
+// gascity-dashboard-uxvk: the Runs view builds rows from rig-store molecule
+// root beads, so an orphaned molecule (bead graph persisted, supervisor
+// workflow registry has NO entry, zero step progress — the gc-odssky repro)
+// rendered as a LIVE run with a stage and a relative time. The lane builder now
+// carries an explicit registration fact derived from the last COMPLETE
+// supervisor formula-feed observation, so the UI can render the stranded state
+// instead of a live stage.
+describe('buildRunSummary — orphaned molecules carry a stranded registration (gascity-dashboard-uxvk)', () => {
+  const OBSERVED_AT_MS = Date.parse('2026-06-12T08:20:00.000Z');
+  const DISPATCHED_AT = '2026-06-12T01:20:05.000Z';
+
+  function orphanGroup(id: string): RunIssue[] {
+    return [
+      {
+        id,
+        title: 'mol-pr-start: gascity issue #3192',
+        status: 'open',
+        issue_type: 'molecule',
+        updated_at: DISPATCHED_AT,
+        metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+      },
+      {
+        id: `${id}-s1`,
+        title: 'read issue',
+        status: 'open',
+        issue_type: 'task',
+        updated_at: DISPATCHED_AT,
+        metadata: { 'gc.kind': 'step', 'gc.root_bead_id': id, 'gc.step_id': 'read-issue' },
+      },
+      {
+        id: `${id}-s2`,
+        title: 'plan implementation',
+        status: 'open',
+        issue_type: 'task',
+        updated_at: DISPATCHED_AT,
+        metadata: {
+          'gc.kind': 'step',
+          'gc.root_bead_id': id,
+          'gc.step_id': 'plan-implementation',
+        },
+      },
+    ];
+  }
+
+  function observation(rootIds: string[]) {
+    return { rootIds: new Set(rootIds), observedAtMs: OBSERVED_AT_MS };
+  }
+
+  test('absent from a complete feed observation → registration stranded', () => {
+    const summary = buildRunSummary(orphanGroup('gc-odssky'), new Map(), false, observation([]));
+    const lane = summary.lanes.find((l) => l.id === 'gc-odssky');
+    assert.ok(lane);
+    assert.deepEqual(lane.registration, { status: 'stranded' });
+    // The false-alive part of the repro: the orphan must never read as a
+    // mid-run stage.
+    assert.equal(lane.phase, 'intake');
+    assert.notEqual(lane.phaseLabel.toLowerCase(), 'implementation');
+  });
+
+  test('present in the feed observation → registered', () => {
+    const summary = buildRunSummary(
+      orphanGroup('gc-known'),
+      new Map(),
+      false,
+      observation(['gc-known']),
+    );
+    const lane = summary.lanes.find((l) => l.id === 'gc-known');
+    assert.ok(lane);
+    assert.deepEqual(lane.registration, { status: 'registered' });
+  });
+
+  test('no feed observation → registration unknown, lane renders as before', () => {
+    const summary = buildRunSummary(orphanGroup('gc-blind'));
+    const lane = summary.lanes.find((l) => l.id === 'gc-blind');
+    assert.ok(lane);
+    assert.equal(lane.registration.status, 'unknown');
+  });
+
+  test('a progressed run absent from the observation is unknown, not stranded', () => {
+    const group = orphanGroup('gc-aged');
+    group[1] = { ...group[1]!, status: 'closed' };
+    const summary = buildRunSummary(group, new Map(), false, observation([]));
+    const lane = summary.lanes.find((l) => l.id === 'gc-aged');
+    assert.ok(lane);
+    assert.equal(lane.registration.status, 'unknown');
+  });
+});

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -9,7 +9,7 @@ import type {
 import { fromRootMetadataScope } from '../run-scope.js';
 import { stripNonPrintable } from '../strip-non-printable.js';
 import { resolveRunFormulaIdentity } from './formula-name.js';
-import { isDanglingRootGroup } from './liveness.js';
+import { isDanglingRootGroup, isStrandedRun, type RunRegistryObservation } from './liveness.js';
 import {
   baseStepId,
   isPrimaryStepIssue,
@@ -57,6 +57,11 @@ export function buildRunSummary(
   issues: RunIssue[],
   feedScopes: RunFeedScopeMap = new Map(),
   partial = false,
+  // gascity-dashboard-uxvk: the last COMPLETE formula-feed observation, used
+  // to mark orphaned molecules (no supervisor workflow record) as stranded.
+  // Omitted (feed never read completely) → every lane's registration is
+  // 'unknown' — a feed outage must never strand the whole board.
+  registry?: RunRegistryObservation,
 ): RunSummary {
   const { laneIssues, sortedLanes } = buildSortedRunLanes(issues, feedScopes);
 
@@ -138,7 +143,7 @@ function buildSortedRunLanes(
   );
   const laneIssues = runGroups.flatMap(([, groupIssues]) => groupIssues);
   const sortedLanes = runGroups
-    .map(([rootId, groupIssues]) => runLane(rootId, groupIssues, feedScopes))
+    .map(([rootId, groupIssues]) => runLane(rootId, groupIssues, feedScopes, registry))
     .sort(compareLanes);
   return { laneIssues, sortedLanes };
 }
@@ -209,7 +214,12 @@ export function runKind(
   return 'other';
 }
 
-export function runLane(rootId: string, issues: RunIssue[], feedScopes: RunFeedScopeMap): RunLane {
+export function runLane(
+  rootId: string,
+  issues: RunIssue[],
+  feedScopes: RunFeedScopeMap,
+  registry?: RunRegistryObservation,
+): RunLane {
   const phase = mapRunPhase(issues);
   const updatedAt = latestUpdatedAt(issues);
   const formula = runFormula(rootId, issues);
@@ -252,6 +262,31 @@ export function runLane(rootId: string, issues: RunIssue[], feedScopes: RunFeedS
     progress,
     formulaStageResolved,
     health: runHealthUnavailable(),
+    registration: runRegistration(rootId, issues, registry),
+  };
+}
+
+// gascity-dashboard-uxvk: tri-state on purpose. 'stranded' needs the strong
+// evidence isStrandedRun demands; everything weaker is an explicit 'unknown'
+// rather than a guessed 'registered', so consumers can never treat a feed gap
+// as a confirmation either way.
+function runRegistration(
+  rootId: string,
+  issues: RunIssue[],
+  registry?: RunRegistryObservation,
+): RunLane['registration'] {
+  if (registry === undefined) {
+    return { status: 'unknown', error: 'supervisor formula feed not observed' };
+  }
+  if (registry.rootIds.has(rootId)) {
+    return { status: 'registered' };
+  }
+  if (isStrandedRun(rootId, issues, registry)) {
+    return { status: 'stranded' };
+  }
+  return {
+    status: 'unknown',
+    error: 'run absent from the supervisor formula feed but not conclusively stranded',
   };
 }
 

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -63,7 +63,7 @@ export function buildRunSummary(
   // 'unknown' — a feed outage must never strand the whole board.
   registry?: RunRegistryObservation,
 ): RunSummary {
-  const { laneIssues, sortedLanes } = buildSortedRunLanes(issues, feedScopes);
+  const { laneIssues, sortedLanes } = buildSortedRunLanes(issues, feedScopes, registry);
 
   // gascity-dashboard-4xcv: blocked lanes are split out of Active. A stale
   // blocked formula latch (gc-1920 repro) is not progressing; it surfaces in
@@ -123,6 +123,10 @@ export function buildRunHistory(
 function buildSortedRunLanes(
   issues: RunIssue[],
   feedScopes: RunFeedScopeMap,
+  // gascity-dashboard-uxvk: forwarded to runLane so each lane derives its
+  // registration (registered/stranded/unknown) from the same complete-feed
+  // observation; omitted → every lane is 'unknown'.
+  registry?: RunRegistryObservation,
 ): { laneIssues: RunIssue[]; sortedLanes: RunLane[] } {
   const groups = new Map<string, RunIssue[]>();
 

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -275,19 +275,9 @@ function runRegistration(
   issues: RunIssue[],
   registry?: RunRegistryObservation,
 ): RunLane['registration'] {
-  if (registry === undefined) {
-    return { status: 'unknown', error: 'supervisor formula feed not observed' };
-  }
-  if (registry.rootIds.has(rootId)) {
-    return { status: 'registered' };
-  }
-  if (isStrandedRun(rootId, issues, registry)) {
-    return { status: 'stranded' };
-  }
-  return {
-    status: 'unknown',
-    error: 'run absent from the supervisor formula feed but not conclusively stranded',
-  };
+  if (registry === undefined) return 'unknown';
+  if (registry.rootIds.has(rootId)) return 'registered';
+  return isStrandedRun(rootId, issues, registry) ? 'stranded' : 'unknown';
 }
 
 export function runRootId(issue: RunIssue): string {

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -349,10 +349,14 @@ export interface RunLane {
   registration: RunLaneRegistration;
 }
 
-export type RunLaneRegistration =
-  | { status: 'registered' }
-  | { status: 'stranded' }
-  | { status: 'unknown'; error: string };
+/**
+ * 'unknown' covers both "no complete feed observation yet" and "absent from
+ * the feed but not conclusively stranded" (inside the dispatch grace, or
+ * showing step progress so it merely aged out of the feed window) — neither
+ * is evidence either way, so consumers must never read 'unknown' as
+ * registered.
+ */
+export type RunLaneRegistration = 'registered' | 'stranded' | 'unknown';
 
 export type RunLaneUpdatedAt = Avail<{
   at: string;

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -337,7 +337,22 @@ export interface RunLane {
    * it with available health facts.
    */
   health: RunLaneHealthState;
+  /**
+   * Supervisor-registry fact (gascity-dashboard-uxvk). Lanes are built from
+   * rig-store molecule root beads, so a molecule orphaned by a supervisor crash
+   * at dispatch time (bead graph persisted, workflow registry has no entry,
+   * zero step progress) is otherwise indistinguishable from a live run.
+   * 'stranded' is only asserted from a COMPLETE formula-feed observation plus
+   * the dispatch grace (see isStrandedRun); anything weaker stays 'unknown' so
+   * a feed outage can never strand every lane.
+   */
+  registration: RunLaneRegistration;
 }
+
+export type RunLaneRegistration =
+  | { status: 'registered' }
+  | { status: 'stranded' }
+  | { status: 'unknown'; error: string };
 
 export type RunLaneUpdatedAt = Avail<{
   at: string;


### PR DESCRIPTION
## Problem (gascity-dashboard-uxvk)

A molecule orphaned by a supervisor crash at dispatch time (bead graph persisted, workflow registry has no entry, zero step progress) was indistinguishable from a live run: the furthest-stage fallback ranked its all-open step vocabulary into a mid-run phase (gc-odssky read as "implementation" with every step still open), and the lane rendered a live stage ladder.

## Change

- **Phase clamp** (`shared/runs/phaseMapping`): zero step progress never invents a mid-run phase — all-open graphs read as intake, registration-agnostic (pinned by tests).
- **Registration tri-state** (`shared`): `RunLaneRegistration` = registered / stranded / unknown, derived in `shared/runs/liveness` from a COMPLETE formula-feed observation plus a 10-minute dispatch grace anchored to the observation, never a later clock read. Anything weaker stays `unknown`, so a feed outage can never strand the board.
- **Evidence discipline** (hardened through review):
  - absence is only asserted from a complete feed read in which every item carried `root_bead_id`; the observation cache is gated on that
  - presence overlays from ANY read, but only via authoritative `root_bead_id` values — a `workflow_id`-only row can neither strand nor recover a lane
  - a stranded lane recovers the moment any read lists its root (partial reads included), or on step progress
- **UI** (`LaneCard`, `FormulaRunDetail`): stranded lanes swap the phase label for "(!) stranded" (glyph + word per DESIGN.md) and the stage ladder for an explanation; the detail route's optimistic skeleton mirrors the same treatment, and its 404 copy names the orphaned-molecule cause.
- **Snap harness**: fixture recency anchored to run time (un-rots the 24h stale-latch demotion); v1/wisp copy assertion updated; pre-existing em dash in that copy cleared (DESIGN.md §6).
- **Coverage canary**: frontend vitest coverage (v8) with ratchet thresholds ~5 pts under the measured baseline (89% lines / 77% branches), wired into CI.

## Review

4-reviewer pipeline (code, security, typescript, codex), 3 iterations to convergence — all approve. Codex reproduced two real evidence-discipline bugs that were fixed with regression tests (discarded presence evidence from partial reads; workflow_id-collision recovery). Remaining accepted follow-ups: vitest `coverage.all: true` ratchet hardening; DESIGN.md entry for the stranded status treatment.

## Gates (local CI parity, all green)

build · typecheck src+test · eslint --max-warnings=0 · prettier · openapi drift · shared 174 · backend 577 · frontend 933 (coverage thresholds pass) · snap harness PASSED both themes