### PR TITLE
refactor(runs): retire dead RunCounts.visible, immutable normalizeBead, trim incident comments (xk7u)

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -28,7 +28,6 @@ function freshRunsSource(): SourceState<RunSummary> {
       strandedLanes: [],
       runCounts: {
         total: 0,
-        visible: 0,
         prReview: 0,
         designReview: 0,
         bugfix: 0,

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -1058,7 +1058,6 @@ function runSummary(lanes: readonly RunLane[]): RunSummary {
     totalActive: activeLanes.length,
     runCounts: {
       total: activeLanes.length,
-      visible: activeLanes.length,
       prReview: 0,
       designReview: 0,
       bugfix: 0,

--- a/frontend/src/routes/AmbientHome.test.tsx
+++ b/frontend/src/routes/AmbientHome.test.tsx
@@ -176,7 +176,6 @@ function runSource({
       strandedLanes: [],
       runCounts: {
         total: lanes.length,
-        visible: lanes.length,
         prReview: 0,
         designReview: 0,
         bugfix: 0,

--- a/frontend/src/routes/FormulaRunDetail.test.tsx
+++ b/frontend/src/routes/FormulaRunDetail.test.tsx
@@ -928,7 +928,6 @@ function runSummarySource(lanes: RunLane[] = []): SourceState<RunSummary> {
       strandedLanes: [],
       runCounts: {
         total: lanes.length,
-        visible: lanes.length,
         prReview: 0,
         designReview: 0,
         bugfix: 0,

--- a/frontend/src/routes/Runs.test.tsx
+++ b/frontend/src/routes/Runs.test.tsx
@@ -97,7 +97,6 @@ function buildRunSource(
       strandedLanes: [],
       runCounts: {
         total: 0,
-        visible: 0,
         prReview: 0,
         designReview: 0,
         bugfix: 0,
@@ -281,7 +280,6 @@ describe('RunsPage — SSE wiring (gascity-dashboard-bqn)', () => {
     const previewRuns = requireRunData(preview);
     previewRuns.totalActive = 1;
     previewRuns.runCounts.total = 1;
-    previewRuns.runCounts.visible = 1;
     previewRuns.lanes = [activeLane({ title: 'Preview formula run' })];
     mockLoadRunSummaryPreview.mockResolvedValue(preview);
     const full = deferred<SourceState<RunSummary>>();
@@ -751,7 +749,7 @@ describe('RunsPage — blocked lanes are not Active (gascity-dashboard-4xcv)', (
       }),
     ];
     runs.blockedLanes = [blockedLane()];
-    runs.runCounts = { ...runs.runCounts, total: 1, visible: 1, blocked: 1 };
+    runs.runCounts = { ...runs.runCounts, total: 1, blocked: 1 };
     mockLoadRunSummary.mockResolvedValue(source);
 
     mount();

--- a/frontend/src/runs/runSummarySubscription.test.tsx
+++ b/frontend/src/runs/runSummarySubscription.test.tsx
@@ -62,7 +62,6 @@ function buildRunSource(
       strandedLanes: [],
       runCounts: {
         total: 0,
-        visible: 0,
         prReview: 0,
         designReview: 0,
         bugfix: 0,

--- a/frontend/src/supervisor/normalizeBead.ts
+++ b/frontend/src/supervisor/normalizeBead.ts
@@ -11,26 +11,25 @@ import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
 // absent on the projection rather than becoming an explicit `undefined`.
 
 export function normalizeBead(bead: Bead): DashboardBead {
-  const normalized: DashboardBead = {
+  return {
     id: bead.id,
     title: bead.title,
     status: bead.status,
     issue_type: bead.issue_type,
     priority: bead.priority ?? null,
     created_at: bead.created_at,
+    ...(bead.description !== undefined && { description: bead.description }),
+    ...(bead.assignee !== undefined && { assignee: bead.assignee }),
+    ...(Array.isArray(bead.labels) && { labels: bead.labels }),
+    ...(bead.metadata !== undefined && { metadata: bead.metadata }),
+    ...(bead.ref !== undefined && { ref: bead.ref }),
+    ...(bead.parent !== undefined && { parent: bead.parent }),
+    ...(bead.from !== undefined && { from: bead.from }),
+    ...(bead.ephemeral !== undefined && { ephemeral: bead.ephemeral }),
+    ...(bead.needs !== undefined && { needs: bead.needs }),
+    ...(bead.dependencies !== undefined && { dependencies: bead.dependencies }),
+    ...(bead.updated_at !== undefined && { updated_at: bead.updated_at }),
   };
-  if (bead.description !== undefined) normalized.description = bead.description;
-  if (bead.assignee !== undefined) normalized.assignee = bead.assignee;
-  if (Array.isArray(bead.labels)) normalized.labels = bead.labels;
-  if (bead.metadata !== undefined) normalized.metadata = bead.metadata;
-  if (bead.ref !== undefined) normalized.ref = bead.ref;
-  if (bead.parent !== undefined) normalized.parent = bead.parent;
-  if (bead.from !== undefined) normalized.from = bead.from;
-  if (bead.ephemeral !== undefined) normalized.ephemeral = bead.ephemeral;
-  if (bead.needs !== undefined) normalized.needs = bead.needs;
-  if (bead.dependencies !== undefined) normalized.dependencies = bead.dependencies;
-  if (bead.updated_at !== undefined) normalized.updated_at = bead.updated_at;
-  return normalized;
 }
 
 export function normalizeBeads(beads: readonly Bead[]): DashboardBead[] {

--- a/frontend/src/supervisor/runSummary.test.ts
+++ b/frontend/src/supervisor/runSummary.test.ts
@@ -498,7 +498,6 @@ describe('loadSupervisorRunSummarySource', () => {
     // The phantom (the 10th, session-less latch) is demoted; all 9 live runs survive.
     expect(source.data.lanes.map((lane) => lane.id)).toEqual(liveRuns.map((_, i) => `live-${i}`));
     expect(source.data.runCounts.total).toBe(9);
-    expect(source.data.runCounts.visible).toBe(9);
   });
 
   it('keeps available lanes while marking the summary partial when the feed read fails (gascity-dashboard-n6f1)', async () => {

--- a/frontend/src/supervisor/runSummary.ts
+++ b/frontend/src/supervisor/runSummary.ts
@@ -34,10 +34,8 @@ import { listIsIncomplete, listIsPartial } from './listPartial';
 import { normalizeBeads } from './normalizeBead';
 import { normalizeSessions } from './sessionReads';
 
-// Pre-exposure load bound (gascity-dashboard-q89b): the primary in-flight
-// bead fetch refreshes on SSE bursts (10s debounce floor in the shared
-// run-summary subscription) per client. listIsIncomplete keeps truncation
-// visible in the lanes-partial signal.
+// Bounded in-flight bead fetch (gascity-dashboard-q89b); truncation stays
+// visible via listIsIncomplete in the lanes-partial signal.
 const RUNS_FETCH_LIMIT = 500;
 // gascity-dashboard-4xcv: the supervisor's bead list has no sort/recency
 // guarantee, so a small `all=true` window can drop run roots and step beads
@@ -74,16 +72,11 @@ const REQUIRED_RUN_SUMMARY_TIMEOUT_MS = 15_000;
 // first-paint spinner a single global raise would cause.
 const PREVIEW_ENRICHMENT_TIMEOUT_MS = 2_500;
 const REFRESH_ENRICHMENT_TIMEOUT_MS = 30_000;
-// Header-first restructure (supersedes the gascity-dashboard-9rk2 3s molecule
-// bound): the closed-history fan-out — the molecule(all=true) scan over the
-// ~340k-row history (measured 9.9s live, so it timed out against the old 3s
-// bound on EVERY refresh and chronically latched the "runs partial" badge) plus
-// the per-rig task(all=true) closed reads (measured 10.9s on a 29.8k-issue rig
-// store) — now runs ONLY on the lazy history source, fetched when the operator
-// opens the /runs history section. There it IS the payload, so it rides this
-// wide budget (matching the refresh budget / the 30s background samplers) and
-// the measured reads land instead of degrading. A genuinely slow scan still
-// folds to history-partial, never an error.
+// The closed-history fan-out (molecule + per-rig task all=true scans, ~10s live
+// on a large store) runs only on the lazy history source, where it IS the
+// payload, so it rides this wide budget; a genuinely slow scan folds to
+// history-partial, never an error (gascity-dashboard-9rk2 superseded the old 3s
+// bound that chronically latched a spurious "runs partial" badge).
 const HISTORY_ENRICHMENT_TIMEOUT_MS = 30_000;
 
 interface LoadedRunBeads {
@@ -691,14 +684,11 @@ function enrichRunSummary(
     (lane) => lane.phase !== 'blocked' && lane.registration !== 'stranded',
   );
 
-  // gascity-dashboard-s4rp: sessions only resolve here at enrichment, so this is
-  // the earliest seam with enough information to demote stale session-less
-  // latches (the gc-1920 phantom: no live session, no in_progress step, days
-  // stale) out of the Active set. buildRunSummary hands us the FULL active set
-  // (not the capped window), so totalActive is recomputed exactly from the
-  // surviving lanes — a phantom past the 8th slot is demoted too. Staleness is
-  // judged against the snapshot generation time, not a live clock, so the result
-  // is stable for a snapshot.
+  // gascity-dashboard-s4rp: sessions resolve only here at enrichment, so this is
+  // the earliest seam to demote stale sessionless latches (the gc-1920 phantom)
+  // out of the Active set. The FULL active set is handed in, so totalActive is
+  // recomputed from the survivors; staleness is judged against the snapshot
+  // generation time, not a live clock, so the result is stable per snapshot.
   const liveActive = activeEnriched.filter(
     (lane) => !isStaleSessionlessLatch(lane, generationMs, sessionsAvailable),
   );
@@ -723,7 +713,7 @@ function enrichRunSummary(
     lanes: liveActive,
     blockedLanes,
     strandedLanes: liveStranded,
-    runCounts: runCounts(liveActive, liveActive.length, blockedLanes.length, liveStranded.length),
+    runCounts: runCounts(liveActive, blockedLanes.length, liveStranded.length),
     census: { status: 'available', data: census },
   };
 }

--- a/shared/src/runs/summary.test.ts
+++ b/shared/src/runs/summary.test.ts
@@ -321,7 +321,6 @@ describe('buildRunSummary — active lanes carry the full set (component-collaps
     assert.equal(summary.totalActive, count);
     assert.equal(summary.lanes.length, count);
     assert.equal(summary.runCounts.total, count);
-    assert.equal(summary.runCounts.visible, count);
   });
 });
 

--- a/shared/src/runs/summary.ts
+++ b/shared/src/runs/summary.ts
@@ -100,12 +100,7 @@ export function buildRunSummary(
   // mirroring the historical section — so the wire is never pre-capped.
   const summary: RunSummary = {
     totalActive: activeLanes.length,
-    runCounts: runCounts(
-      activeLanes,
-      activeLanes.length,
-      blockedLanes.length,
-      strandedLanes.length,
-    ),
+    runCounts: runCounts(activeLanes, blockedLanes.length, strandedLanes.length),
     lanes: activeLanes,
     blockedLanes,
     strandedLanes,
@@ -192,15 +187,9 @@ function isRunGroup(rootId: string, issues: RunIssue[]): boolean {
   );
 }
 
-export function runCounts(
-  lanes: RunLane[],
-  visible: number,
-  blocked: number,
-  stranded: number,
-): RunCounts {
+export function runCounts(lanes: RunLane[], blocked: number, stranded: number): RunCounts {
   const counts: RunCounts = {
     total: lanes.length,
-    visible,
     prReview: 0,
     designReview: 0,
     bugfix: 0,
@@ -520,7 +509,6 @@ export function emptyRunSummary(): RunSummary {
     totalActive: 0,
     runCounts: {
       total: 0,
-      visible: 0,
       prReview: 0,
       designReview: 0,
       bugfix: 0,

--- a/shared/src/snapshot/types.ts
+++ b/shared/src/snapshot/types.ts
@@ -310,12 +310,6 @@ export type RunLaneHealthState = Avail<{
 
 export interface RunCounts {
   total: number;
-  /** @deprecated use total — RunMap owns the rendered collapse; always equals total.
-   *
-   *  Count of active lanes carried on the wire. Now equal to `total` (the full
-   *  active set), since RunMap owns the rendered collapse rather than the wire
-   *  pre-capping at MAX_VISIBLE_ACTIVE_LANES. */
-  visible: number;
   prReview: number;
   designReview: number;
   bugfix: number;


### PR DESCRIPTION
DEEP_AUDIT erosion cleanup, on main post-pxvb #131:
1. Removed `@deprecated RunCounts.visible` (always `=== total`) from the interface, `runCounts()` signature + body, `emptyRunSummary`, both callers, and 9 test sites.
2. `normalizeBead` → a single immutable conditional-spread literal; absent-stays-absent behavior preserved and pinned by `normalizeBead.test.ts`.
3. Trimmed gc-1920 / q89b / 9rk2 incident-narrative comments down to their invariants.

Net −38 lines. Behavior-preserving (the dead field is unused by rendering). CI parity green; independently code-reviewed PASS + ship-pass.
