### PR TITLE
fix(runs): fold stranded lanes into census/attention partitioning

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -25,6 +25,7 @@ function freshRunsSource(): SourceState<RunSummary> {
     data: {
       totalActive: 0,
       blockedLanes: [],
+      strandedLanes: [],
       runCounts: {
         total: 0,
         visible: 0,
@@ -32,6 +33,7 @@ function freshRunsSource(): SourceState<RunSummary> {
         designReview: 0,
         bugfix: 0,
         blocked: 0,
+        stranded: 0,
         other: 0,
       },
       lanes: [],

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -16,7 +16,11 @@ import type {
   Message,
   TypedEventStreamEnvelope,
 } from 'gas-city-dashboard-shared/gc-supervisor';
-import { selectAgentsNeedingYou, selectBlockedRuns } from 'gas-city-dashboard-shared';
+import {
+  selectAgentsNeedingYou,
+  selectBlockedRuns,
+  selectStrandedRuns,
+} from 'gas-city-dashboard-shared';
 import { ATTENTION_DOMAINS, composeAttention } from './compose';
 import { createAttentionContributors, type AgentsAttentionFacts } from './registry';
 
@@ -218,6 +222,35 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.runs.watch).toBe(0);
     expect(model.byDomain.runs.items.map((item) => item.id)).toEqual(['runs:blocked-1:blocked']);
     expect(model.byDomain.runs.items[0]?.href).toBe('/runs/blocked-1');
+  });
+
+  it('emits a counting attention item for a stranded run (gascity-dashboard-pxvb)', () => {
+    const summary = runSummary([
+      runLane({
+        id: 'gc-odssky',
+        title: 'mol-pr-start: gascity issue #3192',
+        phase: 'intake',
+        registration: 'stranded',
+        health: { phaseConfidence: 'known', needsOperator: false, thrashingDetected: false },
+      }),
+      runLane({
+        id: 'active-1',
+        title: 'Healthy active run',
+        phase: 'implementation',
+        health: { phaseConfidence: 'known', needsOperator: false, thrashingDetected: false },
+      }),
+    ]);
+
+    const model = composeAttention(createAttentionContributors({ runs: { summary } }));
+
+    // The stranded run is the only operator-actionable runs item — a healthy
+    // active lane never counts. The badge number, the page Stranded CountTile,
+    // and the Stranded section header read one selector and must agree.
+    expect(model.byDomain.runs.attention).toBe(1);
+    expect(model.byDomain.runs.items.map((item) => item.id)).toEqual(['runs:gc-odssky:stranded']);
+    expect(model.byDomain.runs.items[0]?.href).toBe('/runs/gc-odssky');
+    expect(summary.runCounts.stranded).toBe(1);
+    expect(selectStrandedRuns(summary.strandedLanes).length).toBe(1);
   });
 
   it('nav badge count equals the page Blocked count for a mixed summary (gascity-dashboard-2j8e.6)', () => {
@@ -1008,11 +1041,20 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
   for (const lane of lanes) {
     byPhase[lane.phase] += 1;
   }
-  const blockedLanes = lanes.filter((lane) => lane.phase === 'blocked');
-  const activeLanes = lanes.filter((lane) => lane.phase !== 'blocked' && lane.phase !== 'complete');
+  const strandedLanes = lanes.filter(
+    (lane) => lane.registration === 'stranded' && lane.phase !== 'complete',
+  );
+  const blockedLanes = lanes.filter(
+    (lane) => lane.phase === 'blocked' && lane.registration !== 'stranded',
+  );
+  const activeLanes = lanes.filter(
+    (lane) =>
+      lane.phase !== 'blocked' && lane.phase !== 'complete' && lane.registration !== 'stranded',
+  );
   return {
     lanes: activeLanes,
     blockedLanes,
+    strandedLanes,
     totalActive: activeLanes.length,
     runCounts: {
       total: activeLanes.length,
@@ -1021,16 +1063,20 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
       designReview: 0,
       bugfix: 0,
       blocked: blockedLanes.length,
+      stranded: strandedLanes.length,
       other: 0,
     },
     recentChanges: [],
     census: {
       status: 'available',
+      // gascity-dashboard-pxvb: the production census excludes stranded lanes
+      // from the in-flight count (they never executed), so mirror that here —
+      // only active + blocked are in flight.
       data: {
         byPhase,
-        totalInFlight: lanes.length,
+        totalInFlight: activeLanes.length + blockedLanes.length,
         unverifiable: 0,
-        knownDenominator: lanes.length,
+        knownDenominator: activeLanes.length + blockedLanes.length,
         thrashing: 0,
       },
     },
@@ -1045,6 +1091,7 @@ function runLane({
   scope,
   statusCounts = {},
   activeAssignees = [],
+  registration,
 }: {
   id: string;
   title: string;
@@ -1057,6 +1104,7 @@ function runLane({
   scope?: RunLane['scope'];
   statusCounts?: Record<string, number>;
   activeAssignees?: string[];
+  registration?: RunLane['registration'];
 }): RunLane {
   return {
     id,
@@ -1072,7 +1120,7 @@ function runLane({
     stages: [],
     progress: { status: 'unavailable', error: 'run progress unavailable' },
     formulaStageResolved: false,
-    registration: 'unknown',
+    registration: registration ?? 'unknown',
     health: {
       status: 'available',
       data: {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -10,6 +10,7 @@ import type {
 import {
   selectAgentsNeedingYou,
   selectBlockedRuns,
+  selectStrandedRuns,
   selectOperatorActionableUnread,
 } from 'gas-city-dashboard-shared';
 import { selectBeadsNeedingAttention, type BeadAttentionReason } from './beadsNeedingAttention';
@@ -301,7 +302,7 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
       ),
     );
   }
-  for (const lane of [...summary.lanes, ...summary.blockedLanes]) {
+  for (const lane of [...summary.lanes, ...summary.blockedLanes, ...summary.strandedLanes]) {
     if (lane.health.status === 'available') continue;
     items.push(
       domainUnavailable(
@@ -328,6 +329,23 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
         id: `runs:${run.id}:blocked`,
         title: `${run.title} blocked`,
         summary: run.reason,
+        href: runDetailHref(run.id, run.scope),
+      }),
+    );
+  }
+
+  // gascity-dashboard-pxvb: a stranded run (orphaned molecule that never
+  // executed) is the state most needing an operator action — clean up or
+  // re-dispatch — yet it emitted no attention item and rode the Active set as
+  // false-alive work. Surface it as a counting attention item, the same
+  // selectStrandedRuns set the /runs Stranded section renders, so the badge
+  // number and the page count read one selector and cannot disagree.
+  for (const run of selectStrandedRuns(summary.strandedLanes)) {
+    items.push(
+      domainAttention('runs', {
+        id: `runs:${run.id}:stranded`,
+        title: `${run.title} stranded`,
+        summary: run.remedy,
         href: runDetailHref(run.id, run.scope),
       }),
     );

--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -23,6 +23,14 @@ interface LaneCardProps {
    * do) rather than just "blocked". Derived by selectBlockedRuns.
    */
   blocked?: { reason: string; remedy: string };
+  /**
+   * gascity-dashboard-pxvb: the operator's next step for an orphaned run, shown
+   * only in the Stranded section. The why-stranded line is already part of every
+   * stranded lane's body (below); this adds the how-to-resolve remedy so the
+   * Stranded section reads as actionable, mirroring the Blocked section. Derived
+   * by selectStrandedRuns.
+   */
+  stranded?: { reason: string; remedy: string };
 }
 
 /**
@@ -44,12 +52,18 @@ function phaseLabelTone(phase: RunLane['phase']): 'text-accent' | 'text-fg-muted
   return 'text-fg';
 }
 
-export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneCardProps) {
+export function LaneCard({
+  lane,
+  now,
+  attentionSeverity = null,
+  blocked,
+  stranded,
+}: LaneCardProps) {
   // gascity-dashboard-uxvk: an orphaned molecule (no supervisor workflow
   // record, never executed) must not read as a live run. Stranded lanes swap
   // the phase label for a glyph + word and the stage ladder for an
   // explanation — a run that never started has no live stage to show.
-  const stranded = lane.registration === 'stranded';
+  const isStranded = lane.registration === 'stranded';
   const statusEntries = Object.entries(lane.statusCounts).sort((a, b) =>
     statusSortKey(a[0]).localeCompare(statusSortKey(b[0])),
   );
@@ -63,7 +77,7 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
     >
       <div className="flex items-baseline justify-between gap-4">
         <span className={`text-label uppercase tracking-wider ${phaseLabelTone(lane.phase)}`}>
-          {stranded ? (
+          {isStranded ? (
             <>
               <span aria-hidden="true">(!)</span> stranded
             </>
@@ -107,7 +121,7 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
         </div>
       )}
 
-      {stranded ? (
+      {isStranded ? (
         <p className="mt-2 text-body text-fg-muted leading-snug">
           Dispatched but never registered with the supervisor, likely a supervisor restart or crash
           at dispatch time. This run never executed.
@@ -145,6 +159,13 @@ export function LaneCard({ lane, now, attentionSeverity = null, blocked }: LaneC
           </p>
           <p className="mt-1 text-body text-fg-muted leading-snug">{blocked.remedy}</p>
         </div>
+      )}
+
+      {/* gascity-dashboard-pxvb: the why-stranded line is already rendered above
+          (the orphan explanation replaces the stage ladder); the Stranded
+          section adds only the operator remedy so the row reads as actionable. */}
+      {stranded !== undefined && (
+        <p className="mt-2 text-body text-fg-muted leading-snug">{stranded.remedy}</p>
       )}
     </li>
   );

--- a/frontend/src/components/run/RunMap.test.tsx
+++ b/frontend/src/components/run/RunMap.test.tsx
@@ -153,6 +153,31 @@ function blockedLane(id: string): RunLane {
   return { ...activeLane(id), title: `Blocked run ${id}`, phase: 'blocked', phaseLabel: 'blocked' };
 }
 
+function strandedLane(id: string): RunLane {
+  return {
+    ...activeLane(id),
+    title: `Stranded run ${id}`,
+    phase: 'intake',
+    phaseLabel: 'intake',
+    registration: 'stranded',
+  };
+}
+
+function strandedSummarySource(strandedLanes: RunLane[]): SourceState<RunSummary> {
+  return {
+    source: 'runs',
+    status: 'fresh',
+    fetchedAt: '2026-05-24T12:00:00Z',
+    staleAt: '2026-05-24T12:01:00Z',
+    error: { kind: 'none' },
+    data: {
+      ...emptyRunSummary(),
+      strandedLanes,
+      runCounts: { ...emptyRunSummary().runCounts, stranded: strandedLanes.length },
+    },
+  };
+}
+
 function makeActiveLanes(count: number): RunLane[] {
   return Array.from({ length: count }, (_, i) => activeLane(`gc-active-${i}`));
 }
@@ -203,6 +228,40 @@ function renderActive(lanes: RunLane[]) {
     </MemoryRouter>,
   );
 }
+
+describe('RunMap stranded section (gascity-dashboard-pxvb)', () => {
+  it('renders stranded lanes in their own labeled section with a count and remedy', () => {
+    renderRunMap(strandedSummarySource([strandedLane('gc-odssky')]), undefined);
+
+    const section = screen.getByRole('region', { name: /stranded runs/i });
+    expect(within(section).getByText(/Stranded \(1\)/)).toBeTruthy();
+    expect(within(section).getByText(/Stranded run gc-odssky/)).toBeTruthy();
+    // The operator remedy (selectStrandedRuns) makes the row actionable.
+    expect(within(section).getByText(/re-dispatch/i)).toBeTruthy();
+  });
+
+  it('shows a Stranded count tile in the header and omits the section when empty', () => {
+    const { rerender } = renderRunMap(
+      strandedSummarySource([strandedLane('gc-odssky')]),
+      undefined,
+    );
+    expect(screen.getByText('Stranded')).toBeTruthy();
+
+    rerender(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <RunMap
+          source={strandedSummarySource([])}
+          now={Date.parse('2026-05-24T12:01:00Z')}
+          showHistory={true}
+          history={undefined}
+          historyLoading={false}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('region', { name: /stranded runs/i })).toBeNull();
+    expect(screen.queryByText('Stranded')).toBeNull();
+  });
+});
 
 describe('RunMap active expand-in-place (lane-cap expander)', () => {
   it('collapses to MAX_VISIBLE_ACTIVE_LANES with a Show-more toggle, no static footnote', () => {

--- a/frontend/src/components/run/RunMap.tsx
+++ b/frontend/src/components/run/RunMap.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   MAX_VISIBLE_ACTIVE_LANES,
   selectBlockedRuns,
+  selectStrandedRuns,
   type RunHistory,
   type RunLane,
   type RunSummary,
@@ -105,6 +106,11 @@ export function RunMap({
         now={now}
         {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
       />
+      <StrandedSection
+        summary={summary}
+        now={now}
+        {...(attentionSeverity === undefined ? {} : { attentionSeverity })}
+      />
       {showHistory && (
         <HistoricalSection
           history={reconciledHistory}
@@ -133,10 +139,17 @@ export function RunMap({
  * pre-split single summary maintained continuously.
  */
 function reconcileHistory(history: RunHistory, summary: RunSummary): RunHistory {
-  if (summary.lanes.length === 0 && summary.blockedLanes.length === 0) return history;
+  if (
+    summary.lanes.length === 0 &&
+    summary.blockedLanes.length === 0 &&
+    summary.strandedLanes.length === 0
+  ) {
+    return history;
+  }
   const liveIds = new Set<string>();
   for (const lane of summary.lanes) liveIds.add(lane.id);
   for (const lane of summary.blockedLanes) liveIds.add(lane.id);
+  for (const lane of summary.strandedLanes) liveIds.add(lane.id);
   const lanes = history.lanes.filter((lane) => !liveIds.has(lane.id));
   if (lanes.length === history.lanes.length) return history;
   return {
@@ -327,6 +340,52 @@ function BlockedSection({
   );
 }
 
+/** Stranded runs (gascity-dashboard-pxvb). An orphaned molecule that never
+ *  executed and never will — partitioned out of Active alongside Blocked so it
+ *  stops reading as live work, but kept on the page in its own labeled section
+ *  because it is the state most needing an operator action (clean up /
+ *  re-dispatch). Hidden entirely when nothing is stranded: the calm room does
+ *  not announce the absence of trouble. Mirrors BlockedSection. */
+function StrandedSection({
+  summary,
+  now,
+  attentionSeverity,
+}: {
+  summary: RunSummary;
+  now: number;
+  attentionSeverity?: (lane: RunLane) => BadgeSeverity | null;
+}) {
+  // gascity-dashboard-pxvb: selectStrandedRuns is the SAME selector the nav
+  // badge counts, so the header count here and the badge number are one number.
+  // Each row carries why-stranded + how-to-resolve (LaneCard `stranded`), so the
+  // destination is a path to action, not just a list.
+  const detailById = new Map(selectStrandedRuns(summary.strandedLanes).map((run) => [run.id, run]));
+  if (detailById.size === 0) return null;
+  return (
+    <section aria-label="Stranded runs" className="mt-12">
+      <h2 className="text-label uppercase tracking-wider text-fg-faint tnum">
+        Stranded ({detailById.size})
+      </h2>
+      <ol className="mt-3 divide-y divide-rule">
+        {summary.strandedLanes.map((lane) => {
+          const detail = detailById.get(lane.id);
+          return (
+            <LaneCard
+              key={lane.id}
+              lane={lane}
+              now={now}
+              {...(attentionSeverity === undefined
+                ? {}
+                : { attentionSeverity: attentionSeverity(lane) })}
+              {...(detail === undefined ? {} : { stranded: detail })}
+            />
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
 // Header-first: the historical section renders from the lazy history source,
 // with explicit loading / unavailable / partial states of its own. The summary's
 // lanesPartial never speaks for history, and vice versa — each signal flags only
@@ -467,6 +526,7 @@ function CountsHeader({ summary }: { summary: RunSummary | null }) {
   // surface via the toggle button in the page header, not here.
   const total = summary?.runCounts.total ?? 0;
   const blocked = summary?.runCounts.blocked ?? 0;
+  const stranded = summary?.runCounts.stranded ?? 0;
   return (
     <header className="space-y-2">
       <div className="flex items-baseline gap-x-6 gap-y-2 flex-wrap">
@@ -475,6 +535,7 @@ function CountsHeader({ summary }: { summary: RunSummary | null }) {
           <CountTile key={key} label={label} value={summary?.runCounts[key] ?? 0} tone="muted" />
         ))}
         {blocked > 0 && <CountTile label="Blocked" value={blocked} tone="muted" />}
+        {stranded > 0 && <CountTile label="Stranded" value={stranded} tone="muted" />}
       </div>
     </header>
   );

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -173,6 +173,7 @@ function runSource({
     data: {
       totalActive: lanes.length,
       blockedLanes: [],
+      strandedLanes: [],
       runCounts: {
         total: lanes.length,
         visible: lanes.length,
@@ -180,6 +181,7 @@ function runSource({
         designReview: 0,
         bugfix: 0,
         blocked: 0,
+        stranded: 0,
         other: 0,
       },
       lanes,

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -861,6 +861,7 @@ function runSummarySource(lanes: RunLane[] = []): SourceState<RunSummary> {
     data: {
       totalActive: lanes.length,
       blockedLanes: [],
+      strandedLanes: [],
       runCounts: {
         total: lanes.length,
         visible: lanes.length,
@@ -868,6 +869,7 @@ function runSummarySource(lanes: RunLane[] = []): SourceState<RunSummary> {
         designReview: 0,
         bugfix: 0,
         blocked: 0,
+        stranded: 0,
         other: lanes.length,
       },
       lanes,

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -136,9 +136,14 @@ export function FormulaRunDetailPage() {
     const runsData =
       warmRunSummary && warmRunSummary.status !== 'error' ? warmRunSummary.data : null;
     if (runsData === null || runsData === undefined) return null;
-    // gascity-dashboard-4xcv: blocked lanes live in their own bucket now, and
-    // a blocked run is the most likely one the operator clicks into.
-    return [...runsData.lanes, ...runsData.blockedLanes].find((lane) => lane.id === runId) ?? null;
+    // gascity-dashboard-4xcv / -pxvb: blocked and stranded lanes live in their
+    // own buckets now; a blocked or stranded run is a likely click target (the
+    // operator opens a stranded run to clean it up), so search all three sets.
+    return (
+      [...runsData.lanes, ...runsData.blockedLanes, ...runsData.strandedLanes].find(
+        (lane) => lane.id === runId,
+      ) ?? null
+    );
   }, [warmRunSummary, runId]);
 
   const synopsis = detail

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -94,6 +94,7 @@ function buildRunSource(
     data: {
       totalActive: 0,
       blockedLanes: [],
+      strandedLanes: [],
       runCounts: {
         total: 0,
         visible: 0,
@@ -101,6 +102,7 @@ function buildRunSource(
         designReview: 0,
         bugfix: 0,
         blocked: 0,
+        stranded: 0,
         other: 0,
       },
       lanes: [],

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -59,6 +59,7 @@ function buildRunSource(
     data: {
       totalActive: 0,
       blockedLanes: [],
+      strandedLanes: [],
       runCounts: {
         total: 0,
         visible: 0,
@@ -66,6 +67,7 @@ function buildRunSource(
         designReview: 0,
         bugfix: 0,
         blocked,
+        stranded: 0,
         other: 0,
       },
       lanes: [],

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -205,7 +205,8 @@ export function useRunSummarySubscription(): RunSummarySubscription {
         : staleDueToFailureRef.current ||
           (runs.data.lanesPartial === true &&
             runs.data.lanes.length === 0 &&
-            runs.data.blockedLanes.length === 0);
+            runs.data.blockedLanes.length === 0 &&
+            runs.data.strandedLanes.length === 0);
     if (!degraded) {
       retryAttemptRef.current = 0;
       return;

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -1126,9 +1126,34 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
 
     expect(source.status).toBe('fresh');
     if (source.status === 'error') throw new Error(source.error);
-    const lane = source.data.lanes.find((l) => l.id === 'gc-odssky');
+    // gascity-dashboard-pxvb: the stranded lane is partitioned out of Active
+    // into its own bucket and must not count as live work.
+    const lane = source.data.strandedLanes.find((l) => l.id === 'gc-odssky');
     expect(lane?.registration).toBe('stranded');
     expect(lane?.phase).toBe('intake');
+    expect(source.data.lanes.some((l) => l.id === 'gc-odssky')).toBe(false);
+    expect(source.data.totalActive).toBe(0);
+    expect(source.data.runCounts.stranded).toBe(1);
+    // The census in-flight count excludes the orphan entirely — the false-alive
+    // bug pxvb fixes was exactly this lane reading as live work.
+    if (source.data.census.status !== 'available') throw new Error('census unavailable');
+    expect(source.data.census.data.totalInFlight).toBe(0);
+    expect(source.data.census.data.byPhase.intake).toBe(0);
+  });
+
+  it('demotes a stranded lane past the 24h stale latch out of the board (pxvb precedence)', async () => {
+    // Documented precedence on isStrandedRun: a day-old orphan leaves the board
+    // with the rest of the stale latches rather than accumulating in Stranded
+    // forever. The orphan's last write (created_at 11:00) is read against a much
+    // later snapshot generation time so it ages past STALE_LATCH_AFTER_MS.
+    vi.setSystemTime(new Date('2026-06-03T12:00:00.000Z'));
+    wideApi(feed([]));
+
+    const source = await loadSupervisorRunSummarySource();
+
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.strandedLanes.some((l) => l.id === 'gc-odssky')).toBe(false);
+    expect(source.data.lanes.some((l) => l.id === 'gc-odssky')).toBe(false);
   });
 
   it('a run listed by the feed is registered', async () => {
@@ -1172,7 +1197,9 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     wideApi(feed([]));
     const first = await loadSupervisorRunSummarySource();
     if (first.status === 'error') throw new Error(first.error);
-    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(first.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
 
     wideApi(
       feed([feedRun({ id: 'gc-odssky', root_bead_id: 'gc-odssky', workflow_id: 'gc-odssky' })]),
@@ -1188,7 +1215,9 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     wideApi(feed([]));
     const first = await loadSupervisorRunSummarySource();
     if (first.status === 'error') throw new Error(first.error);
-    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(first.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
 
     wideApi(
       feed(
@@ -1205,7 +1234,9 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     wideApi(feed([]));
     const first = await loadSupervisorRunSummarySource();
     if (first.status === 'error') throw new Error(first.error);
-    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(first.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
 
     const { root_bead_id: _omitted, ...rootless } = feedRun({
       id: 'other-run',
@@ -1229,7 +1260,9 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     wideApi(feed([]));
     const first = await loadSupervisorRunSummarySource();
     if (first.status === 'error') throw new Error(first.error);
-    expect(first.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(first.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
 
     const { root_bead_id: _omitted, ...rootless } = feedRun({
       id: 'gc-odssky',
@@ -1238,14 +1271,18 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
     wideApi(feed([rootless]));
     const second = await loadSupervisorRunSummarySource();
     if (second.status === 'error') throw new Error(second.error);
-    expect(second.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(second.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
   });
 
   it('the cheap active source reuses the cached complete-feed observation (no flap)', async () => {
     wideApi(feed([]));
     const wide = await loadSupervisorRunSummarySource();
     if (wide.status === 'error') throw new Error(wide.error);
-    expect(wide.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(wide.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
 
     // The cheap source: core active read + sessions only, NO feed read.
     const listBeads = vi.fn(async () => beadList(orphanBeads()));
@@ -1261,7 +1298,9 @@ describe('run registration (gascity-dashboard-uxvk)', () => {
 
     if (cheap.status === 'error') throw new Error(cheap.error);
     expect(formulaFeed).not.toHaveBeenCalled();
-    expect(cheap.data.lanes.find((l) => l.id === 'gc-odssky')?.registration).toBe('stranded');
+    expect(cheap.data.strandedLanes.find((l) => l.id === 'gc-odssky')?.registration).toBe(
+      'stranded',
+    );
   });
 
   it('without any complete feed observation the cheap source reports unknown', async () => {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -633,10 +633,15 @@ function enrichRunSummary(
   source: SourceAvailableState<RunSummary>,
   sessionsLookup: RunSessionsLookup,
 ): RunSummary {
-  // gascity-dashboard-4xcv: blocked lanes are enriched alongside active
-  // ones so they carry derived health (needsOperator) for the attention
-  // layer, then split back out — they are not part of the Active set.
-  const inFlight = [...source.data.lanes, ...source.data.blockedLanes];
+  // gascity-dashboard-4xcv / -pxvb: blocked AND stranded lanes are enriched
+  // alongside active ones so they carry derived health (needsOperator,
+  // health.status for the attention layer), then split back out — neither is
+  // part of the Active set.
+  const inFlight = [
+    ...source.data.lanes,
+    ...source.data.blockedLanes,
+    ...source.data.strandedLanes,
+  ];
   const state = progressStateByCity.get(cityName);
   const generationMs = Date.parse(source.fetchedAt);
   let marks = state?.marks ?? new Map<string, LaneProgressMark>();
@@ -653,8 +658,19 @@ function enrichRunSummary(
     marks,
   });
 
-  const blockedLanes = lanes.filter((lane) => lane.phase === 'blocked');
-  const activeEnriched = lanes.filter((lane) => lane.phase !== 'blocked');
+  // gascity-dashboard-pxvb: re-split with stranded precedence so every lane
+  // lands in exactly one partition. Stranded is keyed on `registration`, not
+  // `phase` (an orphan's all-open steps map it to phase 'intake'), so it must be
+  // filtered out of both the blocked and active sets here.
+  const strandedEnriched = lanes.filter(
+    (lane) => lane.registration === 'stranded' && lane.phase !== 'complete',
+  );
+  const blockedLanes = lanes.filter(
+    (lane) => lane.phase === 'blocked' && lane.registration !== 'stranded',
+  );
+  const activeEnriched = lanes.filter(
+    (lane) => lane.phase !== 'blocked' && lane.registration !== 'stranded',
+  );
 
   // gascity-dashboard-s4rp: sessions only resolve here at enrichment, so this is
   // the earliest seam with enough information to demote stale session-less
@@ -667,6 +683,16 @@ function enrichRunSummary(
   const liveActive = activeEnriched.filter(
     (lane) => !isStaleSessionlessLatch(lane, generationMs, sessionsAvailable),
   );
+  // gascity-dashboard-pxvb: a stranded lane is sessionless with no in_progress
+  // step, so the same stale-latch demotion applies — documented precedence on
+  // isStrandedRun: a day-old orphan leaves the board with the rest of the stale
+  // latches rather than accumulating in the Stranded section forever.
+  const liveStranded = strandedEnriched.filter(
+    (lane) => !isStaleSessionlessLatch(lane, generationMs, sessionsAvailable),
+  );
+  // Stranded runs never executed and never will, so they are excluded from the
+  // in-flight census entirely (byPhase / totalInFlight) — the bug pxvb fixes was
+  // exactly the orphan counting as live work. Only liveActive + blocked count.
   const census = buildCensus([...liveActive, ...blockedLanes]);
 
   // gascity-dashboard: `lanes` carries the FULL active set; RunMap owns the
@@ -677,7 +703,8 @@ function enrichRunSummary(
     totalActive: liveActive.length,
     lanes: liveActive,
     blockedLanes,
-    runCounts: runCounts(liveActive, liveActive.length, blockedLanes.length),
+    strandedLanes: liveStranded,
+    runCounts: runCounts(liveActive, liveActive.length, blockedLanes.length, liveStranded.length),
     census: { status: 'available', data: census },
   };
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -33,6 +33,7 @@ export * from './runs/runtime-state.js';
 export * from './runs/session-link.js';
 export * from './runs/summary.js';
 export * from './runs/status.js';
+export * from './runs/stranded.js';
 export * from './bead-id.js';
 export * from './links.js';
 export * from './links/build-link-view.js';

--- a/shared/src/runs/stranded.test.ts
+++ b/shared/src/runs/stranded.test.ts
@@ -1,0 +1,79 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectStrandedRuns, strandedRunReason, strandedRunRemedy } from './stranded.js';
+import type { RunLane } from '../snapshot/types.js';
+
+// gascity-dashboard-pxvb: the single stranded-runs selector, the analogue of
+// selectBlockedRuns. Both the Runs nav badge and the /runs page read it, so the
+// badge count and the page count cannot disagree. Input is buildRunSummary's
+// strandedLanes — already dangling-root suppressed and asserted stranded only
+// from a complete feed observation upstream (isStrandedRun).
+
+function lane(overrides: Partial<RunLane> = {}): RunLane {
+  return {
+    id: 'gc-100',
+    title: 'mol-pr-start: gascity issue #3192',
+    formula: { status: 'known', name: 'mol-pr-start' },
+    scope: { status: 'available', kind: 'rig', ref: 'app', rootStoreRef: 'rig:app' },
+    external: { status: 'unavailable', error: 'external reference unavailable' },
+    phase: 'intake',
+    phaseLabel: 'intake',
+    statusCounts: { open: 3 },
+    activeAssignees: [],
+    updatedAt: { status: 'available', at: '2026-06-01T00:00:00.000Z' },
+    stages: [],
+    progress: { status: 'unavailable', error: 'run progress unavailable' },
+    formulaStageResolved: false,
+    registration: 'stranded',
+    health: { status: 'unavailable', error: 'run health has not been derived' },
+    ...overrides,
+  };
+}
+
+describe('selectStrandedRuns — gascity-dashboard-pxvb', () => {
+  test('projects one StrandedRun per stranded lane, preserving id/title/scope', () => {
+    const scope = {
+      status: 'available',
+      kind: 'rig',
+      ref: 'app',
+      rootStoreRef: 'rig:app',
+    } as const;
+    const runs = selectStrandedRuns([
+      lane({ id: 'gc-1', title: 'Run one', scope }),
+      lane({ id: 'gc-2', title: 'Run two', scope }),
+    ]);
+    assert.equal(runs.length, 2);
+    assert.deepEqual(
+      runs.map((r) => r.id),
+      ['gc-1', 'gc-2'],
+    );
+    assert.equal(runs[0]?.title, 'Run one');
+    assert.deepEqual(runs[0]?.scope, scope);
+  });
+
+  test('selects only stranded lanes — registered and unknown are excluded', () => {
+    const runs = selectStrandedRuns([
+      lane({ id: 'registered', registration: 'registered' }),
+      lane({ id: 'unknown', registration: 'unknown' }),
+      lane({ id: 'stranded', registration: 'stranded' }),
+    ]);
+    assert.deepEqual(
+      runs.map((r) => r.id),
+      ['stranded'],
+    );
+  });
+
+  test('every stranded row carries an actionable reason and remedy', () => {
+    const [run] = selectStrandedRuns([lane()]);
+    assert.ok(run);
+    assert.equal(run.reason, strandedRunReason());
+    assert.equal(run.remedy, strandedRunRemedy());
+    assert.match(run.reason, /never executed/i);
+    assert.match(run.remedy, /re-dispatch|clean up/i);
+  });
+
+  test('empty input yields no stranded runs', () => {
+    assert.deepEqual(selectStrandedRuns([]), []);
+  });
+});

--- a/shared/src/runs/stranded.ts
+++ b/shared/src/runs/stranded.ts
@@ -1,0 +1,45 @@
+import type { RunLane, RunLaneScope } from '../snapshot/types.js';
+
+// gascity-dashboard-pxvb: the stranded-runs selector, the analogue of
+// selectBlockedRuns (runs/blocked.ts). The Runs nav badge and the /runs page
+// both read this one projection of `summary.strandedLanes`, so the badge count
+// and the page's Stranded count read the same selector and cannot disagree.
+// Its input is buildRunSummary's `strandedLanes` — already dangling-root
+// suppressed, run-marker gated (isRunGroup), and asserted stranded only from a
+// COMPLETE formula-feed observation plus the dispatch grace (isStrandedRun), so
+// a feed outage never strands a lane and this selector only ever sees a
+// conclusively orphaned run.
+
+export interface StrandedRun {
+  id: string;
+  title: string;
+  /** Why the run is stranded — a structural, glyph+word-friendly phrase. */
+  reason: string;
+  /** The operator's next step to resolve the orphan. */
+  remedy: string;
+  scope: RunLaneScope;
+}
+
+/** Project the stranded lanes into operator-actionable rows. */
+export function selectStrandedRuns(strandedLanes: readonly RunLane[]): StrandedRun[] {
+  return strandedLanes
+    .filter((lane) => lane.registration === 'stranded')
+    .map((lane) => ({
+      id: lane.id,
+      title: lane.title,
+      reason: strandedRunReason(),
+      remedy: strandedRunRemedy(),
+      scope: lane.scope,
+    }));
+}
+
+/** Structural why-stranded phrase. A stranded run has no live stage to read, so
+ *  the reason is the orphan fact itself, not a stage label (ZFC). */
+export function strandedRunReason(): string {
+  return 'Never registered with the supervisor; this run never executed.';
+}
+
+/** The single next step the operator takes to resolve the orphan. */
+export function strandedRunRemedy(): string {
+  return 'Clean up the orphaned run or re-dispatch it.';
+}

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -770,13 +770,37 @@ describe('buildRunSummary — orphaned molecules carry a stranded registration (
 
   test('absent from a complete feed observation → registration stranded', () => {
     const summary = buildRunSummary(orphanGroup('gc-odssky'), new Map(), false, observation([]));
-    const lane = summary.lanes.find((l) => l.id === 'gc-odssky');
+    // gascity-dashboard-pxvb: a stranded lane is partitioned out of Active into
+    // its own bucket — it must NOT appear in `lanes` or count as live work.
+    const lane = summary.strandedLanes.find((l) => l.id === 'gc-odssky');
     assert.ok(lane);
     assert.equal(lane.registration, 'stranded');
+    assert.equal(
+      summary.lanes.some((l) => l.id === 'gc-odssky'),
+      false,
+    );
     // The false-alive part of the repro: the orphan must never read as a
     // mid-run stage.
     assert.equal(lane.phase, 'intake');
     assert.notEqual(lane.phaseLabel.toLowerCase(), 'implementation');
+  });
+
+  // gascity-dashboard-pxvb: the orphan never executed, so it must stop counting
+  // as live work in the Active set and surface in its own partition + count.
+  test('stranded lane is excluded from Active and counted separately', () => {
+    const summary = buildRunSummary(
+      [...orphanGroup('gc-odssky'), ...activeRun('run-1')],
+      new Map(),
+      false,
+      observation([]),
+    );
+    assert.equal(summary.totalActive, 1);
+    assert.equal(summary.lanes.length, 1);
+    assert.equal(summary.lanes[0]?.id, 'run-1');
+    assert.equal(summary.strandedLanes.length, 1);
+    assert.equal(summary.strandedLanes[0]?.id, 'gc-odssky');
+    assert.equal(summary.runCounts.stranded, 1);
+    assert.equal(summary.runCounts.total, 1);
   });
 
   test('present in the feed observation → registered', () => {

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -72,10 +72,24 @@ export function buildRunSummary(
   // Header-first restructure: completed lanes are DROPPED here, not carried.
   // They are the lazy history read's payload (buildRunHistory) so the default
   // refresh never pays the closed-history fan-out for them.
-  const activeLanes = sortedLanes.filter(
-    (lane) => lane.phase !== 'complete' && lane.phase !== 'blocked',
+  // gascity-dashboard-pxvb: stranded lanes (orphaned molecules that never
+  // executed) are partitioned out of Active alongside blocked. Stranded is
+  // keyed on `registration`, not `phase` — an orphan's steps are all open, so
+  // it maps to phase 'intake' and would otherwise count as live work. It takes
+  // precedence over the blocked/active phase split so every lane lands in
+  // exactly one partition (a stranded run has all-open steps, so it is never
+  // also blocked — but the explicit precedence keeps the partition disjoint
+  // regardless of how mapRunPhase classifies a degenerate group).
+  const strandedLanes = sortedLanes.filter(
+    (lane) => lane.registration === 'stranded' && lane.phase !== 'complete',
   );
-  const blockedLanes = sortedLanes.filter((lane) => lane.phase === 'blocked');
+  const activeLanes = sortedLanes.filter(
+    (lane) =>
+      lane.phase !== 'complete' && lane.phase !== 'blocked' && lane.registration !== 'stranded',
+  );
+  const blockedLanes = sortedLanes.filter(
+    (lane) => lane.phase === 'blocked' && lane.registration !== 'stranded',
+  );
 
   // gascity-dashboard-s4rp: `lanes` carries the FULL active set, not a capped
   // window. Session-less-latch demotion (enrichRunSummary) is session-aware and
@@ -86,9 +100,15 @@ export function buildRunSummary(
   // mirroring the historical section — so the wire is never pre-capped.
   const summary: RunSummary = {
     totalActive: activeLanes.length,
-    runCounts: runCounts(activeLanes, activeLanes.length, blockedLanes.length),
+    runCounts: runCounts(
+      activeLanes,
+      activeLanes.length,
+      blockedLanes.length,
+      strandedLanes.length,
+    ),
     lanes: activeLanes,
     blockedLanes,
+    strandedLanes,
     recentChanges: recentChanges(laneIssues),
     census: runCensusUnavailable(),
   };
@@ -172,7 +192,12 @@ function isRunGroup(rootId: string, issues: RunIssue[]): boolean {
   );
 }
 
-export function runCounts(lanes: RunLane[], visible: number, blocked: number): RunCounts {
+export function runCounts(
+  lanes: RunLane[],
+  visible: number,
+  blocked: number,
+  stranded: number,
+): RunCounts {
   const counts: RunCounts = {
     total: lanes.length,
     visible,
@@ -180,6 +205,7 @@ export function runCounts(lanes: RunLane[], visible: number, blocked: number): R
     designReview: 0,
     bugfix: 0,
     blocked,
+    stranded,
     other: 0,
   };
 
@@ -499,10 +525,12 @@ export function emptyRunSummary(): RunSummary {
       designReview: 0,
       bugfix: 0,
       blocked: 0,
+      stranded: 0,
       other: 0,
     },
     lanes: [],
     blockedLanes: [],
+    strandedLanes: [],
     recentChanges: [],
     census: runCensusUnavailable(),
   };

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -148,6 +148,24 @@ export interface RunSummary {
    *  blocked lane is an operator-attention item and must not be silently
    *  truncated the way the active 8-cap window trims calm lanes. */
   blockedLanes: RunLane[];
+  /** Stranded (`registration === 'stranded'`) lanes, sorted by compareLanes
+   *  (gascity-dashboard-pxvb). An orphaned molecule that never executed and
+   *  never will — partitioned out of the Active set alongside `blockedLanes`
+   *  so it stops reading as live work in `totalActive`/`census.totalInFlight`,
+   *  but stays on the page (and in the attention surface) as the state most
+   *  needing an operator action (clean up / re-dispatch). `runCounts.stranded`
+   *  counts this array. Deliberately uncapped, mirroring `blockedLanes`: every
+   *  stranded lane is an operator-attention item and must not be truncated by
+   *  the active 8-cap window.
+   *
+   *  Visibility precedence vs the 24h stale latch (isStaleSessionlessLatch): a
+   *  stranded lane is sessionless with no in_progress step, so once its last
+   *  write ages past STALE_LATCH_AFTER_MS the latch demotes it out of this set
+   *  exactly like any other abandoned lane — a day-old orphan leaves the board
+   *  rather than accumulating forever (see isStrandedRun in runs/liveness.ts).
+   *  That demotion happens at enrichment (frontend), where session facts and
+   *  the snapshot generation time are available. */
+  strandedLanes: RunLane[];
   recentChanges: RunChange[];
   /**
    * City-level health census (gascity-dashboard-3ax). Threshold-INDEPENDENT
@@ -307,6 +325,12 @@ export interface RunCounts {
    *  phase 'blocked' (mapRunPhase checks members first), so this is the
    *  complete blocked count, not a subset. */
   blocked: number;
+  /** Count of stranded lanes (`registration === 'stranded'`, i.e.
+   *  `strandedLanes.length`). gascity-dashboard-pxvb: disjoint from `total`
+   *  and `blocked` — a stranded run (orphaned molecule that never executed) is
+   *  partitioned out of the Active set alongside blocked, so it is never
+   *  double-counted as live work. */
+  stranded: number;
   other: number;
 }
 


### PR DESCRIPTION
## What

Folds stranded lanes into the census/attention partitioning so a stranded run is its own disjoint bucket (not mis-counted as active/blocked). Adds `shared/src/runs/stranded.ts` (`StrandedRun` + `selectStrandedRuns`), `RunSummary.strandedLanes` / `RunCounts.stranded`, and renders stranded lanes with a static reason + remedy in `LaneCard`/`RunMap`/`FormulaRunDetail`.

## Partitioning (disjoint by construction, both wire + enrichment layers)

- stranded: `registration === 'stranded' && phase !== 'complete'` (registration takes precedence over phase)
- blocked: `phase === 'blocked' && registration !== 'stranded'`
- active: `phase !== 'blocked' && phase !== 'complete' && registration !== 'stranded'`

Census excludes stranded from `byPhase`/`totalInFlight`.

## Review + checks

- Reviewers: code **APPROVE**, typescript **APPROVE**, security **APPROVE** (0 findings), Codex inconclusive → 3-Claude-agent mode. 0 blockers, 0 majors. Partitioning correctness independently confirmed disjoint.
- CI-parity (local, 8/8 green): build, typecheck (src+test), lint, prettier, openapi drift, shared/backend/frontend tests. 1337 tests pass.
- Wire-shape SSOT: new type defined once in `shared/`, all `*.test` fixtures updated (`typecheck:test` green).

## Follow-ups (non-blocking minors, tracked separately)

- `selectStrandedRuns` redundant defensive re-filter on an already-stranded array.
- `enrichRunSummary` `activeEnriched` could add the `phase !== 'complete'` guard for local robustness (safe today — input pre-filtered).
- `registry.test.ts` fixture `byPhase` counts stranded (production excludes); no current assertion depends on it.
