### PR TITLE
fix(runs): log feed/session read failures before degrading

### DIFF
--- a/frontend/src/lib/logging.ts
+++ b/frontend/src/lib/logging.ts
@@ -11,9 +11,15 @@
 export const LOG_COMPONENT = {
   views: 'views',
   convoy: 'convoy',
+  runs: 'runs',
 } as const;
 
 export type LogComponent = (typeof LOG_COMPONENT)[keyof typeof LOG_COMPONENT];
+
+export function logError(component: LogComponent, message: string): void {
+  // eslint-disable-next-line no-console -- single-point seam (mirrors backend/logging.ts).
+  console.error(`[${component}] ${message}`);
+}
 
 export function logWarn(component: LogComponent, message: string): void {
   // eslint-disable-next-line no-console -- single-point seam (mirrors backend/logging.ts).

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -506,6 +506,8 @@ describe('loadSupervisorRunSummarySource', () => {
     // the lane set may be degraded (scopes unresolved) — flag partial, but the
     // active lanes from the core read still render. Never required: a feed
     // failure must not blank the view (live it measured 14.3s city-scoped).
+    // gascity-dashboard-dh7t: the failure must also be logged, not swallowed.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const listBeads = vi.fn(async () => beadList([runRoot()]));
     setSupervisorApiForTests({
       ...baseApi,
@@ -522,6 +524,39 @@ describe('loadSupervisorRunSummarySource', () => {
     if (source.status === 'error') throw new Error(source.error);
     expect(source.data.totalActive).toBe(1);
     expect(source.data.lanesPartial).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('formula feed read failed for city=test-city'),
+    );
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('feed unavailable');
+    errorSpy.mockRestore();
+  });
+
+  it('logs and degrades lane health to unavailable when the session read fails (gascity-dashboard-dh7t)', async () => {
+    // A swallowed session-read failure leaves every lane health at 'unavailable'
+    // with no operator-visible reason. The lanes still render (sessions are
+    // enrichment, not required); the failure must be logged before degrading.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const listBeads = vi.fn(async () => beadList([runRoot()]));
+    setSupervisorApiForTests({
+      ...baseApi,
+      listBeads,
+      formulaFeed: vi.fn(async () => feed([feedRun()])),
+      listSessions: vi.fn(async () => {
+        throw new Error('sessions unavailable');
+      }),
+    });
+
+    const source = await loadSupervisorRunSummarySource();
+
+    expect(source.status).toBe('fresh');
+    if (source.status === 'error') throw new Error(source.error);
+    expect(source.data.totalActive).toBe(1);
+    expect(source.data.lanes[0]?.health.status).toBe('unavailable');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run sessions read failed for city=test-city'),
+    );
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('sessions unavailable');
+    errorSpy.mockRestore();
   });
 
   it('marks the summary partial when the active bead list is cursor-truncated', async () => {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -26,6 +26,7 @@ import {
   type LaneProgressMark,
 } from 'gas-city-dashboard-shared';
 import { activeCityOrThrow } from '../api/cityBase';
+import { logError, LOG_COMPONENT } from '../lib/logging';
 import type { FormulaFeedBody, ListBodyBead } from 'gas-city-dashboard-shared/gc-supervisor';
 import { supervisorApiForRequestBudget } from './client';
 import { fetchCoreRead } from './coreRead';
@@ -601,7 +602,16 @@ async function discoverFromFeed(
       rootIdsComplete,
       partial: feedIsPartial(runs),
     };
-  } catch {
+  } catch (err) {
+    // gascity-dashboard-dh7t: a swallowed feed failure silently degrades the
+    // whole run set — scopes go unresolved and every run-registration judgment
+    // collapses to 'unknown' (a stranded run reads as merely 'unknown', a
+    // false-alive). Surface it before returning the partial fallback so the
+    // degradation is visible instead of silent (Don't Swallow Errors).
+    logError(
+      LOG_COMPONENT.runs,
+      `formula feed read failed for city=${cityName}; degrading run registration to unknown and marking lanes partial: ${errorMessage(err, 'formula feed unavailable')}`,
+    );
     return {
       rigNames: [],
       scopes: new Map(),
@@ -624,7 +634,15 @@ async function loadRunSessions(cityName: string, budgetMs: number): Promise<RunS
       kind: 'available',
       sessions: normalizeSessions(list),
     };
-  } catch {
+  } catch (err) {
+    // gascity-dashboard-dh7t: a swallowed session-read failure makes every
+    // lane's health degrade to 'unavailable' (no session resolution), so the
+    // operator loses needs-operator/thrash signal with no indication why.
+    // Surface it before returning the unavailable fallback (Don't Swallow Errors).
+    logError(
+      LOG_COMPONENT.runs,
+      `run sessions read failed for city=${cityName}; degrading lane health to unavailable: ${errorMessage(err, 'run sessions unavailable')}`,
+    );
     return { kind: 'unavailable', sessions: [] };
   }
 }


### PR DESCRIPTION
## What

Logs feed/session read failures before the runs view degrades to its fallback. Pure internal diagnostics — when `discoverFromFeed` or `loadRunSessions` hits an error and degrades (run registration → unknown / lanes → partial / sessions → unavailable), it now emits a `logError` with the city name + the degradation consequence + the underlying error, instead of degrading silently.

## Behavior

- Control flow and fallback return values are **unchanged** (byte-for-byte): no rethrow, no altered branching, no swallow-difference. The log fires first, then the same fallback returns.
- Console-only; no operator-visible / API / UI change.

## Review + checks

- code **APPROVE** — 0 findings; confirmed log-then-degrade with control flow preserved, actionable messages, no console-spy leak.
- CI-parity (local): build, typecheck (src+test), lint, prettier, frontend tests — all green. New tests assert both the log fires AND degradation still happens, for the feed and session paths.

Rebased onto current main (resolved a trivial `logging.ts` LOG_COMPONENT conflict — kept both `convoy` and `runs`).
