### PR TITLE
fix(shared): run-diff panel resolves the run's recorded worktree, not the shared checkout (M15)

### DIFF
--- a/shared/src/runs/execution-path.test.ts
+++ b/shared/src/runs/execution-path.test.ts
@@ -1,0 +1,109 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveRunExecutionPath } from './execution-path.js';
+import type { RunSnapshotBead } from '../run-snapshot.js';
+
+// M15: the run-detail "Local changes" diff panel diffed whatever gc.work_dir
+// pointed at. For run ga-wisp-x0tank that was the SHARED checkout
+// /data/projects/gascity — live on another workflow's branch with 67 dirty
+// files — while the run's actual execution worktree was already recorded on
+// the root bead as work_dir (/data/projects/gascity/.gc/worktrees/ga-hvg0gb).
+// The supervisor resolves work_dir BEFORE gc.work_dir
+// (gascity internal/dispatch/ralph.go resolveInheritedMetadata(store, bead,
+// contract.LegacyWorkDirKey, "gc.work_dir")), so the dashboard must match
+// that precedence or the panel presents another workflow's working tree as
+// this run's changes.
+
+function bead(
+  id: string,
+  metadata: Record<string, string>,
+  overrides: Partial<RunSnapshotBead> = {},
+): RunSnapshotBead {
+  return {
+    id,
+    title: 'mol-adopt-pr-v2',
+    status: 'pending',
+    kind: 'workflow',
+    metadata,
+    ...overrides,
+  };
+}
+
+describe('resolveRunExecutionPath — per-run work_dir beats inherited gc.work_dir (M15)', () => {
+  test('root carrying both keys resolves the recorded run worktree, not the shared checkout', () => {
+    // Shaped like the ga-wisp-x0tank root bead: gc.work_dir is the shared rig
+    // checkout inherited from dispatch, work_dir is the gc-managed worktree
+    // where the run actually executed.
+    const root = bead('ga-wisp-x0tank', {
+      'gc.formula_contract': 'graph.v2',
+      'gc.input_convoy_id': 'ga-hvg0gb',
+      'gc.kind': 'workflow',
+      'gc.root_store_ref': 'rig:gascity',
+      'gc.routed_to': 'gascity/gc.run-operator',
+      'gc.work_dir': '/data/projects/gascity',
+      work_dir: '/data/projects/gascity/.gc/worktrees/ga-hvg0gb',
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root]), {
+      kind: 'known',
+      path: '/data/projects/gascity/.gc/worktrees/ga-hvg0gb',
+    });
+  });
+
+  test('root work_dir beats step beads carrying the shared-checkout gc.work_dir', () => {
+    const root = bead('ga-wisp-x0tank', {
+      'gc.work_dir': '/data/projects/gascity',
+      work_dir: '/data/projects/gascity/.gc/worktrees/ga-hvg0gb',
+    });
+    const steps = [
+      bead('ga-wisp-s9lygz', { 'gc.work_dir': '/data/projects/gascity' }, { kind: 'task' }),
+      bead('ga-wisp-9rsood', { 'gc.work_dir': '/data/projects/gascity' }, { kind: 'task' }),
+    ];
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root, ...steps]), {
+      kind: 'known',
+      path: '/data/projects/gascity/.gc/worktrees/ga-hvg0gb',
+    });
+  });
+
+  test('gc.cwd still outranks work_dir when present', () => {
+    const root = bead('ga-wisp-x0tank', {
+      'gc.cwd': '/data/projects/gascity/.gc/worktrees/explicit-cwd',
+      'gc.work_dir': '/data/projects/gascity',
+      work_dir: '/data/projects/gascity/.gc/worktrees/ga-hvg0gb',
+    });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root]), {
+      kind: 'known',
+      path: '/data/projects/gascity/.gc/worktrees/explicit-cwd',
+    });
+  });
+
+  test('gc.work_dir alone still resolves (no regression when only the prefixed key exists)', () => {
+    const root = bead('ga-wisp-x0tank', { 'gc.work_dir': '/data/projects/gascity' });
+
+    assert.deepEqual(resolveRunExecutionPath(root, [root]), {
+      kind: 'known',
+      path: '/data/projects/gascity',
+    });
+  });
+
+  test('falls back to rig roots, then the rigRoot argument, then unavailable', () => {
+    const root = bead('ga-wisp-x0tank', { 'gc.rig_root': '/data/projects/gascity' });
+    assert.deepEqual(resolveRunExecutionPath(root, [root]), {
+      kind: 'known',
+      path: '/data/projects/gascity',
+    });
+
+    const bare = bead('ga-wisp-x0tank', {});
+    assert.deepEqual(resolveRunExecutionPath(bare, [bare], '/data/projects/gascity'), {
+      kind: 'known',
+      path: '/data/projects/gascity',
+    });
+    assert.deepEqual(resolveRunExecutionPath(bare, [bare]), {
+      kind: 'unavailable',
+      reason: 'missing_cwd_and_rig_root',
+    });
+  });
+});

