### PR TITLE
fix(runs): attach scope-check badges to nested-pipeline step nodes (audit M5)

### DIFF
--- a/shared/src/runs/groups.test.ts
+++ b/shared/src/runs/groups.test.ts
@@ -1,0 +1,206 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { groupRunBeads } from './groups.js';
+import type { RunSnapshotBead } from '../run-snapshot.js';
+
+// Scope-check badge targeting regression coverage (audit finding M5,
+// run ga-wisp-x0tank). The review-pipeline steps live inside a check loop
+// ('review-loop.iteration.1.review-pipeline.<step>'), so their scope-check
+// beads carry gc.step_id='review-pipeline.<step>' while the runtime-ref
+// fallback in hiddenBadgeTargetFor reduces to the bare last segment
+// ('review-claude'). The visible node for each step is the physical retry
+// bead (the attempt task bead's gc.logical_bead_id merges into it), whose
+// alias set includes the full gc.step_id but NOT the bare segment. Without
+// the scope-check bead's own gc.step_id in the badge-target candidate list,
+// resolveBadgeTarget returns the bare fallback, a key no group carries, and
+// the badges silently vanish from the run-detail page.
+
+const ROOT_ID = 'ga-wisp-x0tank';
+
+function bead(partial: Partial<RunSnapshotBead> & { id: string }): RunSnapshotBead {
+  return {
+    title: partial.id,
+    status: 'open',
+    kind: 'task',
+    metadata: {},
+    ...partial,
+  } as RunSnapshotBead;
+}
+
+function rootBead(): RunSnapshotBead {
+  return bead({
+    id: ROOT_ID,
+    title: 'Adopt PR',
+    status: 'in_progress',
+    kind: 'workflow',
+    metadata: { 'gc.kind': 'workflow' },
+  });
+}
+
+// Shapes mirror the live ga-wisp-x0tank supervisor payload: a kind=retry
+// logical bead plus a kind=task attempt bead pointing at it, and two
+// scope-check beads (one per runtime ref form, with and without .attempt.N).
+function reviewClaudeBeads(): RunSnapshotBead[] {
+  return [
+    bead({
+      id: 'ga-wisp-dftrbb',
+      title: 'Code review: Claude (reasoning-heavy)',
+      status: 'completed',
+      kind: 'retry',
+      step_ref: 'review-loop.iteration.1.review-pipeline.review-claude',
+      scope_ref: 'review-loop.iteration.1',
+      metadata: {
+        'gc.kind': 'retry',
+        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.step_id': 'review-pipeline.review-claude',
+        'gc.step_ref': 'review-loop.iteration.1.review-pipeline.review-claude',
+      },
+    }),
+    bead({
+      id: 'ga-wisp-ov9nus',
+      title: 'Code review: Claude (reasoning-heavy)',
+      status: 'completed',
+      kind: 'task',
+      step_ref: 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
+      logical_bead_id: 'ga-wisp-dftrbb',
+      scope_ref: 'review-loop.iteration.1',
+      metadata: {
+        'gc.logical_bead_id': 'ga-wisp-dftrbb',
+        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.step_id': 'review-pipeline.review-claude',
+        'gc.step_ref': 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
+      },
+    }),
+    bead({
+      id: 'ga-wisp-k2xt12',
+      title: 'Finalize scope for Code review: Claude (reasoning-heavy)',
+      status: 'completed',
+      kind: 'scope-check',
+      step_ref:
+        'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude.attempt.1-scope-check',
+      scope_ref: 'review-loop.iteration.1',
+      metadata: {
+        'gc.kind': 'scope-check',
+        'gc.control_for': 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
+        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.step_id': 'review-pipeline.review-claude',
+        'gc.step_ref':
+          'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude.attempt.1-scope-check',
+      },
+    }),
+    bead({
+      id: 'ga-wisp-u6zevb',
+      title: 'Finalize scope for Code review: Claude (reasoning-heavy)',
+      status: 'completed',
+      kind: 'scope-check',
+      step_ref:
+        'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
+      scope_ref: 'review-loop.iteration.1',
+      metadata: {
+        'gc.kind': 'scope-check',
+        'gc.control_for': 'review-loop.iteration.1.review-pipeline.review-claude',
+        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.step_id': 'review-pipeline.review-claude',
+        'gc.step_ref':
+          'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
+      },
+    }),
+  ];
+}
+
+// A step whose gc.step_id has no pipeline prefix (mirrors the live
+// pre-review-ci repair step, ga-wisp-a2s47g): the bare-segment fallback
+// already equals gc.step_id and the badges attach today. Coverage that the
+// fix does not regress this path.
+function repairStepBeads(): RunSnapshotBead[] {
+  return [
+    bead({
+      id: 'ga-wisp-a2s47g',
+      title: 'Repair pre-review CI failures',
+      status: 'completed',
+      kind: 'retry',
+      step_ref: 'pre-review-ci.iteration.1.repair-pre-review-ci-failures',
+      metadata: {
+        'gc.kind': 'retry',
+        'gc.step_id': 'repair-pre-review-ci-failures',
+        'gc.step_ref': 'pre-review-ci.iteration.1.repair-pre-review-ci-failures',
+      },
+    }),
+    bead({
+      id: 'ga-wisp-6sslpf',
+      title: 'Repair pre-review CI failures',
+      status: 'completed',
+      kind: 'task',
+      step_ref: 'pre-review-ci.iteration.1.repair-pre-review-ci-failures.attempt.1',
+      logical_bead_id: 'ga-wisp-a2s47g',
+      metadata: {
+        'gc.logical_bead_id': 'ga-wisp-a2s47g',
+        'gc.step_id': 'repair-pre-review-ci-failures',
+        'gc.step_ref': 'pre-review-ci.iteration.1.repair-pre-review-ci-failures.attempt.1',
+      },
+    }),
+    bead({
+      id: 'ga-wisp-6nm1th',
+      title: 'Finalize scope for Repair pre-review CI failures',
+      status: 'completed',
+      kind: 'scope-check',
+      step_ref:
+        'mol-adopt-pr-v2.pre-review-ci.iteration.1.repair-pre-review-ci-failures-scope-check',
+      metadata: {
+        'gc.kind': 'scope-check',
+        'gc.control_for': 'pre-review-ci.iteration.1.repair-pre-review-ci-failures',
+        'gc.step_id': 'repair-pre-review-ci-failures',
+        'gc.step_ref':
+          'mol-adopt-pr-v2.pre-review-ci.iteration.1.repair-pre-review-ci-failures-scope-check',
+      },
+    }),
+  ];
+}
+
+describe('groupRunBeads — scope-check badge targeting (audit M5)', () => {
+  test('scope-checks for a nested-pipeline step attach to the merged retry-bead node', () => {
+    const { groups, badgesByTarget } = groupRunBeads(
+      [rootBead(), ...reviewClaudeBeads()],
+      ROOT_ID,
+    );
+
+    const reviewNode = groups.find((group) => group.semanticNodeId === 'ga-wisp-dftrbb');
+    assert.ok(reviewNode, 'retry + attempt beads merge into one node keyed by the retry bead id');
+    assert.deepEqual(
+      reviewNode.beads.map((b) => b.id).sort(),
+      ['ga-wisp-dftrbb', 'ga-wisp-ov9nus'],
+    );
+
+    const badges = badgesByTarget.get('ga-wisp-dftrbb') ?? [];
+    assert.deepEqual(
+      badges.map((badge) => badge.id).sort(),
+      ['ga-wisp-k2xt12', 'ga-wisp-u6zevb'],
+      'both scope-check beads must land on the visible node the run-detail page renders',
+    );
+    assert.ok(
+      badges.every((badge) => badge.label === 'scope check'),
+      'badges carry the scope-check label',
+    );
+
+    assert.equal(
+      badgesByTarget.has('review-claude'),
+      false,
+      'no badges may be stranded under the bare semantic segment, which no group carries',
+    );
+  });
+
+  test('scope-checks for a non-nested step keep attaching via the runtime-ref fallback path', () => {
+    const { groups, badgesByTarget } = groupRunBeads([rootBead(), ...repairStepBeads()], ROOT_ID);
+
+    const repairNode = groups.find((group) => group.semanticNodeId === 'ga-wisp-a2s47g');
+    assert.ok(repairNode, 'retry + attempt beads merge into one node keyed by the retry bead id');
+
+    const badges = badgesByTarget.get('ga-wisp-a2s47g') ?? [];
+    assert.deepEqual(
+      badges.map((badge) => badge.id),
+      ['ga-wisp-6nm1th'],
+      'previously-working scope-check attachment is preserved',
+    );
+  });
+});

