### PR TITLE
fix(convoy): scope the graph.v2 partial short-circuit to the genuinely-empty case (3i31)

### DIFF
--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -9,6 +9,7 @@ import {
   type SupervisorApi,
 } from './client';
 import {
+  fetchBeadSubtreeIds,
   fetchSupervisorBead,
   listSupervisorBeads,
   listSupervisorBeadsAssignedTo,
@@ -183,6 +184,38 @@ describe('supervisor bead reads', () => {
 
     await expect(fetchSupervisorBead('rc-decision')).rejects.toMatchObject({ status: 503 });
     expect(listBeads).not.toHaveBeenCalled();
+  });
+
+  // gascity-dashboard-3i31: fetchBeadSubtreeIds is the authoritative completeness
+  // walk behind the convoy "Partial convoy" notice. Its root-exclusion, dedup,
+  // and `beads ?? []` guard were previously only reached through a hoisted module
+  // mock — exercise the real impl here.
+  it('returns the graph descendant ids, excluding the root and de-duplicating', async () => {
+    const beadsGraph = vi.fn(async () => ({
+      root: bead({ id: 'root' }),
+      beads: [
+        bead({ id: 'root' }),
+        bead({ id: 'a' }),
+        bead({ id: 'b' }),
+        bead({ id: 'a' }),
+      ],
+      deps: [],
+    }));
+    setSupervisorApiForTests({ ...baseApi, beadsGraph });
+
+    const ids = await fetchBeadSubtreeIds('root');
+
+    expect(beadsGraph).toHaveBeenCalledWith('test-city', 'root');
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('treats a root-only / null-beads graph response as an empty descendant set', async () => {
+    // The generated BeadGraphResponse types `beads` as nullable; a graph.v2 root
+    // collapses to root-only, so the walk must yield [] rather than throw.
+    const beadsGraph = vi.fn(async () => ({ root: bead({ id: 'root' }), beads: null, deps: [] }));
+    setSupervisorApiForTests({ ...baseApi, beadsGraph });
+
+    await expect(fetchBeadSubtreeIds('root')).resolves.toEqual([]);
   });
 
   it('does not flag the assigned-bead union partial when assignees merely share a bead', async () => {

--- a/frontend/src/supervisor/beadReads.test.ts
+++ b/frontend/src/supervisor/beadReads.test.ts
@@ -193,12 +193,7 @@ describe('supervisor bead reads', () => {
   it('returns the graph descendant ids, excluding the root and de-duplicating', async () => {
     const beadsGraph = vi.fn(async () => ({
       root: bead({ id: 'root' }),
-      beads: [
-        bead({ id: 'root' }),
-        bead({ id: 'a' }),
-        bead({ id: 'b' }),
-        bead({ id: 'a' }),
-      ],
+      beads: [bead({ id: 'root' }), bead({ id: 'a' }), bead({ id: 'b' }), bead({ id: 'a' })],
       deps: [],
     }));
     setSupervisorApiForTests({ ...baseApi, beadsGraph });

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -175,6 +175,61 @@ describe('loadConvoyView', () => {
     warn.mockRestore();
   });
 
+  it('walks the subtree for a graph.v2 root once any parent-linked step is captured', async () => {
+    // The graph_v2_root_only short-circuit fires ONLY when the captured child
+    // set is empty (gascity-dashboard-3i31). A graph.v2 root that DOES expose a
+    // parent-linked step is `exposed`, not collapsed, so it is not exempt from
+    // the authoritative completeness walk — proving the short-circuit cannot
+    // clear `partial` for a graph.v2 root whose steps the page actually carries.
+    const root = bead('root', {
+      status: 'in_progress',
+      metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+      title: 'mol-focus-review',
+    });
+    mockFetchSupervisorBead.mockResolvedValue(root);
+    mockListSupervisorBeads.mockResolvedValue(
+      list([root, bead('a', { parent: 'root', created_at: '2026-06-12T00:00:01Z' })], {
+        partial: true,
+      }),
+    );
+    // Authoritative walk surfaces a step 'c' the truncated page dropped.
+    mockFetchBeadSubtreeIds.mockResolvedValue(['a', 'c']);
+
+    const load = await loadConvoyView('root');
+
+    expect(load.view.exposure.kind).toBe('exposed');
+    expect(mockFetchBeadSubtreeIds).toHaveBeenCalledWith('root');
+    expect(load.partial).toBe(true);
+  });
+
+  it('walks the subtree for a genuine no_children leaf on a truncated page', async () => {
+    // A non-graph.v2 leaf collapses to `no_children`, NOT `graph_v2_root_only`,
+    // so it is not short-circuited: a truncated page might be hiding children the
+    // leaf actually has, so the authoritative walk must run and over-warn when it
+    // surfaces an uncaptured descendant.
+    mockFetchSupervisorBead.mockResolvedValue(bead('root'));
+    mockListSupervisorBeads.mockResolvedValue(list([bead('root')], { partial: true }));
+    mockFetchBeadSubtreeIds.mockResolvedValue(['hidden-child']);
+
+    const load = await loadConvoyView('root');
+
+    expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'no_children' });
+    expect(mockFetchBeadSubtreeIds).toHaveBeenCalledWith('root');
+    expect(load.partial).toBe(true);
+  });
+
+  it('rejects an invalid root bead id at the loader boundary before any supervisor read', async () => {
+    // The `/convoy/:rootBead` route param is untrusted input; a malformed id must
+    // be turned away at the loader edge (as a 404 the route renders as not-found)
+    // rather than reaching a supervisor path param (gascity-dashboard-3i31).
+    await expect(loadConvoyView('../etc/passwd')).rejects.toMatchObject({
+      name: 'SupervisorApiError',
+      status: 404,
+    });
+    expect(mockFetchSupervisorBead).not.toHaveBeenCalled();
+    expect(mockListSupervisorBeads).not.toHaveBeenCalled();
+  });
+
   it('does not treat a self-parent bead as its own child', async () => {
     mockFetchSupervisorBead.mockResolvedValue(bead('root'));
     mockListSupervisorBeads.mockResolvedValue(list([bead('root', { parent: 'root' })]));

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -1,7 +1,8 @@
 import type { ConvoyView, DashboardBead } from 'gas-city-dashboard-shared';
-import { projectConvoyView } from 'gas-city-dashboard-shared';
+import { BEAD_ID_RE, projectConvoyView } from 'gas-city-dashboard-shared';
 import { LOG_COMPONENT, logWarn } from '../lib/logging';
 import { fetchBeadSubtreeIds, fetchSupervisorBead, listSupervisorBeads } from './beadReads';
+import { SupervisorApiError } from './client';
 import { normalizeBead, normalizeBeads } from './normalizeBead';
 
 // Loader for the /convoy/:rootBead route (gascity-dashboard-caag, Shape A).
@@ -52,6 +53,16 @@ export interface ConvoyLoad {
 }
 
 export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
+  // The root id is the untrusted `/convoy/:rootBead` route param. Validate it at
+  // this loader boundary — the single chokepoint before either supervisor read
+  // (the root `bead/{id}` and the `beads/graph/{rootID}` completeness walk) — so
+  // a malformed id never reaches a supervisor path param. A garbage id cannot
+  // name a real bead, so surface it as the route's honest not-found state rather
+  // than a generic failure (the proxy's traversal gate already blocks the
+  // high-risk forms; this is defense-in-depth at the data edge).
+  if (!BEAD_ID_RE.test(rootBeadId)) {
+    throw new SupervisorApiError(404, `invalid bead id: ${rootBeadId}`, undefined);
+  }
   const root = normalizeBead(await fetchSupervisorBead(rootBeadId));
   const list = await listSupervisorBeads({
     includeClosed: true,
@@ -75,10 +86,20 @@ export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
  * truncated city page only matters when it could be hiding a member of THIS
  * convoy's subtree, so the broad `list.partial` is narrowed in two steps:
  *
- *  - A graph.v2 run root's steps live in the workflow snapshot, never as
- *    parent-linked beads in the city page (the gascity-dashboard-jl3c hole), so
- *    a truncated page provably cannot hide them — the collapse to
- *    `graph_v2_root_only` is structural, not truncation-induced.
+ *  - A graph.v2 run root collapses to `graph_v2_root_only`, and a truncated page
+ *    cannot be hiding its steps — but the empty parent-scan is NOT itself the
+ *    proof of that (an empty scan looks the same whether the steps don't exist
+ *    or were truncated away). The proof is upstream and was verified live
+ *    (against the live supervisor, 2026-06-16): the supervisor bead wire shape carries no
+ *    `parent` field at all, so graph.v2 steps are never parent-linked city beads
+ *    in the first place, and `beads/graph/{root}` collapses graph.v2 snapshots to
+ *    the root alone (the gascity-dashboard-jl3c hole) — neither the list nor the
+ *    authoritative walk can surface a graph.v2 step, so there is no descendant a
+ *    truncated page could drop. The steps live only in the workflow snapshot
+ *    (jl3c, out of scope here). Were that to change upstream (parent-linked
+ *    graph.v2 steps materialized in the city page), this short-circuit would no
+ *    longer hold and the walk below would have to decide — but the walk would
+ *    also need beads/graph to stop collapsing, so revisit jl3c together.
  *  - Otherwise (materialized steps, or a leaf a truncated page might be hiding
  *    children behind) the authoritative graph walk reports the true descendant
  *    set; the convoy is partial only when that set holds an id the bounded page

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -90,16 +90,19 @@ export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {
  *    cannot be hiding its steps — but the empty parent-scan is NOT itself the
  *    proof of that (an empty scan looks the same whether the steps don't exist
  *    or were truncated away). The proof is upstream and was verified live
- *    (against the live supervisor, 2026-06-16): the supervisor bead wire shape carries no
- *    `parent` field at all, so graph.v2 steps are never parent-linked city beads
- *    in the first place, and `beads/graph/{root}` collapses graph.v2 snapshots to
- *    the root alone (the gascity-dashboard-jl3c hole) — neither the list nor the
- *    authoritative walk can surface a graph.v2 step, so there is no descendant a
- *    truncated page could drop. The steps live only in the workflow snapshot
- *    (jl3c, out of scope here). Were that to change upstream (parent-linked
- *    graph.v2 steps materialized in the city page), this short-circuit would no
- *    longer hold and the walk below would have to decide — but the walk would
- *    also need beads/graph to stop collapsing, so revisit jl3c together.
+ *    (against the live supervisor, 2026-06-16): the supervisor does not
+ *    materialize graph.v2 step beads as city beads at all (the
+ *    gascity-dashboard-jl3c hole) — they never appear as `parent`-linked rows in
+ *    the city page (the `parent` field exists on the wire and `descendantsOf`
+ *    uses it, but no graph.v2 step is ever present to carry it), and
+ *    `beads/graph/{root}` collapses graph.v2 snapshots to the root alone —
+ *    neither the list nor the authoritative walk can surface a graph.v2 step, so
+ *    there is no descendant a truncated page could drop. The steps live only in
+ *    the workflow snapshot (jl3c, out of scope here). Were that to change
+ *    upstream (parent-linked graph.v2 steps materialized in the city page), this
+ *    short-circuit would no longer hold and the walk below would have to decide —
+ *    but the walk would also need beads/graph to stop collapsing, so revisit
+ *    jl3c together.
  *  - Otherwise (materialized steps, or a leaf a truncated page might be hiding
  *    children behind) the authoritative graph walk reports the true descendant
  *    set; the convoy is partial only when that set holds an id the bounded page


### PR DESCRIPTION
Fix-forward from the PR #134 review. `deriveConvoyPartial` graph_v2_root_only short-circuit scoped to the genuinely-empty child set, with the upstream basis documented honestly (verified live: graph.v2 step beads are never materialized as city beads — jl3c — and beads/graph collapses graph.v2 to root-only).

- Short-circuit fires only when the captured child set is empty; a graph.v2 root exposing any parent-linked step goes through the authoritative completeness walk (regression test).
- `BEAD_ID_RE` validation of the untrusted `/convoy/:rootBead` param at the loader boundary (404).
- Regression tests: graph.v2-with-captured-step → walked; no_children leaf → walked; invalid id → 404; `fetchBeadSubtreeIds` root-exclusion / dedup / null-beads.

CI parity green.