--- a/shared/src/runs/execution-path.ts
+++ b/shared/src/runs/execution-path.ts
@@ -21,11 +21,17 @@ export function resolveRunExecutionPath(
 }
 
 function executionWorkDirs(bead: RunSnapshotBead | undefined): Array<string | undefined> {
+  // work_dir before gc.work_dir, matching the supervisor's own resolution
+  // order (gascity resolveInheritedMetadata reads work_dir first). When the
+  // two disagree, work_dir is the per-run execution worktree recorded on the
+  // bead, while gc.work_dir is the shared rig checkout inherited from
+  // dispatch vars — diffing the latter shows whatever workflow currently
+  // occupies the shared checkout, not this run's work (M15).
   return [
     meta(bead, 'gc.cwd'),
     meta(bead, 'cwd'),
-    meta(bead, 'gc.work_dir'),
     meta(bead, 'work_dir'),
+    meta(bead, 'gc.work_dir'),
   ];
 }
 


### PR DESCRIPTION
## Summary

- Audit finding **M15**: the run-detail "Local changes for the run execution folder" panel for run `ga-wisp-x0tank` diffed the **shared checkout** `/data/projects/gascity` — live on another workflow's branch (`fix/required-artifact-store-errors-ga-ksno8`, 67 dirty files of unrelated work) — even though the run's actual PR #3212 work lived in the gc-managed worktree `/data/projects/gascity/.gc/worktrees/ga-hvg0gb`, already recorded on the root bead as `work_dir`. The page presented another workflow's live working tree as this run's changes.
- Root cause: `resolveRunExecutionPath` (shared/src/runs/execution-path.ts) preferred `gc.work_dir` over `work_dir`. When the two disagree, `work_dir` is the per-run execution worktree and `gc.work_dir` is the rig checkout inherited via dispatch vars. The supervisor itself resolves `work_dir` first (gascity `internal/dispatch/ralph.go` `resolveInheritedMetadata(store, bead, contract.LegacyWorkDirKey, "gc.work_dir")`).
- Fix: swap the candidate order so `work_dir` outranks `gc.work_dir` (`gc.cwd`/`cwd` still win; `gc.work_dir`-only beads behave exactly as before). Verified against the captured `ga-wisp-x0tank` supervisor payload (72 beads): the resolver now returns the run's execution worktree.

## Scope

- Named Rule touched: None.
- Views or routes affected: run detail (`/runs/:id` Local changes diff panel) — the path POSTed to `/api/city/{city}/runs/{id}/diff`. No UI copy or visual change.
- Layer: shared.

## Test plan

- Tests added: `shared/src/runs/execution-path.test.ts` — reproduces M15 with root-bead metadata shaped like the real ga-wisp-x0tank payload (fails on `origin/main`), pins `gc.cwd` precedence, the `gc.work_dir`-only no-regression path, root-before-step-bead ordering, and the rig-root / `unavailable` fallbacks.
- Automated checks run (Node 24.x, matching CI): `npm run typecheck`, `npm run lint`, `npm --workspace shared test` (162 pass), `npm --workspace frontend test` (921 pass), `npm --workspace backend test` (582 pass), `npm --workspace frontend run build`.
- Manual checks run: ran the fixed resolver over the captured supervisor workflow payload for ga-wisp-x0tank — returns `{"kind":"known","path":"/data/projects/gascity/.gc/worktrees/ga-hvg0gb"}` (previously the shared checkout). No visual change, so no `snap.mjs` run.

## Risk + rollback

- Runs whose root bead carries both keys now diff the recorded per-run worktree instead of the shared checkout; an operator would notice first on a run-detail diff panel if a supervisor ever recorded a bogus `work_dir` alongside a good `gc.work_dir` (no such shape observed; the supervisor's own reader uses the same precedence). Beads with only `gc.work_dir` are unchanged.
- Back out: revert the single commit (`474b9e5`) / the merge commit.

## Linked issue

Audit finding M15 (run ga-wisp-x0tank visualization-vs-truth audit). N/A for repo issues.

## Operator-affecting changes

- [x] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [x] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)