### PR TITLE
feat(convoy): convoy page with client-side step-graph projection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ const AmbientHomePage = lazy(() =>
   import('./routes/AmbientHome').then((m) => ({ default: m.AmbientHomePage })),
 );
 const BeadsPage = lazy(() => import('./routes/Beads').then((m) => ({ default: m.BeadsPage })));
+const ConvoyPage = lazy(() => import('./routes/Convoy').then((m) => ({ default: m.ConvoyPage })));
 const MailPage = lazy(() => import('./routes/Mail').then((m) => ({ default: m.MailPage })));
 const FormulaRunDetailPage = lazy(() =>
   import('./routes/FormulaRunDetail').then((m) => ({ default: m.FormulaRunDetailPage })),
@@ -101,6 +102,7 @@ export function App() {
                       <Route path="/agents" element={<AgentsPage />} />
                       <Route path="/agents/:slug" element={<AgentDetailPage />} />
                       <Route path="/beads" element={<BeadsPage />} />
+                      <Route path="/convoy/:rootBead" element={<ConvoyPage />} />
                       <Route path="/runs" element={<RunsPage />} />
                       <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
                       <Route path="/mail" element={<MailPage />} />

--- a/frontend/src/hooks/useConvoyView.ts
+++ b/frontend/src/hooks/useConvoyView.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { formatApiError } from '../api/client';
+import { SupervisorApiError } from '../supervisor/client';
+import { loadConvoyView, type ConvoyLoad } from '../supervisor/convoyReads';
+
+// Fetch the convoy view for a root bead (gascity-dashboard-caag, Shape A).
+//
+// Convoy structure changes slowly relative to a session's lifetime, so this is
+// static-with-explicit-refresh — it loads on rootBeadId change and exposes a
+// `refresh` for the page's Refresh control, matching useEntityLinks rather than
+// wiring an SSE auto-refresh. A genuinely missing root surfaces as a distinct
+// `not_found` state (not a generic failure) so the page renders an honest
+// "no such convoy" message instead of an opaque error.
+
+export type ConvoyViewState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; load: ConvoyLoad; refreshing: boolean }
+  | { kind: 'not_found' }
+  | { kind: 'failed'; error: string };
+
+export interface UseConvoyView {
+  state: ConvoyViewState;
+  refresh: () => Promise<void>;
+}
+
+export function useConvoyView(rootBeadId: string | null): UseConvoyView {
+  const [state, setState] = useState<ConvoyViewState>({ kind: 'idle' });
+  // Latest mounted root, so a manual refresh that resolves after the route
+  // param changed (or the page unmounted) discards its stale result instead of
+  // clobbering the new convoy's state.
+  const liveRootRef = useRef<string | null>(rootBeadId);
+  liveRootRef.current = rootBeadId;
+
+  const load = useCallback(
+    async (id: string, mode: 'initial' | 'refresh', isCurrent: () => boolean): Promise<void> => {
+      setState((prev) =>
+        mode === 'refresh' && prev.kind === 'ready'
+          ? { ...prev, refreshing: true }
+          : { kind: 'loading' },
+      );
+      try {
+        const result = await loadConvoyView(id);
+        if (isCurrent()) setState({ kind: 'ready', load: result, refreshing: false });
+      } catch (err) {
+        if (!isCurrent()) return;
+        if (err instanceof SupervisorApiError && err.status === 404) {
+          setState({ kind: 'not_found' });
+          return;
+        }
+        setState({ kind: 'failed', error: formatApiError(err, 'convoy load failed') });
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (rootBeadId === null || rootBeadId.length === 0) {
+      setState({ kind: 'idle' });
+      return;
+    }
+    let cancelled = false;
+    void load(rootBeadId, 'initial', () => !cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [rootBeadId, load]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (rootBeadId === null || rootBeadId.length === 0) return;
+    await load(rootBeadId, 'refresh', () => liveRootRef.current === rootBeadId);
+  }, [rootBeadId, load]);
+
+  return { state, refresh };
+}

--- a/frontend/src/routes/Convoy.test.tsx
+++ b/frontend/src/routes/Convoy.test.tsx
@@ -1,0 +1,168 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardBead } from 'gas-city-dashboard-shared';
+import { projectConvoyView } from 'gas-city-dashboard-shared';
+import { NowProvider } from '../contexts/NowContext';
+import type { ConvoyLoad } from '../supervisor/convoyReads';
+import { ConvoyPage } from './Convoy';
+import { SupervisorApiError } from '../supervisor/client';
+
+const mockLoadConvoyView = vi.hoisted(() => vi.fn());
+
+vi.mock('../supervisor/convoyReads', () => ({
+  loadConvoyView: mockLoadConvoyView,
+}));
+
+vi.mock('../hooks/useEntityLinks', () => ({
+  useEntityLinks: () => ({ view: null, loading: false, error: null }),
+}));
+
+// Isolate the convoy page from the related-entity index and bead modal — both
+// are exercised by their own suites; here we assert the convoy composition.
+vi.mock('../components/RelatedEntities', () => ({ RelatedEntities: () => null }));
+vi.mock('../components/BeadDetailModal', () => ({ BeadDetailModal: () => null }));
+
+vi.mock('../api/client', () => ({
+  formatApiError: (err: unknown, fallback = 'request failed') =>
+    err instanceof Error ? err.message : fallback,
+}));
+
+vi.mock('../supervisor/client', () => ({
+  SupervisorApiError: class extends Error {
+    constructor(
+      public readonly status: number | undefined,
+      message: string,
+      public readonly requestId?: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+function bead(id: string, overrides: Partial<DashboardBead> = {}): DashboardBead {
+  return {
+    id,
+    title: `bead ${id}`,
+    status: 'open',
+    issue_type: 'task',
+    priority: null,
+    created_at: '2026-06-12T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function loadFixture(
+  root: DashboardBead,
+  children: readonly DashboardBead[],
+  partial = false,
+): ConvoyLoad {
+  return {
+    view: projectConvoyView(root, children, null),
+    partial,
+    fetchedAt: '2026-06-12T00:00:00Z',
+  };
+}
+
+function renderConvoy(rootBeadId = 'root') {
+  return render(
+    <NowProvider>
+      <MemoryRouter
+        initialEntries={[`/convoy/${rootBeadId}`]}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <Routes>
+          <Route path="/convoy/:rootBead" element={<ConvoyPage />} />
+        </Routes>
+      </MemoryRouter>
+    </NowProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ConvoyPage', () => {
+  it('shows a loading state before the convoy resolves', () => {
+    mockLoadConvoyView.mockReturnValue(new Promise(() => {}));
+    renderConvoy();
+    expect(screen.getByText('Loading convoy.')).toBeTruthy();
+  });
+
+  it('renders the step timeline with glyph+word status and the waiting-on set', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula': 'mol-pr-start' },
+    });
+    const children = [
+      bead('a', { title: 'plan', status: 'closed', created_at: '2026-06-12T00:00:01Z' }),
+      bead('b', {
+        title: 'execute',
+        status: 'open',
+        needs: ['a', 'c'],
+        created_at: '2026-06-12T00:00:02Z',
+      }),
+      bead('c', { title: 'review', status: 'in_progress', created_at: '2026-06-12T00:00:03Z' }),
+    ];
+    mockLoadConvoyView.mockResolvedValue(loadFixture(root, children));
+
+    renderConvoy();
+
+    expect(await screen.findByText('plan')).toBeTruthy();
+    expect(screen.getByText('execute')).toBeTruthy();
+    expect(screen.getByText('review')).toBeTruthy();
+    expect(screen.getByText('closed')).toBeTruthy();
+    // 'b' needs 'a' (closed → not blocking) and 'c' (in_progress → blocking).
+    expect(screen.getByText('waiting on c')).toBeTruthy();
+    // Formula name surfaces from metadata (page title + formula meta cell).
+    expect(screen.getAllByText('mol-pr-start').length).toBeGreaterThan(0);
+    expect(screen.getByText('1 of 3 steps closed.', { exact: false })).toBeTruthy();
+  });
+
+  it('degrades honestly when the supervisor collapses a graph.v2 run to its root', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      title: 'mol-focus-review',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+    });
+    mockLoadConvoyView.mockResolvedValue(loadFixture(root, []));
+
+    renderConvoy();
+
+    expect(await screen.findByText(/does not expose this run/i)).toBeTruthy();
+    expect(screen.getByText(/gascity-dashboard-jl3c/)).toBeTruthy();
+  });
+
+  it('warns when the formula name is a title fallback, not canonical metadata', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      title: 'mol-focus-review',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+    });
+    mockLoadConvoyView.mockResolvedValue(loadFixture(root, [bead('a', { parent: 'root' })]));
+
+    renderConvoy();
+
+    expect(await screen.findByText('inferred from bead title')).toBeTruthy();
+  });
+
+  it('renders an honest not-found state for a missing root bead', async () => {
+    mockLoadConvoyView.mockRejectedValue(new SupervisorApiError(404, 'not found', undefined));
+    renderConvoy('ghost');
+
+    expect(await screen.findByText(/No bead with id/i)).toBeTruthy();
+    expect(screen.getByText('ghost')).toBeTruthy();
+  });
+
+  it('surfaces a generic load failure as an alert', async () => {
+    mockLoadConvoyView.mockRejectedValue(new Error('city offline'));
+    renderConvoy();
+
+    expect(await screen.findByText('city offline')).toBeTruthy();
+  });
+});

