### PR TITLE
fix(runs): run-detail phase reads supervisor wire statuses; furthest-stage fallback ranks only advanced steps (audit M2)

### DIFF
--- a/frontend/src/attention/beadsNeedingAttention.test.ts
+++ b/frontend/src/attention/beadsNeedingAttention.test.ts
@@ -32,6 +32,17 @@ describe('selectBeadsNeedingAttention (gascity-dashboard-2j8e.3)', () => {
     ]);
   });
 
+  it('surfaces a ready-unclaimed bead under a cased / padded open wire spelling', () => {
+    // readyUnclaimedRow normalizes the status, so a wire-cased 'Open' (or padded
+    // ' open ') is still recognized as claimable work rather than silently dropped.
+    const rows = select({
+      beads: [bead({ id: 'B-cased', status: ' Open ', created_at: '2026-06-05T11:00:00.000Z' })],
+    });
+    expect(rows).toEqual([
+      expect.objectContaining({ beadId: 'B-cased', reason: 'ready-unclaimed' }),
+    ]);
+  });
+
   it('escalates a long-stale ready-unclaimed bead to attention', () => {
     const rows = select({
       beads: [bead({ id: 'B-stale', status: 'open', created_at: '2026-06-01T11:00:00.000Z' })],
@@ -90,6 +101,34 @@ describe('selectBeadsNeedingAttention (gascity-dashboard-2j8e.3)', () => {
       escalations: [bead({ id: 'B-done', status: 'closed', labels: ['gc:escalation'] })],
     });
     expect(rows).toEqual([]);
+  });
+
+  it('excludes a wire-resolved escalation (completed/done), not only bd closed', () => {
+    expect(
+      select({
+        escalations: [bead({ id: 'B-completed', status: 'completed', labels: ['gc:escalation'] })],
+      }),
+    ).toEqual([]);
+    expect(
+      select({
+        escalations: [bead({ id: 'B-wire-done', status: 'done', labels: ['gc:escalation'] })],
+      }),
+    ).toEqual([]);
+  });
+
+  it('excludes a terminal failed/skipped escalation (resolved, no longer needs the operator)', () => {
+    // failed and skipped are terminal/resolved — the escalation is over, so it
+    // must drop out of attention rather than linger as actionable work.
+    expect(
+      select({
+        escalations: [bead({ id: 'B-failed', status: 'failed', labels: ['gc:escalation'] })],
+      }),
+    ).toEqual([]);
+    expect(
+      select({
+        escalations: [bead({ id: 'B-skipped', status: 'skipped', labels: ['gc:escalation'] })],
+      }),
+    ).toEqual([]);
   });
 
   it('does not count a P1 high-priority open bead just for its priority', () => {

--- a/frontend/src/attention/beadsNeedingAttention.ts
+++ b/frontend/src/attention/beadsNeedingAttention.ts
@@ -1,3 +1,4 @@
+import { isOpenStatus, isResolvedStatus } from 'gas-city-dashboard-shared';
 import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
 import { elapsedSince, formatElapsed } from './elapsed';
 
@@ -74,9 +75,12 @@ export function selectBeadsNeedingAttention(
 }
 
 // Escalated / help-requested: an open escalation bead is abnormal blocking —
-// counted immediately, regardless of age. A resolved (closed) escalation is not.
+// counted immediately, regardless of age. A resolved escalation is not.
 function escalatedRow(bead: Bead): BeadAttentionRow | null {
-  if (bead.status === 'closed') return null;
+  // A resolved escalation no longer needs the operator — accept every terminal
+  // spelling (bd closed and the supervisor wire completed/done/failed/skipped)
+  // via isResolvedStatus, or a finished escalation lingers in the attention rows.
+  if (isResolvedStatus(bead.status)) return null;
   return {
     beadId: bead.id,
     reason: 'escalated',
@@ -91,7 +95,7 @@ function escalatedRow(bead: Bead): BeadAttentionRow | null {
 // `blocked` = "blocked by a dependency") and in-progress/closed work are not
 // surfaced — only genuinely-claimable open beads.
 function readyUnclaimedRow(bead: Bead, nowMs: number): BeadAttentionRow | null {
-  if (bead.status !== 'open' || hasAssignee(bead)) return null;
+  if (!isOpenStatus(bead.status) || hasAssignee(bead)) return null;
   const ageMs = elapsedSince(bead.created_at, nowMs);
   if (ageMs === null || ageMs < READY_UNCLAIMED_WATCH_MS) return null;
   const stale = ageMs >= READY_UNCLAIMED_STALE_MS;

--- a/frontend/src/components/StatusBadge.test.ts
+++ b/frontend/src/components/StatusBadge.test.ts
@@ -9,4 +9,19 @@ describe('beadStatusTone', () => {
     expect(beadStatusTone('closed')).toBe('neutral');
     expect(beadStatusTone('deferred')).toBe('warn');
   });
+
+  it('tones supervisor wire spellings through the shared normalized vocabulary', () => {
+    // Wire-native spellings the old hardcoded switch dropped into the warn
+    // default now tone the same as their bd-ledger twins.
+    expect(beadStatusTone('active')).toBe('ok');
+    expect(beadStatusTone('running')).toBe('ok');
+    expect(beadStatusTone('completed')).toBe('neutral');
+    expect(beadStatusTone('done')).toBe('neutral');
+  });
+
+  it('normalizes cased / padded spellings instead of falling through to warn', () => {
+    expect(beadStatusTone('Active')).toBe('ok');
+    expect(beadStatusTone(' completed ')).toBe('neutral');
+    expect(beadStatusTone('Blocked')).toBe('stuck');
+  });
 });

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { isBlockedStatus, isClosedStatus, isInFlightStatus } from 'gas-city-dashboard-shared';
 
 // Status is always carried by glyph + word + color, in that order of
 // importance. Strip color (the greyscale test) and the badge still
@@ -56,19 +57,17 @@ export function StatusBadge({
   );
 }
 
+// Route the raw bead status through the shared, normalized status vocabulary so
+// supervisor wire spellings tone the same way they classify: in-flight
+// (in_progress / active / running) → ok, closed (closed / completed / done) →
+// neutral, blocked → stuck. Cased or padded spellings ('Active', ' completed ',
+// 'Blocked') resolve correctly instead of falling through to the warn default
+// reserved for open / deferred / ready / unknown.
 export function beadStatusTone(status: string): StatusTone {
-  switch (status) {
-    case 'closed':
-      return 'neutral';
-    case 'in_progress':
-      return 'ok';
-    case 'blocked':
-      return 'stuck';
-    case 'open':
-    case 'deferred':
-    default:
-      return 'warn';
-  }
+  if (isInFlightStatus(status)) return 'ok';
+  if (isClosedStatus(status)) return 'neutral';
+  if (isBlockedStatus(status)) return 'stuck';
+  return 'warn';
 }
 
 // Single source of truth for session/agent state → tone mapping. Aligned with

--- a/frontend/src/hooks/activeWorkers.test.ts
+++ b/frontend/src/hooks/activeWorkers.test.ts
@@ -90,6 +90,26 @@ describe('deriveActiveWorkers', () => {
     expect(result.workers[0]?.bead).toBeUndefined();
   });
 
+  it('attaches a supervisor wire in-flight bead (active/running), not only bd in_progress', () => {
+    const sessions = [session({ id: 'gc-9001', template: 'polecat', rig: 'gascity' })];
+    const active = deriveActiveWorkers(sessions, [
+      bead({ id: 'gc-active', status: 'active', assignee: 'polecat-gc-9001' }),
+    ]);
+    expect(active.workers[0]?.bead?.id).toBe('gc-active');
+    const running = deriveActiveWorkers(sessions, [
+      bead({ id: 'gc-running', status: 'running', assignee: 'polecat-gc-9001' }),
+    ]);
+    expect(running.workers[0]?.bead?.id).toBe('gc-running');
+  });
+
+  it('does not attach a resolved wire bead (completed/done) to a worker', () => {
+    const sessions = [session({ id: 'gc-9002', template: 'polecat', rig: 'gascity' })];
+    const result = deriveActiveWorkers(sessions, [
+      bead({ id: 'gc-completed', status: 'completed', assignee: 'polecat-gc-9002' }),
+    ]);
+    expect(result.workers[0]?.bead).toBeUndefined();
+  });
+
   it('orders worker rows by most-recent activity first', () => {
     const sessions = [
       session({ id: 'gc-1', rig: 'gascity', last_active: '2026-06-03T10:00:00Z' }),

--- a/frontend/src/hooks/activeWorkers.ts
+++ b/frontend/src/hooks/activeWorkers.ts
@@ -1,4 +1,4 @@
-import { parseAssignee, IN_PROGRESS_STATUS } from 'gas-city-dashboard-shared';
+import { parseAssignee, isInFlightStatus } from 'gas-city-dashboard-shared';
 import type { SupervisorBead } from '../supervisor/beadReads';
 import type { SupervisorSession } from '../supervisor/sessionReads';
 import { canonicalRigLabel, cleanWorkerName, isWorkerSession, sessionProject } from './projectOf';
@@ -80,7 +80,10 @@ export function deriveActiveWorkers(
   // Map a live session id -> the in-progress bead assigned to it (if any).
   const beadBySession = new Map<string, SupervisorBead>();
   for (const bead of beads) {
-    if (bead.status !== IN_PROGRESS_STATUS) continue;
+    // Supervisor wire beads spell in-flight 'active'/'running', not only the bd
+    // ledger's 'in_progress'; the shared predicate accepts every spelling so a
+    // live worker's current bead is not dropped here.
+    if (!isInFlightStatus(bead.status)) continue;
     const assignee = bead.assignee?.trim();
     if (!assignee) continue;
     const { sessionId } = parseAssignee(assignee);

--- a/frontend/src/lib/beadGraph.test.ts
+++ b/frontend/src/lib/beadGraph.test.ts
@@ -72,6 +72,50 @@ describe('buildBeadGraph — column placement', () => {
     expect(columnOf([bead('A', 'closed')], 'A')).toBe('done');
   });
 
+  it('maps supervisor wire spellings to columns too (active/running, completed/done)', () => {
+    // A board fed supervisor-wire beads must not mis-column an in-flight or
+    // finished bead into open/ready just because it is not the bd spelling.
+    expect(columnOf([bead('A', 'active')], 'A')).toBe('in_progress');
+    expect(columnOf([bead('A', 'running')], 'A')).toBe('in_progress');
+    expect(columnOf([bead('A', 'completed')], 'A')).toBe('done');
+    expect(columnOf([bead('A', 'done')], 'A')).toBe('done');
+  });
+
+  it('normalizes cased / padded blocked spellings into the blocked column', () => {
+    // The board must column a blocked bead the same way the status badge and
+    // filter chip classify it — both via isBlockedStatus (normalized trim +
+    // lowercase). A raw === 'blocked' here would mis-column a 'Blocked' or
+    // ' blocked ' wire spelling into open/ready, an internally inconsistent board.
+    expect(columnOf([bead('A', 'Blocked')], 'A')).toBe('blocked');
+    expect(columnOf([bead('A', ' blocked ')], 'A')).toBe('blocked');
+  });
+
+  it('columns terminal failed/skipped wire spellings into done (no work remains)', () => {
+    // failed and skipped are terminal/resolved — they belong in done, not left in
+    // open/ready as if work still remained on them.
+    expect(columnOf([bead('A', 'failed')], 'A')).toBe('done');
+    expect(columnOf([bead('A', 'skipped')], 'A')).toBe('done');
+  });
+
+  it('does NOT call a bead ready when its blocking need failed/skipped (readiness is a success gate)', () => {
+    // Distinct from column placement: a failed or skipped blocker is resolved (no
+    // work remains on it) but did NOT pass, so its dependent is not ready. The
+    // ready gate stays on successful completion, never the terminal/resolved test.
+    const failed = buildBeadGraph([bead('A', 'failed'), bead('B', 'open', { needs: ['A'] })]);
+    expect(failed.nodes.get('B')?.ready).toBe(false);
+    expect(failed.nodes.get('B')?.column).toBe('open');
+    const skipped = buildBeadGraph([bead('A', 'skipped'), bead('C', 'open', { needs: ['A'] })]);
+    expect(skipped.nodes.get('C')?.ready).toBe(false);
+    expect(skipped.nodes.get('C')?.column).toBe('open');
+  });
+
+  it('treats a wire-completed/done blocking need as resolved (the open bead becomes ready)', () => {
+    expect(columnOf([bead('A', 'completed'), bead('B', 'open', { needs: ['A'] })], 'B')).toBe(
+      'ready',
+    );
+    expect(columnOf([bead('A', 'done'), bead('C', 'open', { needs: ['A'] })], 'C')).toBe('ready');
+  });
+
   it('places an open bead with no needs in the ready column', () => {
     const graph = buildBeadGraph([bead('A', 'open')]);
     expect(graph.nodes.get('A')?.column).toBe('ready');

--- a/frontend/src/lib/beadGraph.ts
+++ b/frontend/src/lib/beadGraph.ts
@@ -1,3 +1,10 @@
+import {
+  isBlockedStatus,
+  isClosedStatus,
+  isInFlightStatus,
+  isOpenStatus,
+  isResolvedStatus,
+} from 'gas-city-dashboard-shared';
 import type { SupervisorBead } from '../supervisor/beadReads';
 
 // Pure dependency-graph + kanban-column builder for the Beads board
@@ -93,17 +100,16 @@ function blockingNeedIds(bead: SupervisorBead): readonly string[] {
 }
 
 function columnFor(node: { bead: SupervisorBead; ready: boolean }): BoardColumnId {
-  switch (node.bead.status) {
-    case 'in_progress':
-      return 'in_progress';
-    case 'blocked':
-      return 'blocked';
-    case 'closed':
-      return 'done';
-    case 'open':
-    default:
-      return node.ready ? 'ready' : 'open';
-  }
+  // Status may arrive as a bd ledger spelling (in_progress/closed) or a
+  // supervisor wire spelling (active/running, completed/done/failed/skipped); the
+  // shared predicates accept both so a wire bead is not mis-columned into
+  // open/ready. failed and skipped are terminal — no work remains — so they land
+  // in done via isResolvedStatus, never the open/ready fallback.
+  const status = node.bead.status;
+  if (isInFlightStatus(status)) return 'in_progress';
+  if (isBlockedStatus(status)) return 'blocked';
+  if (isResolvedStatus(status)) return 'done';
+  return node.ready ? 'ready' : 'open';
 }
 
 function byPriorityThenId(a: BeadNode, b: BeadNode): number {
@@ -130,7 +136,13 @@ export function buildBeadGraph(beads: readonly SupervisorBead[]): BeadGraph {
     const hasUnresolvedDeps = deps.some((d) => d.bead === null);
 
     const needs = blockingNeedIds(b);
-    const ready = b.status === 'open' && needs.every((id) => byId.get(id)?.status === 'closed');
+    // A blocking need clears only when its bead completed SUCCESSFULLY — closed,
+    // or the supervisor wire spellings completed/done. Readiness is a success
+    // gate, NOT the terminal/no-work-remains test used for columns: a failed or
+    // skipped blocker is resolved yet did not pass, so it must not mark the
+    // dependent ready (use isClosedStatus here, never isResolvedStatus).
+    const ready =
+      isOpenStatus(b.status) && needs.every((id) => isClosedStatus(byId.get(id)?.status ?? ''));
 
     const node: BeadNode = {
       bead: b,

--- a/frontend/src/routes/Beads.render.test.tsx
+++ b/frontend/src/routes/Beads.render.test.tsx
@@ -121,6 +121,26 @@ describe('BeadsPage supervisor reads', () => {
     expect(within(actions as HTMLElement).getByText('Read-only')).toBeTruthy();
   });
 
+  it('disables the Close action for a terminal failed/skipped bead even when writable', async () => {
+    // failed/skipped are terminal in the shared status vocabulary — no work
+    // remains, so there is nothing to Close. The guard must fire on resolved
+    // status, not only bd 'closed'. Writable mode (no Read-only affordance) plus
+    // an enabled Nudge prove the disable is the resolved-status guard, not
+    // read-only or in-flight busy state.
+    renderPage('/beads?bead=td-failed-resolved');
+
+    const dialog = await screen.findByRole('dialog');
+    const actions = (within(dialog).getByRole('button', { name: 'Nudge' }) as HTMLButtonElement)
+      .parentElement;
+    expect(actions).not.toBeNull();
+    const scope = within(actions as HTMLElement);
+    expect(scope.queryByText('Read-only')).toBeNull();
+    expect((scope.getByRole('button', { name: 'Nudge' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect((scope.getByRole('button', { name: 'Close' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it('keeps the New bead control active when the dashboard is writable', async () => {
     renderPage('/beads');
 
@@ -197,6 +217,16 @@ function stubFetch() {
             title: 'direct supervisor bead',
             assignee: 'mayor',
             needs: ['td-parent-1'],
+          }),
+        );
+      }
+      if (url.pathname === '/gc-supervisor/v0/city/test-city/bead/td-failed-resolved') {
+        return jsonResponse(
+          bead({
+            id: 'td-failed-resolved',
+            title: 'failed resolved bead',
+            status: 'failed',
+            assignee: 'mayor',
           }),
         );
       }

--- a/frontend/src/routes/Beads.status.test.ts
+++ b/frontend/src/routes/Beads.status.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { SupervisorBead } from '../supervisor/beadReads';
+import { BEAD_CHIPS, buildSynopsis } from './Beads';
+
+// The city bead list can emit supervisor-wire status spellings (`active`/`running`
+// for in-flight, `completed`/`done`/`failed`/`skipped` for terminal) alongside the
+// bd-ledger spellings (`in_progress`, `closed`). The board's chips and synopsis
+// route through the shared isInFlightStatus/isResolvedStatus predicates so a
+// wire-spelled bead is columned, counted, and closeable the same as its bd-ledger
+// twin — never silently mis-filtered. failed/skipped are terminal too: no work
+// remains, so they belong under the closed filter. These pin that both
+// vocabularies classify identically.
+
+function bead(status: string): SupervisorBead {
+  return {
+    id: `td-${status}`,
+    title: `${status} bead`,
+    status,
+    issue_type: 'task',
+    priority: 0,
+    labels: [],
+    created_at: '2026-06-01T00:00:00Z',
+  };
+}
+
+function chipMatch(id: string): (bead: SupervisorBead) => boolean {
+  const chip = BEAD_CHIPS.find((c) => c.id === id);
+  if (chip === undefined) throw new Error(`missing chip ${id}`);
+  return chip.match;
+}
+
+describe('Beads board — supervisor wire status vocabulary', () => {
+  it('the in-progress chip matches bd in_progress and wire active/running, not closed spellings', () => {
+    const match = chipMatch('in_progress');
+    expect(match(bead('in_progress'))).toBe(true);
+    expect(match(bead('active'))).toBe(true);
+    expect(match(bead('running'))).toBe(true);
+    expect(match(bead('open'))).toBe(false);
+    expect(match(bead('completed'))).toBe(false);
+    expect(match(bead('done'))).toBe(false);
+    // Terminal failed/skipped are resolved, not in-flight.
+    expect(match(bead('failed'))).toBe(false);
+    expect(match(bead('skipped'))).toBe(false);
+  });
+
+  it('the closed chip matches bd closed and all terminal wire spellings (completed/done/failed/skipped), not in-flight', () => {
+    const match = chipMatch('closed');
+    expect(match(bead('closed'))).toBe(true);
+    expect(match(bead('completed'))).toBe(true);
+    expect(match(bead('done'))).toBe(true);
+    // failed and skipped are terminal/resolved — they belong under the closed
+    // filter, not left unmatched by every chip.
+    expect(match(bead('failed'))).toBe(true);
+    expect(match(bead('skipped'))).toBe(true);
+    expect(match(bead('active'))).toBe(false);
+    expect(match(bead('running'))).toBe(false);
+    expect(match(bead('open'))).toBe(false);
+  });
+
+  it('the open chip normalizes cased / padded open spellings and rejects others', () => {
+    const match = chipMatch('open');
+    expect(match(bead('open'))).toBe(true);
+    expect(match(bead('Open'))).toBe(true);
+    expect(match(bead(' open '))).toBe(true);
+    expect(match(bead('blocked'))).toBe(false);
+    expect(match(bead('in_progress'))).toBe(false);
+    expect(match(bead('closed'))).toBe(false);
+  });
+
+  it('the blocked chip normalizes cased / padded blocked spellings and rejects others', () => {
+    const match = chipMatch('blocked');
+    expect(match(bead('blocked'))).toBe(true);
+    expect(match(bead('Blocked'))).toBe(true);
+    expect(match(bead(' blocked '))).toBe(true);
+    expect(match(bead('open'))).toBe(false);
+    expect(match(bead('active'))).toBe(false);
+    expect(match(bead('closed'))).toBe(false);
+  });
+
+  it('the synopsis counts wire active/running in the in-progress tally', () => {
+    const rows = [
+      bead('open'),
+      bead('in_progress'),
+      bead('active'),
+      bead('running'),
+      bead('blocked'),
+    ];
+    const summary = buildSynopsis(rows, rows.length, '');
+    // in_progress + active + running all roll into the one "in progress" count.
+    expect(summary).toContain('3 in progress');
+    expect(summary).toContain('1 open');
+    expect(summary).toContain('1 blocked');
+  });
+
+  it('the synopsis tallies open / blocked under cased and padded wire spellings', () => {
+    const rows = [bead('Open'), bead(' open '), bead('Blocked'), bead(' blocked ')];
+    const summary = buildSynopsis(rows, rows.length, '');
+    expect(summary).toContain('2 open');
+    expect(summary).toContain('2 blocked');
+  });
+});

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { GC_EVENT_PREFIX } from 'gas-city-dashboard-shared';
+import {
+  GC_EVENT_PREFIX,
+  isBlockedStatus,
+  isInFlightStatus,
+  isOpenStatus,
+  isResolvedStatus,
+} from 'gas-city-dashboard-shared';
 import { formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { useAttentionModel } from '../attention/context';
@@ -50,11 +56,11 @@ interface ActionMessage {
   text: string;
 }
 
-const BEAD_CHIPS: ReadonlyArray<FilterChip<SupervisorBead>> = [
-  { id: 'open', label: 'open', match: (b) => b.status === 'open' },
-  { id: 'in_progress', label: 'in progress', match: (b) => b.status === 'in_progress' },
-  { id: 'blocked', label: 'blocked', match: (b) => b.status === 'blocked' },
-  { id: CLOSED_CHIP_ID, label: 'closed', match: (b) => b.status === 'closed' },
+export const BEAD_CHIPS: ReadonlyArray<FilterChip<SupervisorBead>> = [
+  { id: 'open', label: 'open', match: (b) => isOpenStatus(b.status) },
+  { id: 'in_progress', label: 'in progress', match: (b) => isInFlightStatus(b.status) },
+  { id: 'blocked', label: 'blocked', match: (b) => isBlockedStatus(b.status) },
+  { id: CLOSED_CHIP_ID, label: 'closed', match: (b) => isResolvedStatus(b.status) },
 ];
 
 const BEAD_SEARCH_FIELDS = (b: SupervisorBead): ReadonlyArray<string | undefined> => [
@@ -328,7 +334,7 @@ export function BeadsPage() {
             size="sm"
             tone="quiet"
             title={roTitle}
-            disabled={readOnly || busy || bead.status === 'closed'}
+            disabled={readOnly || busy || isResolvedStatus(bead.status)}
             onClick={() => {
               setCloseReason('');
               setActionMessage(null);
@@ -678,15 +684,15 @@ function normalizeSelectedBeadParam(value: string | null): string | null {
   return clean && clean.length > 0 ? clean : null;
 }
 
-function buildSynopsis(
+export function buildSynopsis(
   filtered: ReadonlyArray<SupervisorBead>,
   totalShown: number,
   rigFilter: string,
 ): string {
   if (rigFilter !== RIG_FILTER_ALL && filtered.length === 0) return `No beads on ${rigFilter}.`;
-  const open = filtered.filter((bead) => bead.status === 'open').length;
-  const inProgress = filtered.filter((bead) => bead.status === 'in_progress').length;
-  const blocked = filtered.filter((bead) => bead.status === 'blocked').length;
+  const open = filtered.filter((bead) => isOpenStatus(bead.status)).length;
+  const inProgress = filtered.filter((bead) => isInFlightStatus(bead.status)).length;
+  const blocked = filtered.filter((bead) => isBlockedStatus(bead.status)).length;
   const parts: string[] = [];
   if (open > 0) parts.push(`${open} open`);
   if (inProgress > 0) parts.push(`${inProgress} in progress`);

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -75,6 +75,66 @@ describe('supervisor bead reads', () => {
     expect(result.upstream_total).toBe(4);
   });
 
+  it('drops wire-resolved spellings (completed/done) like closed, keeps in-flight wire spellings', async () => {
+    // The city bead list can emit supervisor-wire status spellings. The default
+    // (includeClosed: false) read must filter out the wire-closed spellings
+    // (completed/done), not only the bd-ledger 'closed', or resolved beads would
+    // linger on the board; in-flight wire spellings (active/running) must stay.
+    const listBeads = vi.fn(async () => ({
+      items: [
+        bead({ id: 'td-open', status: 'open' }),
+        bead({ id: 'td-active', status: 'active' }),
+        bead({ id: 'td-running', status: 'running' }),
+        bead({ id: 'td-completed', status: 'completed' }),
+        bead({ id: 'td-done', status: 'done' }),
+        bead({ id: 'td-closed', status: 'closed' }),
+      ],
+      total: 6,
+    }));
+    setSupervisorApiForTests({ ...baseApi, listBeads });
+
+    const result = await listSupervisorBeads();
+
+    expect(result.items.map((item) => item.id)).toEqual(['td-open', 'td-active', 'td-running']);
+  });
+
+  it('keeps wire-resolved spellings when includeClosed is set', async () => {
+    const listBeads = vi.fn(async () => ({
+      items: [
+        bead({ id: 'td-open', status: 'open' }),
+        bead({ id: 'td-completed', status: 'completed' }),
+        bead({ id: 'td-done', status: 'done' }),
+      ],
+      total: 3,
+    }));
+    setSupervisorApiForTests({ ...baseApi, listBeads });
+
+    const result = await listSupervisorBeads({ includeClosed: true });
+
+    expect(result.items.map((item) => item.id)).toEqual(['td-open', 'td-completed', 'td-done']);
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 1000, all: true });
+  });
+
+  it('drops terminal failed/skipped wire spellings from the default list (no work remains)', async () => {
+    // failed and skipped are terminal in the shared status vocabulary — no work
+    // remains — so the default (includeClosed: false) board read must filter them
+    // out alongside completed/done/closed, or a finished-but-not-'closed' bead
+    // lingers on the open board.
+    const listBeads = vi.fn(async () => ({
+      items: [
+        bead({ id: 'td-open', status: 'open' }),
+        bead({ id: 'td-failed', status: 'failed' }),
+        bead({ id: 'td-skipped', status: 'skipped' }),
+      ],
+      total: 3,
+    }));
+    setSupervisorApiForTests({ ...baseApi, listBeads });
+
+    const result = await listSupervisorBeads();
+
+    expect(result.items.map((item) => item.id)).toEqual(['td-open']);
+  });
+
   // gascity-dashboard-sg9o: a "needs you" decision alert can deep-link to a
   // bead the supervisor has since pruned (e.g. gc-316879). fetchSupervisorBead
   // is the data edge the deep-link modal sits on: it must surface a true 404 as

--- a/frontend/src/supervisor/beadReads.ts
+++ b/frontend/src/supervisor/beadReads.ts
@@ -3,6 +3,7 @@ import type {
   GetV0CityByCityNameBeadsData,
   ListBodyBead,
 } from 'gas-city-dashboard-shared/gc-supervisor';
+import { isResolvedStatus } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
 import { SupervisorApiError, supervisorApi } from './client';
 
@@ -59,7 +60,9 @@ export async function listSupervisorBeads(
   };
   const list = await supervisorApi().listBeads(cityName, baseQuery);
   const items = uniqueById(list.items ?? []);
-  const statusFiltered = includeClosed ? items : items.filter((bead) => bead.status !== 'closed');
+  const statusFiltered = includeClosed
+    ? items
+    : items.filter((bead) => !isResolvedStatus(bead.status));
   const filtered = includeBookkeeping ? statusFiltered : statusFiltered.filter(defaultBeadFilter);
   const upstreamTotal = countAsNumber(list.total);
   return {

--- a/shared/src/runs/bead-fields.ts
+++ b/shared/src/runs/bead-fields.ts
@@ -39,8 +39,13 @@ export function externalizeId(id: string): string {
   return id.replace(/(^|[^A-Za-z0-9])ralph(?=$|[^A-Za-z0-9])/gi, '$1check-loop');
 }
 
-function numericRefSegment(bead: RunSnapshotBead, marker: string): number | undefined {
-  const ref = normalizedStepRef(bead);
+/**
+ * Parse the positive integer following `marker` in a dotted ref string, e.g.
+ * refSegment('mol-adopt-pr-v2.review-loop.iteration.6.apply-fixes.attempt.1',
+ * 'attempt') === 1. Returns undefined when the marker is absent or is not
+ * followed by a positive integer.
+ */
+export function refSegment(ref: string | null | undefined, marker: string): number | undefined {
   if (!ref) return undefined;
   const parts = ref.split('.');
   for (let i = 0; i < parts.length - 1; i += 1) {
@@ -49,6 +54,10 @@ function numericRefSegment(bead: RunSnapshotBead, marker: string): number | unde
     if (parsed !== undefined) return parsed;
   }
   return undefined;
+}
+
+function numericRefSegment(bead: RunSnapshotBead, marker: string): number | undefined {
+  return refSegment(normalizedStepRef(bead), marker);
 }
 
 function numericMeta(bead: RunSnapshotBead, key: string): number | undefined {

--- a/shared/src/runs/display-state.ts
+++ b/shared/src/runs/display-state.ts
@@ -1,6 +1,5 @@
 import type { RunDisplayEdge, RunDisplayNode, RunNodeStatus } from '../run-detail.js';
-
-const TERMINAL_STATUSES = new Set<RunNodeStatus>(['completed', 'done', 'failed', 'skipped']);
+import { isTerminalNodeStatus } from './status.js';
 
 /**
  * Convert raw bead state into graph presentation state. The supervisor exposes
@@ -43,7 +42,7 @@ function displayStatusFor(
   if (blockers.length === 0) return 'ready';
   const allDone = blockers.every((blockerId) => {
     const blocker = byId.get(blockerId);
-    return blocker ? TERMINAL_STATUSES.has(blocker.status) : false;
+    return blocker ? isTerminalNodeStatus(blocker.status) : false;
   });
   return allDone ? 'ready' : 'blocked';
 }

--- a/shared/src/runs/formula-run.ts
+++ b/shared/src/runs/formula-run.ts
@@ -163,11 +163,12 @@ export function buildRunningFormulaRun(input: RunningFormulaRunInput): RunningFo
  * Adapt a supervisor run-snapshot bead to the phase classifier's
  * RunIssue input. The phase pipeline's own fromDashboardBead adapter consumes the
  * city-wide DashboardBead shape (issue_type, created_at); the run-snapshot wire row
- * is a different shape (kind, no created_at). mapRunPhase only reads
- * status / title / metadata / issue_type / parent, so this maps the run-bead
- * `kind` onto `issue_type` and leaves updated_at empty (the snapshot carries
- * no per-bead timestamp — latestStepId's ordering degrades gracefully to
- * input order, which the phase classifier does not depend on).
+ * is a different shape (kind, no created_at). mapRunPhase reads
+ * status / title / metadata / issue_type / parent plus the step_ref / scope_ref
+ * retry signals, so this maps the run-bead `kind` onto `issue_type`, carries the
+ * first-class refs, and leaves updated_at empty (the snapshot carries no per-bead
+ * timestamp — latestStepId's ordering degrades gracefully to input order, which
+ * the phase classifier does not depend on).
  */
 function fromRunSnapshotBead(bead: RunSnapshotBead): RunIssue {
   const parent = meta(bead, 'gc.parent_bead_id');
@@ -181,6 +182,13 @@ function fromRunSnapshotBead(bead: RunSnapshotBead): RunIssue {
   };
   if (bead.assignee !== undefined) issue.assignee = bead.assignee;
   if (parent !== undefined) issue.parent = parent;
+  // Carry the first-class run-snapshot refs so retry/iteration cohorting reads the
+  // canonical step_ref/scope_ref, not only their metadata mirror — some snapshot
+  // rows populate the first-class field without the gc.* mirror. The `.attempt.N`
+  // / `.iteration.N` segments here are how latestAttempt drops a stale failed
+  // attempt of a retried step (see phaseMapping.attemptRank).
+  if (bead.step_ref !== undefined) issue.step_ref = bead.step_ref;
+  if (bead.scope_ref !== undefined) issue.scope_ref = bead.scope_ref;
   return issue;
 }
 

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -294,6 +294,59 @@ describe('mapRunPhase — supervisor wire status vocabulary (M2)', () => {
     };
   }
 
+  // Captured graph.v2 retry shape (live mol-adopt-pr-v2 review loop, root
+  // gd-wisp-0ye1): a retried step's WORK bead carries an attempt-SUFFIXED
+  // gc.step_id / step_ref (apply-fixes.attempt.N), while gc.attempt mirrors the
+  // review-loop ITERATION (6) — identical across every attempt of the iteration,
+  // so it cannot discriminate per-step retries. The BASE step id lives only on the
+  // gc.kind=retry / scope-check latch beads. These helpers reproduce that shape so
+  // the cohorting fix is pinned to real metadata, not an invented base-id+gc.attempt
+  // model.
+  const RETRY_ITERATION = 6;
+  function loopRefs(stepId: string): { step_ref: string; scope_ref: string } {
+    const scope_ref = `mol-adopt-pr-v2.review-loop.iteration.${RETRY_ITERATION}`;
+    return { step_ref: `${scope_ref}.${stepId}`, scope_ref };
+  }
+  function workAttempt(step: string, attempt: number, status: string): RunIssue {
+    const stepId = `${step}.attempt.${attempt}`;
+    const refs = loopRefs(stepId);
+    return {
+      id: `work-${stepId}`,
+      title: 'step',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      step_ref: refs.step_ref,
+      scope_ref: refs.scope_ref,
+      metadata: {
+        'gc.kind': 'work',
+        'gc.step_id': stepId,
+        'gc.attempt': String(RETRY_ITERATION),
+        'gc.step_ref': refs.step_ref,
+        'gc.scope_ref': refs.scope_ref,
+      },
+    };
+  }
+  function retryLatch(step: string, status: string): RunIssue {
+    const refs = loopRefs(step);
+    return {
+      id: `retry-${step}`,
+      title: 'retry latch',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      step_ref: refs.step_ref,
+      scope_ref: refs.scope_ref,
+      metadata: {
+        'gc.kind': 'retry',
+        'gc.step_id': step,
+        'gc.attempt': String(RETRY_ITERATION),
+        'gc.step_ref': refs.step_ref,
+        'gc.scope_ref': refs.scope_ref,
+      },
+    };
+  }
+
   test("an 'active' (wire) step drives the structured phase, exactly like 'in_progress'", () => {
     const phase = mapRunPhase([
       root({ id: 'w1', updated_at: '', status: 'pending' }),
@@ -420,6 +473,503 @@ describe('mapRunPhase — supervisor wire status vocabulary (M2)', () => {
       step('w6-s3', 'cleanup-worktree', 'open'),
     ]);
     assert.equal(phase.phase, 'implementation');
+  });
+
+  test("a raw 'failed' (wire) step counts as advanced — phase does not regress below it", () => {
+    // presentationStatus defends against raw 'failed' (status.ts), so phase
+    // derivation must too: the step demonstrably ran, and the normal failure
+    // encoding (closed + gc.outcome=fail) already ranks as advanced.
+    const phase = mapRunPhase([
+      root({ id: 'w7', updated_at: '', status: 'pending' }),
+      wireStep('implement-change', 'failed'),
+      wireStep('cleanup-worktree', 'pending'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test("a raw 'skipped' step does not block an otherwise finished run from 'complete'", () => {
+    // A skipped step is resolved — it will never run. Mirrors the bd encoding
+    // closed + gc.outcome=skipped, which already counts toward complete.
+    const phase = mapRunPhase([
+      root({ id: 'w8', updated_at: '', status: 'completed' }),
+      wireStep('implement-change', 'completed'),
+      wireStep('repair-pre-review-ci-failures', 'skipped'),
+      wireStep('finalize', 'completed'),
+    ]);
+    assert.equal(phase.phase, 'complete');
+  });
+
+  test("a raw 'done' step counts as resolved for advancement and completion, like 'completed'", () => {
+    // 'done' is an accepted closed spelling (isClosedStatus). Pin it directly so
+    // a future status-helper refactor cannot silently drop the arm without a
+    // failing test (the other accepted spellings are each already pinned).
+    const advanced = mapRunPhase([
+      root({ id: 'w-done-1', updated_at: '', status: 'pending' }),
+      wireStep('implement-change', 'done'),
+      wireStep('cleanup-worktree', 'pending'),
+    ]);
+    assert.equal(advanced.phase, 'implementation');
+
+    const complete = mapRunPhase([
+      root({ id: 'w-done-2', updated_at: '', status: 'done' }),
+      wireStep('implement-change', 'done'),
+      wireStep('finalize', 'done'),
+    ]);
+    assert.equal(complete.phase, 'complete');
+  });
+
+  test('formula ladder between steps (wire): completed stages + pending remainder → first open stage active', () => {
+    // Nothing in flight, so currentIndex falls to the first stage that has not
+    // succeeded (!stageSucceeded) — Review here, whose only materialized steps
+    // are still pending — and that stage renders active under the wire
+    // completed/pending spellings.
+    const issues = [
+      root({ id: 'w9', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'pending'),
+      wireStep('apply-fixes', 'pending'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+  });
+
+  test('completed reviewers with pending synthesize/apply-fixes keep Review active, not complete (F1)', () => {
+    // The mol-adopt-pr-v2 Review stage bundles several required steps. A run
+    // BETWEEN review substeps — reviewers completed, but synthesize,
+    // quality-scorecard, and apply-fixes still pending — must keep Review the
+    // current stage. Before the fix one succeeded step completed the whole stage,
+    // so Review rendered complete and Pre-approval CI active while required review
+    // work was still pending (the ga-wisp-x0tank between-steps shape).
+    const issues = [
+      root({ id: 'wf5', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.review-codex', 'completed'),
+      wireStep('review-pipeline.review-gemini', 'completed'),
+      wireStep('review-pipeline.synthesize', 'pending'),
+      wireStep('review-pipeline.quality-scorecard', 'pending'),
+      wireStep('apply-fixes', 'pending'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  // The formula ladder must split SUCCESSFUL completion from mere resolution.
+  // isResolvedStatus folds in failed + skipped, so before the fix a failed or
+  // skipped step advanced the ladder as if its stage had passed — the failed
+  // stage rendered complete while the next materialized pending shell rendered
+  // active (the M2 overstatement class, reached through the failed/skipped door).
+  test('failed apply-fixes with pending shells (wire): review blocks, the ladder does not advance past it', () => {
+    const issues = [
+      root({ id: 'wf1', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('review-pipeline.quality-scorecard', 'completed'),
+      wireStep('apply-fixes', 'failed'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'blocked');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  test('skipped late tail (wire), root unresolved: the skip stays current, later stages do not complete', () => {
+    // Every late step is 'skipped' (resolved), so the pre-fix ladder marked the
+    // whole tail complete. A skipped step did not run — it must not render its
+    // stage, or any later stage, as done.
+    const issues = [
+      root({ id: 'wf2', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+      wireStep('pre-approval-ci', 'skipped'),
+      wireStep('human-approval', 'skipped'),
+      wireStep('finalize', 'skipped'),
+      wireStep('cleanup-worktree', 'skipped'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'complete');
+    assert.equal(byKey.get('ci'), 'active');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  // The contrast to the root-unresolved case above. The bypassed-tail-parks-
+  // active rule is right ONLY while the run is still in flight: a skipped tail
+  // cannot prove the run passed it. Once the whole run is resolved (mapRunPhase
+  // → complete) there is no work left to be 'current', so a skipped or
+  // unmaterialized tail must render complete, not a stuck active stage.
+  test('skipped tail, root RESOLVED (complete): every stage renders complete, no parked active tail (M-2)', () => {
+    // An accepted-as-is adopt-pr run: the CI/approval/finalize/cleanup tail was
+    // skipped while the root closed complete.
+    const issues = [
+      root({ id: 'wfc1', updated_at: '', status: 'completed' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+      wireStep('pre-approval-ci', 'skipped'),
+      wireStep('human-approval', 'skipped'),
+      wireStep('finalize', 'skipped'),
+      wireStep('cleanup-worktree', 'skipped'),
+    ];
+    const phase = mapRunPhase(issues);
+    assert.equal(phase.phase, 'complete');
+    const stages = stageProgress(phase, 'mol-adopt-pr-v2', issues);
+    for (const stage of stages) {
+      assert.equal(stage.status, 'complete', `${stage.key} should be complete`);
+    }
+  });
+
+  test('UNMATERIALIZED tail, root RESOLVED (complete): every stage renders complete (M-2)', () => {
+    // Same completion rule when the tail stages never materialized a bead at all
+    // (empty stage). A complete run must not show a pending/active tail just
+    // because the later steps were never poured.
+    const issues = [
+      root({ id: 'wfc2', updated_at: '', status: 'completed' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+    ];
+    const phase = mapRunPhase(issues);
+    assert.equal(phase.phase, 'complete');
+    const stages = stageProgress(phase, 'mol-adopt-pr-v2', issues);
+    for (const stage of stages) {
+      assert.equal(stage.status, 'complete', `${stage.key} should be complete`);
+    }
+  });
+
+  test('RESOLVED run with a failed stage still renders it blocked, not falsely complete (M-2 guard)', () => {
+    // Over-correction guard: the complete-run rule must not paper over a real
+    // failure. mapRunPhase buckets an all-resolved run as complete even when a
+    // step FAILED, so the formula ladder must still surface the failure point as
+    // blocked — never swallow it into a green 'complete'. The skipped tail after
+    // the failure is honestly pending, not retroactively complete.
+    const issues = [
+      root({ id: 'wfc3', updated_at: '', status: 'completed' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'failed'),
+      wireStep('pre-approval-ci', 'skipped'),
+      wireStep('human-approval', 'skipped'),
+      wireStep('finalize', 'skipped'),
+      wireStep('cleanup-worktree', 'skipped'),
+    ];
+    const phase = mapRunPhase(issues);
+    assert.equal(phase.phase, 'complete');
+    const stages = stageProgress(phase, 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'blocked');
+  });
+
+  test('conditional skip alongside a real success still completes the stage', () => {
+    // repair-ci-failures is skipped whenever CI is green; the CI stage still
+    // PASSED via pre-approval-ci. The skip must not demote a genuinely complete
+    // stage — guards against over-correcting the failed/skipped fix.
+    const issues = [
+      root({ id: 'wf3', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+      wireStep('pre-approval-ci', 'completed'),
+      wireStep('repair-ci-failures', 'skipped'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'complete');
+    assert.equal(byKey.get('ci'), 'complete');
+    assert.equal(byKey.get('approval'), 'active');
+    assert.equal(byKey.get('finalize'), 'pending');
+  });
+
+  test('bd-encoded failure (closed + gc.outcome=fail) blocks the stage, like a wire failure', () => {
+    // The summary lane feeds bd ledger statuses: a failed step is closed with
+    // gc.outcome=fail, not raw 'failed'. The ladder reads the outcome so the lane
+    // and the run-detail page agree on where the run failed.
+    const failed = (id: string, stepId: string): RunIssue =>
+      step(id, stepId, 'closed', {
+        metadata: { 'gc.kind': 'step', 'gc.step_id': stepId, 'gc.outcome': 'fail' },
+      });
+    const issues = [
+      root({ id: 'wf4', status: 'open' }),
+      step('wf4-s1', 'preflight', 'closed'),
+      step('wf4-s2', 'rebase-check', 'closed'),
+      step('wf4-s3', 'review-pipeline.review-claude', 'closed'),
+      failed('wf4-s4', 'apply-fixes'),
+      step('wf4-s5', 'pre-approval-ci', 'open'),
+      step('wf4-s6', 'human-approval', 'open'),
+      step('wf4-s7', 'finalize', 'open'),
+      step('wf4-s8', 'cleanup-worktree', 'open'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'blocked');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+  });
+
+  test('retried step (real graph.v2 shape): a stale failed attempt.1 does not block the stage after attempt.2 passes (F1)', () => {
+    // apply-fixes failed at attempt.1 then passed at attempt.2 within review-loop
+    // iteration 6. The work beads carry attempt-suffixed gc.step_id/step_ref;
+    // gc.attempt is the iteration (6) on BOTH, so cohorting keys off the
+    // `.attempt.N` suffix. latestAttempt must keep only attempt.2 (passed) — the
+    // stale failed attempt.1 must not pin Review to blocked — so Review completes
+    // and the ladder advances to Pre-approval CI. The base-id retry latch
+    // (gc.kind=retry) ranks attempt 0 and is superseded too.
+    const issues = [
+      root({ id: 'wf-retry-real', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('review-pipeline.quality-scorecard', 'completed'),
+      retryLatch('apply-fixes', 'completed'),
+      workAttempt('apply-fixes', 1, 'failed'),
+      workAttempt('apply-fixes', 2, 'completed'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'complete');
+    assert.equal(byKey.get('ci'), 'active');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  test('retried step (real graph.v2 shape): an in-flight attempt-suffixed work bead is matched to its stage', () => {
+    // Mirrors the live shape of this very run: apply-fixes.attempt.1 in flight
+    // under review-loop.iteration.6, with the base id only on the gc.kind=retry
+    // latch. Exact gc.step_id matching missed the suffixed work bead, so its stage
+    // saw only the open latch and mis-derived the current stage; base-id cohorting
+    // places the in-flight work bead in Review, keeping Review the active stage.
+    const issues = [
+      root({ id: 'wf-inflight-real', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.review-codex', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('review-pipeline.quality-scorecard', 'completed'),
+      retryLatch('apply-fixes', 'open'),
+      workAttempt('apply-fixes', 1, 'active'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  test('bypassed (skipped) middle stage before a later success completes, not stalls the ladder (F2)', () => {
+    // human-approval was skipped (auto-approve), yet finalize and cleanup then
+    // completed. A fully-skipped MIDDLE stage with later succeeded stages must
+    // render complete — the run demonstrably moved past it — instead of pinning
+    // the ladder at approval and mislabeling the completed tail pending.
+    const issues = [
+      root({ id: 'wf-bypass', updated_at: '', status: 'completed' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+      wireStep('pre-approval-ci', 'completed'),
+      wireStep('human-approval', 'skipped'),
+      wireStep('finalize', 'completed'),
+      wireStep('cleanup-worktree', 'completed'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'complete');
+    assert.equal(byKey.get('ci'), 'complete');
+    assert.equal(byKey.get('approval'), 'complete');
+    assert.equal(byKey.get('finalize'), 'complete');
+    assert.equal(byKey.get('cleanup'), 'complete');
+  });
+
+  test('unmaterialized (empty) middle stage before a later success completes (F2)', () => {
+    // The same advance-past-a-bypassed-stage rule for a stage that never
+    // materialized at all (no human-approval bead): finalize + cleanup completed,
+    // so the empty approval stage must render complete, not stall the ladder.
+    const issues = [
+      root({ id: 'wf-empty', updated_at: '', status: 'completed' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'completed'),
+      wireStep('apply-fixes', 'completed'),
+      wireStep('pre-approval-ci', 'completed'),
+      // human-approval never materialized — the approval stage has no beads.
+      wireStep('finalize', 'completed'),
+      wireStep('cleanup-worktree', 'completed'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'complete');
+    assert.equal(byKey.get('ci'), 'complete');
+    assert.equal(byKey.get('approval'), 'complete');
+    assert.equal(byKey.get('finalize'), 'complete');
+    assert.equal(byKey.get('cleanup'), 'complete');
+  });
+
+  test("two concurrently 'active' (wire) reviewers with empty timestamps resolve deterministically", () => {
+    // The review-wave norm: multiple reviewers in flight at once, updated_at=''
+    // on every snapshot bead. The pick must come from the rank/id tiebreak, not
+    // input order.
+    const issues = [
+      root({ id: 'w10', updated_at: '', status: 'pending' }),
+      wireStep('review-pipeline.review-codex', 'active'),
+      wireStep('review-pipeline.review-claude', 'active'),
+      wireStep('preflight', 'completed'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    assert.equal(mapRunPhase(issues).phase, 'review');
+    assert.equal(mapRunPhase([...issues].reverse()).phase, 'review');
+  });
+});
+
+describe('mapRunPhase — first-class-only step refs without a gc.step_id mirror (codex Major)', () => {
+  // The run-detail snapshot adapter (formula-run.fromRunSnapshotBead) preserves a
+  // supervisor row's first-class step_ref/scope_ref even when the row omits the
+  // gc.step_id metadata mirror. Step identity must then derive the step id from
+  // those refs (scope_ref + "." stripped off step_ref), or both the structured
+  // phase pick and the formula-stage ladder silently ignore valid run-detail data
+  // — the phase falls through to the conservative 'active' fallback and the ladder
+  // parks on preflight. These fixtures carry ONLY the first-class refs: metadata
+  // holds the kind but no gc.step_id / gc.step_ref / gc.scope_ref mirror.
+  const MOLECULE = 'mol-adopt-pr-v2';
+  const ITERATION_SCOPE = `${MOLECULE}.review-loop.iteration.3`;
+  function refOnlyStep(stepId: string, status: string, scopeRef: string): RunIssue {
+    return {
+      id: `fc-${stepId}`,
+      title: 'step',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      step_ref: `${scopeRef}.${stepId}`,
+      scope_ref: scopeRef,
+      metadata: { 'gc.kind': 'work' },
+    };
+  }
+
+  test('an active review step carried first-class-only drives the review phase, not the active fallback', () => {
+    const issues = [
+      root({ id: 'fc-run', updated_at: '', status: 'pending' }),
+      refOnlyStep('review-pipeline.review-claude', 'active', ITERATION_SCOPE),
+    ];
+    // Before the fix latestStepId/furthestStageStepId read only gc.step_id, found
+    // none, and mapRunPhase fell through to the keyword fallback → 'active'.
+    assert.equal(mapRunPhase(issues).phase, 'review');
+  });
+
+  test('the formula ladder honors first-class-only refs instead of parking on preflight', () => {
+    // A realistic between-steps mol-adopt-pr-v2 run whose entire step identity is
+    // first-class refs: top-level steps scope to the molecule root, the in-flight
+    // retried apply-fixes work bead scopes to the review-loop iteration and carries
+    // an attempt suffix. The derived ids must place Review as the active stage.
+    const issues = [
+      root({ id: 'fc-run2', updated_at: '', status: 'pending' }),
+      refOnlyStep('preflight', 'completed', MOLECULE),
+      refOnlyStep('rebase-check', 'completed', MOLECULE),
+      refOnlyStep('apply-fixes.attempt.1', 'active', ITERATION_SCOPE),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), MOLECULE, issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    // Before the fix none of these refs resolved to a step id, so every stage was
+    // "bypassed", currentIndex fell to 0, and Preflight rendered active.
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  test('a gc.step_id mirror still wins when present (first-class refs do not override it)', () => {
+    // The summary/dashboard projection always carries the mirror; the accessor must
+    // prefer it so mirrored summary-lane beads and first-class-only run-detail beads
+    // for the same step resolve identically.
+    const issues = [
+      root({ id: 'fc-run3', updated_at: '', status: 'pending' }),
+      {
+        id: 'mirrored',
+        title: 'step',
+        status: 'active',
+        issue_type: 'task',
+        updated_at: '',
+        // The ref points at finalize, but the mirror says apply-fixes — the mirror wins.
+        step_ref: `${ITERATION_SCOPE}.finalize`,
+        scope_ref: ITERATION_SCOPE,
+        metadata: { 'gc.kind': 'work', 'gc.step_id': 'apply-fixes' },
+      } satisfies RunIssue,
+    ];
+    const stages = stageProgress(mapRunPhase(issues), MOLECULE, issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('finalize'), 'pending');
   });
 });
 

--- a/shared/src/runs/phaseMapping.test.ts
+++ b/shared/src/runs/phaseMapping.test.ts
@@ -1,7 +1,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { mapRunPhase, stepIdPhase, type RunIssue } from './phaseMapping.js';
+import { mapRunPhase, stageProgress, stepIdPhase, type RunIssue } from './phaseMapping.js';
 
 // gascity-dashboard-q3p1: phase is derived from the run's CURRENT step
 // (structured-first), not from a keyword scan over title+description+metadata.
@@ -266,6 +266,160 @@ describe('mapRunPhase — tightened keyword fallback (no structured steps)', () 
     assert.notEqual(phase.phase, 'approval');
     assert.notEqual(phase.phase, 'finalization');
     assert.equal(phase.phase, 'active');
+  });
+});
+
+// M2 audit (run ga-wisp-x0tank): the run-detail page feeds phase derivation
+// SUPERVISOR WIRE statuses (pending/active/completed via fromRunSnapshotBead),
+// not bd ledger statuses (open/in_progress/closed). Two layered defects:
+//   (1) structuredPhase matched only status==='in_progress', so the in-flight
+//       step detection could NEVER fire on the run-detail page — a live
+//       'active' bead was invisible to it.
+//   (2) the no-in-flight fallback (furthestStageStepId) ranked ALL materialized
+//       steps, including pending/unstarted shells. graph.v2 runs materialize
+//       the full DAG at pour time, so a pending 'cleanup-worktree' wisp drove
+//       phase='finalization' (ladder: Intake/Implementation/Review/Approval
+//       all complete) for the run's ENTIRE life while it was mid-review.
+describe('mapRunPhase — supervisor wire status vocabulary (M2)', () => {
+  function wireStep(stepId: string, status: string, overrides: Partial<RunIssue> = {}): RunIssue {
+    // Run-detail snapshot shape: wire statuses, no per-bead timestamp.
+    return {
+      id: `step-${stepId}`,
+      title: 'step',
+      status,
+      issue_type: 'task',
+      updated_at: '',
+      metadata: { 'gc.kind': 'step', 'gc.step_id': stepId },
+      ...overrides,
+    };
+  }
+
+  test("an 'active' (wire) step drives the structured phase, exactly like 'in_progress'", () => {
+    const phase = mapRunPhase([
+      root({ id: 'w1', updated_at: '', status: 'pending' }),
+      wireStep('implement-change', 'active'),
+      wireStep('cleanup-worktree', 'pending'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('fallback ignores materialized pending shells — only ADVANCED steps rank', () => {
+    // Nothing in flight; implementation completed; the post-review wave
+    // (approval gate, finalize, cleanup) is materialized but unstarted.
+    const phase = mapRunPhase([
+      root({ id: 'w2', updated_at: '', status: 'pending' }),
+      wireStep('implement-change', 'completed'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
+  });
+
+  test('ga-wisp-x0tank shape: review wave done, synthesize active, post-review wave pending → review', () => {
+    // Mirrors the captured supervisor payload for ga-wisp-x0tank: the review
+    // pipeline is mid-flight, yet the deployed pipeline derived 'finalization'.
+    const issues = [
+      root({ id: 'ga-wisp-x0tank', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('pre-review-ci', 'completed'),
+      wireStep('repair-pre-review-ci-failures', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.review-codex', 'completed'),
+      wireStep('review-pipeline.review-gemini', 'completed'),
+      wireStep('review-pipeline.synthesize', 'active'),
+      wireStep('apply-fixes', 'pending'),
+      wireStep('review-pipeline.quality-scorecard', 'pending'),
+      wireStep('review-loop', 'pending'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('repair-pre-approval-ci-failures', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const phase = mapRunPhase(issues);
+    assert.equal(phase.phase, 'review');
+  });
+
+  test('ga-wisp-x0tank shape between steps (nothing active) still reads review, not finalization', () => {
+    const issues = [
+      root({ id: 'ga-wisp-x0tank', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.review-codex', 'completed'),
+      wireStep('review-pipeline.review-gemini', 'completed'),
+      wireStep('review-pipeline.synthesize', 'pending'),
+      wireStep('apply-fixes', 'pending'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const phase = mapRunPhase(issues);
+    assert.equal(phase.phase, 'review');
+    // The generic ladder must not mark Approval/Finalization-preceding stages
+    // complete past the truth.
+    const stages = stageProgress(phase, null, issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalization'), 'pending');
+  });
+
+  test("all steps 'completed' (wire) → complete, like all 'closed'", () => {
+    const phase = mapRunPhase([
+      root({ id: 'w3', updated_at: '', status: 'completed' }),
+      wireStep('implement-change', 'completed'),
+      wireStep('finalize', 'completed'),
+    ]);
+    assert.equal(phase.phase, 'complete');
+  });
+
+  test('freshly poured run (full DAG materialized, all pending) stays conservative', () => {
+    const phase = mapRunPhase([
+      root({ id: 'w4', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'pending'),
+      wireStep('review-loop', 'pending'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ]);
+    assert.notEqual(phase.phase, 'approval');
+    assert.notEqual(phase.phase, 'finalization');
+    assert.equal(phase.phase, 'active');
+  });
+
+  test('formula-specific ladder (mol-adopt-pr-v2) reads wire statuses too', () => {
+    const issues = [
+      root({ id: 'w5', updated_at: '', status: 'pending' }),
+      wireStep('preflight', 'completed'),
+      wireStep('rebase-check', 'completed'),
+      wireStep('review-pipeline.review-claude', 'completed'),
+      wireStep('review-pipeline.synthesize', 'active'),
+      wireStep('pre-approval-ci', 'pending'),
+      wireStep('human-approval', 'pending'),
+      wireStep('finalize', 'pending'),
+      wireStep('cleanup-worktree', 'pending'),
+    ];
+    const stages = stageProgress(mapRunPhase(issues), 'mol-adopt-pr-v2', issues);
+    const byKey = new Map(stages.map((s) => [s.key, s.status]));
+    assert.equal(byKey.get('preflight'), 'complete');
+    assert.equal(byKey.get('rebase'), 'complete');
+    assert.equal(byKey.get('review'), 'active');
+    assert.equal(byKey.get('ci'), 'pending');
+    assert.equal(byKey.get('approval'), 'pending');
+    assert.equal(byKey.get('finalize'), 'pending');
+    assert.equal(byKey.get('cleanup'), 'pending');
+  });
+
+  test('bd-fed summary lane: fallback skips OPEN shells too, not only wire-pending ones', () => {
+    const phase = mapRunPhase([
+      root({ id: 'w6' }),
+      step('w6-s1', 'implement-change', 'closed'),
+      step('w6-s2', 'human-approval', 'open'),
+      step('w6-s3', 'cleanup-worktree', 'open'),
+    ]);
+    assert.equal(phase.phase, 'implementation');
   });
 });
 

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -43,7 +43,7 @@ export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
     return { phase: 'blocked', label: 'blocked', reviewRound: null };
   }
 
-  if (issues.length > 0 && issues.every((i) => i.status === 'closed')) {
+  if (issues.length > 0 && issues.every((i) => isClosedStatus(i.status))) {
     return { phase: 'complete', label: 'complete', reviewRound: null };
   }
 
@@ -70,15 +70,17 @@ export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
 /**
  * gascity-dashboard-q3p1: derive the phase from the run's current step.
  *
- * The active step is the latest in_progress primary step; if none is in_progress
- * (e.g. between steps) it is the latest primary step that carries a gc.step_id.
- * The step-id is classified into a generic RunPhase by stepIdPhase. Returns null
- * when no primary step carries a gc.step_id (no structured signal to use).
+ * The active step is the latest in-flight primary step; if none is in flight
+ * (e.g. between steps) it is the furthest-ADVANCED primary step that carries a
+ * gc.step_id (started or completed — never a merely materialized pending
+ * shell). The step-id is classified into a generic RunPhase by stepIdPhase.
+ * Returns null when no primary step carries a gc.step_id (no structured signal
+ * to use).
  */
 function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   const primary = issues.filter(isPrimaryStepIssue);
-  const inProgressStep = latestStepId(primary.filter((i) => i.status === 'in_progress'));
-  // gascity-dashboard (Major 3): when no step is in_progress, the current step
+  const inProgressStep = latestStepId(primary.filter((i) => isInFlightStatus(i.status)));
+  // gascity-dashboard (Major 3): when no step is in flight, the current step
   // is the FURTHEST-ADVANCED step by stage rank — a deterministic, order- and
   // timestamp-independent signal. The run-detail snapshot adapter sets every
   // bead updated_at='' (the snapshot carries no per-bead timestamp), so a
@@ -86,17 +88,56 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   // summary lane. Stage rank is derived from gc.step_id alone, so the summary
   // context (real timestamps) and the detail context (empty timestamps) resolve
   // the same run to the same phase.
-  const activeStepId = inProgressStep ?? furthestStageStepId(primary);
-  if (activeStepId === null) {
-    return null;
+  //
+  // M2 audit (ga-wisp-x0tank): only ADVANCED steps (in flight or closed) may
+  // rank here. graph.v2 runs materialize their full DAG at pour time, so
+  // pending shells for late steps (finalize, cleanup-worktree) exist from the
+  // start; ranking them drove phase='finalization' while the run was
+  // mid-review.
+  const activeStepId = inProgressStep ?? furthestStageStepId(primary.filter(hasAdvanced));
+  if (activeStepId !== null) {
+    const phase = stepIdPhase(activeStepId);
+    if (phase === 'review') {
+      const resolved = reviewRoundForIssues(issues) ?? fallbackReviewRound(issues);
+      return { phase: 'review', label: `review round ${resolved}`, reviewRound: resolved };
+    }
+    return { phase, label: phase, reviewRound: null };
   }
 
-  const phase = stepIdPhase(activeStepId);
-  if (phase === 'review') {
-    const resolved = reviewRoundForIssues(issues) ?? fallbackReviewRound(issues);
-    return { phase: 'review', label: `review round ${resolved}`, reviewRound: resolved };
+  // Structured signal exists (some primary step carries a gc.step_id) but no
+  // step has advanced yet — a freshly poured run. Stay conservative instead of
+  // falling through to the keyword scan, which would match late-stage words in
+  // the materialized step titles/ids (e.g. 'approval' in pre-approval-ci).
+  if (furthestStageStepId(primary) !== null) {
+    return { phase: 'active', label: 'active', reviewRound: null };
   }
-  return { phase, label: phase, reviewRound: null };
+  return null;
+}
+
+// ── Status vocabulary ───────────────────────────────────────────────────────
+//
+// Phase derivation reads beads from two adapters with DIFFERENT status
+// vocabularies: the summary lane feeds bd ledger statuses
+// (open/in_progress/closed) via fromDashboardBead, while the run-detail page
+// feeds supervisor wire statuses (pending/active/completed) via
+// fromRunSnapshotBead. Every status comparison here must accept both — the M2
+// audit found the in_progress-only filter made structured phase detection
+// unable to ever fire on the run-detail page. The accepted spellings mirror
+// presentationStatus in status.ts.
+
+/** True when the bead status marks a step currently being worked. */
+export function isInFlightStatus(status: string): boolean {
+  return status === 'in_progress' || status === 'active' || status === 'running';
+}
+
+/** True when the bead status marks a finished step. */
+export function isClosedStatus(status: string): boolean {
+  return status === 'closed' || status === 'completed' || status === 'done';
+}
+
+/** True when the step has actually advanced (started or finished). */
+function hasAdvanced(issue: RunIssue): boolean {
+  return isInFlightStatus(issue.status) || isClosedStatus(issue.status);
 }
 
 /**
@@ -579,14 +620,14 @@ function formulaStageProgress(
   issues: RunIssue[],
 ): RunStage[] {
   const primary = issues.filter(isPrimaryStepIssue);
-  const activeStepId = latestStepId(primary.filter((i) => i.status === 'in_progress'));
+  const activeStepId = latestStepId(primary.filter((i) => isInFlightStatus(i.status)));
   const activeIndex = activeStepId
     ? stages.findIndex((s) => s.steps.includes(activeStepId))
     : firstOpenStageIndex(stages, primary);
   const furthestClosedIndex = furthestClosedStageIndex(stages, primary);
 
   const stageHasClosed = (stage: { steps: string[] }): boolean =>
-    stage.steps.some((step) => stepIssues(primary, step).some((i) => i.status === 'closed'));
+    stage.steps.some((step) => stepIssues(primary, step).some((i) => isClosedStatus(i.status)));
 
   return stages.map((stage, idx) => {
     let status: RunStage['status'];
@@ -603,14 +644,14 @@ function formulaStageProgress(
 
 function firstOpenStageIndex(stages: Array<{ steps: string[] }>, issues: RunIssue[]): number {
   return stages.findIndex((s) =>
-    s.steps.some((step) => stepIssues(issues, step).some((i) => i.status !== 'closed')),
+    s.steps.some((step) => stepIssues(issues, step).some((i) => !isClosedStatus(i.status))),
   );
 }
 
 function furthestClosedStageIndex(stages: Array<{ steps: string[] }>, issues: RunIssue[]): number {
   let furthest = -1;
   stages.forEach((s, idx) => {
-    if (s.steps.some((step) => stepIssues(issues, step).some((i) => i.status === 'closed'))) {
+    if (s.steps.some((step) => stepIssues(issues, step).some((i) => isClosedStatus(i.status)))) {
       furthest = idx;
     }
   });

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -17,6 +17,15 @@
 
 import type { DashboardBead } from '../dashboard-beads.js';
 import type { RunPhase as SharedRunPhase, RunStage } from '../snapshot/types.js';
+import {
+  isBlockedStatus,
+  isClosedStatus,
+  isFailedStatus,
+  isInFlightStatus,
+  isResolvedStatus,
+  isSkippedStatus,
+} from './status.js';
+import { refSegment } from './bead-fields.js';
 
 export interface RunIssue {
   id: string;
@@ -28,6 +37,14 @@ export interface RunIssue {
   updated_at: string;
   /** Populated from DashboardBead.parent or metadata['gc.parent_bead_id']. */
   parent?: string;
+  /**
+   * First-class graph.v2 run-snapshot refs (run-detail adapter only). They encode
+   * the review-loop iteration and per-step retry attempt as `.iteration.N` /
+   * `.attempt.N` segments — the canonical signal latestAttempt cohorts on. The
+   * summary/dashboard adapter has no equivalent and leaves them undefined.
+   */
+  step_ref?: string;
+  scope_ref?: string;
   metadata?: Record<string, string>;
 }
 
@@ -39,11 +56,16 @@ export interface PhaseMapping {
 
 export function mapRunPhase(issues: RunIssue[]): PhaseMapping {
   // Status-based branches first — these are authoritative and correct.
-  if (issues.some((i) => i.status === 'blocked' || textForIssue(i).includes('blocked'))) {
+  if (issues.some((i) => isBlockedStatus(i.status) || textForIssue(i).includes('blocked'))) {
     return { phase: 'blocked', label: 'blocked', reviewRound: null };
   }
 
-  if (issues.length > 0 && issues.every((i) => isClosedStatus(i.status))) {
+  // Resolved-with-failure intentionally reports lane phase 'complete': isResolvedStatus
+  // covers failed/skipped, so an all-resolved run buckets here even when a step failed.
+  // The detail ladder still surfaces that failure as a 'blocked' stage (formulaStageProgress),
+  // so "no work remains" (lane) and the visible failure (ladder) coexist by design — the
+  // M2-guarded choice. Don't narrow this to closed-only without a terminal-failure lane phase.
+  if (issues.length > 0 && issues.every((i) => isResolvedStatus(i.status))) {
     return { phase: 'complete', label: 'complete', reviewRound: null };
   }
 
@@ -89,8 +111,9 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   // context (real timestamps) and the detail context (empty timestamps) resolve
   // the same run to the same phase.
   //
-  // M2 audit (ga-wisp-x0tank): only ADVANCED steps (in flight or closed) may
-  // rank here. graph.v2 runs materialize their full DAG at pour time, so
+  // M2 audit (ga-wisp-x0tank): only ADVANCED steps — in flight or resolved
+  // (closed/failed/skipped, exactly what hasAdvanced admits) — may rank here.
+  // graph.v2 runs materialize their full DAG at pour time, so
   // pending shells for late steps (finalize, cleanup-worktree) exist from the
   // start; ranking them drove phase='finalization' while the run was
   // mid-review.
@@ -114,30 +137,17 @@ function structuredPhase(issues: RunIssue[]): PhaseMapping | null {
   return null;
 }
 
-// ── Status vocabulary ───────────────────────────────────────────────────────
+// ── Step advancement ────────────────────────────────────────────────────────
 //
-// Phase derivation reads beads from two adapters with DIFFERENT status
-// vocabularies: the summary lane feeds bd ledger statuses
-// (open/in_progress/closed) via fromDashboardBead, while the run-detail page
-// feeds supervisor wire statuses (pending/active/completed) via
-// fromRunSnapshotBead. Every status comparison here must accept both — the M2
-// audit found the in_progress-only filter made structured phase detection
-// unable to ever fire on the run-detail page. The accepted spellings mirror
-// presentationStatus in status.ts.
+// The raw bead-status vocabulary (in-flight / closed / resolved) lives in
+// status.ts so presentationStatus and this derivation share one source of truth.
+// The M2 audit found a divergent in_progress-only filter here that made
+// structured phase detection unable to ever fire on the run-detail page's
+// supervisor wire statuses; centralizing the predicates removes that drift class.
 
-/** True when the bead status marks a step currently being worked. */
-export function isInFlightStatus(status: string): boolean {
-  return status === 'in_progress' || status === 'active' || status === 'running';
-}
-
-/** True when the bead status marks a finished step. */
-export function isClosedStatus(status: string): boolean {
-  return status === 'closed' || status === 'completed' || status === 'done';
-}
-
-/** True when the step has actually advanced (started or finished). */
+/** True when the step has actually advanced (started or resolved). */
 function hasAdvanced(issue: RunIssue): boolean {
-  return isInFlightStatus(issue.status) || isClosedStatus(issue.status);
+  return isInFlightStatus(issue.status) || isResolvedStatus(issue.status);
 }
 
 /**
@@ -302,7 +312,7 @@ function fallbackPhase(issues: RunIssue[]): PhaseMapping {
  * summary_for_human value, a "ship gate" mention) never drive the phase.
  */
 function stepSignalText(issue: RunIssue): string {
-  const stepId = stringValue(issue.metadata?.['gc.step_id']);
+  const stepId = stepIdOf(issue);
   return [issue.title, stepId].filter(Boolean).join(' ').toLowerCase();
 }
 
@@ -440,7 +450,7 @@ export function stageProgress(
 ): RunStage[] {
   const formulaStages = stagesForFormula(formula);
   if (formulaStages.length > 0) {
-    return formulaStageProgress(formulaStages, issues);
+    return formulaStageProgress(formulaStages, issues, phase.phase === 'complete');
   }
 
   if (phase.phase === 'blocked') {
@@ -615,26 +625,197 @@ export function stagesForFormula(
   return [];
 }
 
+// ── Stage completion vs resolution ──────────────────────────────────────────
+//
+// The formula ladder needs a STRICTER predicate than isResolvedStatus. Resolved
+// folds in failed and skipped — correct for "no work remains", wrong for "this
+// stage passed". A failed or skipped step must not advance the ladder as if its
+// stage completed, or it reintroduces the M2 overstatement class (the failed
+// stage rendering complete while a later materialized pending shell renders
+// active). These per-step helpers split successful completion from failure and
+// skip, reading the raw status AND the gc.outcome a closed bd step carries
+// (closed + gc.outcome=fail / skipped), so the bd summary lane and the
+// supervisor-wire run-detail page classify a failed stage the same way.
+
+function stepOutcome(issue: RunIssue): string {
+  return stringValue(issue.metadata?.['gc.outcome']).toLowerCase();
+}
+
+/** A step that ran but FAILED: raw 'failed', or a closed step whose gc.outcome is a failure. */
+function isFailedStep(issue: RunIssue): boolean {
+  const outcome = stepOutcome(issue);
+  if (outcome === 'fail' || outcome === 'failed') return true;
+  return isFailedStatus(issue.status);
+}
+
+/** A step that was SKIPPED and never ran: raw 'skipped', or a closed step whose gc.outcome is skipped. */
+function isSkippedStep(issue: RunIssue): boolean {
+  if (stepOutcome(issue) === 'skipped') return true;
+  return isSkippedStatus(issue.status);
+}
+
+/** A step that completed SUCCESSFULLY: closed/completed/done, and neither failed nor skipped. */
+function isSucceededStep(issue: RunIssue): boolean {
+  return isClosedStatus(issue.status) && !isFailedStep(issue) && !isSkippedStep(issue);
+}
+
+/** The richest canonical ref for a run bead: the first-class step_ref, else its
+ *  gc.step_ref metadata mirror, else the (possibly attempt-suffixed) gc.step_id. */
+function stepRefOf(issue: RunIssue): string {
+  return (
+    stringValue(issue.step_ref) ||
+    stringValue(issue.metadata?.['gc.step_ref']) ||
+    stringValue(issue.metadata?.['gc.step_id'])
+  );
+}
+
+/** The scope ref for a run bead (carries the review-loop `.iteration.N`). */
+function scopeRefOf(issue: RunIssue): string {
+  return stringValue(issue.scope_ref) || stringValue(issue.metadata?.['gc.scope_ref']);
+}
+
+/**
+ * The canonical step id for a run bead. Step identity is the gc.step_id metadata
+ * mirror when present (the summary/dashboard projection always carries it). The
+ * run-detail snapshot adapter, however, preserves first-class step_ref/scope_ref
+ * for rows the supervisor emits WITHOUT that gc.* mirror (see
+ * formula-run.fromRunSnapshotBead); for those, derive the step id by stripping
+ * the enclosing `scope_ref + "."` prefix off step_ref — exactly the identity the
+ * mirror would have held (scope `…review-loop.iteration.8` + step
+ * `…iteration.8.apply-fixes.attempt.1` → `apply-fixes.attempt.1`). Without a
+ * resolvable mirror or scoped ref there is no step identity, so return ''. Every
+ * step-identity reader (latestStepId, furthestStageStepId, byMostRecentThenStage,
+ * stepIssues, the fallback step-signal scan) routes through here so first-class-
+ * only run-detail rows classify the same as their mirrored summary-lane twins.
+ */
+function stepIdOf(issue: RunIssue): string {
+  const mirrored = stringValue(issue.metadata?.['gc.step_id']);
+  if (mirrored) return mirrored;
+  const ref = stepRefOf(issue);
+  const scope = scopeRefOf(issue);
+  if (ref && scope) {
+    const prefix = `${scope}.`;
+    if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+  }
+  return '';
+}
+
+/**
+ * A step's [iteration, attempt] cohort rank. The per-step retry attempt is the
+ * `.attempt.N` segment of the step ref — NOT gc.attempt, which graph.v2 sets to
+ * the enclosing review-loop ITERATION (identical across every step and attempt of
+ * that iteration; captured from a live mol-adopt-pr-v2 run, where the in-flight
+ * apply-fixes work bead carries gc.step_id `apply-fixes.attempt.1` and gc.attempt
+ * `6` == `…review-loop.iteration.6`). Un-suffixed beads (single-attempt steps and
+ * the base-id retry/scope-check latches) rank attempt 0.
+ */
+function attemptRank(issue: RunIssue): readonly [number, number] {
+  const ref = stepRefOf(issue);
+  const iteration = refSegment(ref, 'iteration') ?? refSegment(scopeRefOf(issue), 'iteration') ?? 0;
+  const attempt = refSegment(ref, 'attempt') ?? 0;
+  return [iteration, attempt];
+}
+
+function rankIsBefore(a: readonly [number, number], b: readonly [number, number]): boolean {
+  return a[0] < b[0] || (a[0] === b[0] && a[1] < b[1]);
+}
+
+/**
+ * Narrow one step's beads to its LATEST attempt. A retried step materializes a
+ * fresh work bead per attempt, distinguished by the `.attempt.N` suffix of its
+ * gc.step_id / gc.step_ref (apply-fixes.attempt.1 failed, then
+ * apply-fixes.attempt.2 passed). Stage success and failure must read only the
+ * latest attempt, or an older failed attempt keeps the stage blocked after the
+ * retry has passed. Cohorts rank by [iteration, attempt] (see attemptRank), so a
+ * later loop pass and a later in-pass retry both win; the base-id retry/scope
+ * latches rank attempt 0 and a real attempt bead supersedes them.
+ */
+function latestAttempt(stepBeads: RunIssue[]): RunIssue[] {
+  if (stepBeads.length <= 1) return stepBeads;
+  const ranked = stepBeads.map((bead) => ({ bead, rank: attemptRank(bead) }));
+  const max = ranked.reduce((hi, candidate) =>
+    rankIsBefore(hi.rank, candidate.rank) ? candidate : hi,
+  );
+  return ranked
+    .filter((r) => r.rank[0] === max.rank[0] && r.rank[1] === max.rank[1])
+    .map((r) => r.bead);
+}
+
 function formulaStageProgress(
   stages: Array<{ key: string; label: string; steps: string[] }>,
   issues: RunIssue[],
+  runComplete: boolean,
 ): RunStage[] {
   const primary = issues.filter(isPrimaryStepIssue);
   const activeStepId = latestStepId(primary.filter((i) => isInFlightStatus(i.status)));
-  const activeIndex = activeStepId
-    ? stages.findIndex((s) => s.steps.includes(activeStepId))
-    : firstOpenStageIndex(stages, primary);
-  const furthestClosedIndex = furthestClosedStageIndex(stages, primary);
 
-  const stageHasClosed = (stage: { steps: string[] }): boolean =>
-    stage.steps.some((step) => stepIssues(primary, step).some((i) => isClosedStatus(i.status)));
+  // Per stage, the beads that decide its state: each of its steps narrowed to
+  // that step's LATEST attempt (latestAttempt), so an older failed attempt of a
+  // retried step cannot mask a later successful retry.
+  const summaries = stages.map((stage) => {
+    const steps = stage.steps.flatMap((step) => latestAttempt(stepIssues(primary, step)));
+    return {
+      // Succeeded: at least one step passed and EVERY materialized step resolved
+      // as a success or a skip — a still-pending or in-flight required sibling
+      // (review-pipeline.synthesize / apply-fixes while the reviewers completed)
+      // or a failed step keeps the multi-step stage from completing, while a
+      // conditional skip alongside a real success (repair-ci-failures skipped
+      // after pre-approval-ci passed) still completes it.
+      succeeded:
+        steps.some(isSucceededStep) &&
+        steps.every((step) => isSucceededStep(step) || isSkippedStep(step)),
+      failed: steps.some(isFailedStep),
+      // Advanced = real forward progress: a success, a failure, or a step in
+      // flight. A fully skipped, all-pending, or unmaterialized stage has NOT
+      // advanced, so a later "bypassed" stage cannot claim the run moved past it.
+      advanced:
+        steps.some(isSucceededStep) ||
+        steps.some(isFailedStep) ||
+        steps.some((step) => isInFlightStatus(step.status)),
+      // Bypassed = every materialized step skipped, or the stage never
+      // materialized (empty). While the run is in flight such a stage is behind
+      // the run ONLY once a later stage has advanced; a bypassed TAIL with
+      // nothing advanced after it stays the current/parked stage. Once the whole
+      // run has resolved (runComplete) that exception lifts — a skipped tail is
+      // final, not parked (see stageComplete).
+      bypassed: steps.length === 0 || steps.every(isSkippedStep),
+    };
+  });
+
+  const laterStageAdvanced = (idx: number): boolean =>
+    summaries.slice(idx + 1).some((s) => s.advanced);
+  // A stage is behind the run when it succeeded outright, or it was bypassed and
+  // either the run has already advanced into a later stage OR the whole run has
+  // resolved. The runComplete arm fixes the bypassed-TAIL case: when mapRunPhase
+  // buckets an all-resolved run as complete, a skipped or unmaterialized tail
+  // must render complete, not park as the current 'active' stage — there is no
+  // work left to be current. A failed stage is neither succeeded nor bypassed,
+  // so it still surfaces as the current/blocked point even in a resolved run; the
+  // failure is never swallowed into a green complete.
+  const stageComplete = (idx: number): boolean => {
+    const s = summaries[idx]!;
+    return s.succeeded || (s.bypassed && (laterStageAdvanced(idx) || runComplete));
+  };
+
+  // The current stage is the in-flight step's stage; with nothing in flight it is
+  // the FIRST stage the run has not moved past. That keeps a failed stage as the
+  // current problem point and holds a bypassed TAIL as current while the run is
+  // in flight, yet advances over a bypassed MIDDLE stage that a later succeeded
+  // stage proves the run passed (and over a bypassed tail once the run resolves).
+  const inFlightIndex = activeStepId
+    ? stages.findIndex((s) => s.steps.includes(baseStepId(activeStepId)))
+    : -1;
+  const currentIndex =
+    inFlightIndex >= 0 ? inFlightIndex : summaries.findIndex((_s, idx) => !stageComplete(idx));
 
   return stages.map((stage, idx) => {
     let status: RunStage['status'];
-    if (activeIndex >= 0) {
-      status = idx < activeIndex ? 'complete' : idx === activeIndex ? 'active' : 'pending';
-    } else if (stageHasClosed(stage) || idx < furthestClosedIndex) {
+    if (currentIndex < 0 || idx < currentIndex) {
       status = 'complete';
+    } else if (idx === currentIndex) {
+      // A failed current stage with nothing in flight renders blocked — the real
+      // failure point — rather than a misleading 'active'.
+      status = inFlightIndex < 0 && summaries[idx]!.failed ? 'blocked' : 'active';
     } else {
       status = 'pending';
     }
@@ -642,27 +823,11 @@ function formulaStageProgress(
   });
 }
 
-function firstOpenStageIndex(stages: Array<{ steps: string[] }>, issues: RunIssue[]): number {
-  return stages.findIndex((s) =>
-    s.steps.some((step) => stepIssues(issues, step).some((i) => !isClosedStatus(i.status))),
-  );
-}
-
-function furthestClosedStageIndex(stages: Array<{ steps: string[] }>, issues: RunIssue[]): number {
-  let furthest = -1;
-  stages.forEach((s, idx) => {
-    if (s.steps.some((step) => stepIssues(issues, step).some((i) => isClosedStatus(i.status)))) {
-      furthest = idx;
-    }
-  });
-  return furthest;
-}
-
 export function latestStepId(issues: RunIssue[]): string | null {
   return (
     [...issues]
       .sort(byMostRecentThenStage)
-      .map((i) => stringValue(i.metadata?.['gc.step_id']))
+      .map((i) => stepIdOf(i))
       .find(Boolean) ?? null
   );
 }
@@ -678,9 +843,7 @@ export function latestStepId(issues: RunIssue[]): string | null {
  * rank break on the step id string for total determinism.
  */
 function furthestStageStepId(issues: RunIssue[]): string | null {
-  const stepIds = issues
-    .map((i) => stringValue(i.metadata?.['gc.step_id']))
-    .filter((id): id is string => id.length > 0);
+  const stepIds = issues.map((i) => stepIdOf(i)).filter((id): id is string => id.length > 0);
   if (stepIds.length === 0) return null;
   return [...stepIds].sort((a, b) => {
     const rankDelta = stageRank(stepIdPhase(b)) - stageRank(stepIdPhase(a));
@@ -727,8 +890,8 @@ function stageRank(phase: SharedRunPhase): number {
 function byMostRecentThenStage(a: RunIssue, b: RunIssue): number {
   const timeDelta = parseTimestamp(b.updated_at) - parseTimestamp(a.updated_at);
   if (timeDelta !== 0) return timeDelta;
-  const aStep = stringValue(a.metadata?.['gc.step_id']);
-  const bStep = stringValue(b.metadata?.['gc.step_id']);
+  const aStep = stepIdOf(a);
+  const bStep = stepIdOf(b);
   const rankDelta = stageRank(stepIdPhase(bStep)) - stageRank(stepIdPhase(aStep));
   if (rankDelta !== 0) return rankDelta;
   return aStep < bStep ? -1 : aStep > bStep ? 1 : 0;
@@ -739,8 +902,21 @@ function parseTimestamp(value: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+const ATTEMPT_SUFFIX = /\.attempt\.\d+$/;
+
+/**
+ * A step id with any trailing `.attempt.N` retry suffix removed
+ * (apply-fixes.attempt.1 → apply-fixes). graph.v2 materializes a retried step's
+ * work bead under a suffixed gc.step_id, while stagesForFormula and the
+ * retry/scope-check latches use the base id, so cohorting must compare base ids.
+ */
+export function baseStepId(stepId: string): string {
+  return stepId.replace(ATTEMPT_SUFFIX, '');
+}
+
 export function stepIssues(issues: RunIssue[], step: string): RunIssue[] {
-  return issues.filter((i) => stringValue(i.metadata?.['gc.step_id']) === step);
+  const base = baseStepId(step);
+  return issues.filter((i) => baseStepId(stepIdOf(i)) === base);
 }
 
 export function isPrimaryStepIssue(issue: RunIssue): boolean {

--- a/shared/src/runs/status.test.ts
+++ b/shared/src/runs/status.test.ts
@@ -1,0 +1,167 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isBlockedStatus,
+  isClosedStatus,
+  isFailedStatus,
+  isInFlightStatus,
+  isOpenStatus,
+  isResolvedStatus,
+  isSkippedStatus,
+  presentationStatus,
+} from './status.js';
+import type { RunSnapshotBead } from '../run-snapshot.js';
+
+// status.ts is the single home for the raw bead-status vocabulary. Phase, lane,
+// and stage derivation read TWO vocabularies through these predicates: bd ledger
+// (open/in_progress/closed) and supervisor wire (pending/active/completed). The
+// predicates normalize (trim + lowercase) so a cased or padded wire spelling
+// classifies the same way presentationStatus renders it — closing the M2 drift
+// class where a status could be visible to the node graph yet invisible to phase
+// derivation.
+
+describe('isInFlightStatus', () => {
+  for (const s of ['in_progress', 'active', 'running']) {
+    test(`'${s}' is in flight`, () => assert.equal(isInFlightStatus(s), true));
+  }
+  for (const s of [
+    'open',
+    'pending',
+    'ready',
+    'closed',
+    'completed',
+    'done',
+    'failed',
+    'skipped',
+  ]) {
+    test(`'${s}' is not in flight`, () => assert.equal(isInFlightStatus(s), false));
+  }
+  test('normalizes casing and surrounding whitespace', () => {
+    assert.equal(isInFlightStatus('Active'), true);
+    assert.equal(isInFlightStatus(' running '), true);
+    assert.equal(isInFlightStatus('IN_PROGRESS'), true);
+  });
+});
+
+describe('isClosedStatus', () => {
+  for (const s of ['closed', 'completed', 'done']) {
+    test(`'${s}' is closed`, () => assert.equal(isClosedStatus(s), true));
+  }
+  for (const s of ['failed', 'skipped', 'in_progress', 'active', 'pending', 'open', 'ready']) {
+    test(`'${s}' is not closed`, () => assert.equal(isClosedStatus(s), false));
+  }
+  test('normalizes casing and surrounding whitespace', () => {
+    assert.equal(isClosedStatus(' Completed '), true);
+    assert.equal(isClosedStatus('DONE'), true);
+  });
+});
+
+describe('isResolvedStatus', () => {
+  for (const s of ['closed', 'completed', 'done', 'failed', 'skipped']) {
+    test(`'${s}' is resolved`, () => assert.equal(isResolvedStatus(s), true));
+  }
+  for (const s of ['in_progress', 'active', 'running', 'pending', 'open', 'ready', 'blocked']) {
+    test(`'${s}' is not resolved`, () => assert.equal(isResolvedStatus(s), false));
+  }
+  test('normalizes casing and surrounding whitespace', () => {
+    assert.equal(isResolvedStatus('Failed'), true);
+    assert.equal(isResolvedStatus(' skipped'), true);
+  });
+});
+
+describe('isFailedStatus / isSkippedStatus — the failed and skipped arms of resolved', () => {
+  test("only 'failed' is a failed status", () => {
+    assert.equal(isFailedStatus('failed'), true);
+    assert.equal(isFailedStatus('Failed'), true);
+    assert.equal(isFailedStatus(' failed '), true);
+    for (const s of ['skipped', 'closed', 'completed', 'done', 'active', 'pending', 'open']) {
+      assert.equal(isFailedStatus(s), false);
+    }
+  });
+
+  test("only 'skipped' is a skipped status", () => {
+    assert.equal(isSkippedStatus('skipped'), true);
+    assert.equal(isSkippedStatus('SKIPPED'), true);
+    assert.equal(isSkippedStatus(' skipped'), true);
+    for (const s of ['failed', 'closed', 'completed', 'done', 'active', 'pending', 'open']) {
+      assert.equal(isSkippedStatus(s), false);
+    }
+  });
+
+  test('resolved is exactly closed OR failed OR skipped', () => {
+    for (const s of ['closed', 'completed', 'done', 'failed', 'skipped']) {
+      assert.equal(
+        isResolvedStatus(s),
+        isClosedStatus(s) || isFailedStatus(s) || isSkippedStatus(s),
+      );
+      assert.equal(isResolvedStatus(s), true);
+    }
+  });
+});
+
+describe('isOpenStatus / isBlockedStatus — frontend filter/tone helpers', () => {
+  test("only 'open' is an open status, normalized for cased / padded wire spellings", () => {
+    assert.equal(isOpenStatus('open'), true);
+    assert.equal(isOpenStatus('Open'), true);
+    assert.equal(isOpenStatus(' open '), true);
+    for (const s of [
+      'blocked',
+      'in_progress',
+      'active',
+      'closed',
+      'completed',
+      'ready',
+      'pending',
+    ]) {
+      assert.equal(isOpenStatus(s), false);
+    }
+  });
+
+  test("only 'blocked' is a blocked status, normalized for cased / padded wire spellings", () => {
+    assert.equal(isBlockedStatus('blocked'), true);
+    assert.equal(isBlockedStatus('Blocked'), true);
+    assert.equal(isBlockedStatus(' blocked '), true);
+    for (const s of ['open', 'in_progress', 'active', 'closed', 'completed', 'ready', 'pending']) {
+      assert.equal(isBlockedStatus(s), false);
+    }
+  });
+});
+
+describe('presentationStatus — built on the shared vocabulary predicates', () => {
+  function bead(status: string, metadata: Record<string, string> = {}): RunSnapshotBead {
+    return { id: 'b', title: 'b', status, kind: 'step', metadata };
+  }
+
+  test('maps every closed spelling to completed', () => {
+    assert.equal(presentationStatus(bead('closed')), 'completed');
+    assert.equal(presentationStatus(bead('completed')), 'completed');
+    assert.equal(presentationStatus(bead('done')), 'completed');
+  });
+
+  test('gc.outcome refines a closed step to failed / skipped', () => {
+    assert.equal(presentationStatus(bead('closed', { 'gc.outcome': 'fail' })), 'failed');
+    assert.equal(presentationStatus(bead('completed', { 'gc.outcome': 'failed' })), 'failed');
+    assert.equal(presentationStatus(bead('done', { 'gc.outcome': 'skipped' })), 'skipped');
+  });
+
+  test('maps every in-flight spelling to active', () => {
+    assert.equal(presentationStatus(bead('in_progress')), 'active');
+    assert.equal(presentationStatus(bead('active')), 'active');
+    assert.equal(presentationStatus(bead('running')), 'active');
+  });
+
+  test('keeps the blocked / ready / failed / skipped / pending arms', () => {
+    assert.equal(presentationStatus(bead('blocked')), 'blocked');
+    assert.equal(presentationStatus(bead('ready')), 'ready');
+    assert.equal(presentationStatus(bead('failed')), 'failed');
+    assert.equal(presentationStatus(bead('skipped')), 'skipped');
+    assert.equal(presentationStatus(bead('')), 'pending');
+    assert.equal(presentationStatus(bead('something-unknown')), 'pending');
+  });
+
+  test('classifies cased / padded wire spellings the same as their canonical form', () => {
+    assert.equal(presentationStatus(bead(' Completed ')), 'completed');
+    assert.equal(presentationStatus(bead('ACTIVE')), 'active');
+  });
+});

--- a/shared/src/runs/status.ts
+++ b/shared/src/runs/status.ts
@@ -2,21 +2,99 @@ import type { RunSnapshotBead } from '../run-snapshot.js';
 import type { RunExecutionInstance, RunNodeStatus } from '../run-detail.js';
 import { meta, nonEmpty } from './bead-fields.js';
 
+// ── Raw bead-status vocabulary ──────────────────────────────────────────────
+//
+// Phase, lane, and stage derivation read beads from two adapters with DIFFERENT
+// raw status vocabularies: the summary lane feeds bd ledger statuses
+// (open/in_progress/closed) via fromDashboardBead, while the run-detail page
+// feeds supervisor wire statuses (pending/active/completed) via
+// fromRunSnapshotBead. Neither is enum-typed on the wire
+// (backend/openapi/gc-supervisor.openapi.json types bead status as a plain
+// string), so nothing upstream guarantees casing or trimming. These predicates
+// are the SINGLE home for that raw vocabulary — presentationStatus below and the
+// phaseMapping/summary derivation all reuse them, so the two vocabularies cannot
+// drift. They normalize (trim + lowercase) so a cased or padded spelling
+// ('Active', ' completed') classifies the same way it renders, never silently
+// falling through to 'pending'/non-advanced.
+
+/** Canonicalize a raw bead status (trim + lowercase) so cased or padded wire
+ * spellings classify and aggregate the same way they render. */
+export function normalizeStatus(status: string): string {
+  return status.trim().toLowerCase();
+}
+
+/** True when the bead status marks a step currently being worked. */
+export function isInFlightStatus(status: string): boolean {
+  const s = normalizeStatus(status);
+  return s === 'in_progress' || s === 'active' || s === 'running';
+}
+
+/** True when the bead status marks a step that completed. */
+export function isClosedStatus(status: string): boolean {
+  const s = normalizeStatus(status);
+  return s === 'closed' || s === 'completed' || s === 'done';
+}
+
+/** True when the bead status marks a step that ran but failed. */
+export function isFailedStatus(status: string): boolean {
+  return normalizeStatus(status) === 'failed';
+}
+
+/** True when the bead status marks a step that was skipped and never ran. */
+export function isSkippedStatus(status: string): boolean {
+  return normalizeStatus(status) === 'skipped';
+}
+
+/** True when the bead status is open (ready/unclaimed) — normalized so cased or
+ * padded wire spellings ('Open', ' open ') match the same way they render. */
+export function isOpenStatus(status: string): boolean {
+  return normalizeStatus(status) === 'open';
+}
+
+/** True when the bead status is blocked (waiting on a dependency) — normalized
+ * so cased or padded wire spellings ('Blocked', ' blocked ') match. */
+export function isBlockedStatus(status: string): boolean {
+  return normalizeStatus(status) === 'blocked';
+}
+
+/**
+ * True when the bead status marks a step no work remains for — finished, failed,
+ * OR skipped. This is the right test for "the run has no work left" and "this
+ * assignee is no longer active", but NOT for "this stage completed successfully":
+ * a failed or skipped step is resolved yet did not pass, so stage/ladder
+ * advancement must use successful-completion handling, not this predicate.
+ */
+export function isResolvedStatus(status: string): boolean {
+  return isClosedStatus(status) || isFailedStatus(status) || isSkippedStatus(status);
+}
+
+/**
+ * True when a graph presentation status is terminal — the node has finished,
+ * failed, or was skipped and will not advance further. The terminal node
+ * statuses (done/completed/failed/skipped) are exactly the resolved raw
+ * statuses, so this reuses isResolvedStatus rather than re-declaring the
+ * boundary, keeping the run-detail graph and the run-state predicates from
+ * drifting.
+ */
+export function isTerminalNodeStatus(status: RunNodeStatus): boolean {
+  return isResolvedStatus(status);
+}
+
 export function presentationStatus(bead: RunSnapshotBead): RunNodeStatus {
-  const raw = (nonEmpty(bead.status) ?? '').toLowerCase();
+  const raw = normalizeStatus(nonEmpty(bead.status) ?? '');
   const outcome = meta(bead, 'gc.outcome')?.toLowerCase();
-  if (raw === 'closed' || raw === 'completed' || raw === 'done') {
+  if (isClosedStatus(raw)) {
     if (outcome === 'fail' || outcome === 'failed') return 'failed';
     if (outcome === 'skipped') return 'skipped';
     return 'completed';
   }
-  if (raw === 'in_progress' || raw === 'active' || raw === 'running') {
+  if (isInFlightStatus(raw)) {
     return 'active';
   }
   if (raw === 'blocked') return 'blocked';
   if (raw === 'ready') return 'ready';
-  if (raw === 'failed') return 'failed';
-  if (raw === 'skipped') return 'skipped';
+  if (isFailedStatus(raw)) return 'failed';
+  if (isSkippedStatus(raw)) return 'skipped';
   return 'pending';
 }
 

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -5,6 +5,7 @@ import {
   buildRunSummary,
   emptyRunSummary,
   runLane,
+  statusCounts,
   MAX_HISTORICAL_LANES,
   MAX_VISIBLE_ACTIVE_LANES,
 } from './summary.js';
@@ -515,5 +516,164 @@ describe('runLane scope sanitisation — gascity-dashboard-5e5v', () => {
     assert.equal(lane.scope.rootStoreRef, 'rig:demoapp');
     assert.ok(!lane.scope.ref.includes('\x1b'), 'no ESC byte may survive in ref');
     assert.ok(!lane.scope.rootStoreRef.includes('\x1b'), 'no ESC byte may survive in rootStoreRef');
+  });
+});
+
+// M2 audit propagation: the lane's active-step filter must accept the full
+// in-flight status vocabulary (in_progress/active/running), exactly like
+// structuredPhase. With a raw 'in_progress'-only filter, a supervisor wire
+// 'active' primary step left activeStepId null and degraded progress to
+// stage_only ('active run step unavailable') while the stage ladder showed an
+// active stage.
+describe('runLane — wire in-flight statuses resolve the active step (M2)', () => {
+  function wireRun(stepStatus: string): RunIssue[] {
+    return [
+      runIssue({
+        id: 'run-wire',
+        title: 'Adopt PR #124',
+        status: 'pending',
+        updated_at: '',
+        metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+      }),
+      runIssue({
+        id: 'run-wire-step-1',
+        title: 'Implementation patch',
+        status: stepStatus,
+        updated_at: '',
+        metadata: {
+          'gc.kind': 'step',
+          'gc.root_bead_id': 'run-wire',
+          'gc.step_id': 'implementation.patch',
+        },
+      }),
+    ];
+  }
+
+  for (const status of ['active', 'running'] as const) {
+    test(`a wire '${status}' primary step produces progress.status === 'active_step'`, () => {
+      const lane = runLane('run-wire', wireRun(status), new Map());
+
+      assert.equal(lane.phase, 'implementation');
+      assert.equal(lane.progress.status, 'active_step');
+      if (lane.progress.status !== 'active_step') return;
+      assert.equal(lane.progress.stepId, 'implementation.patch');
+    });
+  }
+});
+
+// PR #124 review fix (attempt-2 blocker): runLane broadened the active-STEP
+// filter to the supervisor wire in-flight vocabulary, but activeAssignees still
+// filtered status !== 'closed'. So the assignee of a wire completed/done/failed/
+// skipped step surfaced as an ACTIVE assignee on the lane — and that lane field
+// feeds blockedRunRemedy (no-worker vs open-detail) and health session matching.
+// activeAssignees must reuse the same resolved-status vocabulary the rest of the
+// builder does.
+describe('runLane — activeAssignees excludes resolved wire statuses (PR #124)', () => {
+  function mixedRun(resolvedStatus: string): RunIssue[] {
+    return [
+      runIssue({
+        id: 'run-mixed',
+        title: 'Adopt PR #124',
+        status: 'pending',
+        updated_at: '',
+        metadata: { 'gc.formula_contract': 'graph.v2', 'gc.kind': 'run' },
+      }),
+      runIssue({
+        id: 'run-mixed-resolved',
+        title: 'Implementation patch',
+        status: resolvedStatus,
+        assignee: 'app/resolved-worker',
+        updated_at: '',
+        metadata: {
+          'gc.kind': 'step',
+          'gc.root_bead_id': 'run-mixed',
+          'gc.step_id': 'implement-change',
+        },
+      }),
+      runIssue({
+        id: 'run-mixed-active',
+        title: 'Review',
+        status: 'active',
+        assignee: 'app/active-worker',
+        updated_at: '',
+        metadata: {
+          'gc.kind': 'step',
+          'gc.root_bead_id': 'run-mixed',
+          'gc.step_id': 'review-pipeline.synthesize',
+        },
+      }),
+    ];
+  }
+
+  // 'closed' already worked under the old filter — it is the regression guard
+  // that the fix does not change well-formed ledger behavior. The wire spellings
+  // are the ones the old `!== 'closed'` filter wrongly reported as active.
+  for (const resolved of ['closed', 'completed', 'done', 'failed', 'skipped'] as const) {
+    test(`a '${resolved}' assigned step is excluded; the active step's assignee remains`, () => {
+      const lane = runLane('run-mixed', mixedRun(resolved), new Map());
+      assert.deepEqual(lane.activeAssignees, ['app/active-worker']);
+    });
+  }
+});
+
+// PR #124 review fix: stageProgress maps an attempt-suffixed retry work bead
+// (apply-fixes.attempt.1) to its base formula stage by stripping `.attempt.N`,
+// but formulaStageResolved compared the raw suffixed progress.stepId against the
+// base formula step ids, so a known retry step read as unresolved and downgraded
+// the lane health phaseConfidence to 'inferred'. The resolution must normalize
+// the step id the same way stage cohorting does.
+describe('runLane — formulaStageResolved normalizes attempt-suffixed retry steps (PR #124)', () => {
+  function retryRun(): RunIssue[] {
+    return [
+      runIssue({
+        id: 'run-retry',
+        title: 'Adopt PR #124',
+        status: 'pending',
+        updated_at: '',
+        metadata: {
+          'gc.formula_contract': 'graph.v2',
+          'gc.kind': 'run',
+          'gc.formula': 'mol-adopt-pr-v2',
+        },
+      }),
+      runIssue({
+        id: 'run-retry-apply-fixes',
+        title: 'Apply review fixes',
+        status: 'active',
+        assignee: 'app/fixer',
+        updated_at: '',
+        metadata: {
+          'gc.kind': 'work',
+          'gc.root_bead_id': 'run-retry',
+          'gc.step_id': 'apply-fixes.attempt.1',
+        },
+      }),
+    ];
+  }
+
+  test('an active apply-fixes.attempt.1 step resolves to a known formula stage', () => {
+    const lane = runLane('run-retry', retryRun(), new Map());
+    assert.equal(lane.progress.status, 'active_step');
+    if (lane.progress.status === 'active_step') {
+      assert.equal(lane.progress.stepId, 'apply-fixes.attempt.1');
+    }
+    assert.equal(lane.formulaStageResolved, true);
+  });
+});
+
+// PR #124 review fix (F2): statusCounts keys feed blocked-run consumers that
+// look them up by canonical lowercase spelling (blocked.ts reads
+// statusCounts['blocked']). The wire status is not enum-typed, so a cased or
+// padded spelling must aggregate under the same canonical key it would render
+// as, never silently fall into a raw key the consumer never reads.
+describe('statusCounts — canonical key normalization (PR #124)', () => {
+  test('cased and padded spellings collapse onto the canonical lowercase key', () => {
+    const counts = statusCounts([
+      runIssue({ id: 'a', status: 'blocked' }),
+      runIssue({ id: 'b', status: 'Blocked' }),
+      runIssue({ id: 'c', status: ' blocked ' }),
+    ]);
+    assert.equal(counts['blocked'], 3);
+    assert.equal(counts['Blocked'], undefined);
   });
 });

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -4,6 +4,7 @@ import { stripNonPrintable } from '../strip-non-printable.js';
 import { resolveRunFormulaIdentity } from './formula-name.js';
 import { isDanglingRootGroup } from './liveness.js';
 import {
+  baseStepId,
   isPrimaryStepIssue,
   latestStepId,
   mapRunPhase,
@@ -14,6 +15,7 @@ import {
   stringValue,
   type RunIssue,
 } from './phaseMapping.js';
+import { isInFlightStatus, isResolvedStatus, normalizeStatus } from './status.js';
 
 // Default collapsed active-lane count (component-controlled). The wire carries
 // the FULL active set in `lanes`; RunMap renders this many by default and offers
@@ -179,16 +181,22 @@ export function runLane(rootId: string, issues: RunIssue[], feedScopes: RunFeedS
   const activeStage = foundStageIndex >= 0 ? stages[foundStageIndex] : undefined;
 
   const primaryInProgress = issues.filter(
-    (issue) => isPrimaryStepIssue(issue) && issue.status === 'in_progress',
+    (issue) => isPrimaryStepIssue(issue) && isInFlightStatus(issue.status),
   );
   const activeStepId = latestStepId(primaryInProgress);
   const progress = runProgress(stages, foundStageIndex, activeStepId, issues);
 
   const formulaStages = stagesForFormula(formulaName);
+  // Normalize the active step id with the same base-step-id logic stage
+  // cohorting uses (strip a trailing `.attempt.N`): a retried step materializes
+  // its work bead under a suffixed gc.step_id (apply-fixes.attempt.1) while the
+  // formula stage table lists the base id, so without this an active retry step
+  // reads as an unknown stage and downgrades lane health confidence to inferred.
+  const activeBaseStepId = progress.status === 'active_step' ? baseStepId(progress.stepId) : null;
   const formulaStageResolved =
     formulaStages.length > 0 &&
-    progress.status === 'active_step' &&
-    formulaStages.some((stage) => stage.steps.includes(progress.stepId));
+    activeBaseStepId !== null &&
+    formulaStages.some((stage) => stage.steps.includes(activeBaseStepId));
   const scope = runScope(rootId, issues, feedScopes);
 
   return {
@@ -323,17 +331,26 @@ export function displayTitle(rootId: string, issues: RunIssue[]): string {
 }
 
 export function statusCounts(issues: RunIssue[]): Record<string, number> {
+  // Normalize keys with the same trim/lowercase canonicalization the status
+  // predicates use, so downstream consumers that look up canonical keys (e.g.
+  // blocked.ts reading statusCounts['blocked']) still match a cased or padded
+  // wire spelling like 'Blocked' instead of silently counting it under a raw key.
   return issues.reduce<Record<string, number>>((counts, i) => {
-    counts[i.status] = (counts[i.status] ?? 0) + 1;
+    const status = normalizeStatus(i.status);
+    counts[status] = (counts[status] ?? 0) + 1;
     return counts;
   }, {});
 }
 
 export function activeAssignees(issues: RunIssue[]): string[] {
+  // gascity-dashboard (PR #124): exclude every RESOLVED step, not just the
+  // bd-only `closed` spelling. runLane carries supervisor wire statuses too, so
+  // a completed/done/failed/skipped step's assignee is not active — surfacing it
+  // would mislead the lane UI, blocked-run remedy, and health session matching.
   return Array.from(
     new Set(
       issues
-        .filter((i) => i.status !== 'closed')
+        .filter((i) => !isResolvedStatus(i.status))
         .map((i) => i.assignee?.trim())
         .filter((a): a is string => Boolean(a)),
     ),

--- a/shared/src/work-in-flight.ts
+++ b/shared/src/work-in-flight.ts
@@ -74,9 +74,3 @@ export function parseAssignee(assignee: string): ParsedAssignee {
   // the separator boundary, so slice up to match.index.
   return { role: trimmed.slice(0, match.index), sessionId };
 }
-
-/**
- * The bead status that means "actively being worked on". A single literal so
- * the work-in-flight filter and the status badge stay in lockstep.
- */
-export const IN_PROGRESS_STATUS = 'in_progress';


### PR DESCRIPTION
## Summary

- Audit finding M2 (run ga-wisp-x0tank): the run-detail stage ladder showed "Intake / Implementation / Review / Approval complete, Finalization active" for the run's ENTIRE life while the true state was mid-review (review wave done, synthesize in flight, apply-fixes / scorecard / human approval / finalize / cleanup unstarted).
- Root cause 1: `structuredPhase` filtered in-flight steps on `status === 'in_progress'`, but the run-detail page feeds supervisor WIRE statuses (`pending/active/completed`) through `fromRunSnapshotBead` — structured in-flight detection could never fire there; a live `active` bead was invisible.
- Root cause 2: the no-in-flight fallback (`furthestStageStepId`) ranked ALL materialized steps with no status filter; graph.v2 runs materialize the full DAG at pour time, so the pending `cleanup-worktree` shell always won and pinned `phase='finalization'`, marking every earlier stage complete.

Fix (shared/src/runs/phaseMapping.ts only): added `isInFlightStatus` / `isClosedStatus` helpers that accept both the bd ledger vocabulary (`open/in_progress/closed`) and the supervisor wire vocabulary (`pending/active/completed`), mirroring `presentationStatus` in status.ts, and applied them to every status comparison (structured phase, all-closed→complete, and the formula-specific ladder). The furthest-stage fallback now ranks only steps that have actually ADVANCED (in flight or finished); a freshly poured run with nothing advanced stays conservative (`active`) instead of falling through to the keyword scan, which would match late-stage words in materialized step titles/ids.

Verified against the captured ga-wisp-x0tank supervisor payload (72 beads): the pipeline now derives `phase='review'`, ladder Review active / Approval pending / Finalization pending — the deployed code derived `finalization` with four stages falsely complete.

## Scope

- Named Rule touched: None.
- Views or routes affected: Formula Run detail (stage ladder + phase); Runs lane phase where statuses arrive in wire vocabulary.
- Layer: shared.

## Test plan

- Tests added: `shared/src/runs/phaseMapping.test.ts` — new "supervisor wire status vocabulary (M2)" suite (8 tests, written first and watched fail): `active` drives in-flight detection like `in_progress`; fallback ignores pending/open shells in both vocabularies; x0tank-shaped payload with and without an in-flight step derives `review` (not `finalization`); all-`completed` → `complete`; freshly poured fully-pending DAG stays conservative (`active`, never approval/finalization); mol-adopt-pr-v2 formula ladder reads wire statuses.
- Automated checks run: `npm run typecheck`, backend/frontend `typecheck:test`, `npm --workspace shared test` (165 pass), `npm --workspace backend test` (582 pass), `npm --workspace frontend test` (891 pass; the 30 failures reproduce identically on pristine `origin/main` — pre-existing timer-isolation issue tracked on `fix/tdxk-runs-test-timer-isolation`), `npm --workspace frontend run build`, `npm run lint`.
- Manual checks run: re-derivation harness over the captured ga-wisp-x0tank supervisor payload through `enrichFormulaRun` from the rebuilt `shared/dist` confirms phase/ladder now match the true bead state. No visual change beyond corrected data, so no snap run.

## Risk + rollback

- Phase/ladder derivation is shared by the runs summary lane and the run-detail page; a regression would show as a run's phase reading EARLIER than before (the old behavior overstated). First noticeable on the Runs lane phase chips and the run-detail stage ladder.
- Back out: revert the single commit (509cf21).

## Linked issue

Audit finding M2 (ga-wisp-x0tank visualization-vs-truth audit); no bd id.

## Operator-affecting changes

- [x] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [x] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)