### PR TITLE
fix(runs): resolve formula identity from gc.routed_to roots (audit M3)

### DIFF
--- a/frontend/src/supervisor/runDetail.test.ts
+++ b/frontend/src/supervisor/runDetail.test.ts
@@ -104,6 +104,87 @@ describe('loadSupervisorFormulaRunDetail', () => {
     expect(detail.completeness).toEqual({ kind: 'complete' });
   });
 
+  // Audit finding M3 (ga-wisp-x0tank): current supervisor graph.v2 roots
+  // carry `gc.routed_to` instead of the retired `gc.run_target` (upstream
+  // gascity ga-eld2x / #2763). The title fallback must still resolve the
+  // formula name so the /formulas/{name} fetch fires instead of the page
+  // degrading to 'metadata missing' with the generic ladder.
+  it('title-falls-back and fetches formula detail when the root carries gc.routed_to only', async () => {
+    workflowRun.mockResolvedValue(
+      workflowSnapshot({
+        status: 'pending',
+        title: 'mol-adopt-pr-v2',
+        metadata: {
+          'gc.kind': 'workflow',
+          'gc.formula_contract': 'graph.v2',
+          'gc.routed_to': 'gascity/gc.run-operator',
+        },
+      }),
+    );
+    formulaDetail.mockResolvedValue({
+      ...formulaDetailResponse(),
+      name: 'mol-adopt-pr-v2',
+    });
+
+    const detail = await loadSupervisorFormulaRunDetail('wf-1', 'rig', 'gascity');
+
+    // The successful detail fetch is canonical, so provenance upgrades from
+    // 'title_fallback' to 'metadata' (e7hj/sadp precedence).
+    expect(detail.formula).toEqual({
+      kind: 'known',
+      name: 'mol-adopt-pr-v2',
+      source: 'metadata',
+    });
+    expect(detail.formulaDetail).toEqual({
+      kind: 'available',
+      name: 'mol-adopt-pr-v2',
+      target: 'gascity/gc.run-operator',
+    });
+    expect(formulaDetail).toHaveBeenCalledWith('test-city', 'mol-adopt-pr-v2', {
+      target: 'gascity/gc.run-operator',
+      scope_kind: 'rig',
+      scope_ref: 'gascity',
+    });
+  });
+
+  // Same routed_to root, but the formula registry fetch fails: the formula
+  // cell must still resolve via the title fallback (warn tone) instead of
+  // collapsing to 'metadata missing'. This is the rendered-page half of M3 —
+  // before the fix the page never even attempted the fetch.
+  it('keeps the title-fallback formula name for routed_to roots when the detail fetch fails', async () => {
+    workflowRun.mockResolvedValue(
+      workflowSnapshot({
+        status: 'pending',
+        title: 'mol-adopt-pr-v2',
+        metadata: {
+          'gc.kind': 'workflow',
+          'gc.formula_contract': 'graph.v2',
+          'gc.routed_to': 'gascity/gc.run-operator',
+        },
+      }),
+    );
+    formulaDetail.mockRejectedValue(new SupervisorApiError(400, 'target not found', undefined));
+
+    const detail = await loadSupervisorFormulaRunDetail('wf-1', 'rig', 'gascity');
+
+    expect(detail.formula).toEqual({
+      kind: 'known',
+      name: 'mol-adopt-pr-v2',
+      source: 'title_fallback',
+    });
+    expect(detail.formulaDetail).toEqual({
+      kind: 'unavailable',
+      reason: 'fetch_failed',
+      name: 'mol-adopt-pr-v2',
+      target: 'gascity/gc.run-operator',
+      failure: 'upstream_error',
+    });
+    expect(detail.completeness).toEqual({
+      kind: 'partial',
+      reasons: ['formula_detail_fetch_failed'],
+    });
+  });
+
   it('reports missing formula metadata without calling the formula endpoint', async () => {
     workflowRun.mockResolvedValue(
       workflowSnapshot({
@@ -250,6 +331,7 @@ describe('loadSupervisorFormulaRunDetail', () => {
 function workflowSnapshot(
   overrides: {
     status?: string;
+    title?: string;
     metadata?: Record<string, string>;
   } = {},
 ) {
@@ -267,7 +349,7 @@ function workflowSnapshot(
     beads: [
       {
         id: 'wf-1',
-        title: 'Direct supervisor run',
+        title: overrides.title ?? 'Direct supervisor run',
         status: overrides.status ?? 'in_progress',
         kind: 'workflow',
         metadata: overrides.metadata ?? {

--- a/shared/src/runs/formula-name.test.ts
+++ b/shared/src/runs/formula-name.test.ts
@@ -1,0 +1,134 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveRunFormulaIdentity, resolveRunFormulaName } from './formula-name.js';
+import type { RunSnapshotBead } from '../run-snapshot.js';
+
+// Audit finding M3 (run ga-wisp-x0tank): the supervisor retired
+// `gc.run_target` as a root wire field (upstream gascity ga-eld2x / #2763)
+// in favor of `gc.routed_to`, but the title-fallback gate still required
+// the retired key. Every current graph.v2 root (27 of 32 surveyed live
+// workflow roots carry only `gc.routed_to`) resolved to name=null, so the
+// run-detail page rendered Formula='metadata missing', the generic 5-stage
+// ladder, and never fetched /formulas/{name}.
+
+/**
+ * Shape mirrors the real ga-wisp-x0tank root bead: a live graph.v2
+ * mol-adopt-pr-v2 run whose root carries `gc.routed_to` and NO
+ * `gc.formula` / `gc.run_target`.
+ */
+function routedToRoot(overrides: Partial<RunSnapshotBead> = {}): RunSnapshotBead {
+  return {
+    id: 'ga-wisp-x0tank',
+    title: 'mol-adopt-pr-v2',
+    status: 'pending',
+    kind: 'workflow',
+    metadata: {
+      'gc.formula_contract': 'graph.v2',
+      'gc.graphv2_root_key': 'graphv2-root:ga-hvg0gb:mol-adopt-pr-v2:15569633545c81d0:default',
+      'gc.input_convoy_id': 'ga-hvg0gb',
+      'gc.kind': 'workflow',
+      'gc.root_store_ref': 'rig:gascity',
+      'gc.routed_to': 'gascity/gc.run-operator',
+      'gc.session_name': 'gc__design-test-risk-reviewer-mc-wisp-nw0w7v',
+      'gc.work_dir': '/data/projects/gascity',
+    },
+    ...overrides,
+  };
+}
+
+function withMetadata(extra: Record<string, string>, drop: string[] = []): RunSnapshotBead {
+  const root = routedToRoot();
+  const metadata = { ...root.metadata, ...extra };
+  for (const key of drop) delete metadata[key];
+  return { ...root, metadata };
+}
+
+describe('resolveRunFormulaIdentity title fallback on gc.routed_to roots (M3)', () => {
+  test('route mode resolves the title fallback when the root carries only gc.routed_to', () => {
+    const resolved = resolveRunFormulaIdentity('route', { root: routedToRoot() });
+    assert.deepEqual(resolved, {
+      name: 'mol-adopt-pr-v2',
+      source: 'title_fallback',
+      target: 'gascity/gc.run-operator',
+    });
+  });
+
+  test('state and detail modes resolve the same routed_to root', () => {
+    for (const mode of ['state', 'detail'] as const) {
+      const resolved = resolveRunFormulaIdentity(mode, { root: routedToRoot() });
+      assert.equal(resolved.name, 'mol-adopt-pr-v2', `mode=${mode}`);
+      assert.equal(resolved.source, 'title_fallback', `mode=${mode}`);
+    }
+  });
+
+  test('lane mode keeps the mol- prefix guard for routed_to roots', () => {
+    const molRoot = routedToRoot();
+    assert.equal(
+      resolveRunFormulaIdentity('lane', { root: molRoot, issues: [molRoot] }).name,
+      'mol-adopt-pr-v2',
+    );
+    const retitled = routedToRoot({ title: 'Adopt PR #3212' });
+    assert.equal(
+      resolveRunFormulaIdentity('lane', { root: retitled, issues: [retitled] }).name,
+      null,
+    );
+  });
+
+  test('legacy gc.run_target roots keep resolving (backwards compatibility)', () => {
+    const legacy = withMetadata({ 'gc.run_target': 'test-city/codex' }, ['gc.routed_to']);
+    const resolved = resolveRunFormulaIdentity('route', { root: legacy });
+    assert.deepEqual(resolved, {
+      name: 'mol-adopt-pr-v2',
+      source: 'title_fallback',
+      target: 'test-city/codex',
+    });
+  });
+
+  test('explicit gc.formula metadata still wins over the title fallback', () => {
+    const explicit = withMetadata({ 'gc.formula': 'mol-other' });
+    const resolved = resolveRunFormulaIdentity('route', { root: explicit });
+    assert.equal(resolved.name, 'mol-other');
+    assert.equal(resolved.source, 'metadata');
+  });
+
+  test('terminal routed_to roots are still excluded from the title fallback (xfb7)', () => {
+    for (const status of ['closed', 'completed', 'failed']) {
+      const resolved = resolveRunFormulaIdentity('route', { root: routedToRoot({ status }) });
+      assert.equal(resolved.name, null, `status=${status}`);
+      assert.equal(resolved.source, null, `status=${status}`);
+    }
+  });
+
+  test('roots with neither gc.run_target nor gc.routed_to still resolve to null', () => {
+    const untargeted = withMetadata({}, ['gc.routed_to']);
+    const resolved = resolveRunFormulaIdentity('route', { root: untargeted });
+    assert.equal(resolved.name, null);
+  });
+
+  test('non-graph.v2 roots with gc.routed_to never title-fallback', () => {
+    const nonGraph = withMetadata({ 'gc.formula_contract': 'legacy' });
+    assert.equal(resolveRunFormulaIdentity('route', { root: nonGraph }).name, null);
+  });
+});
+
+describe('resolveRunFormulaName on gc.routed_to roots (M3)', () => {
+  test('resolves the title fallback for a live routed_to root', () => {
+    assert.deepEqual(resolveRunFormulaName(routedToRoot()), {
+      name: 'mol-adopt-pr-v2',
+      source: 'title_fallback',
+    });
+  });
+
+  test('keeps resolving legacy gc.run_target roots', () => {
+    const legacy = withMetadata({ 'gc.run_target': 'test-city/codex' }, ['gc.routed_to']);
+    assert.deepEqual(resolveRunFormulaName(legacy), {
+      name: 'mol-adopt-pr-v2',
+      source: 'title_fallback',
+    });
+  });
+
+  test('returns null for terminal routed_to roots', () => {
+    assert.equal(resolveRunFormulaName(routedToRoot({ status: 'completed' })), null);
+  });
+});

--- a/shared/src/runs/formula-name.ts
+++ b/shared/src/runs/formula-name.ts
@@ -30,10 +30,10 @@ export interface ResolveRunFormulaIdentityInput {
  * `source` carries which resolution path produced `name`:
  *  - `'metadata'` — the workflow root carried an explicit `gc.formula` key.
  *  - `'title_fallback'` — gc.formula was absent and the resolver derived
- *    the name from the bead title under the graph.v2 + `gc.run_target`
- *    gate. The dashboard surfaces this provenance to the operator in a
- *    warn tone instead of letting it pass as canonical metadata. See
- *    gascity-dashboard-e7hj for the precedent.
+ *    the name from the bead title under the graph.v2 + run-target
+ *    (`gc.run_target` / `gc.routed_to`) gate. The dashboard surfaces this
+ *    provenance to the operator in a warn tone instead of letting it pass
+ *    as canonical metadata. See gascity-dashboard-e7hj for the precedent.
  */
 export interface ResolvedRunFormulaName {
   name: string;
@@ -54,10 +54,14 @@ export interface ResolvedRunFormulaName {
  * missing a formula, collapsing every graph.v2 run-detail page to an
  * empty `formula_detail_unavailable` state.
  *
- * The gate on `gc.run_target` is what keeps the fallback honest: only
- * fully-instantiated runnable roots set both `gc.formula_contract` and
- * `gc.run_target`. Operator-edited descriptive titles on closed roots
- * without a target won't be mis-surfaced as formula names.
+ * The gate on a run target is what keeps the fallback honest: only
+ * fully-instantiated runnable roots set `gc.formula_contract` together
+ * with a target key. Operator-edited descriptive titles on closed roots
+ * without a target won't be mis-surfaced as formula names. The supervisor
+ * retired `gc.run_target` as a root wire field in favor of `gc.routed_to`
+ * (upstream gascity ga-eld2x / #2763), so the gate accepts either key:
+ * current roots carry only `gc.routed_to`, older roots only
+ * `gc.run_target` (audit finding M3, run ga-wisp-x0tank).
  *
  * gascity-dashboard-xfb7 (sadp follow-up): terminal graph.v2 roots are
  * additionally excluded from the title fallback even when they retain
@@ -87,7 +91,7 @@ export function resolveRunFormulaName(
   if (explicit !== undefined) return { name: explicit, source: 'metadata' };
   if (
     meta(root, 'gc.formula_contract') === 'graph.v2' &&
-    meta(root, 'gc.run_target') !== undefined &&
+    rootRunTarget(root) !== undefined &&
     !isTerminalRunRootStatus(root.status)
   ) {
     const title = root.title.trim();
@@ -139,7 +143,7 @@ function runFormulaTitleFallback(
   if (root === undefined) return null;
   if (
     rootMeta(root, 'gc.formula_contract') !== 'graph.v2' ||
-    rootMeta(root, 'gc.run_target') === undefined ||
+    rootRunTarget(root) === undefined ||
     isTerminalRunRootStatus(root.status)
   ) {
     return null;
@@ -162,13 +166,18 @@ function isTerminalRunRootStatus(status: string): boolean {
   }
 }
 
+/**
+ * Run target carried by a workflow root's metadata. `gc.run_target` was
+ * retired as a root wire field by the supervisor in favor of
+ * `gc.routed_to` (upstream gascity ga-eld2x / #2763); the dashboard
+ * accepts either so legacy and current roots both resolve.
+ */
+function rootRunTarget(root: RunFormulaRootLike | undefined): string | undefined {
+  return rootMeta(root, 'gc.run_target') ?? rootMeta(root, 'gc.routed_to');
+}
+
 function runFormulaTarget(root: RunFormulaRootLike | undefined): string | null {
-  return (
-    rootMeta(root, 'gc.run_target') ??
-    rootMeta(root, 'gc.routed_to') ??
-    nonEmpty(root?.assignee) ??
-    null
-  );
+  return rootRunTarget(root) ?? nonEmpty(root?.assignee) ?? null;
 }
 
 function rootMeta(root: RunFormulaRootLike | undefined, key: string): string | undefined {


### PR DESCRIPTION
## Summary

- Audit finding **M3** (run `ga-wisp-x0tank`): the run-detail page showed Formula = 'metadata missing', the generic 5-stage ladder, snapshot-order node layout, and never fetched `/formulas/{name}` — even though the run IS `mol-adopt-pr-v2` and a purpose-built 7-stage ladder exists in `phaseMapping.ts`.
- Root cause: the title-fallback gate in `shared/src/runs/formula-name.ts` required root metadata `gc.run_target`, which the supervisor retired as a root wire field in favor of `gc.routed_to` (upstream gascity ga-eld2x / #2763). A live survey found 27 of 32 workflow roots carry only `gc.routed_to`, so formula identity systematically resolved to `name=null` and the whole downstream chain (`formula-run.ts` → `runDetail.ts` → `formula-order.ts` → `FormulaRunDetail.tsx`) degraded.
- Fix: the gate now accepts either `gc.run_target` (legacy roots) or `gc.routed_to` (current roots) via a shared `rootRunTarget` helper — the same key pair `runFormulaTarget` already used. Explicit `gc.formula` precedence, the terminal-root exclusion (xfb7), and the lane-mode `mol-` prefix guard are unchanged. Verified against the captured live payload: identity resolves to `{name: 'mol-adopt-pr-v2', source: 'title_fallback', target: 'gascity/gc.run-operator'}` and the formula-specific 7-stage ladder engages.

## Scope

- Named Rule touched: None.
- Views or routes affected: run detail (`/runs/...`) formula cell, stage ladder, formula-detail fetch; runs lane formula attribution.
- Layer: shared, frontend (tests only).

## Test plan

- Tests added or modified:
  - `shared/src/runs/formula-name.test.ts` (new) — reproduces M3 with a root shaped like the real `ga-wisp-x0tank` bead; pins legacy `gc.run_target` compatibility, explicit-metadata precedence, terminal-root exclusion, no-target null, non-graph.v2 null, and the lane-mode `mol-` guard.
  - `frontend/src/supervisor/runDetail.test.ts` — end-to-end chain: a routed_to-only root now triggers the `/formulas/{name}` fetch with the routed_to target; on fetch failure the warn-tone `title_fallback` name still renders instead of 'metadata missing'.
- Automated checks run (Node 24, matching CI): root `npm run typecheck`, `npm run lint`, `npm --workspace shared test` (168 pass), `npm --workspace frontend test` (923 pass), `npm --workspace backend test` (582 pass), `npm --workspace frontend run build`.
- Manual checks run: re-derived the captured live supervisor payload (`ga-wisp-x0tank`, 72 beads / 176 deps) through the rebuilt shared pipeline — formula resolves and the mol-adopt-pr-v2 ladder replaces the generic one.

## Risk + rollback

- Risk: a graph.v2 root with `gc.routed_to` and an operator-edited title could surface a title-derived formula name. Mitigated by the unchanged honesty gates (graph.v2 contract + non-terminal status + target presence) — the same trade the original `gc.run_target` gate made — and provenance stays `title_fallback` (warn tone) unless the registry fetch confirms it. Operator would notice in the run-detail Formula cell first.
- Known remaining gap (separate follow-up, out of scope): the formula preview/order overlay can still degrade for routed_to roots because the supervisor's graph.v2 `/formulas/{name}` endpoint rejects agent-shaped targets (expects a bead/convoy id). The fetch-failed path is covered by a new test so the page keeps the resolved name and formula-specific ladder.
- Back out: revert the single commit on this branch.

## Linked issue

N/A — multi-agent audit finding M3 (run ga-wisp-x0tank).

## Operator-affecting changes

- [x] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [x] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)