--- a/frontend/src/routes/Convoy.test.tsx
+++ b/frontend/src/routes/Convoy.test.tsx
@@ -60,7 +60,6 @@ function loadFixture(
   return {
     view: projectConvoyView(root, children, null),
     partial,
-    fetchedAt: '2026-06-12T00:00:00Z',
   };
 }
 
@@ -149,6 +148,34 @@ describe('ConvoyPage', () => {
     renderConvoy();
 
     expect(await screen.findByText('inferred from bead title')).toBeTruthy();
+  });
+
+  it('shows the partial-convoy notice when the bounded city read was truncated', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula': 'mol-pr-start' },
+    });
+    const children = [bead('a', { title: 'plan', status: 'closed', parent: 'root' })];
+    mockLoadConvoyView.mockResolvedValue(loadFixture(root, children, true));
+
+    renderConvoy();
+
+    // Steps still render; the notice warns coverage may be incomplete rather
+    // than implying the truncated read is the whole graph.
+    expect(await screen.findByText('plan')).toBeTruthy();
+    expect(screen.getByText(/Partial convoy: the city bead read was truncated/i)).toBeTruthy();
+  });
+
+  it('omits the partial notice when the read was complete', async () => {
+    const root = bead('root', { metadata: { 'gc.formula': 'mol-pr-start' } });
+    mockLoadConvoyView.mockResolvedValue(
+      loadFixture(root, [bead('a', { title: 'plan', parent: 'root' })], false),
+    );
+
+    renderConvoy();
+
+    expect(await screen.findByText('plan')).toBeTruthy();
+    expect(screen.queryByText(/Partial convoy/i)).toBeNull();
   });
 
   it('renders an honest not-found state for a missing root bead', async () => {

--- a/frontend/src/routes/Convoy.tsx
+++ b/frontend/src/routes/Convoy.tsx
@@ -127,7 +127,7 @@ function Meta({ label, value }: { label: string; value: string }) {
 }
 
 const TITLE_FALLBACK_TOOLTIP =
-  'name inferred from bead title — supervisor did not set gc.formula on this graph.v2 root';
+  'name inferred from bead title; supervisor did not set gc.formula on this graph.v2 root';
 
 /**
  * Formula identity cell with provenance. Mirrors FormulaRunDetail's FormulaMeta

--- a/frontend/src/routes/Convoy.tsx
+++ b/frontend/src/routes/Convoy.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type {
+  ConvoyStep,
+  ConvoyStepExposure,
+  ConvoyView,
+  BeadStatus,
+} from 'gas-city-dashboard-shared';
+import { Button } from '../components/Button';
+import { PageHeader } from '../components/PageHeader';
+import { PartialDataNotice } from '../components/PartialDataNotice';
+import { RelatedEntities } from '../components/RelatedEntities';
+import { BeadDetailModal } from '../components/BeadDetailModal';
+import { useNow } from '../contexts/NowContext';
+import { useConvoyView } from '../hooks/useConvoyView';
+import { useEntityLinks } from '../hooks/useEntityLinks';
+
+// The convoy page (gascity-dashboard-caag, Shape A): one route keyed by the
+// root bead that gives the operator the single end-to-end picture of a unit of
+// work — formula identity, step timeline, progress, live session, and the
+// existing related-entity index — by COMPOSING supervisor reads and reusing the
+// run-detail furniture. When the supervisor cannot expose the step DAG
+// (graph.v2 collapses run snapshots to the root) the page says so in words
+// rather than fabricating a timeline.
+
+export function ConvoyPage() {
+  const { rootBead } = useParams<{ rootBead: string }>();
+  const rootBeadId = rootBead ?? null;
+  const { state, refresh } = useConvoyView(rootBeadId);
+  const links = useEntityLinks(rootBeadId);
+  const [viewingBeadId, setViewingBeadId] = useState<string | null>(null);
+  const now = useNow();
+
+  const ready = state.kind === 'ready' ? state : null;
+  const view = ready?.load.view ?? null;
+  const refreshing = ready?.refreshing ?? false;
+  const loading = state.kind === 'loading';
+
+  return (
+    <section>
+      <PageHeader
+        title={view ? (view.formulaName ?? 'Convoy') : 'Convoy'}
+        synopsis={view ? convoySynopsis(view) : undefined}
+        meta={
+          <>
+            <Link
+              to="/runs"
+              className="focus-mark text-label uppercase tracking-wider text-fg-muted hover:text-fg"
+            >
+              Runs
+            </Link>
+            <Button size="sm" onClick={() => void refresh()} disabled={loading || refreshing}>
+              {refreshing ? 'Refreshing' : 'Refresh'}
+            </Button>
+          </>
+        }
+      />
+
+      {loading ? (
+        <p className="text-body text-fg-muted italic">Loading convoy.</p>
+      ) : state.kind === 'not_found' ? (
+        <p className="text-body text-fg-muted" role="status">
+          No bead with id <span className="tnum">{rootBeadId}</span> was found. The convoy may have
+          been pruned, or the id is wrong.
+        </p>
+      ) : state.kind === 'failed' ? (
+        <p className="text-body text-accent" role="alert">
+          {state.error}
+        </p>
+      ) : ready && view ? (
+        <>
+          {ready.load.partial && (
+            <PartialDataNotice
+              glyph="◐"
+              label="Partial convoy: the city bead read was truncated, so some steps may be missing."
+              title="Raise the fetch window if steps sit past the bounded read."
+            />
+          )}
+          <ConvoyMetadata view={view} />
+          <ConvoyTimeline exposure={view.exposure} />
+          <RelatedEntities
+            view={links.view}
+            loading={links.loading}
+            error={links.error}
+            now={now}
+            onOpenBead={setViewingBeadId}
+          />
+          <BeadDetailModal
+            open={viewingBeadId !== null}
+            onClose={() => setViewingBeadId(null)}
+            beadId={viewingBeadId}
+            onOpenBead={setViewingBeadId}
+          />
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function convoySynopsis(view: ConvoyView): string {
+  const progress = view.progress;
+  const progressPart =
+    progress === null
+      ? 'No step progress available'
+      : `${progress.closed} of ${progress.total} steps closed`;
+  return `${view.root.title}. ${progressPart}.`;
+}
+
+function ConvoyMetadata({ view }: { view: ConvoyView }) {
+  return (
+    <dl className="grid gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+      <FormulaMeta view={view} />
+      <Meta label="Root" value={view.rootBeadId} />
+      <Meta label="Status" value={view.root.status} />
+      <Meta label="Session" value={view.sessionName ?? 'not live'} />
+    </dl>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-label uppercase tracking-wider text-fg-faint">{label}</dt>
+      <dd className="text-body text-fg break-all tnum">{value}</dd>
+    </div>
+  );
+}
+
+const TITLE_FALLBACK_TOOLTIP =
+  'name inferred from bead title — supervisor did not set gc.formula on this graph.v2 root';
+
+/**
+ * Formula identity cell with provenance. Mirrors FormulaRunDetail's FormulaMeta
+ * (gascity-dashboard-e7hj): a title-fallback name is surfaced in a warn tone
+ * with a textual correlate per DESIGN.md "states have words", never passed off
+ * as canonical metadata.
+ */
+function FormulaMeta({ view }: { view: ConvoyView }) {
+  if (view.formulaName === null) {
+    return <Meta label="Formula" value="metadata missing" />;
+  }
+  if (view.formulaNameProvenance === 'title_fallback') {
+    return (
+      <div>
+        <dt className="text-label uppercase tracking-wider text-fg-faint">Formula</dt>
+        <dd
+          className="text-body text-warn break-all tnum"
+          title={TITLE_FALLBACK_TOOLTIP}
+          aria-label={`${view.formulaName} (${TITLE_FALLBACK_TOOLTIP})`}
+        >
+          {view.formulaName}
+          <span className="ml-2 text-label uppercase tracking-wider text-warn">
+            inferred from bead title
+          </span>
+        </dd>
+      </div>
+    );
+  }
+  return <Meta label="Formula" value={view.formulaName} />;
+}
+
+function ConvoyTimeline({ exposure }: { exposure: ConvoyStepExposure }) {
+  if (exposure.kind === 'collapsed') {
+    return (
+      <p className="text-body text-fg-muted" role="status">
+        {exposure.reason === 'graph_v2_root_only'
+          ? 'The supervisor does not expose this run’s step graph (graph.v2 collapses run snapshots to the root bead), so the step timeline is unavailable. Tracked by gascity-dashboard-jl3c.'
+          : 'No steps sit below this bead.'}
+      </p>
+    );
+  }
+  return (
+    <ol className="space-y-3">
+      {exposure.steps.map((step) => (
+        <StepRow key={step.bead.id} step={step} />
+      ))}
+    </ol>
+  );
+}
+
+function StepRow({ step }: { step: ConvoyStep }) {
+  const status = describeStatus(step.bead.status);
+  return (
+    <li className="border-b border-rule pb-3 last:border-b-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <Link
+          to={`/convoy/${encodeURIComponent(step.bead.id)}`}
+          className="focus-mark text-body text-fg hover:text-accent leading-snug min-w-0 break-words"
+        >
+          {step.bead.title}
+        </Link>
+        <span className="text-label uppercase tracking-wider text-fg-muted shrink-0">
+          <span aria-hidden="true">{status.glyph}</span> {status.word}
+        </span>
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-4 text-label uppercase tracking-wider text-fg-faint">
+        <span className="tnum">{step.bead.id}</span>
+        {step.stepRef !== null && <span>step {step.stepRef}</span>}
+        {step.blockedBy.length > 0 && <span>waiting on {step.blockedBy.join(', ')}</span>}
+      </div>
+    </li>
+  );
+}
+
+interface StatusDisplay {
+  glyph: string;
+  word: string;
+}
+
+// Bead-status glyph + word, kept greyscale-neutral so the timeline honors the
+// One Mark Rule: a list of many steps must not paint several maroons. Status is
+// carried by the glyph and word, not tone (DESIGN.md "states have words").
+function describeStatus(status: BeadStatus): StatusDisplay {
+  switch (status) {
+    case 'closed':
+      return { glyph: '✓', word: 'closed' };
+    case 'in_progress':
+      return { glyph: '●', word: 'in progress' };
+    case 'blocked':
+      return { glyph: '!', word: 'blocked' };
+    case 'deferred':
+      return { glyph: '∅', word: 'deferred' };
+    case 'open':
+      return { glyph: '·', word: 'open' };
+    default:
+      return { glyph: '·', word: status };
+  }
+}

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -265,6 +265,16 @@ describe('FormulaRunDetailPage', () => {
     ]);
   });
 