--- a/shared/src/runs/groups.test.ts
+++ b/shared/src/runs/groups.test.ts
@@ -38,74 +38,104 @@ function rootBead(): RunSnapshotBead {
   });
 }
 
+interface ReviewClaudeIterationIds {
+  retry: string;
+  attempt: string;
+  scopeCheckAttempt: string;
+  scopeCheckStep: string;
+}
+
 // Shapes mirror the live ga-wisp-x0tank supervisor payload: a kind=retry
 // logical bead plus a kind=task attempt bead pointing at it, and two
 // scope-check beads (one per runtime ref form, with and without .attempt.N).
-function reviewClaudeBeads(): RunSnapshotBead[] {
+// Parameterized by iteration so the same step can appear more than once: a
+// check loop reuses the same gc.step_id ('review-pipeline.review-claude')
+// every pass, and only the iteration index in the step/control refs keeps the
+// iterations apart.
+function reviewClaudeIterationBeads(
+  iteration: number,
+  ids: ReviewClaudeIterationIds,
+): RunSnapshotBead[] {
+  const loop = `review-loop.iteration.${iteration}`;
   return [
     bead({
-      id: 'ga-wisp-dftrbb',
+      id: ids.retry,
       title: 'Code review: Claude (reasoning-heavy)',
       status: 'completed',
       kind: 'retry',
-      step_ref: 'review-loop.iteration.1.review-pipeline.review-claude',
-      scope_ref: 'review-loop.iteration.1',
+      step_ref: `${loop}.review-pipeline.review-claude`,
+      scope_ref: loop,
       metadata: {
         'gc.kind': 'retry',
-        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.scope_ref': loop,
         'gc.step_id': 'review-pipeline.review-claude',
-        'gc.step_ref': 'review-loop.iteration.1.review-pipeline.review-claude',
+        'gc.step_ref': `${loop}.review-pipeline.review-claude`,
       },
     }),
     bead({
-      id: 'ga-wisp-ov9nus',
+      id: ids.attempt,
       title: 'Code review: Claude (reasoning-heavy)',
       status: 'completed',
       kind: 'task',
-      step_ref: 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
-      logical_bead_id: 'ga-wisp-dftrbb',
-      scope_ref: 'review-loop.iteration.1',
+      step_ref: `${loop}.review-pipeline.review-claude.attempt.1`,
+      logical_bead_id: ids.retry,
+      scope_ref: loop,
       metadata: {
-        'gc.logical_bead_id': 'ga-wisp-dftrbb',
-        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.logical_bead_id': ids.retry,
+        'gc.scope_ref': loop,
         'gc.step_id': 'review-pipeline.review-claude',
-        'gc.step_ref': 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
+        'gc.step_ref': `${loop}.review-pipeline.review-claude.attempt.1`,
       },
     }),
     bead({
-      id: 'ga-wisp-k2xt12',
+      id: ids.scopeCheckAttempt,
       title: 'Finalize scope for Code review: Claude (reasoning-heavy)',
       status: 'completed',
       kind: 'scope-check',
-      step_ref:
-        'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude.attempt.1-scope-check',
-      scope_ref: 'review-loop.iteration.1',
+      step_ref: `mol-adopt-pr-v2.${loop}.review-pipeline.review-claude.attempt.1-scope-check`,
+      scope_ref: loop,
       metadata: {
         'gc.kind': 'scope-check',
-        'gc.control_for': 'review-loop.iteration.1.review-pipeline.review-claude.attempt.1',
-        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.control_for': `${loop}.review-pipeline.review-claude.attempt.1`,
+        'gc.scope_ref': loop,
         'gc.step_id': 'review-pipeline.review-claude',
-        'gc.step_ref':
-          'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude.attempt.1-scope-check',
+        'gc.step_ref': `mol-adopt-pr-v2.${loop}.review-pipeline.review-claude.attempt.1-scope-check`,
       },
     }),
     bead({
-      id: 'ga-wisp-u6zevb',
+      id: ids.scopeCheckStep,
       title: 'Finalize scope for Code review: Claude (reasoning-heavy)',
       status: 'completed',
       kind: 'scope-check',
-      step_ref: 'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
-      scope_ref: 'review-loop.iteration.1',
+      step_ref: `mol-adopt-pr-v2.${loop}.review-pipeline.review-claude-scope-check`,
+      scope_ref: loop,
       metadata: {
         'gc.kind': 'scope-check',
-        'gc.control_for': 'review-loop.iteration.1.review-pipeline.review-claude',
-        'gc.scope_ref': 'review-loop.iteration.1',
+        'gc.control_for': `${loop}.review-pipeline.review-claude`,
+        'gc.scope_ref': loop,
         'gc.step_id': 'review-pipeline.review-claude',
-        'gc.step_ref':
-          'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
+        'gc.step_ref': `mol-adopt-pr-v2.${loop}.review-pipeline.review-claude-scope-check`,
       },
     }),
   ];
+}
+
+const ITERATION_1_IDS: ReviewClaudeIterationIds = {
+  retry: 'ga-wisp-dftrbb',
+  attempt: 'ga-wisp-ov9nus',
+  scopeCheckAttempt: 'ga-wisp-k2xt12',
+  scopeCheckStep: 'ga-wisp-u6zevb',
+};
+
+const ITERATION_2_IDS: ReviewClaudeIterationIds = {
+  retry: 'ga-wisp-e7h2kp',
+  attempt: 'ga-wisp-r3m8qd',
+  scopeCheckAttempt: 'ga-wisp-w9b4xt',
+  scopeCheckStep: 'ga-wisp-z5c1nf',
+};
+
+function reviewClaudeBeads(): RunSnapshotBead[] {
+  return reviewClaudeIterationBeads(1, ITERATION_1_IDS);
 }
 
 // A step whose gc.step_id has no pipeline prefix (mirrors the live
@@ -183,6 +213,48 @@ describe('groupRunBeads — scope-check badge targeting (audit M5)', () => {
       badgesByTarget.has('review-claude'),
       false,
       'no badges may be stranded under the bare semantic segment, which no group carries',
+    );
+  });
+
+  test('scope-checks for a repeated nested-pipeline step attach to each iteration’s own retry node', () => {
+    // A review loop re-runs the same review-pipeline step when the first pass
+    // finds blockers. Both iterations register gc.step_id
+    // 'review-pipeline.review-claude', so that alias resolves to two visible
+    // nodes and is dropped as ambiguous. Resolution must fall through to the
+    // iteration-qualified step-ref identity (audit M5); otherwise every
+    // scope-check strands under the shared bare 'review-claude' key again.
+    const { groups, badgesByTarget } = groupRunBeads(
+      [
+        rootBead(),
+        ...reviewClaudeIterationBeads(1, ITERATION_1_IDS),
+        ...reviewClaudeIterationBeads(2, ITERATION_2_IDS),
+      ],
+      ROOT_ID,
+    );
+
+    const iteration1Node = groups.find((group) => group.semanticNodeId === ITERATION_1_IDS.retry);
+    const iteration2Node = groups.find((group) => group.semanticNodeId === ITERATION_2_IDS.retry);
+    assert.ok(iteration1Node, 'iteration 1 retry + attempt beads merge into their own node');
+    assert.ok(
+      iteration2Node,
+      'iteration 2 retry + attempt beads merge into a separate node, not the iteration 1 node',
+    );
+
+    assert.deepEqual(
+      (badgesByTarget.get(ITERATION_1_IDS.retry) ?? []).map((badge) => badge.id).sort(),
+      [ITERATION_1_IDS.scopeCheckStep, ITERATION_1_IDS.scopeCheckAttempt].sort(),
+      'iteration 1 scope-checks attach to the iteration 1 node',
+    );
+    assert.deepEqual(
+      (badgesByTarget.get(ITERATION_2_IDS.retry) ?? []).map((badge) => badge.id).sort(),
+      [ITERATION_2_IDS.scopeCheckStep, ITERATION_2_IDS.scopeCheckAttempt].sort(),
+      'iteration 2 scope-checks attach to the iteration 2 node, not bleeding onto iteration 1',
+    );
+
+    assert.equal(
+      badgesByTarget.has('review-claude'),
+      false,
+      'the ambiguous bare segment shared by both iterations must not strand badges',
     );
   });
 

