### PR TITLE
perf(runs): header-first run lanes, lazy history load behind the toggle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,7 +108,7 @@ The calm "what is working right now" section at the top of the Agents view.
 Both the Active and Historical sections of the Runs view collapse to a small default and offer a quiet "Show N more" control.
 
 - **Same register as the Historical toggle.** The Active section gains a quiet expand-in-place control identical to the Historical "Show N more" toggle: faint tracked-uppercase text, no filled button, expands in place. Collapsed default stays MAX_VISIBLE_ACTIVE_LANES (8); no new color, no filled button, One Mark Rule unaffected.
-- **Wire carries the full set.** The collapse is a render concern: the full active set crosses the wire (`RunSummary.lanes`), and the component owns the window — mirroring `historicalLanes`/`MAX_HISTORICAL_LANES`.
+- **Wire carries the full set.** The collapse is a render concern: the full active set crosses the wire (`RunSummary.lanes`), and the component owns the window — mirroring `RunHistory.lanes`/`MAX_HISTORICAL_LANES` (the lazy history payload behind the toggle).
 
 ## 6. Do's and Don'ts
 

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -24,8 +24,6 @@ function freshRunsSource(): SourceState<RunSummary> {
     error: { kind: 'none' },
     data: {
       totalActive: 0,
-      totalHistorical: 0,
-      historicalLanes: [],
       blockedLanes: [],
       runCounts: {
         total: 0,

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -1012,10 +1012,8 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
   const activeLanes = lanes.filter((lane) => lane.phase !== 'blocked' && lane.phase !== 'complete');
   return {
     lanes: activeLanes,
-    historicalLanes: lanes.filter((lane) => lane.phase === 'complete'),
     blockedLanes,
     totalActive: activeLanes.length,
-    totalHistorical: 0,
     runCounts: {
       total: activeLanes.length,
       visible: activeLanes.length,

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -147,8 +147,40 @@ function activeLane(id: string): RunLane {
   };
 }
 
+function blockedLane(id: string): RunLane {
+  return { ...activeLane(id), title: `Blocked run ${id}`, phase: 'blocked', phaseLabel: 'blocked' };
+}
+
 function makeActiveLanes(count: number): RunLane[] {
   return Array.from({ length: count }, (_, i) => activeLane(`gc-active-${i}`));
+}
+
+function summarySource(lanes: RunLane[], blockedLanes: RunLane[] = []): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-05-24T12:00:00Z',
+    staleAt: '2026-05-24T12:01:00Z',
+    error: { kind: 'none' },
+    data: { ...emptyRunSummary(), totalActive: lanes.length, lanes, blockedLanes },
+  };
+}
+
+function renderRunMap(
+  summary: SourceState<RunSummary>,
+  history: SourceState<RunHistory> | undefined,
+) {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <RunMap
+        source={summary}
+        now={Date.parse('2026-05-24T12:01:00Z')}
+        showHistory={true}
+        history={history}
+        historyLoading={false}
+      />
+    </MemoryRouter>,
+  );
 }
 
 function renderActive(lanes: RunLane[]) {
@@ -298,6 +330,29 @@ describe('RunMap historical lazy-source states (header-first)', () => {
     expect(within(section).getAllByRole('listitem')).toHaveLength(2);
   });
 
+  it('flags stale history with a glyph+word cue when a refresh fails after a good load', () => {
+    // useRunHistory re-publishes the last good payload as 'stale' when an
+    // explicit refresh fails after a good load (last-good retention). The
+    // section must NOT render that indistinguishably from a fresh read: a
+    // visible stale cue is what keeps the silently-behind data honest and the
+    // reopen-reuses-cache retry suppression operator-visible.
+    renderHistorySource({
+      source: 'runs',
+      status: 'stale',
+      fetchedAt: '2026-05-24T12:00:00Z',
+      staleAt: '2026-05-24T12:01:00Z',
+      error: { kind: 'none' },
+      data: { totalHistorical: 2, lanes: makeLanes(2) },
+    });
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    const marker = within(section).getByRole('status');
+    expect(marker.textContent).toContain('◐');
+    expect(marker.textContent).toContain('history stale');
+    // Last-good completed lanes still render alongside the stale signal.
+    expect(within(section).getAllByRole('listitem')).toHaveLength(2);
+  });
+
   it('omits the partial notice on a clean history read', () => {
     renderHistory(makeLanes(2));
 
@@ -310,5 +365,98 @@ describe('RunMap historical lazy-source states (header-first)', () => {
 
     const section = screen.getByRole('region', { name: /historical runs/i });
     expect(within(section).getByText(/No completed runs in the current window\./i)).toBeTruthy();
+  });
+
+  it('renders a single status cue when stale history is also partial (one mark per region)', () => {
+    // DESIGN.md "One mark per region": a payload that is both stale (a failed
+    // refresh re-published the last-good set) AND partial (a degraded fan-out)
+    // must not stack "history stale" beside "history partial". The stale cue —
+    // the more urgent "this is behind, press Refresh" signal — wins.
+    renderHistorySource({
+      source: 'runs',
+      status: 'stale',
+      fetchedAt: '2026-05-24T12:00:00Z',
+      staleAt: '2026-05-24T12:01:00Z',
+      error: { kind: 'none' },
+      data: { totalHistorical: 2, lanes: makeLanes(2), lanesPartial: true },
+    });
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getAllByRole('status')).toHaveLength(1);
+    expect(within(section).getByRole('status').textContent).toContain('history stale');
+    expect(within(section).queryByText(/history partial/i)).toBeNull();
+  });
+});
+
+// Header-first split the formerly-single run summary into a live active+blocked
+// source (SSE-refreshed) and a lazy, cache-backed history source (refreshed only
+// on open / explicit Refresh). The two now run on independent clocks, so a run
+// that was `complete` when history last loaded can reactivate into the live set
+// before history is refreshed. RunMap reconciles at the render boundary so the
+// live set always wins and a run is never double-rendered or double-counted.
+describe('RunMap reconciles lazy history against the live summary (header-first skew)', () => {
+  it('drops a completed run that is active again so it never renders in both sections', () => {
+    renderRunMap(
+      summarySource([activeLane('gc-shared'), activeLane('gc-other')]),
+      historySource([historicalLane('gc-shared'), historicalLane('gc-keep')], 2),
+    );
+
+    const historical = screen.getByRole('region', { name: /historical runs/i });
+    // The reactivated run is gone from Historical...
+    expect(within(historical).queryByText(/Completed run gc-shared/i)).toBeNull();
+    // ...the still-complete run remains...
+    expect(within(historical).getByText(/Completed run gc-keep/i)).toBeTruthy();
+    // ...and the reactivated run renders only in the live Active set.
+    expect(screen.getByText(/Active run gc-shared/i)).toBeTruthy();
+  });
+
+  it('reconciles against blocked lanes and subtracts them from the completed count', () => {
+    // A completed run that is now BLOCKED leaves Active empty, so the
+    // "(N completed.)" hint shows — and must show the decremented count, not the
+    // raw totalHistorical that still includes the now-live run.
+    renderRunMap(
+      summarySource([], [blockedLane('gc-blocked')]),
+      historySource([historicalLane('gc-blocked'), historicalLane('gc-keep')], 2),
+    );
+
+    // 2 completed minus the 1 now-blocked run = 1.
+    expect(screen.getByText(/No active formula runs\. \(1 completed\.\)/i)).toBeTruthy();
+    const historical = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(historical).queryByText(/Completed run gc-blocked/i)).toBeNull();
+    expect(within(historical).getByText(/Completed run gc-keep/i)).toBeTruthy();
+  });
+
+  it('leaves history untouched when no completed run is live', () => {
+    renderRunMap(
+      summarySource([activeLane('gc-active-only')]),
+      historySource([historicalLane('gc-h1'), historicalLane('gc-h2')], 2),
+    );
+
+    const historical = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(historical).getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('reconciles a STALE history payload, dropping a now-live run while keeping the stale cue', () => {
+    // The skew is worst for a STALE payload: a failed refresh is serving an old
+    // completed set while the live summary has already moved the run back to
+    // Active. Reconciliation must run on the stale path too, and the stale cue
+    // must still surface alongside the reconciled set.
+    const staleHistory: SourceState<RunHistory> = {
+      source: 'runs',
+      status: 'stale',
+      fetchedAt: '2026-05-24T12:00:00Z',
+      staleAt: '2026-05-24T12:01:00Z',
+      error: { kind: 'none' },
+      data: {
+        totalHistorical: 2,
+        lanes: [historicalLane('gc-shared'), historicalLane('gc-keep')],
+      },
+    };
+    renderRunMap(summarySource([activeLane('gc-shared')]), staleHistory);
+
+    const historical = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(historical).queryByText(/Completed run gc-shared/i)).toBeNull();
+    expect(within(historical).getByText(/Completed run gc-keep/i)).toBeTruthy();
+    expect(within(historical).getByRole('status').textContent).toContain('history stale');
   });
 });

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, within } from '@testing-library/rea
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
 import { emptyRunSummary, MAX_VISIBLE_ACTIVE_LANES } from 'gas-city-dashboard-shared';
