### PR TITLE
fix(runs): render definitive stranded explanation on the run-detail 404

### DIFF
--- a/frontend/src/components/run/LaneCard.tsx
+++ b/frontend/src/components/run/LaneCard.tsx
@@ -5,6 +5,7 @@ import { attentionListItemProps } from '../../attention/routeHighlight';
 import { formatRelative } from '../../hooks/time';
 import { runDetailHref } from '../../supervisor/runHref';
 import { StageLadder } from './StageLadder';
+import { STRANDED_EXPLANATION, STRANDED_GLYPH, STRANDED_WORD } from './strandedRun';
 
 // Per-lane typographic row. No card chrome — vertical rhythm carries the
 // hierarchy, hairline dividers separate lanes at the RunMap level.
@@ -79,7 +80,7 @@ export function LaneCard({
         <span className={`text-label uppercase tracking-wider ${phaseLabelTone(lane.phase)}`}>
           {isStranded ? (
             <>
-              <span aria-hidden="true">(!)</span> stranded
+              <span aria-hidden="true">{STRANDED_GLYPH}</span> {STRANDED_WORD}
             </>
           ) : (
             lane.phaseLabel
@@ -122,10 +123,7 @@ export function LaneCard({
       )}
 
       {isStranded ? (
-        <p className="mt-2 text-body text-fg-muted leading-snug">
-          Dispatched but never registered with the supervisor, likely a supervisor restart or crash
-          at dispatch time. This run never executed.
-        </p>
+        <p className="mt-2 text-body text-fg-muted leading-snug">{STRANDED_EXPLANATION}</p>
       ) : (
         <StageLadder stages={lane.stages} label={lane.title} />
       )}

--- a/frontend/src/components/run/strandedRun.tsx
+++ b/frontend/src/components/run/strandedRun.tsx
@@ -13,7 +13,7 @@ export const STRANDED_EXPLANATION =
 export function StrandedRunNotice() {
   return (
     <p className="text-body text-fg-muted leading-snug" role="status">
-      <span aria-hidden="true">{STRANDED_GLYPH}</span> {STRANDED_WORD} — {STRANDED_EXPLANATION}
+      <span aria-hidden="true">{STRANDED_GLYPH}</span> {STRANDED_WORD}: {STRANDED_EXPLANATION}
     </p>
   );
 }

--- a/frontend/src/components/run/strandedRun.tsx
+++ b/frontend/src/components/run/strandedRun.tsx
@@ -1,0 +1,19 @@
+// Single source for the "stranded run" copy shared by LaneCard, the run-detail
+// skeleton, and the run-detail 404 branch, so the wording never drifts between
+// them. Per DESIGN.md the state reads as glyph + word in greyscale — never color.
+
+export const STRANDED_GLYPH = '(!)';
+export const STRANDED_WORD = 'stranded';
+export const STRANDED_EXPLANATION =
+  'Dispatched but never registered with the supervisor, likely a supervisor restart or crash at dispatch time. This run never executed.';
+
+// Run-detail notice: glyph + word + explanation in one status paragraph, used by
+// the skeleton and the 404 branch. LaneCard composes the constants into its own
+// layout instead, so it reads them directly rather than through this component.
+export function StrandedRunNotice() {
+  return (
+    <p className="text-body text-fg-muted leading-snug" role="status">
+      <span aria-hidden="true">{STRANDED_GLYPH}</span> {STRANDED_WORD} — {STRANDED_EXPLANATION}
+    </p>
+  );
+}

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -752,6 +752,60 @@ describe('FormulaRunDetailPage', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
+  it('renders the DEFINITIVE stranded explanation on a 404 when the warm lane proves the run is stranded (gascity-dashboard-s36w)', async () => {
+    // The page already resolved this run's lane from the warm run-summary, and
+    // that lane carries the authoritative registration fact. A 404 from the
+    // detail endpoint is then NOT ambiguous: the speculative list (v1/wisp,
+    // unretained snapshot, ...) over-claims uncertainty the page does not have.
+    // Render the same definitive stranded copy LaneCard uses instead.
+    //
+    // gascity-dashboard-1ka9: a stranded lane lives in the `strandedLanes`
+    // bucket (pxvb partitions it out of `lanes`). The notFound branch can only
+    // resolve it because the skeleton lookup searches all three buckets — this
+    // test exercises that exact coupling, so s36w cannot ship without pxvb.
+    const source = runSummarySourceWithActiveLane();
+    if (source.status === 'error') throw new Error(source.error);
+    source.data.strandedLanes = source.data.lanes.map((lane) => ({
+      ...lane,
+      registration: 'stranded' as const,
+    }));
+    source.data.lanes = [];
+    source.data.totalActive = 0;
+    setCached('runs:summary:test-city', source);
+    loadSupervisorFormulaRunDetail.mockImplementation(async () => {
+      throw new SupervisorApiError(404, 'workflow gc-adopt-pr-active not found', undefined);
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/never registered with the supervisor/i)).toBeTruthy();
+    // The speculative list is suppressed — the registration fact is definitive.
+    expect(screen.queryByText(/may be a v1\/wisp run/i)).toBeNull();
+    expect(screen.queryByText(/snapshot was not found/i)).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('keeps the speculative not-found list when the warm lane is registered, not stranded (gascity-dashboard-s36w)', async () => {
+    // A 404 on a lane the supervisor DID register is genuinely ambiguous
+    // (unretained snapshot, pruned run, stale derived scope). Keep the
+    // speculative list — do not assert it is stranded.
+    const source = runSummarySourceWithActiveLane();
+    if (source.status === 'error') throw new Error(source.error);
+    source.data.lanes = source.data.lanes.map((lane) => ({
+      ...lane,
+      registration: 'registered' as const,
+    }));
+    setCached('runs:summary:test-city', source);
+    loadSupervisorFormulaRunDetail.mockImplementation(async () => {
+      throw new SupervisorApiError(404, 'workflow gc-adopt-pr-active not found', undefined);
+    });
+
+    renderPage();
+
+    await screen.findByText(/this run’s detail snapshot was not found/i);
+    expect(screen.getByText(/may be a v1\/wisp run/i)).toBeTruthy();
+  });
+
   it('still shows the generic failure for a malformed graph.v2 snapshot (invalid_snapshot)', async () => {
     // A genuine load failure (malformed graph.v2 snapshot, or any other
     // UnsupportedRunError reason) must NOT be mistaken for a v1 list-only run.

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -17,6 +17,7 @@ import { BeadDetailModal } from '../components/BeadDetailModal';
 import { FormulaRunDiagram } from '../components/run/FormulaRunDiagram';
 import { FormulaRunTabs } from '../components/run/FormulaRunTabs';
 import { StageLadder } from '../components/run/StageLadder';
+import { StrandedRunNotice } from '../components/run/strandedRun';
 import { useNow } from '../contexts/NowContext';
 import { useGcEventRefresh } from '../hooks/useGcEvents';
 import { runEventIdentity, formulaRunDetailEventMatches } from '../hooks/runEventIdentity';
@@ -205,11 +206,7 @@ export function FormulaRunDetailPage() {
             {/* A stranded lane must not flash a live stage ladder while the
                 detail loads — mirror the LaneCard stranded treatment. */}
             {skeletonLane.registration === 'stranded' ? (
-              <p className="text-body text-fg-muted leading-snug" role="status">
-                <span aria-hidden="true">(!)</span> stranded: dispatched but never registered with
-                the supervisor, likely a supervisor restart or crash at dispatch time. This run
-                never executed.
-              </p>
+              <StrandedRunNotice />
             ) : (
               <StageLadder stages={skeletonLane.stages} label={skeletonLane.title} />
             )}
@@ -224,12 +221,18 @@ export function FormulaRunDetailPage() {
           appears in the run list only.
         </p>
       ) : notFound ? (
-        <p className="text-body text-fg-muted" role="status">
-          This run&rsquo;s detail snapshot was not found. It may be a v1/wisp run, a completed run
-          whose snapshot wasn&rsquo;t retained, no longer available, or a run that was dispatched
-          but never registered with the supervisor (a supervisor restart or crash at dispatch time
-          strands a run before it executes).
-        </p>
+        // A warm lane that proves the run stranded makes the 404 unambiguous:
+        // show the definitive explanation, not the speculative list (s36w).
+        skeletonLane?.registration === 'stranded' ? (
+          <StrandedRunNotice />
+        ) : (
+          <p className="text-body text-fg-muted" role="status">
+            This run&rsquo;s detail snapshot was not found. It may be a v1/wisp run, a completed run
+            whose snapshot wasn&rsquo;t retained, no longer available, or a run that was dispatched
+            but never registered with the supervisor (a supervisor restart or crash at dispatch time
+            strands a run before it executes).
+          </p>
+        )
       ) : pageError && !detail ? (
         <p className="text-body text-accent" role="alert">
           {pageError}


### PR DESCRIPTION
## What

Renders a definitive "stranded" explanation on the run-detail page when it 404s because the run was stranded (dispatched but never registered with the supervisor) — replacing the speculative "maybe still loading" list with a clear, final statement. Adds `strandedRun.tsx` (shared status constants + `StrandedRunNotice`), wired into `FormulaRunDetail.tsx` and `LaneCard.tsx`. Stacked on #131 (stranded partitioning); rebased onto main after it merged.

## Behavior

- 404 + warm-cache hit with `registration === 'stranded'` → definitive stranded notice.
- 404 + cache miss / non-stranded → existing speculative list (unchanged). No genuine-missing run shows the stranded copy.

## Review + checks

- Reviewers: code **APPROVE** (1 blocker found+fixed — see below), typescript **APPROVE**, security **APPROVE** (0 findings). Control flow, cold-load fallback, type-safety, and 404-path correctness all confirmed.
- **Blocker fixed in-pipeline (`fca4c7b`):** em-dash → colon in the stranded notice copy, per `DESIGN.md` §6 (no em-dashes in UI copy). DESIGN.md visual contract otherwise clean (glyph + word, Greyscale Test, One Mark Rule — no maroon in the notice).
- CI-parity (local, 8/8 green): build, typecheck (src+test), lint, prettier, openapi, shared/backend/frontend tests; re-verified after the fix.

## Follow-up (non-blocking)

- Copy drift: `strandedRun.tsx` `STRANDED_EXPLANATION` vs shared `strandedRunReason()` encode the same fact in two strings (deliberate, but unguarded). Tracked.