+  it('links the run Root bead to its /convoy/:rootBead page', async () => {
+    // gascity-dashboard-caag: the run root is also the convoy key, so the Root
+    // meta cell steps up from this single run to the end-to-end convoy page.
+    renderPage();
+    await screen.findByRole('heading', { name: /adopt pr #42/i });
+
+    const rootLink = screen.getByRole('link', { name: detail.rootBeadId });
+    expect(rootLink.getAttribute('href')).toBe(`/convoy/${encodeURIComponent(detail.rootBeadId)}`);
+  });
+
   it('starts with no selected node and toggles exactly one selected node', async () => {
     renderPage();
     await screen.findByRole('heading', { name: /adopt pr #42/i });

--- a/frontend/src/routes/FormulaRunDetail.tsx
+++ b/frontend/src/routes/FormulaRunDetail.tsx
@@ -300,7 +300,7 @@ function RunMetadata({ detail }: { detail: FormulaRunDetailData }) {
     <dl className="grid gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-4">
       <FormulaMeta formula={detail.formula} />
       {formulaDetail !== null && <Meta label="Formula Detail" value={formulaDetail} />}
-      <Meta label="Root" value={detail.rootBeadId} />
+      <RootMeta rootBeadId={detail.rootBeadId} />
       <Meta label="Scope" value={`${detail.scopeKind}:${detail.scopeRef}`} />
       <Meta label="Store" value={detail.resolvedRootStore || detail.rootStoreRef || 'unknown'} />
     </dl>
@@ -312,6 +312,25 @@ function Meta({ label, value }: { label: string; value: string }) {
     <div>
       <dt className="text-label uppercase tracking-wider text-fg-faint">{label}</dt>
       <dd className="text-body text-fg break-all tnum">{value}</dd>
+    </div>
+  );
+}
+
+// The run's root bead is also the convoy key (gascity-dashboard-caag): link it
+// to the /convoy/:rootBead page so the operator can step up from this single
+// run to the end-to-end picture of the work it belongs to.
+function RootMeta({ rootBeadId }: { rootBeadId: string }) {
+  return (
+    <div>
+      <dt className="text-label uppercase tracking-wider text-fg-faint">Root</dt>
+      <dd className="text-body break-all tnum">
+        <Link
+          to={`/convoy/${encodeURIComponent(rootBeadId)}`}
+          className="focus-mark text-fg hover:text-accent"
+        >
+          {rootBeadId}
+        </Link>
+      </dd>
     </div>
   );
 }

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -8,7 +8,11 @@ import {
   SupervisorApiError,
   type SupervisorApi,
 } from './client';
-import { fetchSupervisorBead, listSupervisorBeads } from './beadReads';
+import {
+  fetchSupervisorBead,
+  listSupervisorBeads,
+  listSupervisorBeadsAssignedTo,
+} from './beadReads';
 
 const baseApi: SupervisorApi = {
   baseUrl: '/gc-supervisor',
@@ -178,6 +182,33 @@ describe('supervisor bead reads', () => {
 
     await expect(fetchSupervisorBead('rc-decision')).rejects.toMatchObject({ status: 503 });
     expect(listBeads).not.toHaveBeenCalled();
+  });
+
+  it('does not flag the assigned-bead union partial when assignees merely share a bead', async () => {
+    // Each leg is complete (total === its own page) but both legs return the
+    // same bead. The union dedups to one item; a summed-total-vs-deduped-count
+    // check would false-trip partial. Per-leg incompleteness must not.
+    const shared = bead({ id: 'td-shared' });
+    const listBeads = vi.fn(async () => ({ items: [shared], total: 1 }));
+    setSupervisorApiForTests({ ...baseApi, listBeads });
+
+    const result = await listSupervisorBeadsAssignedTo(['a', 'b']);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.partial).toBe(false);
+  });
+
+  it('flags the assigned-bead union partial when any single leg was truncated', async () => {
+    const listBeads = vi.fn(async (_city: string, query?: { assignee?: string }) =>
+      query?.assignee === 'a'
+        ? { items: [bead({ id: 'td-a' })], total: 9 }
+        : { items: [bead({ id: 'td-b' })], total: 1 },
+    );
+    setSupervisorApiForTests({ ...baseApi, listBeads });
+
+    const result = await listSupervisorBeadsAssignedTo(['a', 'b']);
+
+    expect(result.partial).toBe(true);
   });
 });
 

--- a/frontend/src/supervisor/beadReads.ts
+++ b/frontend/src/supervisor/beadReads.ts
@@ -6,6 +6,7 @@ import type {
 import { isResolvedStatus } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
 import { SupervisorApiError, supervisorApi } from './client';
+import { listIsIncomplete } from './listPartial';
 
 export type SupervisorBead = Bead;
 
@@ -15,6 +16,13 @@ export interface SupervisorBeadList extends Omit<ListBodyBead, 'items' | 'total'
   upstream_total?: number;
   upstream_fetched: number;
   fetch_limit: number;
+  /**
+   * The bounded read did not return the full result set — the supervisor
+   * flagged it partial, reported a `next_cursor`, or its total outran the page.
+   * Derived once here via the shared `listIsIncomplete` predicate so every
+   * caller sees cursor-based truncation, not just the total-vs-fetched case.
+   */
+  partial: boolean;
 }
 
 export interface ListSupervisorBeadsOptions {
@@ -71,6 +79,7 @@ export async function listSupervisorBeads(
     ...(upstreamTotal === undefined ? {} : { upstream_total: upstreamTotal }),
     upstream_fetched: items.length,
     fetch_limit: limit,
+    partial: listIsIncomplete(list, items.length),
   };
 }
 
@@ -88,6 +97,7 @@ export async function listSupervisorBeadsAssignedTo(
       total: 0,
       upstream_fetched: 0,
       fetch_limit: limit,
+      partial: false,
     };
   }
   const lists = await Promise.all(
@@ -107,6 +117,11 @@ export async function listSupervisorBeadsAssignedTo(
     ...(upstreamTotal === undefined ? {} : { upstream_total: upstreamTotal }),
     upstream_fetched: items.length,
     fetch_limit: limit,
+    // Truncation is per-leg: each assignee query is its own bounded read, so the
+    // union is incomplete iff any leg is. Checking legs individually avoids
+    // comparing a SUMMED total against the DEDUPED `items.length`, which would
+    // false-trip whenever assignees share a bead.
+    partial: lists.some((leg) => listIsIncomplete(leg, (leg.items ?? []).length)),
   };
 }
 

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { SupervisorBeadList } from './beadReads';
+import { loadConvoyView } from './convoyReads';
+
+const mockFetchSupervisorBead = vi.hoisted(() => vi.fn());
+const mockListSupervisorBeads = vi.hoisted(() => vi.fn());
+
+vi.mock('./beadReads', () => ({
+  fetchSupervisorBead: mockFetchSupervisorBead,
+  listSupervisorBeads: mockListSupervisorBeads,
+}));
+
+function bead(id: string, overrides: Partial<Bead> = {}): Bead {
+  return {
+    id,
+    title: `bead ${id}`,
+    status: 'open',
+    issue_type: 'task',
+    priority: null,
+    created_at: '2026-06-12T00:00:00Z',
+    ...overrides,
+  } as Bead;
+}
+
+function list(items: Bead[], extra: Partial<SupervisorBeadList> = {}): SupervisorBeadList {
+  return {
+    items,
+    total: items.length,
+    upstream_fetched: items.length,
+    fetch_limit: 1000,
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loadConvoyView', () => {
+  it('derives the transitive parent-chain steps below the root and excludes the root', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root', { status: 'in_progress' }));
+    mockListSupervisorBeads.mockResolvedValue(
+      list([
+        bead('root', { status: 'in_progress' }),
+        bead('a', { parent: 'root', status: 'closed', created_at: '2026-06-12T00:00:01Z' }),
+        bead('b', { parent: 'a', status: 'open', created_at: '2026-06-12T00:00:02Z' }),
+        bead('unrelated', { parent: 'other', status: 'open' }),
+      ]),
+    );
+
+    const load = await loadConvoyView('root');
+
+    expect(load.view.rootBeadId).toBe('root');
+    expect(load.view.exposure.kind).toBe('exposed');
+    if (load.view.exposure.kind !== 'exposed') throw new Error('expected exposed');
+    expect(load.view.exposure.steps.map((s) => s.bead.id)).toEqual(['a', 'b']);
+    // Derived progress over the two descendants: one closed.
+    expect(load.view.progress).toEqual({ closed: 1, total: 2 });
+    expect(load.partial).toBe(false);
+  });
+
+  it('passes includeClosed + includeBookkeeping so closed/bookkeeping step beads are read', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root'));
+    mockListSupervisorBeads.mockResolvedValue(list([bead('root')]));
+
+    await loadConvoyView('root');
+
+    expect(mockListSupervisorBeads).toHaveBeenCalledWith(
+      expect.objectContaining({ includeClosed: true, includeBookkeeping: true }),
+    );
+  });
+
+  it('collapses honestly to graph_v2_root_only for a graph.v2 root with no children', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+      title: 'mol-focus-review',
+    });
+    mockFetchSupervisorBead.mockResolvedValue(root);
+    mockListSupervisorBeads.mockResolvedValue(list([root]));
+
+    const load = await loadConvoyView('root');
+
+    expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'graph_v2_root_only' });
+  });
+
+  it('flags partial when the upstream total exceeds the bounded fetch window', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root'));
+    mockListSupervisorBeads.mockResolvedValue(
+      list([bead('root')], { upstream_total: 5000, upstream_fetched: 1000 }),
+    );
+
+    const load = await loadConvoyView('root');
+
+    expect(load.partial).toBe(true);
+  });
+
+  it('does not treat a self-parent bead as its own child', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root'));
+    mockListSupervisorBeads.mockResolvedValue(list([bead('root', { parent: 'root' })]));
+
+    const load = await loadConvoyView('root');
+
+    expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'no_children' });
+  });
+});

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -29,6 +29,7 @@ function list(items: Bead[], extra: Partial<SupervisorBeadList> = {}): Superviso
     total: items.length,
     upstream_fetched: items.length,
     fetch_limit: 1000,