--- a/shared/src/runs/groups.test.ts
+++ b/shared/src/runs/groups.test.ts
@@ -94,8 +94,7 @@ function reviewClaudeBeads(): RunSnapshotBead[] {
       title: 'Finalize scope for Code review: Claude (reasoning-heavy)',
       status: 'completed',
       kind: 'scope-check',
-      step_ref:
-        'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
+      step_ref: 'mol-adopt-pr-v2.review-loop.iteration.1.review-pipeline.review-claude-scope-check',
       scope_ref: 'review-loop.iteration.1',
       metadata: {
         'gc.kind': 'scope-check',
@@ -160,17 +159,14 @@ function repairStepBeads(): RunSnapshotBead[] {
 
 describe('groupRunBeads — scope-check badge targeting (audit M5)', () => {
   test('scope-checks for a nested-pipeline step attach to the merged retry-bead node', () => {
-    const { groups, badgesByTarget } = groupRunBeads(
-      [rootBead(), ...reviewClaudeBeads()],
-      ROOT_ID,
-    );
+    const { groups, badgesByTarget } = groupRunBeads([rootBead(), ...reviewClaudeBeads()], ROOT_ID);
 
     const reviewNode = groups.find((group) => group.semanticNodeId === 'ga-wisp-dftrbb');
     assert.ok(reviewNode, 'retry + attempt beads merge into one node keyed by the retry bead id');
-    assert.deepEqual(
-      reviewNode.beads.map((b) => b.id).sort(),
-      ['ga-wisp-dftrbb', 'ga-wisp-ov9nus'],
-    );
+    assert.deepEqual(reviewNode.beads.map((b) => b.id).sort(), [
+      'ga-wisp-dftrbb',
+      'ga-wisp-ov9nus',
+    ]);
 
     const badges = badgesByTarget.get('ga-wisp-dftrbb') ?? [];
     assert.deepEqual(

--- a/shared/src/runs/groups.ts
+++ b/shared/src/runs/groups.ts
@@ -319,13 +319,20 @@ function resolveBadgeTarget(
 }
 
 function hiddenBadgeTargetCandidates(bead: RunSnapshotBead, fallback: string | null): string[] {
-  // gc.step_id sits between the full runtime ref and the bare-segment
-  // fallback in specificity: for steps nested inside a pipeline (e.g.
-  // 'review-pipeline.review-claude') it is the alias the visible node
-  // actually registers, while the bare last segment is not (audit M5).
+  // Specificity order, most to least specific. The iteration-qualified
+  // identity strips the leading runtime segment from the control/step ref via
+  // the same normalization the visible node uses (fullStepRefIdentity), so it
+  // matches that node's alias 1:1. It sits above gc.step_id because a check
+  // loop reuses the same gc.step_id ('review-pipeline.review-claude') on every
+  // pass: once a step runs more than once that alias resolves to multiple
+  // visible nodes and is dropped as ambiguous, leaving the iteration-qualified
+  // key as the only thing that still targets the right per-iteration retry node
+  // (audit M5). gc.step_id still resolves single-occurrence nested steps, and
+  // the bare last segment remains the final fallback.
   return [
     meta(bead, 'gc.control_for'),
     hiddenBadgeFullTargetFor(bead),
+    hiddenBadgeIterationTargetFor(bead),
     meta(bead, 'gc.step_id'),
     fallback ?? undefined,
   ]
@@ -351,6 +358,16 @@ function hiddenBadgeFullTargetFor(bead: RunSnapshotBead): string | undefined {
   const controlFor = meta(bead, 'gc.control_for');
   if (controlFor) return externalizeId(stripControlSuffix(controlFor));
   return fullStepRefIdentity(stripControlSuffix(normalizedStepRef(bead) ?? ''));
+}
+
+// The iteration-qualified target: the control/step ref reduced through the
+// same normalization the visible node registers (fullStepRefIdentity drops the
+// leading runtime segment), so 'review-loop.iteration.2.review-pipeline.
+// review-claude.attempt.1' resolves to 'iteration.2.review-pipeline.
+// review-claude.attempt.1' and lands on that iteration's retry node even when
+// the shared gc.step_id alias has been dropped as ambiguous (audit M5).
+function hiddenBadgeIterationTargetFor(bead: RunSnapshotBead): string | undefined {
+  return fullStepRefIdentity(meta(bead, 'gc.control_for') ?? normalizedStepRef(bead));
 }
 
 function fullStepRefIdentity(ref: string | null | undefined): string | undefined {

--- a/shared/src/runs/groups.ts
+++ b/shared/src/runs/groups.ts
@@ -319,7 +319,16 @@ function resolveBadgeTarget(
 }
 
 function hiddenBadgeTargetCandidates(bead: RunSnapshotBead, fallback: string | null): string[] {
-  return [meta(bead, 'gc.control_for'), hiddenBadgeFullTargetFor(bead), fallback ?? undefined]
+  // gc.step_id sits between the full runtime ref and the bare-segment
+  // fallback in specificity: for steps nested inside a pipeline (e.g.
+  // 'review-pipeline.review-claude') it is the alias the visible node
+  // actually registers, while the bare last segment is not (audit M5).
+  return [
+    meta(bead, 'gc.control_for'),
+    hiddenBadgeFullTargetFor(bead),
+    meta(bead, 'gc.step_id'),
+    fallback ?? undefined,
+  ]
     .filter((value): value is string => value !== undefined)
     .flatMap((value) => {
       const stripped = stripControlSuffix(value);


### PR DESCRIPTION
## Summary

- Audit finding M5 (run ga-wisp-x0tank): the run-detail page rendered the Claude/Codex/Gemini review, Synthesize, and Quality scorecard nodes with NO scope-check badges, while the bead store truly holds 2 "Finalize scope for ..." scope-check beads per step (10 of 23 scope-checks total, a mix of completed and pending). They were stranded in `badgesByTarget` under dead keys (`review-claude`, `synthesize`, ...) that no rendered group carries, so `formula-run.ts` dropped them.
- Root cause: for steps nested inside a pipeline within a check loop, the visible node (the merged physical retry bead) registers the full `gc.step_id` alias (`review-pipeline.<step>`), but `hiddenBadgeTargetCandidates` in `shared/src/runs/groups.ts` only tried the full runtime ref from `gc.control_for` (never aliased, since `fullStepRefIdentity` strips only the first segment) and the bare last-segment fallback (`<step>`). Zero intersection.
- Fix: add the hidden bead's own `gc.step_id` to the badge-target candidate list, between the full runtime refs and the bare-segment fallback. Verified against the captured 72-bead ga-wisp-x0tank supervisor payload: 23/23 scope-check badges now attach to live nodes (previously 13/23); all previously-attaching badges keep their targets, and spec beads are unaffected (they carry no `gc.step_id`).

## Scope

- Named Rule touched: None.
- Views or routes affected: run detail (`/runs/...` formula-run node badges).
- Layer: shared.

## Test plan

- Tests added: `shared/src/runs/groups.test.ts` (new). TDD: the nested-pipeline test reproduced the vanishing badges before the fix (controlBadges target empty, dead `review-claude` key) and passes after; a second test locks in the previously-working non-nested attachment path (`pre-review-ci` repair step shape).
- Automated checks run: `npm run typecheck` (src + test), `npm --workspace shared test` (159 pass), `npm --workspace backend test` (582 pass), `npm --workspace frontend run build`, `npm run lint`.
- `npm --workspace frontend test`: 30 failures both on this branch AND on clean origin/main, with an identical test list; all are an environmental Node warning (`--localstorage-file was provided without a valid path`) escalated to an error by `src/test/setup.ts`, unrelated to this change. Zero new failures introduced.
- Manual checks run: re-ran `groupRunBeads` over the captured live ga-wisp-x0tank payload (72 beads, 176 deps); the 5 review-pipeline nodes each carry their 2 scope-check badges with correct statuses, and the only remaining dead key is `spec` (a separate, pre-existing audit finding, intentionally out of scope here). No visual snap needed: badge rendering markup is unchanged, only badge targeting data.

## Risk + rollback

- Risk: a hidden control bead whose `gc.step_id` aliases a different node than its runtime ref intends could re-target. Bounded: `gc.step_id` is tried only after both full runtime-ref candidates, alias entries are dropped when ambiguous (`buildBadgeTargetAliases` requires a unique target), and the full real-payload re-derivation shows zero changes to previously-attaching badges. The operator would notice first as a wrong scope-check badge on a run-detail node.
- Rollback: revert the merge commit (single commit, shared-only).

## Linked issue

N/A (multi-agent audit finding M5, adversarially verified against live supervisor data on 2026-06-12).

## Operator-affecting changes

- [x] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [x] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)