### PR TITLE
fix(convoy): subtree-scoped partial detection for the convoy page

### DIFF
--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -20,6 +20,7 @@ const READ_ENDPOINT_TEMPLATES = [
   '/v0/cities',
   '/v0/city/{cityName}/agents',
   '/v0/city/{cityName}/beads',
+  '/v0/city/{cityName}/beads/graph/{rootID}',
   '/v0/city/{cityName}/bead/{id}',
   '/v0/city/{cityName}/events',
   '/v0/city/{cityName}/events/stream',

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -10,6 +10,7 @@ describe('supervisor read allowlist', () => {
       '/v0/cities',
       '/v0/city/test-city/agents',
       '/v0/city/test-city/beads',
+      '/v0/city/test-city/beads/graph/gascity-0001',
       '/v0/city/test-city/bead/gascity-0001',
       '/v0/city/test-city/events',
       '/v0/city/test-city/events/stream',

--- a/frontend/src/lib/logging.ts
+++ b/frontend/src/lib/logging.ts
@@ -10,6 +10,7 @@
 
 export const LOG_COMPONENT = {
   views: 'views',
+  convoy: 'convoy',
 } as const;
 
 export type LogComponent = (typeof LOG_COMPONENT)[keyof typeof LOG_COMPONENT];

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -25,6 +25,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),

--- a/frontend/src/supervisor/beadReads.ts
+++ b/frontend/src/supervisor/beadReads.ts
@@ -125,6 +125,25 @@ export async function listSupervisorBeadsAssignedTo(
   };
 }
 
+/**
+ * Authoritative descendant ids of `rootId`, scoped to the root's graph rather
+ * than the bounded city bead page. Used to confirm whether a convoy's subtree
+ * was fully captured by the page read when that read is truncated. The root
+ * itself is excluded so the result lines up with the parent-chain descendant
+ * scan it is compared against. For graph.v2 run roots the supervisor collapses
+ * this walk to the root alone (the gascity-dashboard-jl3c hole), so it returns
+ * an empty set — the caller short-circuits those before reaching here.
+ */
+export async function fetchBeadSubtreeIds(rootId: string): Promise<string[]> {
+  const cityName = activeCityOrThrow('fetch bead subtree');
+  const graph = await supervisorApi().beadsGraph(cityName, rootId);
+  const ids = new Set<string>();
+  for (const bead of graph.beads ?? []) {
+    if (bead.id !== rootId) ids.add(bead.id);
+  }
+  return [...ids];
+}
+
 export async function fetchSupervisorBead(id: string): Promise<SupervisorBead> {
   const cityName = activeCityOrThrow('fetch supervisor bead');
   try {

--- a/frontend/src/supervisor/beadWrites.test.ts
+++ b/frontend/src/supervisor/beadWrites.test.ts
@@ -29,6 +29,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),

--- a/frontend/src/supervisor/client.test.ts
+++ b/frontend/src/supervisor/client.test.ts
@@ -1233,6 +1233,7 @@ describe('supervisor client wrapper', () => {
     const fake = {
       baseUrl: 'test://supervisor',
       getBead: vi.fn(),
+      beadsGraph: vi.fn(),
       cityHealth: vi.fn(),
       cityStatus: vi.fn(),
       health: vi.fn(),

--- a/frontend/src/supervisor/client.ts
+++ b/frontend/src/supervisor/client.ts
@@ -8,6 +8,7 @@ import {
   getV0CityByCityNameAgentByDirByBasePrime,
   getV0CityByCityNameBeadById,
   getV0CityByCityNameBeads,
+  getV0CityByCityNameBeadsGraphByRootId,
   getV0CityByCityNameEvents,
   getV0CityByCityNameFormulasByName,
   getV0CityByCityNameFormulasFeed,
@@ -36,6 +37,7 @@ import type {
   Bead,
   BeadCloseBody,
   BeadCreateInputBody,
+  BeadGraphResponse,
   BeadUpdateBody,
   AgentPrimeBody,
   FormulaFeedBody,
@@ -123,6 +125,12 @@ export interface SupervisorApi {
     query?: NonNullable<GetV0CityByCityNameEventsData['query']>,
   ): Promise<ListBodyWireEvent>;
   getBead(cityName: string, id: string): Promise<Bead>;
+  /**
+   * Authoritative subtree walk from a root bead. Unlike the bounded city
+   * `listBeads` page, this is scoped to the root's graph, so it carries the
+   * convoy's full descendant set even in a city whose bead page is truncated.
+   */
+  beadsGraph(cityName: string, rootId: string): Promise<BeadGraphResponse>;
   createBead(cityName: string, body: BeadCreateInputBody): Promise<Bead>;
   updateBead(cityName: string, id: string, body: BeadUpdateBody): Promise<OkResponseBody>;
   closeBead(cityName: string, id: string, body?: BeadCloseBody): Promise<OkResponseBody>;
@@ -292,6 +300,15 @@ export function createSupervisorApi(options: CreateSupervisorApiOptions = {}): S
           path: { cityName, id },
         }) as Promise<SupervisorResult<Bead>>,
         'gc supervisor bead response was empty',
+      );
+    },
+    beadsGraph(cityName, rootId) {
+      return unwrapSupervisorResult<BeadGraphResponse>(
+        getV0CityByCityNameBeadsGraphByRootId({
+          client,
+          path: { cityName, rootID: rootId },
+        }) as Promise<SupervisorResult<BeadGraphResponse>>,
+        'gc supervisor bead graph response was empty',
       );
     },
     createBead(cityName, body) {

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -5,10 +5,12 @@ import { loadConvoyView } from './convoyReads';
 
 const mockFetchSupervisorBead = vi.hoisted(() => vi.fn());
 const mockListSupervisorBeads = vi.hoisted(() => vi.fn());
+const mockFetchBeadSubtreeIds = vi.hoisted(() => vi.fn());
 
 vi.mock('./beadReads', () => ({
   fetchSupervisorBead: mockFetchSupervisorBead,
   listSupervisorBeads: mockListSupervisorBeads,
+  fetchBeadSubtreeIds: mockFetchBeadSubtreeIds,
 }));
 
 function bead(id: string, overrides: Partial<Bead> = {}): Bead {
@@ -86,16 +88,91 @@ describe('loadConvoyView', () => {
     expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'graph_v2_root_only' });
   });
 
-  it('propagates the list read partial flag (cursor- or total-based truncation)', async () => {
+  it('clears partial when the city page is complete without walking the subtree', async () => {
     mockFetchSupervisorBead.mockResolvedValue(bead('root'));
-    // listSupervisorBeads folds next_cursor / partial / total>fetched into one
-    // `partial` flag (listIsIncomplete); the loader trusts it rather than
-    // re-deriving from upstream_total, so cursor truncation is not missed.
-    mockListSupervisorBeads.mockResolvedValue(list([bead('root')], { partial: true }));
+    mockListSupervisorBeads.mockResolvedValue(
+      list([bead('root'), bead('a', { parent: 'root' })], { partial: false }),
+    );
+
+    const load = await loadConvoyView('root');
+
+    expect(load.partial).toBe(false);
+    // A complete city page already proves the subtree is whole; no scoped walk.
+    expect(mockFetchBeadSubtreeIds).not.toHaveBeenCalled();
+  });
+
+  it('clears partial for a truncated page when the authoritative subtree is captured', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root', { status: 'in_progress' }));
+    mockListSupervisorBeads.mockResolvedValue(
+      list(
+        [
+          bead('root', { status: 'in_progress' }),
+          bead('a', { parent: 'root', created_at: '2026-06-12T00:00:01Z' }),
+          bead('b', { parent: 'a', created_at: '2026-06-12T00:00:02Z' }),
+        ],
+        { partial: true },
+      ),
+    );
+    // The graph walk reports exactly the descendants the page already captured.
+    mockFetchBeadSubtreeIds.mockResolvedValue(['a', 'b']);
+
+    const load = await loadConvoyView('root');
+
+    expect(mockFetchBeadSubtreeIds).toHaveBeenCalledWith('root');
+    expect(load.partial).toBe(false);
+  });
+
+  it('keeps partial for a truncated page when the subtree holds an uncaptured descendant', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root', { status: 'in_progress' }));
+    mockListSupervisorBeads.mockResolvedValue(
+      list(
+        [
+          bead('root', { status: 'in_progress' }),
+          bead('a', { parent: 'root', created_at: '2026-06-12T00:00:01Z' }),
+        ],
+        { partial: true },
+      ),
+    );
+    // Authoritative walk surfaces a descendant 'c' the bounded page missed.
+    mockFetchBeadSubtreeIds.mockResolvedValue(['a', 'c']);
 
     const load = await loadConvoyView('root');
 
     expect(load.partial).toBe(true);
+  });
+
+  it('does not walk the subtree for a graph.v2 root whose steps the page never carries', async () => {
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+      title: 'mol-focus-review',
+    });
+    mockFetchSupervisorBead.mockResolvedValue(root);
+    mockListSupervisorBeads.mockResolvedValue(list([root], { partial: true }));
+
+    const load = await loadConvoyView('root');
+
+    // graph.v2 steps live in the workflow snapshot, never the bead page, so a
+    // truncated city page provably cannot hide them — no scoped walk, no warning.
+    expect(load.partial).toBe(false);
+    expect(mockFetchBeadSubtreeIds).not.toHaveBeenCalled();
+  });
+
+  it('stays conservative and logs when the subtree walk fails on a truncated page', async () => {
+    mockFetchSupervisorBead.mockResolvedValue(bead('root'));
+    mockListSupervisorBeads.mockResolvedValue(
+      list([bead('root'), bead('a', { parent: 'root' })], { partial: true }),
+    );
+    mockFetchBeadSubtreeIds.mockRejectedValue(new Error('graph read failed'));
+    // The failed refinement read degrades to over-warn rather than swallowing
+    // the error — assert the warning so the global no-warn guard stays in force.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const load = await loadConvoyView('root');
+
+    expect(load.partial).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('subtree completeness check failed'));
+    warn.mockRestore();
   });
 
   it('does not treat a self-parent bead as its own child', async () => {

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -1,6 +1,7 @@
 import type { ConvoyView, DashboardBead } from 'gas-city-dashboard-shared';
 import { projectConvoyView } from 'gas-city-dashboard-shared';
-import { fetchSupervisorBead, listSupervisorBeads } from './beadReads';
+import { LOG_COMPONENT, logWarn } from '../lib/logging';
+import { fetchBeadSubtreeIds, fetchSupervisorBead, listSupervisorBeads } from './beadReads';
 import { normalizeBead, normalizeBeads } from './normalizeBead';
 
 // Loader for the /convoy/:rootBead route (gascity-dashboard-caag, Shape A).
@@ -22,19 +23,24 @@ import { normalizeBead, normalizeBeads } from './normalizeBead';
 //     never addresses.
 //   * beads/graph/{root} collapses graph.v2 snapshots to the root bead alone
 //     (the same upstream hole tracked by gascity-dashboard-jl3c), so it returns
-//     no step children the parent-chain scan does not — and it is slow.
+//     no step children the parent-chain scan does not — and it is slow. So it is
+//     not the projection source; it serves only as the authoritative subtree
+//     walk that confirms completeness on the truncated-page path (jy3d, below).
 // So there is no supervisor progress count to prefer: `projectConvoyView`
 // derives progress from the materialized children, and a graph.v2 root with no
 // exposed children collapses to the honest "steps not exposed" state. The
 // authoritative graph.v2 step graph lives in the workflow snapshot
 // (WorkflowSnapshotResponse) — wiring it here is the jl3c redesign, out of
-// scope for this loader. Because the route composes only the already-allowed
-// `beads` and `bead/{id}` reads, it works under DASHBOARD_READONLY=1 as-is.
+// scope for this loader. The route composes only allowlisted reads — `beads`,
+// `bead/{id}`, and the `beads/graph/{rootID}` completeness walk — so it works
+// under DASHBOARD_READONLY=1 as-is.
 //
-// Truncation is honest: a busy city's closed beads can exceed one bounded page,
-// so `partial` trips when the bounded read is incomplete (the supervisor flags
-// it, returns a `next_cursor`, or its total outruns the page) and the route
-// renders a partial notice rather than silently dropping steps.
+// Truncation is honest AND subtree-scoped: a busy city's closed beads can
+// exceed one bounded page, but a truncated city page only matters when it could
+// be hiding a member of THIS convoy's subtree. So when the page read is
+// incomplete (the supervisor flags it, returns a `next_cursor`, or its total
+// outruns the page) the loader confirms the subtree against the authoritative
+// graph walk before warning — see `deriveConvoyPartial` (gascity-dashboard-jy3d).
 
 // Convoy step beads are bookkeeping-typed and frequently closed, so the read
 // must include both — unlike the board's default open/engineering view.
@@ -54,17 +60,57 @@ export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
   });
   const beads = normalizeBeads(list.items);
   const children = descendantsOf(root.id, beads);