-import type { RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
+import type { RunHistory, RunLane, RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { RunMap } from './RunMap';
 
 afterEach(() => cleanup());
@@ -31,10 +31,24 @@ function historicalLane(id: string): RunLane {
   };
 }
 
-function runsSource(
-  historicalLanes: RunLane[],
-  totalHistorical = historicalLanes.length,
-): SourceState<RunSummary> {
+function emptySummarySource(): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-05-24T12:00:00Z',
+    staleAt: '2026-05-24T12:01:00Z',
+    error: { kind: 'none' },
+    data: emptyRunSummary(),
+  };
+}
+
+// Header-first: history is its own lazy source rendered by RunMap's
+// historical section, not a field on the run summary.
+function historySource(
+  lanes: RunLane[],
+  totalHistorical = lanes.length,
+  lanesPartial = false,
+): SourceState<RunHistory> {
   return {
     source: 'runs',
     status: 'fresh',
@@ -42,9 +56,9 @@ function runsSource(
     staleAt: '2026-05-24T12:01:00Z',
     error: { kind: 'none' },
     data: {
-      ...emptyRunSummary(),
       totalHistorical,
-      historicalLanes,
+      lanes,
+      ...(lanesPartial ? { lanesPartial: true } : {}),
     },
   };
 }
@@ -53,13 +67,19 @@ function makeLanes(count: number): RunLane[] {
   return Array.from({ length: count }, (_, i) => historicalLane(`gc-hist-${i}`));
 }
 
-function renderHistory(historicalLanes: RunLane[], totalHistorical?: number) {
+function renderHistory(lanes: RunLane[], totalHistorical?: number) {
+  return renderHistorySource(historySource(lanes, totalHistorical));
+}
+
+function renderHistorySource(history: SourceState<RunHistory> | undefined, historyLoading = false) {
   return render(
     <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <RunMap
-        source={runsSource(historicalLanes, totalHistorical)}
+        source={emptySummarySource()}
         now={Date.parse('2026-05-24T12:01:00Z')}
         showHistory={true}
+        history={history}
+        historyLoading={historyLoading}
       />
     </MemoryRouter>,
   );
@@ -230,5 +250,68 @@ describe('RunMap historical recency-cap disclosure (gascity-dashboard-9w3k)', ()
 
     const section = screen.getByRole('region', { name: /historical runs/i });
     expect(within(section).queryByText(/most-recent of/i)).toBeNull();
+  });
+});
+
+// Header-first: the historical section owns its lazy source's loading /
+// unavailable / partial states, so the operator always knows whether an empty
+// section means "no completed runs", "still fetching", or "could not read".
+describe('RunMap historical lazy-source states (header-first)', () => {
+  it('shows a loading state before the first history read lands', () => {
+    renderHistorySource(undefined, true);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getByText(/Loading completed runs\./i)).toBeTruthy();
+    expect(within(section).queryByRole('listitem')).toBeNull();
+  });
+
+  it('shows an unavailable state when the history read failed', () => {
+    renderHistorySource({
+      source: 'runs',
+      status: 'error',
+      error: 'gc supervisor request timed out after 30000ms',
+    });
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(
+      within(section).getByText(
+        /Completed runs unavailable: gc supervisor request timed out after 30000ms\./i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders the loading state while a retry is in flight after an error', () => {
+    renderHistorySource(
+      { source: 'runs', status: 'error', error: 'transient timeout' },
+      true,
+    );
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getByText(/Loading completed runs\./i)).toBeTruthy();
+  });
+
+  it('pairs a history-partial notice with the lanes when the fan-out degraded', () => {
+    renderHistorySource(historySource(makeLanes(2), 2, true));
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    const marker = within(section).getByRole('status');
+    expect(marker.textContent).toContain('◐');
+    expect(marker.textContent).toContain('history partial');
+    // The lanes still render alongside the degradation signal.
+    expect(within(section).getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('omits the partial notice on a clean history read', () => {
+    renderHistory(makeLanes(2));
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).queryByRole('status')).toBeNull();
+  });
+
+  it('says so when a clean history read finds no completed runs', () => {
+    renderHistory([]);
+
+    const section = screen.getByRole('region', { name: /historical runs/i });
+    expect(within(section).getByText(/No completed runs in the current window\./i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -281,10 +281,7 @@ describe('RunMap historical lazy-source states (header-first)', () => {
   });
 
   it('renders the loading state while a retry is in flight after an error', () => {
-    renderHistorySource(
-      { source: 'runs', status: 'error', error: 'transient timeout' },
-      true,
-    );
+    renderHistorySource({ source: 'runs', status: 'error', error: 'transient timeout' }, true);
 
     const section = screen.getByRole('region', { name: /historical runs/i });
     expect(within(section).getByText(/Loading completed runs\./i)).toBeTruthy();

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import {
   MAX_VISIBLE_ACTIVE_LANES,
   selectBlockedRuns,
+  type RunHistory,
   type RunLane,
   type RunSummary,
   type SourceState,
 } from 'gas-city-dashboard-shared';
 import type { BadgeSeverity } from '../../attention/compose';
+import { PartialDataNotice } from '../PartialDataNotice';
 import { LaneCard } from './LaneCard';
 
 // Run phase-lane map (gascity-dashboard-0t6). Renders the snapshot's
@@ -20,11 +22,20 @@ import { LaneCard } from './LaneCard';
 // when `showHistory` is true (controlled by ?history=1 in the URL,
 // threaded down from /runs). The historical section is labeled and
 // hairlined to keep the typographic register continuous with active.
+//
+// Header-first restructure: the historical section renders from its OWN lazy
+// source (`history`, loaded on toggle by runs/runHistory) instead of fields on
+// the run summary, with its own loading/unavailable/partial states — so the
+// default summary refresh never pays the closed-history fan-out.
 
 interface RunMapProps {
   source: SourceState<RunSummary>;
   now: number;
   showHistory: boolean;
+  /** The lazy history payload; undefined until the first history read lands. */
+  history?: SourceState<RunHistory> | undefined;
+  /** True while a history read is in flight (loading or refreshing). */
+  historyLoading?: boolean;
   attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }
 
@@ -44,7 +55,14 @@ const ACTIVE_LIST_ID = 'runs-active-list';
 // preview keeps the section ambient by default per DESIGN.md.
 const HISTORICAL_PREVIEW = 5;
 
-export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapProps) {
+export function RunMap({
+  source,
+  now,
+  showHistory,
+  history,
+  historyLoading = false,
+  attentionSeverity,
+}: RunMapProps) {
   if (source.status === 'error') {
     return (
       <section>
@@ -57,6 +75,11 @@ export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapPr
   }
 
   const summary = source.data;
+  // The "(N completed.)" hint on the active empty state needs the lazy history
+  // payload; before it loads the count is honestly unknown, so the hint is
+  // omitted rather than rendered as a fabricated zero.
+  const completedCount =
+    history !== undefined && history.status !== 'error' ? history.data.totalHistorical : null;
 
   return (
     <section>
@@ -64,6 +87,7 @@ export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapPr
       <ActiveSection
         summary={summary}
         now={now}
+        completedCount={completedCount}
         {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
       />
       <BlockedSection
@@ -73,7 +97,8 @@ export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapPr
       />
       {showHistory && (
         <HistoricalSection
-          summary={summary}
+          history={history}
+          historyLoading={historyLoading}
           now={now}
           {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
         />
@@ -85,10 +110,13 @@ export function RunMap({ source, now, showHistory, attentionSeverity }: RunMapPr
 function ActiveSection({
   summary,
   now,
+  completedCount,
   attentionSeverity,
 }: {
   summary: RunSummary;
   now: number;
+  /** totalHistorical from the lazy history payload, or null before it loads. */
+  completedCount: number | null;
   attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
   // gascity-dashboard: `lanes` now carries the FULL active set; the collapsed
@@ -109,8 +137,11 @@ function ActiveSection({
         </p>
       );
     }
-    // Distinguish "nothing at all" from "nothing active but N completed".
-    const trailer = summary.totalHistorical > 0 ? ` (${summary.totalHistorical} completed.)` : '';
+    // Distinguish "nothing at all" from "nothing active but N completed". The
+    // count comes from the lazy history payload, so the hint appears only once
+    // history has loaded (header-first: the default read cannot know it).
+    const trailer =
+      completedCount !== null && completedCount > 0 ? ` (${completedCount} completed.)` : '';
     return (
       <p className="mt-8 text-body text-fg-muted italic">{`No active formula runs.${trailer}`}</p>
     );
@@ -257,58 +288,110 @@ function BlockedSection({
   );
 }
 
+// Header-first: the historical section renders from the lazy history source,
+// with explicit loading / unavailable / partial states of its own. The summary's
+// lanesPartial never speaks for history, and vice versa — each signal flags only
+// its own fan-out (honest-partial rule, gascity-dashboard-n6f1).
 function HistoricalSection({
-  summary,
+  history,
+  historyLoading,
   now,
   attentionSeverity,
 }: {
-  summary: RunSummary;
+  history: SourceState<RunHistory> | undefined;
+  historyLoading: boolean;
   now: number;
   attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const lanes = summary.historicalLanes;
-  const shown = expanded ? lanes : lanes.slice(0, HISTORICAL_PREVIEW);
 
   return (
     <section id={HISTORICAL_SECTION_ID} aria-label="Historical runs" className="mt-12">
-      <h2 className="text-label uppercase tracking-wider text-fg-faint">Historical</h2>
-      {lanes.length === 0 ? (
+      <h2 className="text-label uppercase tracking-wider text-fg-faint">
+        Historical
+        {history !== undefined && history.status !== 'error' && history.data.lanesPartial && (
+          <span className="ml-3 normal-case tracking-normal">
+            <PartialDataNotice
+              glyph="◐"
+              label="history partial"
+              title="one or more closed-history reads were unavailable; the completed set may be incomplete"
+            />
+          </span>
+        )}
+      </h2>
+      {history === undefined || (historyLoading && history.status === 'error') ? (
+        <p className="mt-3 text-body text-fg-muted italic">Loading completed runs.</p>
+      ) : history.status === 'error' ? (
         <p className="mt-3 text-body text-fg-muted italic">
-          No completed runs in the current window.
+          {`Completed runs unavailable: ${history.error}.`}
         </p>
       ) : (
-        <>
-          <LaneList
-            lanes={shown}
-            now={now}
-            listId={HISTORICAL_LIST_ID}
-            {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
-          />
-          {lanes.length > HISTORICAL_PREVIEW && (
-            <button
-              type="button"
-              onClick={() => setExpanded((value) => !value)}
-              aria-expanded={expanded}
-              aria-controls={HISTORICAL_LIST_ID}
-              className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum hover:text-fg focus-mark"
-            >
-              {expanded ? 'Show fewer' : `Show ${lanes.length - HISTORICAL_PREVIEW} more`}
-            </button>
-          )}
-          {/* gascity-dashboard-9w3k: the wire caps historicalLanes at
-              MAX_HISTORICAL_LANES while totalHistorical keeps the true count.
-              Disclose the cap so the operator knows the rendered set is the
-              recent window, not the whole history — mirroring the Active
-              section's "N more not shown" note (same typographic register). */}
-          {summary.totalHistorical > lanes.length && (
-            <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
-              Showing {lanes.length} most-recent of {summary.totalHistorical}
-            </p>
-          )}
-        </>
+        <HistoricalLanes
+          history={history.data}
+          now={now}
+          expanded={expanded}
+          onToggle={() => setExpanded((value) => !value)}
+          {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+        />
       )}
     </section>
+  );
+}
+
+function HistoricalLanes({
+  history,
+  now,
+  expanded,
+  onToggle,
+  attentionSeverity,
+}: {
+  history: RunHistory;
+  now: number;
+  expanded: boolean;
+  onToggle: () => void;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
+}) {
+  const lanes = history.lanes;
+  const shown = expanded ? lanes : lanes.slice(0, HISTORICAL_PREVIEW);
+
+  if (lanes.length === 0) {
+    return (
+      <p className="mt-3 text-body text-fg-muted italic">
+        No completed runs in the current window.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <LaneList
+        lanes={shown}
+        now={now}
+        listId={HISTORICAL_LIST_ID}
+        {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+      />
+      {lanes.length > HISTORICAL_PREVIEW && (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-controls={HISTORICAL_LIST_ID}
+          className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum hover:text-fg focus-mark"
+        >
+          {expanded ? 'Show fewer' : `Show ${lanes.length - HISTORICAL_PREVIEW} more`}
+        </button>
+      )}
+      {/* gascity-dashboard-9w3k: the wire caps history lanes at
+          MAX_HISTORICAL_LANES while totalHistorical keeps the true count.
+          Disclose the cap so the operator knows the rendered set is the
+          recent window, not the whole history — mirroring the Active
+          section's "N more not shown" note (same typographic register). */}
+      {history.totalHistorical > lanes.length && (
+        <p className="mt-3 text-label uppercase tracking-wider text-fg-faint tnum">
+          Showing {lanes.length} most-recent of {history.totalHistorical}
+        </p>
+      )}
+    </>
   );
 }
 

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -75,11 +75,21 @@ export function RunMap({
   }
 
   const summary = source.data;
+  // Reconcile the lazy history payload against the live summary before it feeds
+  // either the count hint or the Historical section (see reconcileHistory): the
+  // two sources refresh on independent clocks, so a completed run that has since
+  // reactivated must render and count in the live Active/Blocked set only.
+  const reconciledHistory: SourceState<RunHistory> | undefined =
+    history !== undefined && history.status !== 'error'
+      ? { ...history, data: reconcileHistory(history.data, summary) }
+      : history;
   // The "(N completed.)" hint on the active empty state needs the lazy history
   // payload; before it loads the count is honestly unknown, so the hint is
   // omitted rather than rendered as a fabricated zero.
   const completedCount =
-    history !== undefined && history.status !== 'error' ? history.data.totalHistorical : null;
+    reconciledHistory !== undefined && reconciledHistory.status !== 'error'
+      ? reconciledHistory.data.totalHistorical
+      : null;
 
   return (
     <section>
@@ -97,7 +107,7 @@ export function RunMap({
       />
       {showHistory && (
         <HistoricalSection
-          history={history}
+          history={reconciledHistory}
           historyLoading={historyLoading}
           now={now}
           {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
@@ -105,6 +115,35 @@ export function RunMap({
       )}
     </section>
   );
+}
+
+/**
+ * Reconcile the lazy history payload against the live summary at the render
+ * boundary. History (loaded on open / explicit Refresh) and the active+blocked
+ * summary (refreshed on every SSE burst) run on independent clocks, so a run
+ * that was `complete` when history last loaded can reactivate into the live set
+ * before history is refreshed. Drop any history lane whose run is now live and
+ * subtract those from `totalHistorical`, so the live set wins and a single run
+ * is never rendered or counted in both regions.
+ *
+ * Only the rendered (MAX_HISTORICAL_LANES-capped) lanes can be reconciled here;
+ * a reactivation of a run beyond that window is invisible at the render
+ * boundary. The operator-facing double-render — a run live in Active while still
+ * listed under Historical — is what this restores, holding the invariant the
+ * pre-split single summary maintained continuously.
+ */
+function reconcileHistory(history: RunHistory, summary: RunSummary): RunHistory {
+  if (summary.lanes.length === 0 && summary.blockedLanes.length === 0) return history;
+  const liveIds = new Set<string>();
+  for (const lane of summary.lanes) liveIds.add(lane.id);
+  for (const lane of summary.blockedLanes) liveIds.add(lane.id);
+  const lanes = history.lanes.filter((lane) => !liveIds.has(lane.id));
+  if (lanes.length === history.lanes.length) return history;
+  return {
+    ...history,
+    lanes,
+    totalHistorical: history.totalHistorical - (history.lanes.length - lanes.length),
+  };
 }
 
 function ActiveSection({
@@ -309,12 +348,37 @@ function HistoricalSection({
     <section id={HISTORICAL_SECTION_ID} aria-label="Historical runs" className="mt-12">
       <h2 className="text-label uppercase tracking-wider text-fg-faint">
         Historical
-        {history !== undefined && history.status !== 'error' && history.data.lanesPartial && (
+        {/* One mark per region (DESIGN.md): partial and stale are mutually
+            exclusive cues. Stale (a failed refresh re-publishing the last-good
+            set) outranks partial here — it is the more urgent "this is behind,
+            press Refresh" signal — so the partial notice yields when both
+            apply, and the two never stack in the same header. */}
+        {history !== undefined &&
+          history.status !== 'error' &&
+          history.status !== 'stale' &&
+          history.data.lanesPartial && (
+            <span className="ml-3 normal-case tracking-normal">
+              <PartialDataNotice
+                glyph="◐"
+                label="history partial"
+                title="one or more closed-history reads were unavailable; the completed set may be incomplete"
+              />
+            </span>
+          )}
+        {/* A failed explicit refresh AFTER a good load keeps serving the last
+            good payload re-published as 'stale' (last-good retention in
+            useRunHistory). Surface that as a glyph+word cue so stale completed
+            lanes never read as a fresh load — the operator sees the refresh
+            failed and can Refresh again rather than trusting silently-behind
+            data. Honest-degradation rule (gascity-dashboard-n6f1); reopen
+            reuses the cache, so this visible warning is what keeps the
+            suppressed retry honest. */}
+        {history !== undefined && history.status === 'stale' && (
           <span className="ml-3 normal-case tracking-normal">
             <PartialDataNotice
               glyph="◐"
-              label="history partial"
-              title="one or more closed-history reads were unavailable; the completed set may be incomplete"
+              label="history stale"
+              title="the last history refresh failed; showing the most recent completed runs that loaded (use Refresh to retry)"
             />
           </span>
         )}

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -171,8 +171,6 @@ function runSource({
     error: { kind: 'none' },
     data: {
       totalActive: lanes.length,
-      totalHistorical: 0,
-      historicalLanes: [],
       blockedLanes: [],
       runCounts: {
         total: lanes.length,

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -831,8 +831,6 @@ function runSummarySource(lanes: RunLane[] = []): SourceState<RunSummary> {
     error: { kind: 'none' },
     data: {
       totalActive: lanes.length,
-      totalHistorical: 0,
-      historicalLanes: [],
       blockedLanes: [],
       runCounts: {
         total: lanes.length,

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import {
   GC_EVENT_PREFIX,
+  type RunHistory,
   type RunSummary,
   type SourceStatus,
   type RunLane,
@@ -16,6 +17,7 @@ import { RunSummaryProvider } from '../runs/runSummarySubscription';
 import { MemoryRouter } from 'react-router-dom';
 import { NowProvider } from '../contexts/NowContext';
 import {
+  loadSupervisorRunHistorySource,
   loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryPreviewSource,
   loadSupervisorRunSummarySource,
@@ -42,6 +44,7 @@ vi.mock('../supervisor/runSummary', () => ({
   loadSupervisorRunSummaryPreviewSource: vi.fn(),
   loadSupervisorRunSummarySource: vi.fn(),
   loadSupervisorRunSummaryActiveSource: vi.fn(),
+  loadSupervisorRunHistorySource: vi.fn(),
 }));
 
 // Capture the prefixes + onMatch passed to useGcEventRefresh so each
@@ -65,6 +68,19 @@ const mockLoadRunSummary = loadSupervisorRunSummarySource as Mock;
 // gascity-dashboard: SSE-driven refreshes route through the CHEAP active source;
 // only the manual Refresh button + one-time first upgrade use the wide source.
 const mockLoadRunSummaryActive = loadSupervisorRunSummaryActiveSource as Mock;
+// Header-first: the lazy history loader behind the ?history=1 toggle.
+const mockLoadRunHistory = loadSupervisorRunHistorySource as Mock;
+
+function buildHistorySource(lanes: RunLane[] = [], totalHistorical = lanes.length) {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-05-25T00:00:00.000Z',
+    staleAt: '2026-05-25T00:01:00.000Z',
+    error: { kind: 'none' },
+    data: { totalHistorical, lanes },
+  } satisfies SourceState<RunHistory>;
+}
 
 function buildRunSource(
   runsStatus: Exclude<SourceStatus, 'error'> = 'fresh',
@@ -77,8 +93,6 @@ function buildRunSource(
     error: { kind: 'none' },
     data: {
       totalActive: 0,
-      totalHistorical: 0,
-      historicalLanes: [],
       blockedLanes: [],
       runCounts: {
         total: 0,
@@ -187,9 +201,12 @@ beforeEach(() => {
   lastHookCall.prefixes = null;
   lastHookCall.onMatch = null;
   invalidateKey('runs:summary:racoon-city');
+  invalidateKey('runs:history:racoon-city');
   mockLoadRunSummaryPreview.mockResolvedValue(buildRunSource('fresh'));
   mockLoadRunSummary.mockResolvedValue(buildRunSource('fresh'));
   mockLoadRunSummaryActive.mockResolvedValue(buildRunSource('fresh'));
+  mockLoadRunHistory.mockReset();
+  mockLoadRunHistory.mockResolvedValue(buildHistorySource());
 });
 
 afterEach(() => {
@@ -375,62 +392,62 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     expect(screen.queryByText(/^0 active runs/i)).toBeNull();
   });
 
-  // yh5i: completed lanes now land in historicalLanes (toggle-visible),
-  // not the default-visible `lanes`. The test below pins the new contract;
-  // see the toggle tests further down for the ?history=1 reveal path.
+  // yh5i, header-first: completed lanes live in the LAZY history source behind
+  // the ?history=1 toggle. The summary carries none, and the expensive
+  // closed-history fan-out fires only when the section opens.
   it('yh5i: hides completed formula runs from default view, shows them under ?history=1', async () => {
-    const source = buildRunSource('fresh');
-    const lane = completedLane();
-    const runs = requireRunData(source);
-    runs.totalActive = 0;
-    runs.totalHistorical = 1;
-    runs.lanes = [];
-    runs.historicalLanes = [lane];
-    runs.census = {
-      status: 'available',
-      data: {
-        byPhase: {
-          intake: 0,
-          implementation: 0,
-          review: 0,
-          approval: 0,
-          finalization: 0,
-          blocked: 0,
-          complete: 1,
-          active: 0,
-        },
-        totalInFlight: 0,
-        unverifiable: 0,
-        knownDenominator: 0,
-        thrashing: 0,
-      },
-    };
-    mockLoadRunSummary.mockResolvedValue(source);
+    mockLoadRunHistory.mockResolvedValue(buildHistorySource([completedLane()]));
 
-    // Default view (/runs): historical lane is hidden, empty-state
-    // trailer hints at the count.
+    // Default view (/runs): no historical lane, and (header-first) the lazy
+    // history fan-out has NOT been paid for the hidden section.
     mount();
     await waitForMount();
     expect(screen.queryByText('Completed formula run')).toBeNull();
-    expect(await screen.findByText(/No active formula runs\. \(1 completed\.\)/i)).toBeTruthy();
-    // The toggle button is enabled (totalHistorical > 0) and labeled
-    // with the count.
+    expect(await screen.findByText(/No active formula runs\./i)).toBeTruthy();
+    expect(mockLoadRunHistory).not.toHaveBeenCalled();
+    // The toggle button is enabled even before the count is known: opening IS
+    // the fetch.
     const toggleDefault = (await screen.findByRole('button', {
-      name: /show 1 completed/i,
+      name: /show completed formula runs/i,
     })) as HTMLButtonElement;
-    await waitFor(() => expect(toggleDefault.disabled).toBe(false));
+    expect(toggleDefault.disabled).toBe(false);
     expect(toggleDefault.getAttribute('aria-expanded')).toBe('false');
     cleanup();
 
-    // History view (?history=1): the historical section renders the lane.
+    // History view (?history=1): the lazy read fires and the historical
+    // section renders the lane.
+    invalidateKey('runs:summary:racoon-city');
     mount('/runs?history=1');
     await waitForMount();
     expect(await screen.findByText('Completed formula run')).toBeTruthy();
+    expect(mockLoadRunHistory).toHaveBeenCalledTimes(1);
+    expect(mockLoadRunHistory).toHaveBeenCalledWith({ forceFresh: false });
     const toggleHistory = (await screen.findByRole('button', {
       name: /hide historical/i,
     })) as HTMLButtonElement;
     expect(toggleHistory.getAttribute('aria-expanded')).toBe('true');
     expect(toggleHistory.getAttribute('aria-controls')).toBeTruthy();
+  });
+
+  it('header-first: shows the history loading state while the lazy read is in flight', async () => {
+    let resolveHistory: (value: SourceState<RunHistory>) => void = () => {};
+    mockLoadRunHistory.mockImplementationOnce(
+      () =>
+        new Promise<SourceState<RunHistory>>((resolve) => {
+          resolveHistory = resolve;
+        }),
+    );
+
+    mount('/runs?history=1');
+    await waitForMount();
+
+    // The section announces the in-flight lazy read instead of blanking.
+    expect(await screen.findByText(/Loading completed runs\./i)).toBeTruthy();
+
+    await act(async () => {
+      resolveHistory(buildHistorySource([completedLane()]));
+    });
+    expect(await screen.findByText('Completed formula run')).toBeTruthy();
   });
 
   it('7hek: groups active lanes by rig under section headers and shows each root bead id', async () => {
@@ -469,24 +486,24 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     expect(await screen.findByText('gc-bbb')).toBeTruthy();
   });
 
-  it('yh5i: toggle button is disabled when totalHistorical is 0', async () => {
-    // Default run source has totalHistorical = 0.
+  it('yh5i, header-first: toggle is enabled before the count is known (opening IS the fetch)', async () => {
     mount();
     await waitForMount();
     const toggle = (await screen.findByRole('button', {
-      name: /no completed formula runs in the current window/i,
+      name: /show completed formula runs/i,
     })) as HTMLButtonElement;
-    expect(toggle.disabled).toBe(true);
+    expect(toggle.disabled).toBe(false);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     // aria-controls must NOT reference a non-existent DOM id when the
     // historical section is not rendered (WAI-ARIA spec).
     expect(toggle.getAttribute('aria-controls')).toBeNull();
+    // Header-first: merely rendering the page never fires the history fan-out.
+    expect(mockLoadRunHistory).not.toHaveBeenCalled();
   });
 
-  it('yh5i: toggle stays enabled when showHistory=true even if totalHistorical drops to 0', async () => {
-    // Reachable via back-button + SSE refresh: URL has ?history=1 but the
-    // last historical lane has since rolled out. The user must still be
-    // able to dismiss the historical section.
+  it('yh5i: toggle stays enabled when showHistory=true even if the loaded history is empty', async () => {
+    // Reachable via back-button: URL has ?history=1 but the lazy read finds no
+    // completed runs. The user must still be able to dismiss the section.
     mount('/runs?history=1');
     await waitForMount();
     const toggle = (await screen.findByRole('button', {
@@ -494,6 +511,35 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     })) as HTMLButtonElement;
     expect(toggle.disabled).toBe(false);
     expect(await screen.findByText(/No completed runs in the current window/i)).toBeTruthy();
+  });
+
+  it('header-first: Refresh refetches history (cache-bypassing) only while the section is open', async () => {
+    mount('/runs?history=1');
+    await waitForMount();
+    await waitFor(() => expect(mockLoadRunHistory).toHaveBeenCalledTimes(1));
+    expect(mockLoadRunHistory).toHaveBeenLastCalledWith({ forceFresh: false });
+
+    const btn = screen.getByRole('button', { name: /refresh/i }) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    // The operator's explicit Refresh re-runs the open history fan-out with the
+    // proxy cache bypass (gascity-dashboard-i3dz).
+    await waitFor(() => expect(mockLoadRunHistory).toHaveBeenCalledTimes(2));
+    expect(mockLoadRunHistory).toHaveBeenLastCalledWith({ forceFresh: true });
+    cleanup();
+
+    // With the section closed, Refresh refreshes only the summary.
+    invalidateKey('runs:summary:racoon-city');
+    mockLoadRunHistory.mockClear();
+    mount();
+    await waitForMount();
+    const btn2 = screen.getByRole('button', { name: /refresh/i }) as HTMLButtonElement;
+    await act(async () => {
+      btn2.click();
+    });
+    expect(mockLoadRunHistory).not.toHaveBeenCalled();
   });
 
   it('manual Refresh button refetches the direct supervisor run summary', async () => {

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -439,9 +439,11 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     );
 
     mount('/runs?history=1');
-    await waitForMount();
 
-    // The section announces the in-flight lazy read instead of blanking.
+    // The section announces the in-flight lazy read instead of blanking. Settle
+    // on this cue rather than waitForMount: the Refresh button is now disabled
+    // while the open-history fan-out is in flight (anti-stacking), so it never
+    // re-enables until this read resolves.
     expect(await screen.findByText(/Loading completed runs\./i)).toBeTruthy();
 
     await act(async () => {
@@ -540,6 +542,49 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
       btn2.click();
     });
     expect(mockLoadRunHistory).not.toHaveBeenCalled();
+  });
+
+  it('disables Refresh while the open-history fan-out is in flight, so multi-clicks cannot stack the expensive read', async () => {
+    // Opening history starts the heaviest fan-out in the view but never sets the
+    // summary `loading` flag, so settle the summary FIRST (section closed,
+    // button enabled), then open history with a hanging lazy read. That isolates
+    // the history gate: anything that disables Refresh now is the history load,
+    // not the summary's own (fast) refresh.
+    const pendingHistory = deferred<SourceState<RunHistory>>();
+    mockLoadRunHistory.mockReturnValueOnce(pendingHistory.promise);
+
+    mount();
+    await waitForMount();
+    const btn = screen.getByRole('button', { name: /refresh/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(mockLoadRunHistory).not.toHaveBeenCalled();
+
+    const toggle = screen.getByRole('button', { name: /show completed formula runs/i });
+    await act(async () => {
+      toggle.click();
+    });
+    await waitFor(() => expect(mockLoadRunHistory).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Loading completed runs\./i)).toBeTruthy();
+
+    // The Refresh button is disabled and reads "Refreshing" while that ~10-20s
+    // closed-history scan runs, even though the summary refresh already settled —
+    // otherwise an impatient operator stacks concurrent history fan-outs, the
+    // exact connection-pool saturation this view set out to remove.
+    await waitFor(() => expect(btn.disabled).toBe(true));
+    expect(btn.textContent).toMatch(/refreshing/i);
+
+    // A click while disabled is a no-op: no second history fan-out is issued.
+    await act(async () => {
+      btn.click();
+    });
+    expect(mockLoadRunHistory).toHaveBeenCalledTimes(1);
+
+    // Once the fan-out resolves the button re-enables.
+    await act(async () => {
+      pendingHistory.resolve(buildHistorySource([completedLane()]));
+      await pendingHistory.promise;
+    });
+    await waitFor(() => expect(btn.disabled).toBe(false));
   });
 
   it('manual Refresh button refetches the direct supervisor run summary', async () => {

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -81,12 +81,25 @@ export function RunsPage() {
   // The operator's explicit Refresh re-fetches the summary fan-out, and — when
   // the history section is open — the lazy history fan-out too, both with the
   // proxy cache bypass (gascity-dashboard-i3dz). A closed history section costs
-  // nothing.
+  // nothing. With history open the two fan-outs overlap: each issues the core
+  // active read and the city feed, and under forceFresh both feed reads carry
+  // cacheBypass so the proxy cannot dedupe them. That bounded, operator-
+  // initiated duplicate burst is the deliberate cost of decoupling the summary
+  // and history sources (intentional, not accidental); a future optimization
+  // could let the history source reuse the summary's just-fetched active/feed.
   const historyRefresh = history.refresh;
   const refreshAll = useCallback(() => {
     void manualRefresh();
     if (showHistory) void historyRefresh({ forceFresh: true });
   }, [manualRefresh, historyRefresh, showHistory]);
+
+  // Opening history fires the heaviest fan-out in the view, and (unlike the
+  // summary) it does not raise the summary `loading` flag — so gate the Refresh
+  // button on the open-history read too. Without this, the button stays enabled
+  // through the ~10-20s closed-history scan and each impatient click stacks
+  // another concurrent fan-out, the exact connection-pool saturation this view
+  // removed. Closed history can't be refreshed by this button, so it never gates.
+  const refreshing = loading || (showHistory && history.loading);
 
   const synopsis = runSynopsis(data);
 
@@ -172,9 +185,9 @@ export function RunsPage() {
                 size="sm"
                 className="w-full justify-center"
                 onClick={refreshAll}
-                disabled={loading}
+                disabled={refreshing}
               >
-                {loading ? 'Refreshing' : 'Refresh'}
+                {refreshing ? 'Refreshing' : 'Refresh'}
               </Button>
             </div>
           </>

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -10,14 +10,15 @@ import { SseIndicator } from '../components/SseIndicator';
 import { RunMap, RUNS_HISTORICAL_SECTION_ID } from '../components/run/RunMap';
 import { useNow } from '../contexts/NowContext';
 import { formatRelative } from '../hooks/time';
+import { useRunHistory } from '../runs/runHistory';
 import { useRunSummary } from '../runs/runSummarySubscription';
 
 // /runs route (gascity-dashboard-0t6, made live in gascity-dashboard-bqn). The
 // fetch, SSE refresh, and degraded-load retry now live in the shared
 // run-summary subscription (gascity-dashboard-2j8e.7), which the nav badge reads
 // too — so the page and the badge render the same source by construction. This
-// component is the source's renderer: it owns only the ?history=1 toggle,
-// freshness label, and lane layout.
+// component is the source's renderer: it owns the ?history=1 toggle (which now
+// drives the LAZY history load, header-first), freshness label, and lane layout.
 //
 // The app-level NowProvider refreshes relative-time labels in lane cards; the
 // shared subscription's SSE path drives actual data updates.
@@ -30,22 +31,33 @@ export function RunsPage() {
   const attention = useAttentionModel();
   const { source: data, loading, error, manualRefresh, sseState } = useRunSummary();
   const [searchParams, setSearchParams] = useSearchParams();
-  // gascity-dashboard-yh5i: ?history=1 toggles the historical lane
-  // section. Pure render-time state — the summary already carries both
-  // active + historical arrays, so the toggle does not trigger a fetch
-  // and the shared run-summary subscription stays stable across modes.
+  // gascity-dashboard-yh5i: ?history=1 toggles the historical lane section.
+  // Header-first restructure: the summary no longer carries historical lanes,
+  // so the toggle is also the LAZY trigger — opening the section fires the
+  // closed-history fan-out (useRunHistory) the first time, while the shared
+  // run-summary subscription stays untouched across modes.
   const showHistory = searchParams.get(HISTORY_QUERY_PARAM) === HISTORY_QUERY_VALUE;
+  const history = useRunHistory(showHistory);
   const now = useNow();
   const runs = data ?? null;
   const runsData =
     runs?.status === 'fresh' || runs?.status === 'fixture' || runs?.status === 'stale'
       ? runs.data
       : null;
-  const totalHistorical = runsData?.totalHistorical ?? 0;
-  // gascity-dashboard-n6f1: the backend now degrades (not collapses) when a
-  // single rig's recent-run query fails, flagging lanesPartial. Surface it
-  // so the operator reads a short lane set as "some rigs unavailable" rather
-  // than "everything's done." Mirrors the roster-partial signal in Agents.tsx.
+  const historyData =
+    history.source !== undefined && history.source.status !== 'error'
+      ? history.source.data
+      : null;
+  // Known only after the lazy history read lands; null keeps the toggle label
+  // honest ("Show history", no fabricated zero) before that.
+  const totalHistorical = historyData?.totalHistorical ?? null;
+  // gascity-dashboard-n6f1: the summary degrades (not collapses) when an
+  // active-set read fails or truncates, flagging lanesPartial. Surface it so
+  // the operator reads a short lane set as "sources unavailable" rather than
+  // "everything's done." Mirrors the roster-partial signal in Agents.tsx.
+  // Header-first: this flags ONLY the active fan-out (core read truncation, a
+  // failed feed); the lazy history payload carries its own partial signal,
+  // rendered inside the historical section.
   const lanesPartial = runsData?.lanesPartial === true;
 
   const toggleHistory = useCallback(() => {
@@ -67,6 +79,16 @@ export function RunsPage() {
     (lane: RunLane) => resourceAttentionSeverity(attention, 'runs', lane.id),
     [attention],
   );
+
+  // The operator's explicit Refresh re-fetches the summary fan-out, and — when
+  // the history section is open — the lazy history fan-out too, both with the
+  // proxy cache bypass (gascity-dashboard-i3dz). A closed history section costs
+  // nothing.
+  const historyRefresh = history.refresh;
+  const refreshAll = useCallback(() => {
+    void manualRefresh();
+    if (showHistory) void historyRefresh({ forceFresh: true });
+  }, [manualRefresh, historyRefresh, showHistory]);
 
   const synopsis = runSynopsis(data);
 
@@ -111,7 +133,7 @@ export function RunsPage() {
                   <PartialDataNotice
                     glyph="◐"
                     label="runs partial"
-                    title="one or more rigs' recent runs were unavailable; the lane set may be incomplete"
+                    title="one or more run sources were unavailable or truncated; the lane set may be incomplete"
                   />
                 ) : (
                   <span aria-hidden="true" className="invisible normal-case text-body text-warn">
@@ -123,12 +145,10 @@ export function RunsPage() {
                 size="sm"
                 className="w-full justify-center"
                 onClick={toggleHistory}
-                // yh5i: disable only when the toggle is off AND there's
-                // nothing to show. If the user already opened history
-                // (showHistory=true) we must let them close it, even if
-                // the last historical lane has since dropped out — otherwise
-                // a back-button + SSE refresh sequence locks the toggle open.
-                disabled={!showHistory && totalHistorical === 0}
+                // Header-first: completed runs load lazily on open, so the
+                // count is unknown until then and the toggle must always be
+                // actionable — opening IS the fetch. Once history has loaded,
+                // the label carries the known count.
                 aria-expanded={showHistory}
                 // aria-controls only references the historical section's id
                 // when that element is actually in the DOM; the WAI-ARIA
@@ -137,21 +157,23 @@ export function RunsPage() {
                 aria-label={
                   showHistory
                     ? 'Hide historical formula runs.'
-                    : totalHistorical === 0
-                      ? 'No completed formula runs in the current window.'
-                      : `Show ${totalHistorical} completed formula runs.`
+                    : totalHistorical === null
+                      ? 'Show completed formula runs.'
+                      : totalHistorical === 0
+                        ? 'Show completed formula runs (none in the current window).'
+                        : `Show ${totalHistorical} completed formula runs.`
                 }
               >
                 {showHistory
                   ? 'Hide history'
-                  : totalHistorical > 0
+                  : totalHistorical !== null && totalHistorical > 0
                     ? `Show history (${totalHistorical})`
                     : 'Show history'}
               </Button>
               <Button
                 size="sm"
                 className="w-full justify-center"
-                onClick={() => void manualRefresh()}
+                onClick={refreshAll}
                 disabled={loading}
               >
                 {loading ? 'Refreshing' : 'Refresh'}
@@ -168,6 +190,8 @@ export function RunsPage() {
           source={runs}
           now={now}
           showHistory={showHistory}
+          history={history.source}
+          historyLoading={history.loading}
           attentionSeverity={runAttentionSeverity}
         />
       )}

--- a/frontend/src/routes/Runs.tsx
+++ b/frontend/src/routes/Runs.tsx
@@ -45,9 +45,7 @@ export function RunsPage() {
       ? runs.data
       : null;
   const historyData =
-    history.source !== undefined && history.source.status !== 'error'
-      ? history.source.data
-      : null;
+    history.source !== undefined && history.source.status !== 'error' ? history.source.data : null;
   // Known only after the lazy history read lands; null keeps the toggle label
   // honest ("Show history", no fabricated zero) before that.
   const totalHistorical = historyData?.totalHistorical ?? null;

--- a/frontend/src/runs/runHistory.test.tsx
+++ b/frontend/src/runs/runHistory.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { RunHistory, SourceState } from 'gas-city-dashboard-shared';
+import { invalidateKey } from '../api/cache';
+import { setActiveCity } from '../api/cityBase';
+import { loadSupervisorRunHistorySource } from '../supervisor/runSummary';
+import { useRunHistory } from './runHistory';
+
+// Header-first restructure: the /runs history section loads lazily. The hook
+// must fetch the expensive closed-history fan-out ONLY when the section is
+// opened — never as a side effect of the page being mounted — and reuse the
+// cached payload across toggles so reopening is instant.
+
+vi.mock('../supervisor/runSummary', () => ({
+  loadSupervisorRunHistorySource: vi.fn(),
+}));
+
+const mockLoadHistory = loadSupervisorRunHistorySource as Mock;
+
+function historySource(total = 1): SourceState<RunHistory> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-06-01T12:00:00.000Z',
+    staleAt: '2026-06-01T12:01:00.000Z',
+    error: { kind: 'none' },
+    data: {
+      totalHistorical: total,
+      lanes: [],
+    },
+  };
+}
+
+beforeEach(() => {
+  setActiveCity('racoon-city');
+  invalidateKey('runs:history:racoon-city');
+  mockLoadHistory.mockReset();
+  mockLoadHistory.mockResolvedValue(historySource());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useRunHistory — lazy load on the history toggle (header-first)', () => {
+  it('does not fetch while the history section is closed', async () => {
+    renderHook(() => useRunHistory(false));
+
+    // Give any stray effect a tick to fire.
+    await act(async () => {});
+    expect(mockLoadHistory).not.toHaveBeenCalled();
+  });
+
+  it('fetches once when the section opens and publishes the payload', async () => {
+    const { result, rerender } = renderHook(({ enabled }) => useRunHistory(enabled), {
+      initialProps: { enabled: false },
+    });
+    expect(result.current.source).toBeUndefined();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockLoadHistory).toHaveBeenCalledTimes(1);
+    expect(mockLoadHistory).toHaveBeenCalledWith({ forceFresh: false });
+    expect(result.current.source?.status).toBe('fresh');
+    if (result.current.source?.status !== 'fresh') throw new Error('expected fresh source');
+    expect(result.current.source.data.totalHistorical).toBe(1);
+  });
+
+  it('reuses the cached payload across close/reopen (no refetch)', async () => {
+    const { result, rerender } = renderHook(({ enabled }) => useRunHistory(enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => expect(result.current.source?.status).toBe('fresh'));
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await act(async () => {});
+
+    expect(mockLoadHistory).toHaveBeenCalledTimes(1);
+    expect(result.current.source?.status).toBe('fresh');
+  });
+
+  it('refresh() refetches and threads forceFresh through to the loader', async () => {
+    const { result } = renderHook(() => useRunHistory(true));
+    await waitFor(() => expect(result.current.source?.status).toBe('fresh'));
+
+    mockLoadHistory.mockResolvedValue(historySource(7));
+    await act(async () => {
+      await result.current.refresh({ forceFresh: true });
+    });
+
+    expect(mockLoadHistory).toHaveBeenLastCalledWith({ forceFresh: true });
+    if (result.current.source?.status !== 'fresh') throw new Error('expected fresh source');
+    expect(result.current.source.data.totalHistorical).toBe(7);
+  });
+
+  it('keeps the last-good payload as stale when a refresh fails (no blank on transient timeout)', async () => {
+    const { result } = renderHook(() => useRunHistory(true));
+    await waitFor(() => expect(result.current.source?.status).toBe('fresh'));
+
+    mockLoadHistory.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'gc supervisor request timed out after 30000ms',
+    } satisfies SourceState<RunHistory>);
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.source?.status).toBe('stale');
+    if (result.current.source === undefined || result.current.source.status === 'error') {
+      throw new Error('expected retained data');
+    }
+    expect(result.current.source.data.totalHistorical).toBe(1);
+  });
+
+  it('surfaces a first-load error and retries when the section is reopened', async () => {
+    mockLoadHistory.mockResolvedValue({
+      source: 'runs',
+      status: 'error',
+      error: 'formula run history unavailable',
+    } satisfies SourceState<RunHistory>);
+
+    const { result, rerender } = renderHook(({ enabled }) => useRunHistory(enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => expect(result.current.source?.status).toBe('error'));
+
+    // An error payload is NOT cached, so closing and reopening retries the load
+    // instead of latching the section dead.
+    mockLoadHistory.mockResolvedValue(historySource(3));
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.source?.status).toBe('fresh'));
+    expect(mockLoadHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('a rejected loader publishes an error source rather than throwing', async () => {
+    mockLoadHistory.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useRunHistory(true));
+
+    await waitFor(() => expect(result.current.source?.status).toBe('error'));
+    if (result.current.source?.status !== 'error') throw new Error('expected error source');
+    expect(result.current.source.error).toBe('network down');
+  });
+});

--- a/frontend/src/runs/runHistory.test.tsx
+++ b/frontend/src/runs/runHistory.test.tsx
@@ -81,6 +81,43 @@ describe('useRunHistory — lazy load on the history toggle (header-first)', () 
     expect(result.current.source?.status).toBe('fresh');
   });
 
+  it('does not start a second fan-out when reopened before the first load resolves', async () => {
+    // The first history read is the heaviest fan-out in the view (molecule scan
+    // + per-rig all=true reads, the latter not proxy-cached). While it is in
+    // flight the cache is still empty, so a closed -> open toggle re-enters the
+    // lazy edge; without an in-flight guard it would fire a second copy. The
+    // guard holds until the first read resolves and populates the cache.
+    let resolveFirst!: (value: SourceState<RunHistory>) => void;
+    const pendingFirst = new Promise<SourceState<RunHistory>>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockLoadHistory.mockReset();
+    mockLoadHistory.mockReturnValue(pendingFirst);
+
+    const { rerender } = renderHook(({ enabled }) => useRunHistory(enabled), {
+      initialProps: { enabled: true },
+    });
+    await act(async () => {});
+    expect(mockLoadHistory).toHaveBeenCalledTimes(1);
+
+    // Close and reopen while the first read is still pending (cache empty).
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await act(async () => {});
+    expect(mockLoadHistory).toHaveBeenCalledTimes(1);
+
+    // Once the first read resolves and caches its payload, a reopen serves the
+    // cache — still exactly one fan-out.
+    await act(async () => {
+      resolveFirst(historySource(2));
+      await pendingFirst;
+    });
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await act(async () => {});
+    expect(mockLoadHistory).toHaveBeenCalledTimes(1);
+  });
+
   it('refresh() refetches and threads forceFresh through to the loader', async () => {
     const { result } = renderHook(() => useRunHistory(true));
     await waitFor(() => expect(result.current.source?.status).toBe('fresh'));
@@ -145,5 +182,48 @@ describe('useRunHistory — lazy load on the history toggle (header-first)', () 
     await waitFor(() => expect(result.current.source?.status).toBe('error'));
     if (result.current.source?.status !== 'error') throw new Error('expected error source');
     expect(result.current.source.error).toBe('network down');
+  });
+
+  it('drops an in-flight response once the active city changed (no cross-city contamination)', async () => {
+    // The hook keys its cache off getActiveCity(); a fetch started under city-a
+    // must never publish under city-b if the operator switches mid-flight. The
+    // stale-response guard keys on the captured cache key, and the city-change
+    // reseed re-reads city-b's own (empty) cache.
+    let resolveCityA!: (value: SourceState<RunHistory>) => void;
+    const pendingCityA = new Promise<SourceState<RunHistory>>((resolve) => {
+      resolveCityA = resolve;
+    });
+    const pendingCityB = new Promise<SourceState<RunHistory>>(() => {
+      // city-b's own load stays in flight, isolating the guard under test.
+    });
+
+    setActiveCity('city-a');
+    invalidateKey('runs:history:city-a');
+    invalidateKey('runs:history:city-b');
+    mockLoadHistory.mockReset();
+    mockLoadHistory.mockReturnValueOnce(pendingCityA).mockReturnValue(pendingCityB);
+
+    const { result, rerender } = renderHook(({ enabled }) => useRunHistory(enabled), {
+      initialProps: { enabled: true },
+    });
+    // city-a's fetch is in flight; nothing published yet.
+    await act(async () => {});
+    expect(result.current.source).toBeUndefined();
+
+    // Operator switches to city-b before city-a's response lands; the reseed
+    // re-reads city-b's empty cache and the lazy edge fires city-b's own fetch.
+    setActiveCity('city-b');
+    rerender({ enabled: true });
+    await act(async () => {});
+    expect(mockLoadHistory).toHaveBeenCalledTimes(2);
+
+    // city-a's request finally resolves — it must be dropped, not shown under
+    // city-b.
+    await act(async () => {
+      resolveCityA(historySource(99));
+      await pendingCityA;
+    });
+
+    expect(result.current.source).toBeUndefined();
   });
 });

--- a/frontend/src/runs/runHistory.ts
+++ b/frontend/src/runs/runHistory.ts
@@ -1,0 +1,103 @@
+import type { RunHistory, SourceState } from 'gas-city-dashboard-shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getCached, setCached } from '../api/cache';
+import { getActiveCity } from '../api/cityBase';
+import { loadSupervisorRunHistorySource } from '../supervisor/runSummary';
+
+// Header-first restructure: completed-run lanes load LAZILY, when the operator
+// opens the /runs history section, instead of riding every run-summary refresh.
+// The closed-history fan-out behind loadSupervisorRunHistorySource is the
+// expensive read set (molecule all=true scan measured 9.9s; per-rig task
+// all=true reads measured 10.9s on the largest rig store) — paying it per
+// refresh for a section hidden by default is what chronically latched the
+// "runs partial" badge. This hook owns that lifecycle: fetch on first open,
+// reuse the cached payload across toggles and remounts, refresh on demand.
+//
+// Deliberately NOT part of the shared run-summary subscription
+// (gascity-dashboard-2j8e.7): the nav attention badge counts blocked runs from
+// the summary's active fan-out and has no use for completed lanes, so history
+// stays a page-local concern with its own loading/partial states.
+
+export interface RunHistorySubscription {
+  /** The history source state; undefined until the first (lazy) read lands. */
+  source: SourceState<RunHistory> | undefined;
+  loading: boolean;
+  /**
+   * Refetch the history fan-out. `forceFresh: true` carries the operator's
+   * explicit Refresh through to the proxy-cached molecule + feed reads
+   * (gascity-dashboard-i3dz); programmatic refreshes leave it false so they
+   * keep serving the proxy's amortized cache.
+   */
+  refresh: (options?: { forceFresh?: boolean }) => Promise<void>;
+}
+
+function historyCacheKey(cityName: string | null): string {
+  return `runs:history:${cityName ?? 'no-city'}`;
+}
+
+/**
+ * Own the lazy /runs history load: no fetch while `enabled` is false, one fetch
+ * when the section first opens, cache-backed reopens, last-good retention on a
+ * failed refresh, and an on-demand refresh for the operator's Refresh button.
+ */
+export function useRunHistory(enabled: boolean): RunHistorySubscription {
+  const key = historyCacheKey(getActiveCity());
+  const [source, setSource] = useState<SourceState<RunHistory> | undefined>(() =>
+    getCached<SourceState<RunHistory>>(key),
+  );
+  const [loading, setLoading] = useState(false);
+  const runIdRef = useRef(0);
+  const keyRef = useRef(key);
+  keyRef.current = key;
+
+  const refresh = useCallback(async (options?: { forceFresh?: boolean }) => {
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    const cacheKey = keyRef.current;
+    setLoading(true);
+    try {
+      const result = await loadSupervisorRunHistorySource({
+        forceFresh: options?.forceFresh === true,
+      }).catch(
+        (err): SourceState<RunHistory> => ({
+          source: 'runs',
+          status: 'error',
+          error: err instanceof Error ? err.message : 'formula run history unavailable',
+        }),
+      );
+      if (runIdRef.current !== runId || keyRef.current !== cacheKey) return;
+      // Last-good retention (mirrors the run-summary subscription): a refresh
+      // that fails AFTER a good load keeps serving the last good payload,
+      // re-published as 'stale', instead of blanking the open section. A
+      // genuine first-load failure still surfaces the error.
+      const prior = getCached<SourceState<RunHistory>>(cacheKey);
+      const published =
+        result.status === 'error' && prior !== undefined && prior.status !== 'error'
+          ? ({ ...prior, status: 'stale' } as SourceState<RunHistory>)
+          : result;
+      // Error payloads are not cached: closing and reopening the section (or a
+      // remount) retries the load instead of latching the error forever.
+      if (published.status !== 'error') setCached(cacheKey, published);
+      setSource(published);
+    } finally {
+      if (runIdRef.current === runId) setLoading(false);
+    }
+  }, []);
+
+  // Reseed when the active city (cache key) changes, so a city switch never
+  // shows another city's history.
+  useEffect(() => {
+    setSource(getCached<SourceState<RunHistory>>(key));
+  }, [key]);
+
+  // The lazy edge: fetch when the section opens with no cached payload for
+  // this city. Reopens reuse the cache; staleness is the operator's Refresh
+  // button's concern, not an automatic refetch.
+  useEffect(() => {
+    if (!enabled) return;
+    if (getCached<SourceState<RunHistory>>(key) !== undefined) return;
+    void refresh();
+  }, [enabled, key, refresh]);
+
+  return { source, loading, refresh };
+}

--- a/frontend/src/runs/runHistory.ts
+++ b/frontend/src/runs/runHistory.ts
@@ -49,11 +49,16 @@ export function useRunHistory(enabled: boolean): RunHistorySubscription {
   const runIdRef = useRef(0);
   const keyRef = useRef(key);
   keyRef.current = key;
+  // The cache key whose read is currently in flight, or null. The lazy edge
+  // checks this so a closed -> open toggle BEFORE the first (uncached) read
+  // resolves does not start a second copy of the heaviest fan-out in the view.
+  const inFlightKeyRef = useRef<string | null>(null);
 
   const refresh = useCallback(async (options?: { forceFresh?: boolean }) => {
     const runId = runIdRef.current + 1;
     runIdRef.current = runId;
     const cacheKey = keyRef.current;
+    inFlightKeyRef.current = cacheKey;
     setLoading(true);
     try {
       const result = await loadSupervisorRunHistorySource({
@@ -80,7 +85,12 @@ export function useRunHistory(enabled: boolean): RunHistorySubscription {
       if (published.status !== 'error') setCached(cacheKey, published);
       setSource(published);
     } finally {
-      if (runIdRef.current === runId) setLoading(false);
+      // Only the latest read clears the in-flight marker; a superseded read
+      // (newer runId already started) leaves it set for the read that owns it.
+      if (runIdRef.current === runId) {
+        inFlightKeyRef.current = null;
+        setLoading(false);
+      }
     }
   }, []);
 
@@ -92,10 +102,13 @@ export function useRunHistory(enabled: boolean): RunHistorySubscription {
 
   // The lazy edge: fetch when the section opens with no cached payload for
   // this city. Reopens reuse the cache; staleness is the operator's Refresh
-  // button's concern, not an automatic refetch.
+  // button's concern, not an automatic refetch. The in-flight guard makes the
+  // open self-idempotent: while the first (uncached) read is still running, a
+  // closed -> open toggle must not start a duplicate fan-out.
   useEffect(() => {
     if (!enabled) return;
     if (getCached<SourceState<RunHistory>>(key) !== undefined) return;
+    if (inFlightKeyRef.current === key) return;
     void refresh();
   }, [enabled, key, refresh]);
 

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -58,8 +58,6 @@ function buildRunSource(
     error: { kind: 'none' },
     data: {
       totalActive: 0,
-      totalHistorical: 0,
-      historicalLanes: [],
       blockedLanes: [],
       runCounts: {
         total: 0,
@@ -101,26 +99,21 @@ function lane(id: string): RunLane {
   };
 }
 
-// Build a source carrying explicit active / blocked / historical lane sets, so a
-// test can assert WHICH run ids land in WHICH section after a cheap merge.
+// Build a source carrying explicit active / blocked lane sets, so a test can
+// assert WHICH run ids land in WHICH section after a cheap refresh.
 function buildLaneSource(opts: {
   status?: Exclude<SourceStatus, 'error'>;
   active?: string[];
   blocked?: string[];
-  historical?: string[];
-  totalHistorical?: number;
 }): SourceState<RunSummary> {
   const base = buildRunSource(opts.status ?? 'fresh');
   if (base.status === 'error') throw new Error('unreachable');
-  const historical = (opts.historical ?? []).map(lane);
   return {
     ...base,
     data: {
       ...base.data,
       lanes: (opts.active ?? []).map(lane),
       blockedLanes: (opts.blocked ?? []).map(lane),
-      historicalLanes: historical,
-      totalHistorical: opts.totalHistorical ?? historical.length,
     },
   };
 }
@@ -133,18 +126,14 @@ function Consumer({ label }: { label: string }) {
   return <div data-testid={label}>{`${source?.status ?? 'pending'}:${blocked}`}</div>;
 }
 
-// A consumer that renders the active+blocked lane ids, the historical lane ids,
-// and totalHistorical — for asserting cheap-refresh history reconciliation.
+// A consumer that renders the live (active + blocked) lane ids.
 function LaneConsumer({ label }: { label: string }) {
   const { source } = useRunSummary();
   if (!source || source.status === 'error') return <div data-testid={label}>none</div>;
-  const live = [...source.data.lanes, ...source.data.blockedLanes].map((l) => l.id).join(',');
-  const hist = source.data.historicalLanes.map((l) => l.id).join(',');
-  return (
-    <div
-      data-testid={label}
-    >{`live=[${live}] hist=[${hist}] totalHist=${source.data.totalHistorical}`}</div>
-  );
+  const live = [...source.data.lanes, ...source.data.blockedLanes]
+    .map((l: RunLane) => l.id)
+    .join(',');
+  return <div data-testid={label}>{`live=[${live}]`}</div>;
 }
 
 beforeEach(() => {
@@ -425,12 +414,12 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
     await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('error:-1'));
   });
 
-  it('reconciles merged history against the fresh active set on a cheap refresh (no double-display)', async () => {
-    // MAJOR 1: the cheap refresh borrows historicalLanes from the last wide
-    // snapshot. If a run that WAS historical is now active/blocked again, it must
-    // appear ONLY in the live set, not in both. The wide upgrade seeds history
-    // with gc-1 (historical); the cheap refresh then reports gc-1 as active again.
-    mockFull.mockResolvedValue(buildLaneSource({ active: [], historical: ['gc-1', 'gc-2'] }));
+  it('publishes the cheap refresh result as-is (header-first: no history merge)', async () => {
+    // The cheap SSE refresh used to borrow historicalLanes from the last wide
+    // snapshot and reconcile them. Header-first removed history from the summary
+    // entirely (it lives in the lazy run-history hook), so the cheap result IS
+    // the published snapshot: the live set replaces wholesale, nothing is merged.
+    mockFull.mockResolvedValue(buildLaneSource({ active: ['gc-2'] }));
 
     render(
       <RunSummaryProvider>
@@ -438,22 +427,16 @@ describe('useRunSummarySubscription / RunSummaryProvider (gascity-dashboard-2j8e
       </RunSummaryProvider>,
     );
 
-    // Wide upgrade landed: gc-1 + gc-2 are historical, nothing live.
-    await waitFor(() =>
-      expect(screen.getByTestId('page').textContent).toBe('live=[] hist=[gc-1,gc-2] totalHist=2'),
-    );
+    // Wide upgrade landed: gc-2 is live.
+    await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('live=[gc-2]'));
 
-    // A bead event lands and the cheap active read now reports gc-1 active again.
-    mockActive.mockResolvedValue(buildLaneSource({ active: ['gc-1'], historical: [] }));
+    // A bead event lands and the cheap active read now reports gc-1 instead.
+    mockActive.mockResolvedValue(buildLaneSource({ active: ['gc-1'] }));
     await act(async () => {
       lastHookCall.onMatch?.();
     });
 
-    // gc-1 appears ONLY in the live set; the borrowed history drops it and the
-    // count is recomputed. gc-2 (still only historical) stays in history.
-    await waitFor(() =>
-      expect(screen.getByTestId('page').textContent).toBe('live=[gc-1] hist=[gc-2] totalHist=1'),
-    );
+    await waitFor(() => expect(screen.getByTestId('page').textContent).toBe('live=[gc-1]'));
   });
 
   it('does not let a cheap SSE success cancel the bounded wide-failure retry', async () => {

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -30,13 +30,14 @@ import {
 //
 // The fetch contract: the cheap preview (2.5s budget) paints first, a one-time
 // full refresh (30s, session-enriched, WIDE) upgrades the snapshot to the
-// page-complete one and populates the historical lanes, a bounded backoff
-// recovers a degraded first load (WIDE), and SSE-driven refetches take the CHEAP
-// active-only path (skips the molecule(all=true) + city feed + per-rig reads,
-// merging historical lanes from the last wide snapshot) gated by an in-component
-// debounce floor on top of useGcEventRefresh's own coalescing (architect H1/H2
-// upstream-load protection during slung-pipeline bursts). The manual Refresh
-// button still triggers a WIDE scan on demand.
+// page-complete one, a bounded backoff recovers a degraded first load (WIDE),
+// and SSE-driven refetches take the CHEAP active-only path (skips the city
+// feed) gated by an in-component debounce floor on top of useGcEventRefresh's
+// own coalescing (architect H1/H2 upstream-load protection during
+// slung-pipeline bursts). The manual Refresh button still triggers a WIDE scan
+// on demand. Historical lanes are NOT part of this subscription (header-first):
+// they load lazily through runs/runHistory when the operator opens the /runs
+// history section.
 
 const REFRESH_DEBOUNCE_MS = 10_000;
 // gascity-dashboard-4xcv: bounded retry backoff for a degraded first load (error
@@ -114,13 +115,13 @@ export function useRunSummarySubscription(): RunSummarySubscription {
   }, []);
 
   // gascity-dashboard: the CHEAP SSE-burst refresh. loadSupervisorRunSummaryActiveSource
-  // skips the molecule(all=true) + city feed + per-rig task reads, so a routine
-  // bead burst no longer saturates the browser connection pool and queues the
-  // run-detail's fast workflowRun read behind it. The active/blocked set is fully
-  // correct (scope/health/counts/census); only HISTORICAL lanes come from the
-  // recent reads, so we merge those back from the last wide snapshot to keep the
-  // History section populated. Failure handling mirrors the wide wrapper.
-  const refreshActiveWithMerge = useCallback(async (): Promise<SourceState<RunSummary>> => {
+  // skips the city feed read, so a routine bead burst no longer saturates the
+  // browser connection pool and queues the run-detail's fast workflowRun read
+  // behind it. The active/blocked set is fully correct (scope/health/counts/
+  // census). Historical lanes are not carried by the summary at all
+  // (header-first) — they live in the lazy run-history hook — so there is
+  // nothing to merge here. Failure handling mirrors the wide wrapper.
+  const refreshActiveWithRetention = useCallback(async (): Promise<SourceState<RunSummary>> => {
     const result = await loadSupervisorRunSummaryActiveSource().catch(
       (err): SourceState<RunSummary> => ({
         source: 'runs',
@@ -133,29 +134,7 @@ export function useRunSummarySubscription(): RunSummarySubscription {
       // the wide retry loop must keep driving off staleDueToFailureRef until a
       // wide refresh actually lands (refreshWithLastGoodRetention clears it). So
       // we deliberately do NOT clear the flag here.
-      const lastGood = lastGoodRef.current;
-      const borrowedHistorical = lastGood?.data.historicalLanes ?? [];
-      // Reconcile the borrowed history against the CURRENT active/blocked set: a
-      // run that was historical in last-good but is active or blocked again in
-      // this fresh snapshot would otherwise appear in BOTH sets (double-display).
-      // Drop any historical lane whose run is now live; recompute the count to
-      // match. (A run that completes between wide refreshes still lags into
-      // History on the next wide scan — accepted; this only kills the overlap.)
-      const liveIds = new Set<string>([
-        ...result.data.lanes.map((lane) => lane.id),
-        ...result.data.blockedLanes.map((lane) => lane.id),
-      ]);
-      const historicalLanes = borrowedHistorical.filter((lane) => !liveIds.has(lane.id));
-      const dropped = borrowedHistorical.length - historicalLanes.length;
-      const totalHistorical = Math.max(0, (lastGood?.data.totalHistorical ?? 0) - dropped);
-      return {
-        ...result,
-        data: {
-          ...result.data,
-          historicalLanes,
-          totalHistorical,
-        },
-      };
+      return result;
     }
     const lastGood = lastGoodRef.current;
     if (lastGood === null) return result;
@@ -168,7 +147,7 @@ export function useRunSummarySubscription(): RunSummarySubscription {
     loadSupervisorRunSummaryPreviewSource,
     {
       refreshFetcher: refreshWithLastGoodRetention,
-      sseRefreshFetcher: refreshActiveWithMerge,
+      sseRefreshFetcher: refreshActiveWithRetention,
     },
   );
   // The operator's explicit Refresh: arm the one-shot bypass flag, then run the

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -11,6 +11,7 @@ import { resetSupervisorApiForTests, setSupervisorApiForTests, type SupervisorAp
 import { SupervisorApiError } from './errors';
 import {
   CORE_RUN_SUMMARY_TIMEOUT_MS,
+  loadSupervisorRunHistorySource,
   loadSupervisorRunSummaryActiveSource,
   loadSupervisorRunSummaryMountSource,
   loadSupervisorRunSummaryPreviewSource,
@@ -70,7 +71,12 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     vi.clearAllMocks();
   });
 
-  it('builds a first-paint summary from bounded active and recent run reads', async () => {
+  it('builds a first-paint summary from the cheap core read + feed only (header-first)', async () => {
+    // Header-first restructure: the default summary path pays ONLY the core
+    // active read (measured ~0.02s) and the formula-feed discovery. The
+    // molecule(all=true) history scan (measured 9.9s) and the per-rig
+    // task(all=true) closed-history reads (measured 10.9s on the largest rig)
+    // exist solely for the lazy history payload and must never fire here.
     const listBeads = vi.fn(async () => beadList([runRoot()]));
     const formulaFeed = vi.fn(async () => feed([feedRun()]));
     const listSessions = vi.fn(async () => sessionList());
@@ -88,19 +94,8 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanes[0]?.id).toBe('run-1');
     expect(source.data.lanes[0]?.health.status).toBe('unavailable');
-    expect(listBeads).toHaveBeenCalledTimes(3);
+    expect(listBeads).toHaveBeenCalledTimes(1);
     expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'molecule',
-      all: true,
-    });
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'task',
-      rig: 'rig-a',
-      all: true,
-    });
     expect(formulaFeed).toHaveBeenCalledWith('test-city', {
       scope_kind: 'city',
       scope_ref: 'test-city',
@@ -108,23 +103,21 @@ describe('loadSupervisorRunSummaryPreviewSource', () => {
     expect(listSessions).not.toHaveBeenCalled();
   });
 
-  it('marks the summary partial when a slow enrichment read exceeds the tight first-paint budget (gascity-dashboard-4bol)', async () => {
+  it('marks the summary partial when the slow feed exceeds the tight first-paint budget (gascity-dashboard-4bol)', async () => {
     // First paint blocks on the preview load, so it keeps a tight 2.5s budget: a
-    // rig read that takes 10s on a slow supervisor degrades to partial rather
+    // city feed that takes 14s on a slow supervisor degrades to partial rather
     // than holding the tab blank. The wider refresh budget then clears it.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') {
-        return new Promise<ListBodyBead>((resolve) => {
-          setTimeout(() => resolve(beadList([])), 10_000);
-        });
-      }
-      return beadList([runRoot()]);
-    });
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
+    const formulaFeed = vi.fn(
+      async () =>
+        new Promise<FormulaFeedBody>((resolve) => {
+          setTimeout(() => resolve(feed([feedRun()])), 14_000);
+        }),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      formulaFeed,
       listSessions: vi.fn(async () => sessionList()),
     });
 
@@ -155,28 +148,27 @@ describe('loadSupervisorRunSummarySource', () => {
     vi.clearAllMocks();
   });
 
-  it('builds the run summary from direct supervisor beads, feed, and sessions', async () => {
+  it('builds the run summary from the core read, feed, and sessions (header-first)', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') {
-        return beadList([
-          bead({
-            id: 'run-1-step-1',
-            title: 'Implementation patch',
-            status: 'in_progress',
-            metadata: {
-              'gc.kind': 'step',
-              'gc.root_bead_id': 'run-1',
-              'gc.parent_bead_id': 'run-1',
-              'gc.step_id': 'implementation.patch',
-            },
-          }),
-        ]);
-      }
-      return beadList([runRoot()]);
-    });
+    // The active run's open/in-progress step beads ride the SAME core active
+    // read — no per-rig all=true fan-out is needed for phase derivation.
+    const listBeads = vi.fn(async () =>
+      beadList([
+        runRoot(),
+        bead({
+          id: 'run-1-step-1',
+          title: 'Implementation patch',
+          status: 'in_progress',
+          metadata: {
+            'gc.kind': 'step',
+            'gc.root_bead_id': 'run-1',
+            'gc.parent_bead_id': 'run-1',
+            'gc.step_id': 'implementation.patch',
+          },
+        }),
+      ]),
+    );
     const formulaFeed = vi.fn(async () => feed([feedRun()]));
     const listSessions = vi.fn(async () => sessionList());
     setSupervisorApiForTests({
@@ -206,18 +198,10 @@ describe('loadSupervisorRunSummarySource', () => {
       statusCounts: { open: 1, in_progress: 1 },
     });
     expect(source.data.census.status).toBe('available');
+    // Header-first: ONLY the cheap core read — no molecule(all=true) scan and
+    // no per-rig task(all=true) reads on the refresh path.
+    expect(listBeads).toHaveBeenCalledTimes(1);
     expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'molecule',
-      all: true,
-    });
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'task',
-      rig: 'rig-a',
-      all: true,
-    });
     expect(formulaFeed).toHaveBeenCalledWith('test-city', {
       scope_kind: 'city',
       scope_ref: 'test-city',
@@ -226,11 +210,8 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('forceFresh marks ONLY the proxy-cached molecule + feed reads for cache bypass (gascity-dashboard-i3dz)', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      return beadList([runRoot()]);
-    });
+  it('forceFresh marks ONLY the proxy-cached feed read for cache bypass (gascity-dashboard-i3dz)', async () => {
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
     const formulaFeed = vi.fn(async () => feed([feedRun()]));
     const listSessions = vi.fn(async () => sessionList());
     setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed, listSessions });
@@ -238,33 +219,19 @@ describe('loadSupervisorRunSummarySource', () => {
     const source = await loadSupervisorRunSummarySource({ forceFresh: true });
     expect(source.status).toBe('fresh');
 
-    // The two proxy-cached city-wide reads carry the bypass option...
-    expect(listBeads).toHaveBeenCalledWith(
-      'test-city',
-      { limit: 500, type: 'molecule', all: true },
-      { cacheBypass: true },
-    );
+    // The proxy-cached city-wide feed read carries the bypass option...
     expect(formulaFeed).toHaveBeenCalledWith(
       'test-city',
       { scope_kind: 'city', scope_ref: 'test-city' },
       { cacheBypass: true },
     );
-    // ...while the uncached core-active and per-rig reads keep the plain
-    // two-arg call (no options object), so they are never marked for bypass.
+    // ...while the uncached core-active read keeps the plain two-arg call (no
+    // options object), so it is never marked for bypass.
     expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'task',
-      rig: 'rig-a',
-      all: true,
-    });
   });
 
-  it('a normal (non-forceFresh) wide refresh leaves the cacheable reads on the plain cacheable call', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      return beadList([runRoot()]);
-    });
+  it('a normal (non-forceFresh) wide refresh leaves the cacheable feed on the plain cacheable call', async () => {
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
     const formulaFeed = vi.fn(async () => feed([feedRun()]));
     const listSessions = vi.fn(async () => sessionList());
     setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed, listSessions });
@@ -273,11 +240,6 @@ describe('loadSupervisorRunSummarySource', () => {
 
     // No bypass option is attached, so the proxy keeps serving its amortized
     // cache for preview/SSE/upgrade reads.
-    expect(listBeads).toHaveBeenCalledWith('test-city', {
-      limit: 500,
-      type: 'molecule',
-      all: true,
-    });
     expect(formulaFeed).toHaveBeenCalledWith('test-city', {
       scope_kind: 'city',
       scope_ref: 'test-city',
@@ -298,11 +260,7 @@ describe('loadSupervisorRunSummarySource', () => {
         'gc.formula_contract': 'graph.v2',
       },
     });
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig !== undefined) return beadList([]);
-      return beadList([rootNoScope]);
-    });
+    const listBeads = vi.fn(async () => beadList([rootNoScope]));
     const cityScopedFeedRun = feedRun({
       id: 'run-2',
       root_bead_id: 'run-2',
@@ -344,11 +302,7 @@ describe('loadSupervisorRunSummarySource', () => {
         'gc.formula_contract': 'graph.v2',
       },
     });
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig !== undefined) return beadList([]);
-      return beadList([rootNoScope]);
-    });
+    const listBeads = vi.fn(async () => beadList([rootNoScope]));
     const malformedFeedRun = feedRun({
       id: 'run-3',
       root_bead_id: 'run-3',
@@ -383,10 +337,8 @@ describe('loadSupervisorRunSummarySource', () => {
     // gc-1920 repro: a stale blocked formula latch must land in
     // blockedLanes (with derived health, so attention still sees it),
     // never in lanes/totalActive.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') return beadList([]);
-      return beadList([
+    const listBeads = vi.fn(async () =>
+      beadList([
         runRoot(),
         runRoot({
           id: 'gc-1920',
@@ -400,8 +352,8 @@ describe('loadSupervisorRunSummarySource', () => {
             'gc.root_store_ref': 'city:test-city',
           },
         }),
-      ]);
-    });
+      ]),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -442,25 +394,23 @@ describe('loadSupervisorRunSummarySource', () => {
   }
 
   it('demotes a stale session-less approval latch out of the Active set (gascity-dashboard-s4rp)', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') {
-        return beadList([
-          bead({
-            id: 'run-1-step-1',
-            title: 'Implementation patch',
-            status: 'in_progress',
-            updated_at: '2026-06-01T11:55:00.000Z',
-            metadata: {
-              'gc.kind': 'step',
-              'gc.root_bead_id': 'run-1',
-              'gc.step_id': 'implementation.patch',
-            },
-          }),
-        ]);
-      }
-      return beadList([runRoot(), staleLatch()]);
-    });
+    const listBeads = vi.fn(async () =>
+      beadList([
+        runRoot(),
+        staleLatch(),
+        bead({
+          id: 'run-1-step-1',
+          title: 'Implementation patch',
+          status: 'in_progress',
+          updated_at: '2026-06-01T11:55:00.000Z',
+          metadata: {
+            'gc.kind': 'step',
+            'gc.root_bead_id': 'run-1',
+            'gc.step_id': 'implementation.patch',
+          },
+        }),
+      ]),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -473,22 +423,19 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
     // run-1 has an in_progress step and stays Active; gc-1920 is demoted out of
-    // the Active set, count, AND the blocked/historical buckets (dropped).
+    // the Active set, count, AND the blocked bucket (dropped).
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
     expect(source.data.blockedLanes).toEqual([]);
-    expect(source.data.historicalLanes.map((lane) => lane.id)).not.toContain('gc-1920');
     expect(source.data.runCounts.total).toBe(1);
   });
 
   it('keeps a session-less recent latch in the Active set (gascity-dashboard-s4rp)', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') return beadList([]);
-      // Same shape as the stale latch but written 30 minutes ago — a recent
-      // session-less latch must still appear as Active (not demoted by liveness).
-      return beadList([{ ...staleLatch(), updated_at: '2026-06-01T11:30:00.000Z' }]);
-    });
+    // Same shape as the stale latch but written 30 minutes ago — a recent
+    // session-less latch must still appear as Active (not demoted by liveness).
+    const listBeads = vi.fn(async () =>
+      beadList([{ ...staleLatch(), updated_at: '2026-06-01T11:30:00.000Z' }]),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -530,11 +477,7 @@ describe('loadSupervisorRunSummarySource', () => {
         },
       }),
     );
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') return beadList([]);
-      return beadList([...liveRuns, staleLatch()]);
-    });
+    const listBeads = vi.fn(async () => beadList([...liveRuns, staleLatch()]));
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -557,16 +500,18 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.runCounts.visible).toBe(9);
   });
 
-  it('keeps available lanes while marking the summary partial when a recent rig read fails', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') throw new Error('rig unavailable');
-      return beadList([runRoot()]);
-    });
+  it('keeps available lanes while marking the summary partial when the feed read fails (gascity-dashboard-n6f1)', async () => {
+    // The feed is discovery + scope fallback for the lane set, so its loss means
+    // the lane set may be degraded (scopes unresolved) — flag partial, but the
+    // active lanes from the core read still render. Never required: a feed
+    // failure must not blank the view (live it measured 14.3s city-scoped).
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      formulaFeed: vi.fn(async () => {
+        throw new Error('feed unavailable');
+      }),
       listSessions: vi.fn(async () => sessionList()),
     });
 
@@ -583,10 +528,7 @@ describe('loadSupervisorRunSummarySource', () => {
     // reports the rest via next_cursor WITHOUT setting partial. Treat a present
     // cursor as partial so saturation surfaces the notice + retry instead of
     // silently dropping lanes at 501+ beads.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      return beadList([runRoot()], false, 'next-page-token');
-    });
+    const listBeads = vi.fn(async () => beadList([runRoot()], false, 'next-page-token'));
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -606,11 +548,7 @@ describe('loadSupervisorRunSummarySource', () => {
     // gascity-dashboard-q89b: the primary fetch is bounded; when the upstream
     // total exceeds what one page returned, active runs may be missing and the
     // lanes must read as partial rather than complete.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') return beadList([]);
-      return { ...beadList([runRoot()]), total: 501 };
-    });
+    const listBeads = vi.fn(async () => ({ ...beadList([runRoot()]), total: 501 }));
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
@@ -626,11 +564,7 @@ describe('loadSupervisorRunSummarySource', () => {
   });
 
   it('does not let optional enrichment reads hold the summary refresh indefinitely', async () => {
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return new Promise<ListBodyBead>(() => {});
-      if (query?.rig === 'rig-a') return beadList([]);
-      return beadList([runRoot()]);
-    });
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
     const formulaFeed = vi.fn(async () => new Promise<FormulaFeedBody>(() => {}));
     setSupervisorApiForTests({
       ...baseApi,
@@ -651,28 +585,26 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.lanesPartial).toBe(true);
   });
 
-  it('clears the spurious partial when a slow-but-available enrichment read lands within the wider refresh budget (gascity-dashboard-4bol)', async () => {
-    // The background refresh tolerates a slow supervisor: a rig read that takes
-    // 10s — past the 2.5s first-paint budget but inside the 30s refresh budget —
+  it('clears the spurious partial when the slow feed lands within the wider refresh budget (gascity-dashboard-4bol)', async () => {
+    // The background refresh tolerates a slow supervisor: a city feed that takes
+    // 14s — past the 2.5s first-paint budget but inside the 30s refresh budget —
     // lands, so the lanes are NOT latched partial (upstream gascity-dashboard#88).
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') {
-        return new Promise<ListBodyBead>((resolve) => {
-          setTimeout(() => resolve(beadList([])), 10_000);
-        });
-      }
-      return beadList([runRoot()]);
-    });
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
+    const formulaFeed = vi.fn(
+      async () =>
+        new Promise<FormulaFeedBody>((resolve) => {
+          setTimeout(() => resolve(feed([feedRun()])), 14_000);
+        }),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      formulaFeed,
       listSessions: vi.fn(async () => sessionList()),
     });
 
     const pending = loadSupervisorRunSummarySource();
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(14_000);
     const source = await pending;
 
     expect(source.status).toBe('fresh');
@@ -682,23 +614,21 @@ describe('loadSupervisorRunSummarySource', () => {
   });
 
   it('keeps the tight first-paint budget on the mount source so Home/Formula Run Detail never block on a slow read (gascity-dashboard-4bol)', async () => {
-    // Same 10s rig read as the refresh test above, but the mount source (Home,
+    // Same 14s feed as the refresh test above, but the mount source (Home,
     // Formula Run Detail first paint) runs on the 2.5s budget — the read does NOT
     // land, so the lanes are latched partial rather than blocking ~30s on a cold
     // navigation. This is the regression guard for the refresh-budget leak.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') {
-        return new Promise<ListBodyBead>((resolve) => {
-          setTimeout(() => resolve(beadList([])), 10_000);
-        });
-      }
-      return beadList([runRoot()]);
-    });
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
+    const formulaFeed = vi.fn(
+      async () =>
+        new Promise<FormulaFeedBody>((resolve) => {
+          setTimeout(() => resolve(feed([feedRun()])), 14_000);
+        }),
+    );
     setSupervisorApiForTests({
       ...baseApi,
       listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      formulaFeed,
       listSessions: vi.fn(async () => sessionList()),
     });
 
@@ -712,70 +642,10 @@ describe('loadSupervisorRunSummarySource', () => {
     expect(source.data.lanesPartial).toBe(true);
   });
 
-  it('keeps active lanes and marks partial when the molecule-history read rejects (gascity-dashboard-9rk2)', async () => {
-    // The molecule(all=true) scan surfaces historical run roots only; it is
-    // best-effort. A rejection must fold to `partial` with the active lanes still
-    // present — never escalate to a whole-view error/"Run data unavailable".
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') throw new Error('molecule history unavailable');
-      if (query?.rig === 'rig-a') return beadList([]);
-      return beadList([runRoot()]);
-    });
-    setSupervisorApiForTests({
-      ...baseApi,
-      listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
-      listSessions: vi.fn(async () => sessionList()),
-    });
-
-    const source = await loadSupervisorRunSummarySource();
-
-    expect(source.status).toBe('fresh');
-    if (source.status === 'error') throw new Error(source.error);
-    expect(source.data.totalActive).toBe(1);
-    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
-    expect(source.data.lanesPartial).toBe(true);
-  });
-
-  it('bounds a slow molecule-history read to its own timeout and folds it to partial (gascity-dashboard-9rk2)', async () => {
-    // Live the molecule scan runs ~6.8s — past the 5s required-fetch budget. On
-    // the wide 30s refresh it would otherwise stall the whole refresh; its own
-    // 3s bound caps it so the active set still paints and only the historical
-    // lanes degrade to partial.
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') {
-        return new Promise<ListBodyBead>((resolve) => {
-          setTimeout(() => resolve(beadList([])), 6_800);
-        });
-      }
-      if (query?.rig === 'rig-a') return beadList([]);
-      return beadList([runRoot()]);
-    });
-    setSupervisorApiForTests({
-      ...baseApi,
-      listBeads,
-      formulaFeed: vi.fn(async () => feed([feedRun()])),
-      listSessions: vi.fn(async () => sessionList()),
-    });
-
-    const pending = loadSupervisorRunSummarySource();
-    // Advance past the molecule's own 3s bound but well short of its 6.8s
-    // completion: the bound fires, the active set still resolves.
-    await vi.advanceTimersByTimeAsync(3_000);
-    const source = await pending;
-
-    expect(source.status).toBe('fresh');
-    if (source.status === 'error') throw new Error(source.error);
-    expect(source.data.totalActive).toBe(1);
-    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
-    expect(source.data.lanesPartial).toBe(true);
-  });
-
   it('returns an error source when the active bead list fails', async () => {
     setSupervisorApiForTests({
       ...baseApi,
-      listBeads: vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-        if (query?.type === 'molecule') return beadList([]);
+      listBeads: vi.fn(async () => {
         throw new Error('beads unavailable');
       }),
       formulaFeed: vi.fn(async () => feed([])),
@@ -796,9 +666,7 @@ describe('loadSupervisorRunSummarySource', () => {
   // snapshot yet). The core active-bead read retries once before giving up.
   it('retries the core active-bead read once on a transient timeout and resolves to data', async () => {
     let coreAttempts = 0;
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
-      if (query?.rig === 'rig-a') return beadList([]);
+    const listBeads = vi.fn(async () => {
       coreAttempts += 1;
       if (coreAttempts === 1) {
         throw new SupervisorApiError(
@@ -830,8 +698,7 @@ describe('loadSupervisorRunSummarySource', () => {
 
   it('surfaces an error when the core active-bead read times out on every attempt', async () => {
     let coreAttempts = 0;
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
+    const listBeads = vi.fn(async () => {
       coreAttempts += 1;
       throw new SupervisorApiError(
         undefined,
@@ -860,8 +727,7 @@ describe('loadSupervisorRunSummarySource', () => {
 
   it('does not retry the core read on a non-transient (4xx) failure', async () => {
     let coreAttempts = 0;
-    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
-      if (query?.type === 'molecule') return beadList([]);
+    const listBeads = vi.fn(async () => {
       coreAttempts += 1;
       throw new SupervisorApiError(400, 'bad request', undefined);
     });
@@ -933,9 +799,6 @@ describe('loadSupervisorRunSummaryActiveSource — cheap SSE-burst path', () => 
     // gc.root_store_ref metadata — no feed needed.
     expect(source.data.lanes.map((lane) => lane.id)).toEqual(['run-1']);
     expect(source.data.lanes[0]?.scope).toMatchObject({ status: 'available', kind: 'rig' });
-    // No history reads on the cheap path.
-    expect(source.data.historicalLanes).toEqual([]);
-    expect(source.data.totalHistorical).toBe(0);
     // The expensive reads were never issued.
     expect(formulaFeed).not.toHaveBeenCalled();
     expect(
@@ -943,6 +806,194 @@ describe('loadSupervisorRunSummaryActiveSource — cheap SSE-burst path', () => 
     ).toBe(true);
     expect(listBeads.mock.calls.some(([, query]) => query?.type === 'molecule')).toBe(false);
     expect(listBeads.mock.calls.some(([, query]) => query?.rig !== undefined)).toBe(false);
+  });
+});
+
+// Header-first restructure: the closed-history fan-out (molecule all=true scan,
+// measured 9.9s vs the old 3s bound; per-rig task all=true reads, measured
+// 10.9s on a 29.8k-issue rig store) moved OFF the default refresh path onto
+// this lazy, on-demand history source with its own wide budget.
+describe('loadSupervisorRunHistorySource — lazy closed-history fan-out', () => {
+  beforeEach(() => {
+    setActiveCity('test-city');
+    resetSupervisorRunSummaryStateForTests();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    resetSupervisorApiForTests();
+    resetSupervisorRunSummaryStateForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function closedMoleculeRoot(id: string): Bead {
+    return bead({
+      id,
+      title: `Done run ${id}`,
+      issue_type: 'molecule',
+      status: 'closed',
+      updated_at: '2026-06-01T10:00:00.000Z',
+      metadata: { 'gc.kind': 'run', 'gc.root_store_ref': 'rig:rig-a' },
+    });
+  }
+
+  it('builds completed lanes from the molecule scan + per-rig closed reads', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([closedMoleculeRoot('hist-1')]);
+      if (query?.rig === 'rig-a') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    const formulaFeed = vi.fn(async () => feed([feedRun()]));
+    setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed });
+
+    const source = await loadSupervisorRunHistorySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    // Only the COMPLETED run becomes a history lane; the active run-1 does not.
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['hist-1']);
+    expect(source.data.totalHistorical).toBe(1);
+    expect(source.data.lanesPartial).toBeUndefined();
+    // The full fan-out fires here, on demand: core read, molecule scan, feed,
+    // and the per-rig closed read discovered from the active set + feed.
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', {
+      limit: 500,
+      type: 'molecule',
+      all: true,
+    });
+    expect(listBeads).toHaveBeenCalledWith('test-city', {
+      limit: 500,
+      type: 'task',
+      rig: 'rig-a',
+      all: true,
+    });
+    expect(formulaFeed).toHaveBeenCalledWith('test-city', {
+      scope_kind: 'city',
+      scope_ref: 'test-city',
+    });
+  });
+
+  it('lets the measured-slow molecule scan land within the wide history budget (no 3s bound)', async () => {
+    // Live the molecule(all=true) scan measured 9.9s — past the old 3s
+    // MOLECULE_HISTORY_TIMEOUT_MS, which made it time out on EVERY refresh and
+    // chronically latch "runs partial". On the lazy history path the scan is the
+    // payload, so it rides the 30s history budget and lands.
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') {
+        return new Promise<ListBodyBead>((resolve) => {
+          setTimeout(() => resolve(beadList([closedMoleculeRoot('hist-1')])), 9_900);
+        });
+      }
+      if (query?.rig !== undefined) return beadList([]);
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+    });
+
+    const pending = loadSupervisorRunHistorySource();
+    await vi.advanceTimersByTimeAsync(9_900);
+    const source = await pending;
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['hist-1']);
+    expect(source.data.lanesPartial).toBeUndefined();
+  });
+
+  it('marks the history partial when the molecule scan rejects, keeping per-rig lanes', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') throw new Error('molecule history unavailable');
+      if (query?.rig === 'rig-a') return beadList([closedMoleculeRoot('hist-rig')]);
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+    });
+
+    const source = await loadSupervisorRunHistorySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['hist-rig']);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
+  it('marks the history partial when a per-rig closed read fails', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([closedMoleculeRoot('hist-1')]);
+      if (query?.rig === 'rig-a') throw new Error('rig unavailable');
+      return beadList([runRoot()]);
+    });
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+    });
+
+    const source = await loadSupervisorRunHistorySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.lanes.map((lane) => lane.id)).toEqual(['hist-1']);
+    expect(source.data.lanesPartial).toBe(true);
+  });
+
+  it('forceFresh marks ONLY the proxy-cached molecule + feed reads for cache bypass (gascity-dashboard-i3dz)', async () => {
+    const listBeads = vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+      if (query?.type === 'molecule') return beadList([]);
+      return beadList([runRoot()]);
+    });
+    const formulaFeed = vi.fn(async () => feed([feedRun()]));
+    setSupervisorApiForTests({ ...baseApi, listBeads, formulaFeed });
+
+    const source = await loadSupervisorRunHistorySource({ forceFresh: true });
+    expect(source.status).toBe('fresh');
+
+    expect(listBeads).toHaveBeenCalledWith(
+      'test-city',
+      { limit: 500, type: 'molecule', all: true },
+      { cacheBypass: true },
+    );
+    expect(formulaFeed).toHaveBeenCalledWith(
+      'test-city',
+      { scope_kind: 'city', scope_ref: 'test-city' },
+      { cacheBypass: true },
+    );
+    // The uncached core-active and per-rig reads keep the plain two-arg call.
+    expect(listBeads).toHaveBeenCalledWith('test-city', { limit: 500 });
+    expect(listBeads).toHaveBeenCalledWith('test-city', {
+      limit: 500,
+      type: 'task',
+      rig: 'rig-a',
+      all: true,
+    });
+  });
+
+  it('returns an error source when the core active-bead read fails', async () => {
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads: vi.fn(async (_cityName: string, query?: Record<string, unknown>) => {
+        if (query?.type === 'molecule') return beadList([]);
+        throw new Error('beads unavailable');
+      }),
+      formulaFeed: vi.fn(async () => feed([])),
+    });
+
+    const source = await loadSupervisorRunHistorySource();
+
+    expect(source).toEqual({
+      source: 'runs',
+      status: 'error',
+      error: 'beads unavailable',
+    });
   });
 });
 

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -3,6 +3,7 @@ import type {
   DashboardSession,
   RunFeedScope,
   RunFeedScopeMap,
+  RunHistory,
   RunSummary,
   SourceAvailableState,
   SourceState,
@@ -10,6 +11,7 @@ import type {
 import {
   advanceProgressMarks,
   buildCensus,
+  buildRunHistory,
   buildRunSummary,
   deriveRunHealth,
   fromFeedScope,
@@ -40,7 +42,8 @@ const RUNS_FETCH_LIMIT = 500;
 // missing most completed runs (a busy rig store holds hundreds of closed
 // task beads). 500 covers the largest observed store with headroom; if a
 // store outgrows it the symptom returns as silently missing lanes, so a
-// real fix beyond raising the cap means cursor pagination.
+// real fix beyond raising the cap means cursor pagination. Used only by the
+// lazy history fan-out now (header-first).
 const RECENT_RUN_FETCH_LIMIT = 500;
 const RUNS_STALE_AFTER_MS = 60 * 1000;
 // The CORE active-bead read is the one fetch whose failure blanks the whole runs
@@ -68,18 +71,17 @@ const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 15_000;
 // first-paint spinner a single global raise would cause.
 const PREVIEW_ENRICHMENT_TIMEOUT_MS = 2_500;
 const REFRESH_ENRICHMENT_TIMEOUT_MS = 30_000;
-// gascity-dashboard-9rk2: the molecule(all=true) read scans the full (large,
-// ~340k-row) molecule history purely to surface HISTORICAL run roots, which the
-// view already caps at MAX_HISTORICAL_LANES (50). Live it runs ~6.8s — past the
-// 5s required-fetch budget — and the supervisor exposes no recency-ordered or
-// bounded molecule query, so it cannot be made cheaper server-side without a new
-// endpoint. It is therefore the FIRST optional read to dominate the wider refresh
-// budget. Bound it well under REQUIRED_RUN_SUMMARY_TIMEOUT_MS so a slow scan
-// degrades the historical lanes to "partial" fast instead of holding the refresh
-// (and so it can never out-wait the active set, which paints from the fast
-// open/active read). It still rides the surrounding enrichment budget too via the
-// min() at the call site, so the tight first-paint path is never loosened.
-const MOLECULE_HISTORY_TIMEOUT_MS = 3_000;
+// Header-first restructure (supersedes the gascity-dashboard-9rk2 3s molecule
+// bound): the closed-history fan-out — the molecule(all=true) scan over the
+// ~340k-row history (measured 9.9s live, so it timed out against the old 3s
+// bound on EVERY refresh and chronically latched the "runs partial" badge) plus
+// the per-rig task(all=true) closed reads (measured 10.9s on a 29.8k-issue rig
+// store) — now runs ONLY on the lazy history source, fetched when the operator
+// opens the /runs history section. There it IS the payload, so it rides this
+// wide budget (matching the refresh budget / the 30s background samplers) and
+// the measured reads land instead of degrading. A genuinely slow scan still
+// folds to history-partial, never an error.
+const HISTORY_ENRICHMENT_TIMEOUT_MS = 30_000;
 
 interface LoadedRunBeads {
   beads: DashboardBead[];
@@ -101,23 +103,30 @@ interface ProgressState {
 const progressStateByCity = new Map<string, ProgressState>();
 
 // The wide-budget run-summary source (gascity-dashboard-4bol): the wide
-// enrichment budget lets slow-but-available list/feed reads land and clear the
-// spurious "runs partial" badge (upstream gascity-dashboard#88). It is the
-// authoritative refresh snapshot for the shared run-summary subscription
-// (runs/runSummarySubscription), which both the /runs page and the nav attention
-// badge read — so the badge counts the same genuinely-blocked runs the page
-// shows, by construction, off a single fan-out (gascity-dashboard-2j8e.7).
+// enrichment budget lets the slow-but-available city feed (measured 14.3s) land
+// and clear the spurious "runs partial" badge (upstream gascity-dashboard#88).
+// It is the authoritative refresh snapshot for the shared run-summary
+// subscription (runs/runSummarySubscription), which both the /runs page and the
+// nav attention badge read — so the badge counts the same genuinely-blocked runs
+// the page shows, by construction, off a single fan-out (gascity-dashboard-2j8e.7).
+//
+// Header-first restructure: this no longer fires the closed-history fan-out
+// (molecule all=true scan + per-rig task all=true reads). The active/blocked set
+// builds entirely from the cheap core active read (measured ~0.02s; active runs'
+// open step beads ride the same read) plus the feed for discovery/scope
+// fallback. Historical lanes are the lazy loadSupervisorRunHistorySource
+// payload, fetched when the operator opens the /runs history section.
 //
 // Do NOT use this as a ROUTE first-paint fetcher — it can block a route view for
 // up to REFRESH_ENRICHMENT_TIMEOUT_MS; route mount consumers (Home, Formula Run
 // Detail) use loadSupervisorRunSummaryMountSource on the tight budget instead.
 // The shared subscription is exempt: it is cache-backed and the always-mounted
 // header reads its result, so its latency never blocks a route view.
-// `forceFresh` flows down to the two cacheable city-wide reads (molecule history
-// + city feed) as the proxy cache-bypass marker. The shared subscription sets it
-// ONLY for the operator's explicit Refresh (gascity-dashboard-i3dz); the one-time
-// preview→full upgrade and SSE refreshes leave it false so they keep serving the
-// proxy's amortized cache.
+// `forceFresh` flows down to the cacheable city-wide feed read as the proxy
+// cache-bypass marker. The shared subscription sets it ONLY for the operator's
+// explicit Refresh (gascity-dashboard-i3dz); the one-time preview→full upgrade
+// and SSE refreshes leave it false so they keep serving the proxy's amortized
+// cache.
 export async function loadSupervisorRunSummarySource(options?: {
   forceFresh?: boolean;
 }): Promise<SourceState<RunSummary>> {
@@ -169,17 +178,16 @@ async function loadRunSummarySource(
   }
 }
 
-// gascity-dashboard: the CHEAP SSE-refresh source. The wide source's loadRunBeads
-// fires the two expensive HISTORICAL/discovery reads (molecule(all=true) ~6.8s,
-// city formulaFeed ~10s) plus per-rig task reads on every SSE burst, saturating
+// gascity-dashboard: the CHEAP SSE-refresh source. Even with the closed-history
+// fan-out gone from the wide source (header-first), the city feed (measured
+// 14.3s) is still too heavy to re-fire on every SSE burst — it would saturate
 // the browser ~6-conn/host cap so the run-detail's fast workflowRun read queues
-// behind them. The active/blocked set and its scope/health/counts/census do NOT
-// need those reads: runScope takes the bead's own gc.root_store_ref/gc.scope_ref
-// metadata first (feedScopes is only a fallback), and runRigNames derives the
-// active rig set from that same per-bead metadata. So this fetches only the core
-// active read + sessions, skipping molecule + city feed + per-rig task reads.
-// historicalLanes/totalHistorical come back empty here; the subscription merges
-// them from the last wide snapshot so History is never blanked.
+// behind it. The active/blocked set and its scope/health/counts/census do NOT
+// need the feed: runScope takes the bead's own gc.root_store_ref/gc.scope_ref
+// metadata first (feedScopes is only a fallback). So this fetches only the core
+// active read + sessions. A missing feed is not flagged partial here — the lane
+// SET is complete from the core read; only a minority scope fallback degrades
+// until the next wide refresh repairs it.
 export async function loadSupervisorRunSummaryActiveSource(): Promise<SourceState<RunSummary>> {
   const cityName = activeCityOrThrow('load supervisor run summary active');
   const fetchedAt = new Date().toISOString();
@@ -258,6 +266,42 @@ export async function loadSupervisorRunSummaryPreviewSource(): Promise<SourceSta
   }
 }
 
+// The lazy history source (header-first restructure): the completed-run lanes
+// behind the /runs ?history=1 toggle. This is the ONLY caller of the expensive
+// closed-history fan-out (molecule all=true scan + per-rig task all=true reads),
+// so the default refresh path never pays it for data hidden by default. Fetched
+// on demand by the history hook (runs/runHistory) when the operator opens the
+// section; `forceFresh` carries the operator's explicit Refresh through to the
+// proxy-cached molecule + feed reads (gascity-dashboard-i3dz).
+export async function loadSupervisorRunHistorySource(options?: {
+  forceFresh?: boolean;
+}): Promise<SourceState<RunHistory>> {
+  const cityName = activeCityOrThrow('load supervisor run history');
+  const fetchedAt = new Date().toISOString();
+  try {
+    const loaded = await loadHistoryBeads(cityName, options?.forceFresh === true);
+    const history = buildRunHistory(
+      loaded.beads.filter(runBeadFilter).map(fromDashboardBead),
+      loaded.feedScopes,
+      loaded.partial,
+    );
+    return {
+      source: 'runs',
+      status: 'fresh',
+      fetchedAt,
+      staleAt: new Date(Date.parse(fetchedAt) + RUNS_STALE_AFTER_MS).toISOString(),
+      error: { kind: 'none' },
+      data: history,
+    };
+  } catch (err) {
+    return {
+      source: 'runs',
+      status: 'error',
+      error: errorMessage(err, 'formula run history unavailable'),
+    };
+  }
+}
+
 export function resetSupervisorRunSummaryStateForTests(): void {
   progressStateByCity.clear();
 }
@@ -283,18 +327,45 @@ function optionalRunSummaryApi(budgetMs: number) {
   return supervisorApiForRequestBudget(budgetMs);
 }
 
+// Header-first: the default run-summary fan-out is the cheap core active read
+// (required) plus the city feed (optional discovery/scope fallback, degrade-to-
+// partial). The closed-history reads live in loadHistoryBeads, paid only by the
+// lazy history source.
 async function loadRunBeads(
   cityName: string,
   limit: number,
   enrichmentBudgetMs: number,
   forceFresh = false,
 ): Promise<LoadedRunBeads> {
-  // The molecule-history read gets its own tight bound (gascity-dashboard-9rk2),
-  // capped to the surrounding enrichment budget so the first-paint path is never
-  // loosened: a slow scan folds to `partial` instead of dominating the refresh.
-  // forceFresh rides the two proxy-cached reads (molecule + feed) so an explicit
-  // Refresh re-scans upstream within the TTL window (gascity-dashboard-i3dz). The
-  // per-rig task reads are not proxy-cached, so they need no bypass.
+  // forceFresh rides the proxy-cached feed read so an explicit Refresh re-scans
+  // upstream within the TTL window (gascity-dashboard-i3dz).
+  const [activeList, feedDiscovery] = await Promise.all([
+    fetchCoreActiveBeads(cityName, limit),
+    discoverFromFeed(cityName, enrichmentBudgetMs, forceFresh),
+  ]);
+  const active = normalizeBeads(activeList.items ?? []);
+  // Truncation at the bounded fetch reads as partial lanes, not complete
+  // (gascity-dashboard-q89b). A failed/slow feed also reads as partial: the lane
+  // set itself is complete from the core read, but lanes whose beads carry no
+  // scope metadata lose their feed fallback, so the snapshot is honestly flagged
+  // (gascity-dashboard-n6f1).
+  return {
+    beads: active,
+    feedScopes: feedDiscovery.scopes,
+    partial: feedDiscovery.partial || listIsIncomplete(activeList, active.length),
+  };
+}
+
+// The lazy closed-history fan-out (header-first): core active read (grouping
+// context + rig discovery), city feed (scope fallback + rig discovery), the
+// molecule(all=true) history scan, and per-rig task(all=true) closed reads.
+// Everything except the core read degrades to `partial`.
+async function loadHistoryBeads(cityName: string, forceFresh: boolean): Promise<LoadedRunBeads> {
+  const budgetMs = HISTORY_ENRICHMENT_TIMEOUT_MS;
+  // forceFresh rides the two proxy-cached city-wide reads (molecule + feed) so
+  // an explicit Refresh re-scans upstream within the TTL window
+  // (gascity-dashboard-i3dz). The per-rig task reads are not proxy-cached, so
+  // they need no bypass.
   const moleculeFetch = settledRecentFetch(
     cityName,
     {
@@ -302,12 +373,12 @@ async function loadRunBeads(
       type: 'molecule',
       all: true,
     },
-    Math.min(MOLECULE_HISTORY_TIMEOUT_MS, enrichmentBudgetMs),
+    budgetMs,
     forceFresh,
   );
   const [activeList, feedDiscovery] = await Promise.all([
-    fetchCoreActiveBeads(cityName, limit),
-    discoverFromFeed(cityName, enrichmentBudgetMs, forceFresh),
+    fetchCoreActiveBeads(cityName, RUNS_FETCH_LIMIT),
+    discoverFromFeed(cityName, budgetMs, forceFresh),
   ]);
   const active = normalizeBeads(activeList.items ?? []);
   const rigNames = unionRigNames(runRigNames(active), feedDiscovery.rigNames);
@@ -321,14 +392,12 @@ async function loadRunBeads(
         rig,
         all: true,
       },
-      enrichmentBudgetMs,
+      budgetMs,
     ),
   );
 
   const settled = await Promise.all([moleculeFetch, ...rigFetches]);
   const recentItems: DashboardBead[] = [];
-  // Truncation at the bounded fetch reads as partial lanes, not complete
-  // (gascity-dashboard-q89b).
   let partial = feedDiscovery.partial || listIsIncomplete(activeList, active.length);
 
   for (const outcome of settled) {

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -2,6 +2,7 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildRunHistory,
   buildRunSummary,
   emptyRunSummary,
   runLane,
@@ -90,15 +91,15 @@ describe('buildRunSummary — blocked lanes are not Active (gascity-dashboard-4x
     assert.equal(summary.runCounts.blocked, 1);
   });
 
-  test('blocked lanes are not historical either', () => {
+  test('completed lanes are dropped from the summary, blocked lanes stay (header-first)', () => {
+    // Header-first restructure: the summary carries the live (active + blocked)
+    // sets only; completed runs are the lazy history read's payload
+    // (buildRunHistory), so the default refresh never pays the closed-history
+    // fan-out for lanes hidden behind ?history=1.
     const summary = buildRunSummary([latch(), ...completedRun('run-done')]);
 
     assert.equal(summary.totalActive, 0);
-    assert.equal(summary.totalHistorical, 1);
-    assert.deepEqual(
-      summary.historicalLanes.map((lane) => lane.id),
-      ['run-done'],
-    );
+    assert.deepEqual(summary.lanes, []);
     assert.deepEqual(
       summary.blockedLanes.map((lane) => lane.id),
       ['gc-1920'],
@@ -147,7 +148,6 @@ describe('buildRunSummary — dangling-root groups are not surfaced (gascity-das
       ['run-1'],
     );
     assert.deepEqual(summary.blockedLanes, []);
-    assert.deepEqual(summary.historicalLanes, []);
     assert.equal(summary.runCounts.total, 1);
   });
 
@@ -303,10 +303,8 @@ describe('buildRunSummary — v1 / wisp runs surface as lanes (gascity-dashboard
     const summary = buildRunSummary([loneTask]);
 
     assert.deepEqual(summary.lanes, []);
-    assert.deepEqual(summary.historicalLanes, []);
     assert.deepEqual(summary.blockedLanes, []);
     assert.equal(summary.totalActive, 0);
-    assert.equal(summary.totalHistorical, 0);
   });
 });
 
@@ -326,12 +324,56 @@ describe('buildRunSummary — active lanes carry the full set (component-collaps
   });
 });
 
-// gascity-dashboard-9w3k (part b): the now-much-larger v1 history can bury
-// active runs in the historical set on the wire. Cap the historical lanes the
-// builder emits to the most-recent MAX_HISTORICAL_LANES, while totalHistorical
-// keeps reporting the true full count.
-describe('buildRunSummary — historical lanes are recency-bounded (gascity-dashboard-9w3k)', () => {
-  test('caps historicalLanes at MAX_HISTORICAL_LANES, keeps the most-recent ones, reports true total', () => {
+// Header-first restructure: completed runs are the lazy history read's payload.
+// buildRunHistory derives ONLY the completed lanes from the (expensive) closed-
+// history fan-out, keeping the 9w3k recency cap and true-total semantics.
+describe('buildRunHistory — completed lanes only, recency-bounded (gascity-dashboard-9w3k)', () => {
+  test('a completed run lands in history; active and blocked runs do not', () => {
+    const history = buildRunHistory([latch(), ...activeRun('run-1'), ...completedRun('run-done')]);
+
+    assert.equal(history.totalHistorical, 1);
+    assert.deepEqual(
+      history.lanes.map((lane) => lane.id),
+      ['run-done'],
+    );
+    assert.equal(history.lanesPartial, undefined);
+  });
+
+  test('marks the history partial when the fan-out was degraded', () => {
+    const history = buildRunHistory(completedRun('run-done'), new Map(), true);
+
+    assert.equal(history.lanesPartial, true);
+  });
+
+  test('a dangling-root group and a lone engineering bead never become history lanes', () => {
+    const orphan: RunIssue = {
+      id: 'gc-1920-step-1',
+      title: 'Implementation patch',
+      status: 'closed',
+      issue_type: 'task',
+      updated_at: '2026-06-01T00:05:00Z',
+      metadata: {
+        'gc.kind': 'step',
+        'gc.formula_contract': 'graph.v2',
+        'gc.root_bead_id': 'gc-1920',
+        'gc.step_id': 'implementation.patch',
+      },
+    };
+    const loneTask: RunIssue = {
+      id: 'task-99',
+      title: 'Fix a typo',
+      status: 'closed',
+      issue_type: 'task',
+      updated_at: '2026-06-02T00:00:00Z',
+    };
+
+    const history = buildRunHistory([orphan, loneTask]);
+
+    assert.deepEqual(history.lanes, []);
+    assert.equal(history.totalHistorical, 0);
+  });
+
+  test('caps lanes at MAX_HISTORICAL_LANES, keeps the most-recent ones, reports true total', () => {
     const total = MAX_HISTORICAL_LANES + 10;
     const issues: RunIssue[] = [];
     // Distinct, monotonically increasing updated_at so newest-first order is
@@ -350,10 +392,10 @@ describe('buildRunSummary — historical lanes are recency-bounded (gascity-dash
       );
     }
 
-    const summary = buildRunSummary(issues);
+    const history = buildRunHistory(issues);
 
-    assert.equal(summary.historicalLanes.length, MAX_HISTORICAL_LANES);
-    assert.equal(summary.totalHistorical, total);
+    assert.equal(history.lanes.length, MAX_HISTORICAL_LANES);
+    assert.equal(history.totalHistorical, total);
 
     // The retained lanes must be the newest N (highest n), newest first.
     const expected = Array.from({ length: MAX_HISTORICAL_LANES }, (_, i) => {
@@ -361,7 +403,7 @@ describe('buildRunSummary — historical lanes are recency-bounded (gascity-dash
       return `hist-${String(n).padStart(3, '0')}`;
     });
     assert.deepEqual(
-      summary.historicalLanes.map((lane) => lane.id),
+      history.lanes.map((lane) => lane.id),
       expected,
     );
   });

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -1,4 +1,11 @@
-import type { RunChange, RunCounts, RunLane, RunSummary, RunStage } from '../snapshot/types.js';
+import type {
+  RunChange,
+  RunCounts,
+  RunHistory,
+  RunLane,
+  RunSummary,
+  RunStage,
+} from '../snapshot/types.js';
 import { fromRootMetadataScope } from '../run-scope.js';
 import { stripNonPrintable } from '../strip-non-printable.js';
 import { resolveRunFormulaIdentity } from './formula-name.js';
@@ -17,14 +24,14 @@ import {
 
 // Default collapsed active-lane count (component-controlled). The wire carries
 // the FULL active set in `lanes`; RunMap renders this many by default and offers
-// a "Show N more runs" expander (mirroring historicalLanes/MAX_HISTORICAL_LANES).
+// a "Show N more runs" expander (mirroring RunHistory/MAX_HISTORICAL_LANES).
 export const MAX_VISIBLE_ACTIVE_LANES = 8;
 export const RECENT_CHANGES_CAP = 12;
 // gascity-dashboard-9w3k: once v1 history is surfaced the completed set can grow
-// into the thousands. Cap the historical lanes carried on the wire to the most-
-// recent N (sortedLanes is already newest-first) so a long tail of old runs
-// cannot bury or out-pay the active set. totalHistorical still reports the full
-// count so the operator sees the true number behind the window.
+// into the thousands. Cap the historical lanes carried on the wire (RunHistory)
+// to the most-recent N (sortedLanes is already newest-first) so a long tail of
+// old runs cannot bury or out-pay the active set. totalHistorical still reports
+// the full count so the operator sees the true number behind the window.
 export const MAX_HISTORICAL_LANES = 50;
 const ENGINEERING_TYPES = new Set([
   'feature',
@@ -49,6 +56,67 @@ export function buildRunSummary(
   feedScopes: RunFeedScopeMap = new Map(),
   partial = false,
 ): RunSummary {
+  const { laneIssues, sortedLanes } = buildSortedRunLanes(issues, feedScopes);
+
+  // gascity-dashboard-4xcv: blocked lanes are split out of Active. A stale
+  // blocked formula latch (gc-1920 repro) is not progressing; it surfaces in
+  // its own section instead of inflating the Active set.
+  //
+  // Header-first restructure: completed lanes are DROPPED here, not carried.
+  // They are the lazy history read's payload (buildRunHistory) so the default
+  // refresh never pays the closed-history fan-out for them.
+  const activeLanes = sortedLanes.filter(
+    (lane) => lane.phase !== 'complete' && lane.phase !== 'blocked',
+  );
+  const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
+
+  // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not a capped
+  // window. Session-less-latch demotion (enrichRunSummary) is session-aware and
+  // can only run downstream of this builder, so it must see every active lane to
+  // recompute totalActive exactly — capping here would hide phantoms beyond the
+  // 8th slot from demotion and leave them in the count. RunMap owns the rendered
+  // collapse (default MAX_VISIBLE_ACTIVE_LANES) and its "Show N more" expander,
+  // mirroring the historical section — so the wire is never pre-capped.
+  const summary: RunSummary = {
+    totalActive: activeLanes.length,
+    runCounts: runCounts(activeLanes, activeLanes.length, blockedLanes.length),
+    lanes: activeLanes,
+    blockedLanes,
+    recentChanges: recentChanges(laneIssues),
+    census: runCensusUnavailable(),
+  };
+  return partial ? { ...summary, lanesPartial: true } : summary;
+}
+
+/**
+ * Build the lazy /runs history payload: ONLY the completed (phase ===
+ * 'complete') lanes, derived from the closed-history fan-out (header-first
+ * restructure). gascity-dashboard-9w3k semantics are preserved: `lanes` is
+ * capped at MAX_HISTORICAL_LANES (newest-first) while totalHistorical reports
+ * the true completed count behind the window.
+ */
+export function buildRunHistory(
+  issues: RunIssue[],
+  feedScopes: RunFeedScopeMap = new Map(),
+  partial = false,
+): RunHistory {
+  const { sortedLanes } = buildSortedRunLanes(issues, feedScopes);
+  const completedLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
+  const history: RunHistory = {
+    totalHistorical: completedLanes.length,
+    lanes: completedLanes.slice(0, MAX_HISTORICAL_LANES),
+  };
+  return partial ? { ...history, lanesPartial: true } : history;
+}
+
+// The shared lane derivation behind buildRunSummary and buildRunHistory:
+// group issues by run root, drop dangling-root and non-run groups, and emit
+// compareLanes-sorted lanes. Splitting active/blocked/complete is the callers'
+// concern.
+function buildSortedRunLanes(
+  issues: RunIssue[],
+  feedScopes: RunFeedScopeMap,
+): { laneIssues: RunIssue[]; sortedLanes: RunLane[] } {
   const groups = new Map<string, RunIssue[]>();
 
   for (const issue of issues) {
@@ -70,37 +138,7 @@ export function buildRunSummary(
   const sortedLanes = runGroups
     .map(([rootId, groupIssues]) => runLane(rootId, groupIssues, feedScopes))
     .sort(compareLanes);
-
-  // gascity-dashboard-4xcv: blocked lanes are split out of Active. A stale
-  // blocked formula latch (gc-1920 repro) is not progressing; it surfaces in
-  // its own section instead of inflating the Active set.
-  const activeLanes = sortedLanes.filter(
-    (lane) => lane.phase !== 'complete' && lane.phase !== 'blocked',
-  );
-  const completedLanes = sortedLanes.filter((lane) => lane.phase === 'complete');
-  // gascity-dashboard-9w3k: cap on the wire, but keep the FULL count for the DTO.
-  const totalHistorical = completedLanes.length;
-  const historicalLanes = completedLanes.slice(0, MAX_HISTORICAL_LANES);
-  const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
-
-  // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not a capped
-  // window. Session-less-latch demotion (enrichRunSummary) is session-aware and
-  // can only run downstream of this builder, so it must see every active lane to
-  // recompute totalActive exactly — capping here would hide phantoms beyond the
-  // 8th slot from demotion and leave them in the count. RunMap owns the rendered
-  // collapse (default MAX_VISIBLE_ACTIVE_LANES) and its "Show N more" expander,
-  // mirroring the historical section — so the wire is never pre-capped.
-  const summary: RunSummary = {
-    totalActive: activeLanes.length,
-    totalHistorical,
-    runCounts: runCounts(activeLanes, activeLanes.length, blockedLanes.length),
-    lanes: activeLanes,
-    historicalLanes,
-    blockedLanes,
-    recentChanges: recentChanges(laneIssues),
-    census: runCensusUnavailable(),
-  };
-  return partial ? { ...summary, lanesPartial: true } : summary;
+  return { laneIssues, sortedLanes };
 }
 
 // gascity-dashboard-9w3k: a group is a run when its root bead carries a run
@@ -408,7 +446,6 @@ export function metadataString(issues: RunIssue[], key: string): string {
 export function emptyRunSummary(): RunSummary {
   return {
     totalActive: 0,
-    totalHistorical: 0,
     runCounts: {
       total: 0,
       visible: 0,
@@ -419,7 +456,6 @@ export function emptyRunSummary(): RunSummary {
       other: 0,
     },
     lanes: [],
-    historicalLanes: [],
     blockedLanes: [],
     recentChanges: [],
     census: runCensusUnavailable(),

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -128,25 +128,19 @@ export interface RunSummary {
    *  operator attention; they are simply not part of the Active set or
    *  the headline `activeRuns` metric. */
   totalActive: number;
-  /** TRUE count of HISTORICAL lanes (phase === 'complete'). gascity-dashboard-yh5i:
-   *  /runs defaults to showing the active set; toggling `?history=1`
-   *  reveals the historical section so the user can see recently-completed
-   *  runs without complete lanes crowding active out of the 8-cap window.
-   *  gascity-dashboard-9w3k: this is the full completed-lane count and may
-   *  EXCEED historicalLanes.length when the MAX_HISTORICAL_LANES cap applies,
-   *  so the operator sees the real number behind the recency window. */
-  totalHistorical: number;
   runCounts: RunCounts;
   /** Active lanes, sorted by compareLanes (newest-first). The FULL active set —
    *  `totalActive === lanes.length`. The rendered collapsed window
    *  (MAX_VISIBLE_ACTIVE_LANES) and its "Show N more runs" expander are applied
-   *  by the consumer (RunMap), mirroring historicalLanes/MAX_HISTORICAL_LANES. */
+   *  by the consumer (RunMap), mirroring RunHistory/MAX_HISTORICAL_LANES.
+   *
+   *  Header-first restructure: the summary deliberately carries NO historical
+   *  (phase === 'complete') lanes. Surfacing them required the expensive
+   *  closed-history fan-out (molecule all=true scan + per-rig all=true reads,
+   *  measured 9.9s + 10.9s against second-scale budgets) on every refresh, for
+   *  data hidden behind ?history=1 by default. Completed runs live in
+   *  {@link RunHistory}, loaded lazily by the /runs history toggle. */
   lanes: RunLane[];
-  /** Historical (phase === 'complete') lanes, sorted by compareLanes, capped at
-   *  MAX_HISTORICAL_LANES (most-recent-first). Frontend renders these only when
-   *  the user toggles ?history=1; backend always returns the array. When the cap
-   *  trims older lanes, totalHistorical still reports the true count. */
-  historicalLanes: RunLane[];
   /** Blocked (phase === 'blocked') lanes, sorted by compareLanes
    *  (gascity-dashboard-4xcv). Rendered as their own section so a blocked
    *  run stays visible for the operator without being misread as Active.
@@ -175,6 +169,31 @@ export interface RunSummary {
    * (gascity-dashboard-19w.1.1): the collector only ever assigns `true`
    * (else leaves the field absent), so consumers must check
    * truthiness/presence, never `=== false`.
+   */
+  lanesPartial?: true;
+}
+
+/**
+ * Completed (phase === 'complete') run lanes, the lazy /runs history payload
+ * (header-first restructure). Deriving these requires the expensive closed-
+ * history fan-out (molecule all=true scan + per-rig all=true task reads), so
+ * the data is fetched on demand when the operator opens the history section,
+ * never on the default run-summary refresh path.
+ */
+export interface RunHistory {
+  /** TRUE count of completed lanes. gascity-dashboard-9w3k: may EXCEED
+   *  `lanes.length` when the MAX_HISTORICAL_LANES cap applies, so the operator
+   *  sees the real number behind the recency window. */
+  totalHistorical: number;
+  /** Completed lanes, sorted by compareLanes (newest-first), capped at
+   *  MAX_HISTORICAL_LANES. When the cap trims older lanes, totalHistorical
+   *  still reports the true count. */
+  lanes: RunLane[];
+  /**
+   * True when one or more closed-history reads failed or truncated during the
+   * fan-out, so the completed set may be incomplete. Optional literal `true`
+   * per the lanesPartial / rigsPartial convention (gascity-dashboard-19w.1.1):
+   * consumers check truthiness/presence, never `=== false`.
    */
   lanesPartial?: true;
 }


### PR DESCRIPTION
## Summary

- Header-first restructure of the /runs summary path: the default refresh now needs only the cheap core active read (0.02s measured) + the formula feed (discovery/scope fallback, degrade-to-partial, never required). The expensive closed-history reads, measured live (molecule all=true scan 9.9s vs its 3s budget so it timed out on EVERY refresh and chronically latched the "runs partial" badge; per-rig task all=true 10.9s on the 29.8k-issue gascity rig; city feed 14.3s vs the 2.5s first-paint budget), move OFF the refresh path entirely.
- Historical lanes leave the RunSummary DTO (compile-checked through shared on both sides) and become a new RunHistory payload loaded lazily by the ?history=1 toggle (new `useRunHistory` hook + `loadSupervisorRunHistorySource`), with its own loading / unavailable / partial states. On its 30s budget the measured 9.9s molecule scan now lands, so history actually displays instead of perpetually degrading.
- `lanesPartial` stays honest: it flags only the active lane set (core-read truncation, failed feed), never off-screen history; history degradation renders as a "◐ history partial" notice inside the section. The operator's explicit Refresh bypasses the proxy cache for the open history fan-out too (i3dz).

- Maintainer addendum (adopt-pr review): the branch also carries a maintainer CI-repair commit (`d4c9d3c`, "fix: clear frontend toolchain audit findings") that bumps the frontend build toolchain across majors (`vite` ^7.3.5 -> ^8.0.16, `@vitejs/plugin-react` ^4.7.0 -> ^6.0.2) with the corresponding `package-lock.json` churn, clearing the npm audit findings surfaced by pre-review CI. Validated at this head on Node 24: typecheck, shared + frontend suites, and the production build are green on the bumped toolchain.

No regressions to the load-bearing invariants: shared badge/page fan-out (2j8e.7), full-active-set latch demotion (s4rp), blocked-lane separation (4xcv), 9w3k cap + true-total semantics (preserved on RunHistory). The cheap SSE refresh drops its history-merge complexity and publishes its result as-is.

## Scope

- Named Rule touched: status = glyph + word (the history-partial notice reuses the ◐ + word PartialDataNotice register); no other Named Rule touched.
- Views or routes affected: Runs (history section states, toggle copy); RunMap consumed nowhere else.
- Layer: frontend, shared.

## Test plan

- Tests added or modified:
  - `shared/src/runs/summary.test.ts` (buildRunSummary drops completed lanes; new buildRunHistory suite: cap, true total, partial, flood/dangling guards)
  - `frontend/src/supervisor/runSummary.test.ts` (default sources fire no molecule/per-rig reads; feed degrade-to-partial on both budgets; new loadSupervisorRunHistorySource suite incl. 9.9s-scan-lands and forceFresh bypass)
  - `frontend/src/runs/runHistory.test.tsx` (new: lazy on toggle, cached reopen, forceFresh, last-good retention, error retry)
  - `frontend/src/runs/runSummarySubscription.test.tsx` (no-merge contract), `frontend/src/routes/Runs.test.tsx` (lazy toggle, loading state, Refresh-refreshes-open-history), `frontend/src/components/run/RunMap.test.tsx` (history source states)
  - Fixture updates: `attention/liveContributors.test.tsx`, `attention/registry.test.ts`, `routes/AmbientHome.test.tsx`, `routes/FormulaRunDetail.test.tsx`
- Automated checks run (Node 24): `npm ci`, `npm run build:shared`, `npm run typecheck`, backend+frontend `typecheck:test`, `npm run lint`, shared (160) + backend (582) + frontend (940) tests, `npm --workspace frontend run build`. All green.
- Manual checks run: snap harness not run (no live supervisor in this environment); the history section UI states are covered by component tests. Recommend a `node scripts/snap.mjs runs` pass on a live checkout before/after.

## Risk + rollback

- Risk: the /runs history section now requires a click-triggered fetch; if the lazy read misbehaves the operator notices it in the Historical section (loading/unavailable copy), never in the active lanes or nav badge. The "(N completed.)" empty-state hint and the toggle count appear only after history loads.
- Rollback (maintainer edit; supersedes the original single-commit note): the branch is no longer single-commit, it carries the perf restructure plus the maintainer toolchain commit above. Reverting the landed merge/squash commit reverts BOTH, so a revert of the perf change alone is a two-part operation: revert the landed commit, then re-land the toolchain bump (or cherry-pick `d4c9d3c`) so the audit repair is not lost.

## Linked issue

N/A (operator perf ask; measurements cited above). Touches prior beads 4bol, 9rk2, q89b, 4xcv, n6f1, 9w3k, s4rp, 2j8e.7, i3dz, yh5i.

## Operator-affecting changes

- [x] No change to impersonation semantics (Reading-as strip stays read-only for non-operator; sends always go from the operator).
- [x] No change to write-route audit shape (`audit.ts` envelope and event fields unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