+    partial: false,
     ...extra,
   };
 }
@@ -85,11 +86,12 @@ describe('loadConvoyView', () => {
     expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'graph_v2_root_only' });
   });
 
-  it('flags partial when the upstream total exceeds the bounded fetch window', async () => {
+  it('propagates the list read partial flag (cursor- or total-based truncation)', async () => {
     mockFetchSupervisorBead.mockResolvedValue(bead('root'));
-    mockListSupervisorBeads.mockResolvedValue(
-      list([bead('root')], { upstream_total: 5000, upstream_fetched: 1000 }),
-    );
+    // listSupervisorBeads folds next_cursor / partial / total>fetched into one
+    // `partial` flag (listIsIncomplete); the loader trusts it rather than
+    // re-deriving from upstream_total, so cursor truncation is not missed.
+    mockListSupervisorBeads.mockResolvedValue(list([bead('root')], { partial: true }));
 
     const load = await loadConvoyView('root');
 

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -7,16 +7,34 @@ import { normalizeBead, normalizeBeads } from './normalizeBead';
 //
 // It COMPOSES the generated supervisor client — the root bead plus a bounded
 // city bead read — and derives the convoy's step graph client-side from the
-// `parent` chain, exactly as the Beads board inverts `needs`. The dashboard's
-// generated client exposes no convoy/{id} or beads/graph/{root} endpoint, so
-// there is no supervisor progress count to prefer: `projectConvoyView` derives
-// progress from the materialized children, and a graph.v2 root with no exposed
-// children collapses to the honest "steps not exposed" state in the projection.
+// `parent` chain, exactly as the Beads board inverts `needs`.
+//
+// Why the derived path, not the supervisor's convoy/{id} or beads/graph/{root}
+// endpoints (both DO exist on the generated client — gascity-dashboard-y6v3):
+// neither yields usable data for the graph.v2 workflow roots this route is
+// reached with (linked only from a run's RootMeta, i.e. a run root bead).
+// Verified against a live city:
+//   * convoy/{id} is keyed by a convoy ENTITY id, not a root bead id — calling
+//     it with a run root returns the workflow-snapshot case, which carries no
+//     `progress` field (and the generated `ConvoyGetResponse` does not model
+//     that case); a plain bead 404s "is not a convoy". Convoy progress is only
+//     populated for non-workflow convoy entities the /convoy/:rootBead route
+//     never addresses.
+//   * beads/graph/{root} collapses graph.v2 snapshots to the root bead alone
+//     (the same upstream hole tracked by gascity-dashboard-jl3c), so it returns
+//     no step children the parent-chain scan does not — and it is slow.
+// So there is no supervisor progress count to prefer: `projectConvoyView`
+// derives progress from the materialized children, and a graph.v2 root with no
+// exposed children collapses to the honest "steps not exposed" state. The
+// authoritative graph.v2 step graph lives in the workflow snapshot
+// (WorkflowSnapshotResponse) — wiring it here is the jl3c redesign, out of
+// scope for this loader. Because the route composes only the already-allowed
+// `beads` and `bead/{id}` reads, it works under DASHBOARD_READONLY=1 as-is.
 //
 // Truncation is honest: a busy city's closed beads can exceed one bounded page,
-// so `partial` trips when the supervisor's reported total outruns the bounded
-// read and the route renders a partial notice rather than silently dropping
-// steps.
+// so `partial` trips when the bounded read is incomplete (the supervisor flags
+// it, returns a `next_cursor`, or its total outruns the page) and the route
+// renders a partial notice rather than silently dropping steps.
 
 // Convoy step beads are bookkeeping-typed and frequently closed, so the read
 // must include both — unlike the board's default open/engineering view.
@@ -25,11 +43,9 @@ const CONVOY_FETCH_LIMIT = 1_000;
 export interface ConvoyLoad {
   view: ConvoyView;
   partial: boolean;
-  fetchedAt: string;
 }
 
 export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
-  const fetchedAt = new Date().toISOString();
   const root = normalizeBead(await fetchSupervisorBead(rootBeadId));
   const list = await listSupervisorBeads({
     includeClosed: true,
@@ -38,16 +54,9 @@ export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
   });
   const beads = normalizeBeads(list.items);
   const children = descendantsOf(root.id, beads);
-  // Truncation signal: the supervisor reported more beads than the bounded read
-  // returned. This caller applies no post-fetch filtering (includeClosed +
-  // includeBookkeeping), so upstream_fetched is the full wire page and the
-  // comparison cleanly reflects a cut-off fetch window — a descendant could sit
-  // past it, so the route shows a partial notice rather than implying coverage.
-  const partial = list.upstream_total !== undefined && list.upstream_total > list.upstream_fetched;
   return {
     view: projectConvoyView(root, children, null),
-    partial,
-    fetchedAt,
+    partial: list.partial,
   };
 }
 

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -56,6 +56,13 @@ export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
   const children = descendantsOf(root.id, beads);
   return {
     view: projectConvoyView(root, children, null),
+    // Conservative by design: a truncated city page cannot prove this convoy's
+    // subtree is complete — a descendant could sit in the unfetched tail, and a
+    // flat list gives no way to tell "all descendants fetched" from "some
+    // missing". So we surface partial whenever the city page is incomplete. This
+    // can over-warn (the convoy may in fact be whole), but never under-warns
+    // (hiding missing steps). Tightening to a true subtree-scoped completeness
+    // check needs a supervisor subtree query — tracked as a follow-up.
     partial: list.partial,
   };
 }

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -1,0 +1,84 @@
+import type { ConvoyView, DashboardBead } from 'gas-city-dashboard-shared';
+import { projectConvoyView } from 'gas-city-dashboard-shared';
+import { fetchSupervisorBead, listSupervisorBeads } from './beadReads';
+import { normalizeBead, normalizeBeads } from './normalizeBead';
+
+// Loader for the /convoy/:rootBead route (gascity-dashboard-caag, Shape A).
+//
+// It COMPOSES the generated supervisor client — the root bead plus a bounded
+// city bead read — and derives the convoy's step graph client-side from the
+// `parent` chain, exactly as the Beads board inverts `needs`. The dashboard's
+// generated client exposes no convoy/{id} or beads/graph/{root} endpoint, so
+// there is no supervisor progress count to prefer: `projectConvoyView` derives
+// progress from the materialized children, and a graph.v2 root with no exposed
+// children collapses to the honest "steps not exposed" state in the projection.
+//
+// Truncation is honest: a busy city's closed beads can exceed one bounded page,
+// so `partial` trips when the supervisor's reported total outruns the bounded
+// read and the route renders a partial notice rather than silently dropping
+// steps.
+
+// Convoy step beads are bookkeeping-typed and frequently closed, so the read
+// must include both — unlike the board's default open/engineering view.
+const CONVOY_FETCH_LIMIT = 1_000;
+
+export interface ConvoyLoad {
+  view: ConvoyView;
+  partial: boolean;
+  fetchedAt: string;
+}
+
+export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
+  const fetchedAt = new Date().toISOString();
+  const root = normalizeBead(await fetchSupervisorBead(rootBeadId));
+  const list = await listSupervisorBeads({
+    includeClosed: true,
+    includeBookkeeping: true,
+    limit: CONVOY_FETCH_LIMIT,
+  });
+  const beads = normalizeBeads(list.items);
+  const children = descendantsOf(root.id, beads);
+  // Truncation signal: the supervisor reported more beads than the bounded read
+  // returned. This caller applies no post-fetch filtering (includeClosed +
+  // includeBookkeeping), so upstream_fetched is the full wire page and the
+  // comparison cleanly reflects a cut-off fetch window — a descendant could sit
+  // past it, so the route shows a partial notice rather than implying coverage.
+  const partial = list.upstream_total !== undefined && list.upstream_total > list.upstream_fetched;
+  return {
+    view: projectConvoyView(root, children, null),
+    partial,
+    fetchedAt,
+  };
+}
+
+/**
+ * Collect the transitive `parent`-chain descendants of `rootId` from the flat
+ * bead list, excluding the root itself. Cycles cannot inflate the result — a
+ * bead already visited is never re-queued.
+ */
+function descendantsOf(rootId: string, beads: readonly DashboardBead[]): DashboardBead[] {
+  const childrenByParent = new Map<string, DashboardBead[]>();
+  for (const bead of beads) {
+    if (bead.parent === undefined || bead.parent === bead.id) continue;
+    const siblings = childrenByParent.get(bead.parent);
+    if (siblings === undefined) childrenByParent.set(bead.parent, [bead]);
+    else siblings.push(bead);
+  }
+
+  const collected: DashboardBead[] = [];
+  const seen = new Set<string>([rootId]);
+  // BFS over a growing frontier. `for...of` yields each id as a plain `string`
+  // (no `shift()`/index `string | undefined` to assert away) and the Array
+  // iterator observes ids pushed mid-loop, so newly-found descendants are
+  // visited in turn. `seen` makes the push idempotent, so a cycle terminates.
+  const frontier: string[] = [rootId];
+  for (const parentId of frontier) {
+    for (const child of childrenByParent.get(parentId) ?? []) {
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      collected.push(child);
+      frontier.push(child.id);
+    }
+  }
+  return collected;
+}

--- a/frontend/src/supervisor/entityLinks.ts
+++ b/frontend/src/supervisor/entityLinks.ts
@@ -1,9 +1,9 @@
-import type { EntityLinkView, DashboardBead, DashboardSession } from 'gas-city-dashboard-shared';
+import type { EntityLinkView, DashboardSession } from 'gas-city-dashboard-shared';
 import { buildLinkView, buildRelationIndex, parseRef } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
-import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
 import { supervisorApi } from './client';
 import { listIsIncomplete } from './listPartial';
+import { normalizeBeads } from './normalizeBead';
 import { normalizeSessions, type SupervisorSessionList } from './sessionReads';
 
 // Pre-exposure load bound (gascity-dashboard-q89b): this fetch runs once per
@@ -37,33 +37,6 @@ export async function loadSupervisorEntityLinks(ref: string): Promise<EntityLink
     supervisorFetchedAt,
     githubFetchedAt: null,
   });