+  const view = projectConvoyView(root, children, null);
   return {
-    view: projectConvoyView(root, children, null),
-    // Conservative by design: a truncated city page cannot prove this convoy's
-    // subtree is complete — a descendant could sit in the unfetched tail, and a
-    // flat list gives no way to tell "all descendants fetched" from "some
-    // missing". So we surface partial whenever the city page is incomplete. This
-    // can over-warn (the convoy may in fact be whole), but never under-warns
-    // (hiding missing steps). Tightening to a true subtree-scoped completeness
-    // check needs a supervisor subtree query — tracked as a follow-up.
-    partial: list.partial,
+    view,
+    partial: await deriveConvoyPartial(view, children, list.partial),
   };
+}
+
+/**
+ * Whether the convoy view is built from an incomplete subtree — the precise
+ * signal behind the route's "Partial convoy" notice (gascity-dashboard-jy3d).
+ *
+ * A complete city page proves the subtree is whole, so it is never partial. A
+ * truncated city page only matters when it could be hiding a member of THIS
+ * convoy's subtree, so the broad `list.partial` is narrowed in two steps:
+ *
+ *  - A graph.v2 run root's steps live in the workflow snapshot, never as
+ *    parent-linked beads in the city page (the gascity-dashboard-jl3c hole), so
+ *    a truncated page provably cannot hide them — the collapse to
+ *    `graph_v2_root_only` is structural, not truncation-induced.
+ *  - Otherwise (materialized steps, or a leaf a truncated page might be hiding
+ *    children behind) the authoritative graph walk reports the true descendant
+ *    set; the convoy is partial only when that set holds an id the bounded page
+ *    did not capture.
+ *
+ * The graph walk runs only on the truncated-page path, so the slower scoped read
+ * is paid only in the large-city case it disambiguates. If it fails the loader
+ * stays conservative (over-warn, never hide missing steps) and logs the
+ * degradation rather than swallowing it.
+ */
+async function deriveConvoyPartial(
+  view: ConvoyView,
+  children: readonly DashboardBead[],
+  cityPagePartial: boolean,
+): Promise<boolean> {
+  if (!cityPagePartial) return false;
+  if (view.exposure.kind === 'collapsed' && view.exposure.reason === 'graph_v2_root_only') {
+    return false;
+  }
+  try {
+    const subtreeIds = await fetchBeadSubtreeIds(view.rootBeadId);
+    const captured = new Set(children.map((child) => child.id));
+    return subtreeIds.some((id) => !captured.has(id));
+  } catch (err) {
+    logWarn(
+      LOG_COMPONENT.convoy,
+      `subtree completeness check failed for ${view.rootBeadId}; staying conservative: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return true;
+  }
 }
 
 /**

--- a/frontend/src/supervisor/entityLinks.test.ts
+++ b/frontend/src/supervisor/entityLinks.test.ts
@@ -20,6 +20,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),

--- a/frontend/src/supervisor/mailReads.test.ts
+++ b/frontend/src/supervisor/mailReads.test.ts
@@ -30,6 +30,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),

--- a/frontend/src/supervisor/runDetail.test.ts
+++ b/frontend/src/supervisor/runDetail.test.ts
@@ -36,6 +36,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -30,6 +30,7 @@ const baseApi: SupervisorApi = {
   listBeads: vi.fn(),
   listEvents: vi.fn(),
   getBead: vi.fn(),
+  beadsGraph: vi.fn(),
   createBead: vi.fn(),
   updateBead: vi.fn(),
   closeBead: vi.fn(),


### PR DESCRIPTION
## What

Makes the convoy page's `partial` flag **subtree-scoped** instead of whole-city-scoped. Previously a city with >1000 beads where the convoy was fully within the fetched page falsely showed "Partial convoy" (the over-warn documented as a follow-up on #133). Now, when the city page is truncated, it fetches the authoritative subtree (`/v0/city/{cityName}/beads/graph/{rootID}`, unpaged) and sets `partial=true` only if a real descendant wasn't captured.

## Soundness (the key property)

Independently confirmed by 3 reviewers + a Codex cross-provider trace: `partial=false` **cannot** hide an unfetched descendant.
- Complete city page → `false` (provably complete).
- Truncated page → fetch the subtree graph (path-param only, no cursor → can't itself be truncated); `partial=true` if any authoritative descendant id is missing from the captured set.
- graph.v2-root-only → `false` (intentional semantic case — steps aren't parent-linked beads, same assumption the old code relied on).
- Graph walk throws → `true` (conservative, logged).

## Review + checks

- code **APPROVE**, typescript **APPROVE**, Codex **approve** — 0 blockers, 0 majors. Soundness: no regression.
- CI-parity (local, 8/8): build, typecheck (src+test), lint, prettier, openapi, all suites (1025 tests). New tests cover all 5 branches (complete / subtree-captured / subtree-incomplete / graph.v2 / walk-throws). Backend allowlist entry + test for the new read endpoint.

## Follow-up (non-blocking)

- `beads: null` edge test + a `deriveConvoyPartial` doc note on the graph.v2 invariant (tracked).