-}
-
-function normalizeBeads(beads: readonly Bead[]): DashboardBead[] {
-  return beads.map(normalizeBead);
-}
-
-function normalizeBead(bead: Bead): DashboardBead {
-  const normalized: DashboardBead = {
-    id: bead.id,
-    title: bead.title,
-    status: bead.status,
-    issue_type: bead.issue_type,
-    priority: bead.priority ?? null,
-    created_at: bead.created_at,
-  };
-  if (bead.description !== undefined) normalized.description = bead.description;
-  if (bead.assignee !== undefined) normalized.assignee = bead.assignee;
-  if (Array.isArray(bead.labels)) normalized.labels = bead.labels;
-  if (bead.metadata !== undefined) normalized.metadata = bead.metadata;
-  if (bead.ref !== undefined) normalized.ref = bead.ref;
-  if (bead.parent !== undefined) normalized.parent = bead.parent;
-  if (bead.from !== undefined) normalized.from = bead.from;
-  if (bead.ephemeral !== undefined) normalized.ephemeral = bead.ephemeral;
-  if (bead.needs !== undefined) normalized.needs = bead.needs;
-  if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
-  if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
-  return normalized;
 }
 
 function sessionListIsPartial(list: SupervisorSessionList): boolean {

--- a/frontend/src/supervisor/normalizeBead.ts
+++ b/frontend/src/supervisor/normalizeBead.ts
@@ -1,0 +1,38 @@
+import type { DashboardBead } from 'gas-city-dashboard-shared';
+import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
+
+// Narrow a supervisor wire `Bead` into the dashboard-owned `DashboardBead`
+// projection at the frontend edge. Shared selectors operate on DashboardBead
+// and never import the generated supervisor type; this is the single seam that
+// drops it (gascity-dashboard-caag consolidated the per-reader copies that had
+// drifted independently in entityLinks.ts and runSummary.ts).
+//
+// Optional wire fields are copied only when present so an absent field stays
+// absent on the projection rather than becoming an explicit `undefined`.
+
+export function normalizeBead(bead: Bead): DashboardBead {
+  const normalized: DashboardBead = {
+    id: bead.id,
+    title: bead.title,
+    status: bead.status,
+    issue_type: bead.issue_type,
+    priority: bead.priority ?? null,
+    created_at: bead.created_at,
+  };
+  if (bead.description !== undefined) normalized.description = bead.description;
+  if (bead.assignee !== undefined) normalized.assignee = bead.assignee;
+  if (Array.isArray(bead.labels)) normalized.labels = bead.labels;
+  if (bead.metadata !== undefined) normalized.metadata = bead.metadata;
+  if (bead.ref !== undefined) normalized.ref = bead.ref;
+  if (bead.parent !== undefined) normalized.parent = bead.parent;
+  if (bead.from !== undefined) normalized.from = bead.from;
+  if (bead.ephemeral !== undefined) normalized.ephemeral = bead.ephemeral;
+  if (bead.needs !== undefined) normalized.needs = bead.needs;
+  if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
+  if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
+  return normalized;
+}
+
+export function normalizeBeads(beads: readonly Bead[]): DashboardBead[] {
+  return beads.map(normalizeBead);
+}

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -26,10 +26,11 @@ import {
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
-import type { Bead, FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
+import type { FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
 import { supervisorApiForRequestBudget } from './client';
 import { fetchCoreRead } from './coreRead';
 import { listIsIncomplete, listIsPartial } from './listPartial';
+import { normalizeBeads } from './normalizeBead';
 import { normalizeSessions } from './sessionReads';
 
 // Pre-exposure load bound (gascity-dashboard-q89b): the primary in-flight
@@ -758,33 +759,6 @@ function uniqueBeads(beads: readonly DashboardBead[]): DashboardBead[] {
     if (!byId.has(bead.id)) byId.set(bead.id, bead);
   }
   return Array.from(byId.values());
-}
-
-function normalizeBeads(beads: readonly Bead[]): DashboardBead[] {
-  return beads.map(normalizeBead);
-}
-
-function normalizeBead(bead: Bead): DashboardBead {
-  const normalized: DashboardBead = {
-    id: bead.id,
-    title: bead.title,
-    status: bead.status,
-    issue_type: bead.issue_type,
-    priority: bead.priority ?? null,
-    created_at: bead.created_at,
-  };
-  if (bead.description !== undefined) normalized.description = bead.description;
-  if (bead.assignee !== undefined) normalized.assignee = bead.assignee;
-  if (Array.isArray(bead.labels)) normalized.labels = bead.labels;
-  if (bead.metadata !== undefined) normalized.metadata = bead.metadata;
-  if (bead.ref !== undefined) normalized.ref = bead.ref;
-  if (bead.parent !== undefined) normalized.parent = bead.parent;
-  if (bead.from !== undefined) normalized.from = bead.from;
-  if (bead.ephemeral !== undefined) normalized.ephemeral = bead.ephemeral;
-  if (bead.needs !== undefined) normalized.needs = bead.needs;
-  if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
-  if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
-  return normalized;
 }
 
 function feedIsPartial(feed: FormulaFeedBody): boolean {

--- a/shared/src/convoy/projection.test.ts
+++ b/shared/src/convoy/projection.test.ts
@@ -1,0 +1,110 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { DashboardBead } from '../dashboard-beads.js';
+import { projectConvoyView } from './projection.js';
+
+function bead(id: string, overrides: Partial<DashboardBead> = {}): DashboardBead {
+  return {
+    id,
+    title: `bead ${id}`,
+    status: 'open',
+    issue_type: 'task',
+    priority: null,
+    created_at: '2026-06-12T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('projectConvoyView', () => {
+  test('exposes ordered step children with derived progress when the graph is materialized', () => {
+    const root = bead('root', {
+      title: 'mol-focus-review',
+      status: 'in_progress',
+      metadata: { 'gc.session_name': 'claude-1-gc-1' },
+    });
+    const children = [
+      bead('s2', { status: 'open', created_at: '2026-06-12T00:00:02Z' }),
+      bead('s1', { status: 'closed', created_at: '2026-06-12T00:00:01Z' }),
+    ];
+
+    const view = projectConvoyView(root, children, null);
+
+    assert.equal(view.rootBeadId, 'root');
+    assert.equal(view.sessionName, 'claude-1-gc-1');
+    assert.equal(view.exposure.kind, 'exposed');
+    if (view.exposure.kind !== 'exposed') throw new Error('expected exposed');
+    // Ordered by created_at ascending.
+    assert.deepEqual(
+      view.exposure.steps.map((s) => s.bead.id),
+      ['s1', 's2'],
+    );
+    // Derived progress over children: one of two closed.
+    assert.deepEqual(view.progress, { closed: 1, total: 2 });
+  });
+
+  test('prefers supervisor convoy progress over the derived count', () => {
+    const view = projectConvoyView(bead('root'), [bead('s1', { status: 'closed' })], {
+      closed: 4,
+      total: 9,
+    });
+    assert.deepEqual(view.progress, { closed: 4, total: 9 });
+  });
+
+  test('marks a step blocked by its open needs that are present in the graph', () => {
+    const root = bead('root', { status: 'in_progress' });
+    const children = [
+      bead('a', { status: 'closed' }),
+      bead('b', { status: 'open', needs: ['a', 'c', 'absent'] }),
+      bead('c', { status: 'in_progress' }),
+    ];
+
+    const view = projectConvoyView(root, children, null);
+    if (view.exposure.kind !== 'exposed') throw new Error('expected exposed');
+    const stepB = view.exposure.steps.find((s) => s.bead.id === 'b');
+    // 'a' is closed (not blocking), 'absent' is not in the graph (unknown,
+    // excluded), only the open in-graph need 'c' blocks.
+    assert.deepEqual(stepB?.blockedBy, ['c']);
+  });
+
+  test('surfaces gc.step_ref on materialized formula steps', () => {
+    const view = projectConvoyView(
+      bead('root'),
+      [bead('s1', { metadata: { 'gc.step_ref': 'review.1' } })],
+      null,
+    );
+    if (view.exposure.kind !== 'exposed') throw new Error('expected exposed');
+    assert.equal(view.exposure.steps[0]?.stepRef, 'review.1');
+  });
+
+  test('degrades honestly to graph_v2_root_only when a graph.v2 root has no exposed children', () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+      title: 'mol-focus-review',
+    });
+
+    const view = projectConvoyView(root, [], { closed: 0, total: 1 });
+
+    assert.deepEqual(view.exposure, { kind: 'collapsed', reason: 'graph_v2_root_only' });
+    // Supervisor progress still shows through the collapse.
+    assert.deepEqual(view.progress, { closed: 0, total: 1 });
+  });
+
+  test('reports no_children for a genuine leaf bead with no graph.v2 contract', () => {
+    const view = projectConvoyView(bead('leaf', { status: 'closed' }), [], null);
+    assert.deepEqual(view.exposure, { kind: 'collapsed', reason: 'no_children' });
+    // No supervisor progress and nothing to derive.
+    assert.equal(view.progress, null);
+  });
+
+  test('resolves the formula name and its provenance from the root', () => {
+    const view = projectConvoyView(
+      bead('root', { metadata: { 'gc.formula': 'mol-pr-start' } }),
+      [],
+      null,
+    );
+    assert.equal(view.formulaName, 'mol-pr-start');
+    assert.equal(view.formulaNameProvenance, 'metadata');
+  });
+});

--- a/shared/src/convoy/projection.test.ts
+++ b/shared/src/convoy/projection.test.ts
@@ -91,6 +91,21 @@ describe('projectConvoyView', () => {
     assert.deepEqual(view.progress, { closed: 0, total: 1 });
   });
 
+  test('degrades to graph_v2_root_only for a current-era root keyed by gc.routed_to (no gc.run_target)', () => {
+    // The supervisor retired gc.run_target in favor of gc.routed_to (gascity
+    // #2763); current roots carry only gc.routed_to. The gate must accept it,
+    // or the primary real-world case misclassifies as no_children.
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.routed_to': 'city/claude-1' },
+      title: 'mol-focus-review',
+    });
+
+    const view = projectConvoyView(root, [], { closed: 0, total: 1 });
+
+    assert.deepEqual(view.exposure, { kind: 'collapsed', reason: 'graph_v2_root_only' });
+  });
+
   test('reports no_children for a genuine leaf bead with no graph.v2 contract', () => {
     const view = projectConvoyView(bead('leaf', { status: 'closed' }), [], null);
     assert.deepEqual(view.exposure, { kind: 'collapsed', reason: 'no_children' });

--- a/shared/src/convoy/projection.test.ts
+++ b/shared/src/convoy/projection.test.ts
@@ -98,6 +98,20 @@ describe('projectConvoyView', () => {
     assert.equal(view.progress, null);
   });
 
+  test('reports no_children for a graph.v2-labelled root that lacks gc.run_target', () => {
+    // Same gate as resolveRunFormulaName (formula-name.ts): the contract label
+    // without a target is not a runnable root (e.g. an operator-retitled closed
+    // root), so a childless one is a genuine leaf — not the misleading
+    // "supervisor does not expose this run's step graph" collapse.
+    const root = bead('root', {
+      status: 'closed',
+      title: 'investigation: some bug',
+      metadata: { 'gc.formula_contract': 'graph.v2' },
+    });
+    const view = projectConvoyView(root, [], null);
+    assert.deepEqual(view.exposure, { kind: 'collapsed', reason: 'no_children' });
+  });
+
   test('resolves the formula name and its provenance from the root', () => {
     const view = projectConvoyView(
       bead('root', { metadata: { 'gc.formula': 'mol-pr-start' } }),

--- a/shared/src/convoy/projection.ts
+++ b/shared/src/convoy/projection.ts
@@ -1,0 +1,121 @@
+import type { DashboardBead } from '../dashboard-beads.js';
+import {
+  resolveRunFormulaIdentity,
+  type ResolvedRunFormulaIdentity,
+} from '../runs/formula-name.js';
+
+// Dashboard-owned projection of a convoy (an end-to-end unit of work keyed by a
+// root bead) into the shape the /convoy/:rootBead route renders. It composes a
+// supervisor bead graph (already narrowed to DashboardBead at the frontend
+// edge) plus the optional convoy progress count — it does NOT mirror a
+// supervisor wire shape, and stays pure so the route's branching (materialized
+// steps vs the honest graph.v2 degradation) is unit-testable without the DOM.
+
+const CLOSED_STATUS = 'closed';
+const GRAPH_V2_CONTRACT = 'graph.v2';
+
+export interface ConvoyStep {
+  bead: DashboardBead;
+  /** In-graph needs that are not yet closed — the steps this one still waits on. */
+  blockedBy: readonly string[];
+  /** gc.step_ref when the bead is a materialized formula step, else null. */
+  stepRef: string | null;
+}
+
+/**
+ * Why the step DAG is not shown. `graph_v2_root_only` is the known upstream
+ * hole (the supervisor collapses graph.v2 run snapshots to the root bead, so
+ * step nodes are not reconstructable — tracked by gascity-dashboard-jl3c);
+ * `no_children` is a genuine leaf with nothing below it.
+ */
+export type ConvoyCollapseReason = 'graph_v2_root_only' | 'no_children';
+
+export type ConvoyStepExposure =
+  | { kind: 'exposed'; steps: readonly ConvoyStep[] }
+  | { kind: 'collapsed'; reason: ConvoyCollapseReason };
+
+export interface ConvoyProgressCounts {
+  closed: number;
+  total: number;
+}
+
+export interface ConvoyView {
+  rootBeadId: string;
+  root: DashboardBead;
+  /** Formula driving the convoy, when the root carries it. */
+  formulaName: string | null;
+  formulaNameProvenance: ResolvedRunFormulaIdentity['source'];
+  /** Live worker session name while the root is in flight, else null. */
+  sessionName: string | null;
+  /** Step completion. Supervisor count when available, else derived from the graph. */
+  progress: ConvoyProgressCounts | null;
+  exposure: ConvoyStepExposure;
+}
+
+/**
+ * Project a convoy root and its in-graph children into the route view model.
+ *
+ * `children` are the graph beads below the root (the root itself excluded by
+ * the caller). `supervisorProgress` is the convoy endpoint's closed/total when
+ * the read succeeded — it is preferred over the derived count because it still
+ * reports a total when the step graph has collapsed.
+ */
+export function projectConvoyView(
+  root: DashboardBead,
+  children: readonly DashboardBead[],
+  supervisorProgress: ConvoyProgressCounts | null,
+): ConvoyView {
+  const identity = resolveRunFormulaIdentity('route', { root });
+  const exposure = computeExposure(root, children);
+  const progress =
+    supervisorProgress ?? (exposure.kind === 'exposed' ? deriveProgress(exposure.steps) : null);
+  return {
+    rootBeadId: root.id,
+    root,
+    formulaName: identity.name,
+    formulaNameProvenance: identity.source,
+    sessionName: metaString(root, 'gc.session_name') ?? null,
+    progress,
+    exposure,
+  };
+}
+
+function computeExposure(
+  root: DashboardBead,
+  children: readonly DashboardBead[],
+): ConvoyStepExposure {
+  if (children.length === 0) {
+    const reason: ConvoyCollapseReason =
+      metaString(root, 'gc.formula_contract') === GRAPH_V2_CONTRACT
+        ? 'graph_v2_root_only'
+        : 'no_children';
+    return { kind: 'collapsed', reason };
+  }
+  const statusById = new Map<string, string>([[root.id, root.status]]);
+  for (const child of children) statusById.set(child.id, child.status);
+  const steps = [...children].sort(compareSteps).map((child) => toStep(child, statusById));
+  return { kind: 'exposed', steps };
+}
+
+function toStep(bead: DashboardBead, statusById: ReadonlyMap<string, string>): ConvoyStep {
+  const blockedBy = (bead.needs ?? []).filter((id) => {
+    const status = statusById.get(id);
+    return status !== undefined && status !== CLOSED_STATUS;
+  });
+  return { bead, blockedBy, stepRef: metaString(bead, 'gc.step_ref') ?? null };
+}
+
+function deriveProgress(steps: readonly ConvoyStep[]): ConvoyProgressCounts {
+  const closed = steps.filter((step) => step.bead.status === CLOSED_STATUS).length;
+  return { closed, total: steps.length };
+}
+
+function compareSteps(a: DashboardBead, b: DashboardBead): number {
+  const byCreated = a.created_at.localeCompare(b.created_at);
+  return byCreated !== 0 ? byCreated : a.id.localeCompare(b.id);
+}
+
+function metaString(bead: DashboardBead, key: string): string | undefined {
+  const value = bead.metadata?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/shared/src/convoy/projection.ts
+++ b/shared/src/convoy/projection.ts
@@ -1,8 +1,6 @@
 import type { DashboardBead } from '../dashboard-beads.js';
-import {
-  resolveRunFormulaIdentity,
-  type ResolvedRunFormulaIdentity,
-} from '../runs/formula-name.js';
+import type { RunFormulaSource } from '../run-detail.js';
+import { resolveRunFormulaIdentity } from '../runs/formula-name.js';
 
 // Dashboard-owned projection of a convoy (an end-to-end unit of work keyed by a
 // root bead) into the shape the /convoy/:rootBead route renders. It composes a
@@ -13,6 +11,8 @@ import {
 
 const CLOSED_STATUS = 'closed';
 const GRAPH_V2_CONTRACT = 'graph.v2';
+const FORMULA_CONTRACT_KEY = 'gc.formula_contract';
+const RUN_TARGET_KEY = 'gc.run_target';
 
 export interface ConvoyStep {
   bead: DashboardBead;
@@ -27,6 +27,19 @@ export interface ConvoyStep {
  * hole (the supervisor collapses graph.v2 run snapshots to the root bead, so
  * step nodes are not reconstructable — tracked by gascity-dashboard-jl3c);
  * `no_children` is a genuine leaf with nothing below it.
+ *
+ * The graph.v2 classification requires BOTH `gc.formula_contract=graph.v2` AND
+ * `gc.run_target` — the same contract+target gate `resolveRunFormulaName` uses
+ * (formula-name.ts): only a fully-instantiated runnable root carries both.
+ * A childless bead that has the contract label but no target (e.g. a stray
+ * label on a non-run bead) is a genuine leaf, so it reports `no_children`
+ * rather than the misleading "supervisor does not expose this run's step graph".
+ *
+ * Unlike the name fallback there, this gate intentionally does NOT also exclude
+ * terminal-status roots: a completed graph.v2 run's steps are just as unexposed
+ * as a running one's, so `graph_v2_root_only` stays the honest reason for it.
+ * (The name fallback excludes terminal roots only to avoid trusting a retitled
+ * closed root's title as a formula name — a different concern.)
  */
 export type ConvoyCollapseReason = 'graph_v2_root_only' | 'no_children';
 
@@ -44,7 +57,13 @@ export interface ConvoyView {
   root: DashboardBead;
   /** Formula driving the convoy, when the root carries it. */
   formulaName: string | null;
-  formulaNameProvenance: ResolvedRunFormulaIdentity['source'];
+  /**
+   * Provenance of `formulaName`. Route-mode resolution only ever yields
+   * `metadata` (explicit `gc.formula`) or `title_fallback` (graph.v2 gate) —
+   * the `formula_detail` source is unreachable without a detail fetch — so the
+   * type is the narrower `RunFormulaSource`, not the full identity source.
+   */
+  formulaNameProvenance: RunFormulaSource | null;
   /** Live worker session name while the root is in flight, else null. */
   sessionName: string | null;
   /** Step completion. Supervisor count when available, else derived from the graph. */
@@ -73,7 +92,9 @@ export function projectConvoyView(
     rootBeadId: root.id,
     root,
     formulaName: identity.name,
-    formulaNameProvenance: identity.source,
+    // `formula_detail` is unreachable in route mode (see the field doc); the
+    // guard narrows the type to `RunFormulaSource | null` without a cast.
+    formulaNameProvenance: identity.source === 'formula_detail' ? null : identity.source,
     sessionName: metaString(root, 'gc.session_name') ?? null,
     progress,
     exposure,
@@ -85,11 +106,10 @@ function computeExposure(
   children: readonly DashboardBead[],
 ): ConvoyStepExposure {
   if (children.length === 0) {
-    const reason: ConvoyCollapseReason =
-      metaString(root, 'gc.formula_contract') === GRAPH_V2_CONTRACT
-        ? 'graph_v2_root_only'
-        : 'no_children';
-    return { kind: 'collapsed', reason };
+    const isGraphV2Run =
+      metaString(root, FORMULA_CONTRACT_KEY) === GRAPH_V2_CONTRACT &&
+      metaString(root, RUN_TARGET_KEY) !== undefined;
+    return { kind: 'collapsed', reason: isGraphV2Run ? 'graph_v2_root_only' : 'no_children' };
   }
   const statusById = new Map<string, string>([[root.id, root.status]]);
   for (const child of children) statusById.set(child.id, child.status);

--- a/shared/src/convoy/projection.ts
+++ b/shared/src/convoy/projection.ts
@@ -13,6 +13,7 @@ const CLOSED_STATUS = 'closed';
 const GRAPH_V2_CONTRACT = 'graph.v2';
 const FORMULA_CONTRACT_KEY = 'gc.formula_contract';
 const RUN_TARGET_KEY = 'gc.run_target';
+const ROUTED_TO_KEY = 'gc.routed_to';
 
 export interface ConvoyStep {
   bead: DashboardBead;
@@ -29,7 +30,9 @@ export interface ConvoyStep {
  * `no_children` is a genuine leaf with nothing below it.
  *
  * The graph.v2 classification requires BOTH `gc.formula_contract=graph.v2` AND
- * `gc.run_target` — the same contract+target gate `resolveRunFormulaName` uses
+ * a run-target key (`gc.run_target` OR the current `gc.routed_to`, which the
+ * supervisor retired `gc.run_target` in favor of per gascity #2763) — the same
+ * dual-key contract+target gate `rootRunTarget`/`resolveRunFormulaName` use
  * (formula-name.ts): only a fully-instantiated runnable root carries both.
  * A childless bead that has the contract label but no target (e.g. a stray
  * label on a non-run bead) is a genuine leaf, so it reports `no_children`
@@ -108,7 +111,8 @@ function computeExposure(
   if (children.length === 0) {
     const isGraphV2Run =
       metaString(root, FORMULA_CONTRACT_KEY) === GRAPH_V2_CONTRACT &&
-      metaString(root, RUN_TARGET_KEY) !== undefined;
+      (metaString(root, RUN_TARGET_KEY) !== undefined ||
+        metaString(root, ROUTED_TO_KEY) !== undefined);
     return { kind: 'collapsed', reason: isGraphV2Run ? 'graph_v2_root_only' : 'no_children' };
   }
   const statusById = new Map<string, string>([[root.id, root.status]]);

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -40,6 +40,7 @@ export * from './links/build-link-view.js';
 export * from './links/instrumentation.js';
 export * from './links/node-ref.js';
 export * from './links/relation-index.js';
+export * from './convoy/projection.js';
 export * from './city.js';
 export * from './operator.js';
 export * from './operator-mail.js';


### PR DESCRIPTION
## What

New **convoy page** (`/convoy/:rootBead`) that reconstructs a run's step graph client-side from the bead parent-chain, and three correctness fixes to the convoy projection. Replaces a wrong premise (the supervisor `convoy/{id}` and graph endpoints don't serve this view) with `fetchSupervisorBead(root)` + `listSupervisorBeads` + a shared `projectConvoyView` projection. Consolidates three copies of `normalizeBead` into one shared module.

## Key pieces

- `shared/src/convoy/projection.ts` (new SSOT): `projectConvoyView`, disjoint step/blockedBy/progress derivation, honest graph.v2 collapse (`graph_v2_root_only` vs `no_children`).
- `frontend/src/routes/Convoy.tsx`, `useConvoyView.ts`, `convoyReads.ts`; route registered in `App.tsx` inside the auth-guarded lazy group.

## Review + checks (4 reviewers: 3 Claude + Codex)

- security **APPROVE** (0 findings — structured path params, no SSRF/XSS, READONLY-compatible), typescript **APPROVE**, code + Codex flagged issues, all **fixed in-pipeline**:
  - **graph.v2 gate accepts `gc.routed_to`** (blocker/major, all 4 reviewers): the supervisor retired `gc.run_target` for `gc.routed_to` (#2763); current-era roots were misclassifying `no_children` instead of `graph_v2_root_only`. Fixed + regression test.
  - **em-dash → semicolon** in the title-fallback tooltip (DESIGN.md UI-copy rule, aria-facing). DESIGN.md otherwise clean (glyph+word, One Mark Rule, Greyscale).
  - **partial detection** (Codex major): documented that the `partial` flag is conservatively whole-city-scoped — sound (never under-warns / hides missing steps), can over-warn on >1000-bead cities. Subtree-scoped precision tracked as a follow-up.
- Projection correctness (BFS descendants, cycle-safe, in-graph blockedBy, ordering, progress preference) and React lifecycle independently confirmed.
- CI-parity (local): build, typecheck (src+test), lint, prettier, openapi, all test suites green — re-verified after fixes + rebase onto current main.
