### PR TITLE
feat(attention): Freshness Spine — board-wide liveness off the freshness fold

### DIFF
--- a/frontend/src/attention/NavAttentionIndicator.tsx
+++ b/frontend/src/attention/NavAttentionIndicator.tsx
@@ -3,9 +3,17 @@ import type { AttentionDomainSummary, BadgeSeverity } from './compose';
 export function NavAttentionIndicator({
   label,
   summary,
+  suppressAccent = false,
 }: {
   label: string;
   summary: AttentionDomainSummary;
+  /**
+   * gascity-dashboard-fchh major 4 (DESIGN.md One Mark): when the board liveness
+   * line owns the viewport's single maroon mark, the count still renders (the
+   * number is the signal) but drops to neutral tone so the header never shows two
+   * maroons at once. The badge count is unchanged — only its colour defers.
+   */
+  suppressAccent?: boolean;
 }) {
   const total = summary.attention + summary.watch;
   if (total === 0 || summary.severity === null) return null;
@@ -14,7 +22,9 @@ export function NavAttentionIndicator({
   return (
     <span
       aria-label={`${label}: ${total} ${summary.severity} ${itemWord}`}
-      className={`ml-1 align-super text-[0.65rem] leading-none tnum ${severityClass(summary.severity)}`}
+      className={`ml-1 align-super text-[0.65rem] leading-none tnum ${
+        suppressAccent ? 'text-fg-muted' : severityClass(summary.severity)
+      }`}
     >
       {total}
     </span>

--- a/frontend/src/attention/NavAttentionIndicator.tsx
+++ b/frontend/src/attention/NavAttentionIndicator.tsx
@@ -9,21 +9,25 @@ export function NavAttentionIndicator({
   summary: AttentionDomainSummary;
   /**
    * gascity-dashboard-fchh major 4 (DESIGN.md One Mark): when the board liveness
-   * line owns the viewport's single maroon mark, the count still renders (the
-   * number is the signal) but drops to neutral tone so the header never shows two
-   * maroons at once. The badge count is unchanged — only its colour defers.
+   * line owns the viewport's single maroon mark, a maroon (attention) badge still
+   * renders its count but drops to neutral tone so the header never shows two
+   * maroons at once. The One Mark Rule is MAROON-only — Caution Ochre (text-warn,
+   * a 'watch' badge) is a separate signal that coexists with one maroon, so it is
+   * left untouched (gascity-dashboard-4q60). The badge count is never changed —
+   * only an attention badge's colour defers.
    */
   suppressAccent?: boolean;
 }) {
   const total = summary.attention + summary.watch;
   if (total === 0 || summary.severity === null) return null;
   const itemWord = total === 1 ? 'item' : 'items';
+  const suppressMaroon = suppressAccent && summary.severity === 'attention';
 
   return (
     <span
       aria-label={`${label}: ${total} ${summary.severity} ${itemWord}`}
       className={`ml-1 align-super text-[0.65rem] leading-none tnum ${
-        suppressAccent ? 'text-fg-muted' : severityClass(summary.severity)
+        suppressMaroon ? 'text-fg-muted' : severityClass(summary.severity)
       }`}
     >
       {total}

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { SourceStatus } from 'gas-city-dashboard-shared';
 import {
   ATTENTION_DOMAINS,
+  boardFreshness,
   composeAttention,
   type AttentionContributor,
   type AttentionItem,
@@ -220,6 +221,58 @@ describe('composeAttention — read-freshness fold (gascity-dashboard-5t0m)', ()
     // The fold must not disturb the existing counts/severity.
     expect(model.byDomain.runs.attention).toBe(1);
     expect(model.byDomain.runs.severity).toBe('attention');
+  });
+});
+
+describe('boardFreshness — board-wide fold for the Header liveness line (gascity-dashboard-5t0m)', () => {
+  it('folds the oldest fetchedAt + worst provenance across domains, with no degraded when all fresh', () => {
+    const fresh = boardFreshness(
+      composeAttention([
+        freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }),
+        freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T08:00:00.000Z' }),
+        freshContributor('agents', { provenance: 'fresh', fetchedAt: '2026-06-18T10:00:00.000Z' }),
+      ]),
+    );
+
+    expect(fresh.provenance).toBe('fresh');
+    expect(fresh.fetchedAt).toBe('2026-06-18T08:00:00.000Z');
+    expect(fresh.degraded).toEqual([]);
+  });
+
+  it('lists every stale/errored domain as degraded — the maroon trigger — and keeps domain order', () => {
+    const fresh = boardFreshness(
+      composeAttention([
+        freshContributor('agents', { provenance: 'error', fetchedAt: '2026-06-18T07:00:00.000Z' }),
+        freshContributor('runs', { provenance: 'stale', fetchedAt: '2026-06-18T09:00:00.000Z' }),
+        freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }),
+      ]),
+    );
+
+    // Worst provenance + oldest read across the board.
+    expect(fresh.provenance).toBe('error');
+    expect(fresh.fetchedAt).toBe('2026-06-18T07:00:00.000Z');
+    // degraded follows ATTENTION_DOMAINS order (agents before runs).
+    expect(fresh.degraded).toEqual([
+      { domain: 'agents', provenance: 'error' },
+      { domain: 'runs', provenance: 'stale' },
+    ]);
+  });
+
+  it('a fixture-only board is not degraded (demo data is not a staleness alarm)', () => {
+    const fresh = boardFreshness(
+      composeAttention([
+        freshContributor('runs', { provenance: 'fixture', fetchedAt: '2026-06-18T12:00:00.000Z' }),
+      ]),
+    );
+    expect(fresh.provenance).toBe('fixture');
+    expect(fresh.degraded).toEqual([]);
+  });
+
+  it('an empty board reports no freshness and stays silent', () => {
+    const fresh = boardFreshness(composeAttention([]));
+    expect(fresh.provenance).toBeUndefined();
+    expect(fresh.fetchedAt).toBeUndefined();
+    expect(fresh.degraded).toEqual([]);
   });
 });
 

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -225,6 +225,11 @@ describe('composeAttention — read-freshness fold (gascity-dashboard-5t0m)', ()
 });
 
 describe('boardFreshness — board-wide fold for the Header liveness line (gascity-dashboard-5t0m)', () => {
+  // For the structural folds, a far-future-proof threshold so the fixed
+  // timestamps are never aged out — staleness-by-age has its own test below.
+  const NOW = Date.parse('2026-06-18T12:00:05.000Z');
+  const NEVER_STALE = 24 * 60 * 60 * 1000;
+
   it('folds the oldest fetchedAt + worst provenance across domains, with no degraded when all fresh', () => {
     const fresh = boardFreshness(
       composeAttention([
@@ -232,6 +237,8 @@ describe('boardFreshness — board-wide fold for the Header liveness line (gasci
         freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T08:00:00.000Z' }),
         freshContributor('agents', { provenance: 'fresh', fetchedAt: '2026-06-18T10:00:00.000Z' }),
       ]),
+      NOW,
+      NEVER_STALE,
     );
 
     expect(fresh.provenance).toBe('fresh');
@@ -246,6 +253,8 @@ describe('boardFreshness — board-wide fold for the Header liveness line (gasci
         freshContributor('runs', { provenance: 'stale', fetchedAt: '2026-06-18T09:00:00.000Z' }),
         freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }),
       ]),
+      NOW,
+      NEVER_STALE,
     );
 
     // Worst provenance + oldest read across the board.
@@ -258,18 +267,38 @@ describe('boardFreshness — board-wide fold for the Header liveness line (gasci
     ]);
   });
 
-  it('a fixture-only board is not degraded (demo data is not a staleness alarm)', () => {
+  it('derives stale from read AGE — a frozen "fresh" read flips to the maroon stale state (fchh blocker 1)', () => {
+    const now = Date.parse('2026-06-18T12:00:00.000Z');
     const fresh = boardFreshness(
       composeAttention([
-        freshContributor('runs', { provenance: 'fixture', fetchedAt: '2026-06-18T12:00:00.000Z' }),
+        // 'fresh' provenance, but the read is 2 minutes old → aged past 60s.
+        freshContributor('agents', { provenance: 'fresh', fetchedAt: '2026-06-18T11:58:00.000Z' }),
+        // 'fresh' and only 2s old → still current.
+        freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T11:59:58.000Z' }),
       ]),
+      now,
+      60_000,
+    );
+
+    // The frozen agents read flips to stale off its AGE, not an error.
+    expect(fresh.degraded).toEqual([{ domain: 'agents', provenance: 'stale' }]);
+    expect(fresh.provenance).toBe('stale');
+  });
+
+  it('a fixture-only board never ages to stale (demo data is not a staleness alarm)', () => {
+    const fresh = boardFreshness(
+      composeAttention([
+        freshContributor('runs', { provenance: 'fixture', fetchedAt: '2026-06-18T00:00:00.000Z' }),
+      ]),
+      NOW,
+      60_000, // even far past the threshold, fixture does not degrade
     );
     expect(fresh.provenance).toBe('fixture');
     expect(fresh.degraded).toEqual([]);
   });
 
   it('an empty board reports no freshness and stays silent', () => {
-    const fresh = boardFreshness(composeAttention([]));
+    const fresh = boardFreshness(composeAttention([]), NOW, NEVER_STALE);
     expect(fresh.provenance).toBeUndefined();
     expect(fresh.fetchedAt).toBeUndefined();
     expect(fresh.degraded).toEqual([]);

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -197,6 +197,21 @@ describe('composeAttention — read-freshness fold (gascity-dashboard-5t0m)', ()
     expect(model.byDomain.mail.fetchedAt).toBe('2026-06-18T08:00:00.000Z');
   });
 
+  it('folds the SOONEST (earliest) staleAt across a domain so it ages as soon as any read would (fchh)', () => {
+    const model = composeAttention([
+      freshContributor('mail', {
+        fetchedAt: '2026-06-18T12:00:00.000Z',
+        staleAt: '2026-06-18T12:01:30.000Z',
+      }),
+      freshContributor('mail', {
+        fetchedAt: '2026-06-18T11:59:00.000Z',
+        staleAt: '2026-06-18T12:00:30.000Z',
+      }),
+    ]);
+
+    expect(model.byDomain.mail.staleAt).toBe('2026-06-18T12:00:30.000Z');
+  });
+
   it('keeps a defined signal over an undefined one, regardless of order', () => {
     const before = composeAttention([
       freshContributor('beads', {}),
@@ -225,20 +240,26 @@ describe('composeAttention — read-freshness fold (gascity-dashboard-5t0m)', ()
 });
 
 describe('boardFreshness — board-wide fold for the Header liveness line (gascity-dashboard-5t0m)', () => {
-  // For the structural folds, a far-future-proof threshold so the fixed
-  // timestamps are never aged out — staleness-by-age has its own test below.
   const NOW = Date.parse('2026-06-18T12:00:05.000Z');
-  const NEVER_STALE = 24 * 60 * 60 * 1000;
+  // A staleAt comfortably in the future so a landed read still reads as current.
+  const FUTURE_STALE = '2026-06-18T12:01:00.000Z';
 
   it('folds the oldest fetchedAt + worst provenance across domains, with no degraded when all fresh', () => {
     const fresh = boardFreshness(
       composeAttention([
         freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }),
-        freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T08:00:00.000Z' }),
-        freshContributor('agents', { provenance: 'fresh', fetchedAt: '2026-06-18T10:00:00.000Z' }),
+        freshContributor('mail', {
+          provenance: 'fresh',
+          fetchedAt: '2026-06-18T08:00:00.000Z',
+          staleAt: FUTURE_STALE,
+        }),
+        freshContributor('agents', {
+          provenance: 'fresh',
+          fetchedAt: '2026-06-18T10:00:00.000Z',
+          staleAt: FUTURE_STALE,
+        }),
       ]),
       NOW,
-      NEVER_STALE,
     );
 
     expect(fresh.provenance).toBe('fresh');
@@ -251,10 +272,13 @@ describe('boardFreshness — board-wide fold for the Header liveness line (gasci
       composeAttention([
         freshContributor('agents', { provenance: 'error', fetchedAt: '2026-06-18T07:00:00.000Z' }),
         freshContributor('runs', { provenance: 'stale', fetchedAt: '2026-06-18T09:00:00.000Z' }),
-        freshContributor('mail', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }),
+        freshContributor('mail', {
+          provenance: 'fresh',
+          fetchedAt: '2026-06-18T12:00:00.000Z',
+          staleAt: FUTURE_STALE,
+        }),
       ]),
       NOW,
-      NEVER_STALE,
     );
 
     // Worst provenance + oldest read across the board.
@@ -267,38 +291,63 @@ describe('boardFreshness — board-wide fold for the Header liveness line (gasci
     ]);
   });
 
-  it('derives stale from read AGE — a frozen "fresh" read flips to the maroon stale state (fchh blocker 1)', () => {
+  it('derives stale from read AGE — a polled "fresh" read past its staleAt flips to maroon stale (fchh blocker 1)', () => {
     const now = Date.parse('2026-06-18T12:00:00.000Z');
     const fresh = boardFreshness(
       composeAttention([
-        // 'fresh' provenance, but the read is 2 minutes old → aged past 60s.
-        freshContributor('agents', { provenance: 'fresh', fetchedAt: '2026-06-18T11:58:00.000Z' }),
-        // 'fresh' and only 2s old → still current.
-        freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T11:59:58.000Z' }),
+        // 'fresh' provenance, but its staleAt has already passed → no longer current.
+        freshContributor('agents', {
+          provenance: 'fresh',
+          fetchedAt: '2026-06-18T11:58:00.000Z',
+          staleAt: '2026-06-18T11:59:30.000Z',
+        }),
+        // 'fresh' with a staleAt still in the future → current.
+        freshContributor('mail', {
+          provenance: 'fresh',
+          fetchedAt: '2026-06-18T11:59:58.000Z',
+          staleAt: '2026-06-18T12:01:28.000Z',
+        }),
       ]),
       now,
-      60_000,
     );
 
-    // The frozen agents read flips to stale off its AGE, not an error.
+    // The frozen agents poll flips to stale off its AGE, not an error.
     expect(fresh.degraded).toEqual([{ domain: 'agents', provenance: 'stale' }]);
     expect(fresh.provenance).toBe('stale');
+  });
+
+  it('does NOT age-flip the event-driven runs source — it carries no staleAt even when its read is old (fchh Option B)', () => {
+    const now = Date.parse('2026-06-18T12:00:00.000Z');
+    const fresh = boardFreshness(
+      composeAttention([
+        // runs read is hours old but has no staleAt: its liveness is the gc event
+        // stream (BoardLiveness/sseState), not a read age, so it must not flip.
+        freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T08:00:00.000Z' }),
+      ]),
+      now,
+    );
+    expect(fresh.degraded).toEqual([]);
+    expect(fresh.provenance).toBe('fresh');
   });
 
   it('a fixture-only board never ages to stale (demo data is not a staleness alarm)', () => {
     const fresh = boardFreshness(
       composeAttention([
-        freshContributor('runs', { provenance: 'fixture', fetchedAt: '2026-06-18T00:00:00.000Z' }),
+        // Even with a long-passed staleAt, fixture is intentional demo data.
+        freshContributor('runs', {
+          provenance: 'fixture',
+          fetchedAt: '2026-06-18T00:00:00.000Z',
+          staleAt: '2026-06-18T00:01:30.000Z',
+        }),
       ]),
       NOW,
-      60_000, // even far past the threshold, fixture does not degrade
     );
     expect(fresh.provenance).toBe('fixture');
     expect(fresh.degraded).toEqual([]);
   });
 
   it('an empty board reports no freshness and stays silent', () => {
-    const fresh = boardFreshness(composeAttention([]), NOW, NEVER_STALE);
+    const fresh = boardFreshness(composeAttention([]), NOW);
     expect(fresh.provenance).toBeUndefined();
     expect(fresh.fetchedAt).toBeUndefined();
     expect(fresh.degraded).toEqual([]);
@@ -318,7 +367,7 @@ function contributor(
 
 function freshContributor(
   domain: AttentionItem['domain'],
-  freshness: { provenance?: SourceStatus; fetchedAt?: string },
+  freshness: { provenance?: SourceStatus; fetchedAt?: string; staleAt?: string },
   items: readonly AttentionItem[] = [],
 ): AttentionContributor {
   return {
@@ -327,6 +376,7 @@ function freshContributor(
     getItems: () => items,
     ...(freshness.provenance !== undefined && { provenance: freshness.provenance }),
     ...(freshness.fetchedAt !== undefined && { fetchedAt: freshness.fetchedAt }),
+    ...(freshness.staleAt !== undefined && { staleAt: freshness.staleAt }),
   };
 }
 

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { SourceStatus } from 'gas-city-dashboard-shared';
 import {
   ATTENTION_DOMAINS,
   composeAttention,
@@ -129,6 +130,99 @@ describe('composeAttention', () => {
   });
 });
 
+describe('composeAttention — read-freshness fold (gascity-dashboard-5t0m)', () => {
+  it('folds a contributor read provenance + fetchedAt onto its domain summary', () => {
+    const model = composeAttention([
+      freshContributor('runs', { provenance: 'fresh', fetchedAt: '2026-06-18T12:00:00.000Z' }, [
+        item('run-1', 'runs', 'attention'),
+      ]),
+    ]);
+
+    expect(model.byDomain.runs.provenance).toBe('fresh');
+    expect(model.byDomain.runs.fetchedAt).toBe('2026-06-18T12:00:00.000Z');
+  });
+
+  it('records freshness for a CALM domain with zero items — the frozen-but-quiet signal', () => {
+    // The whole point of the spine: a domain can be calm (no items, null
+    // severity) yet stale. The fold is contributor-level, so it captures age
+    // even when nothing alarming was emitted.
+    const model = composeAttention([
+      freshContributor(
+        'agents',
+        { provenance: 'stale', fetchedAt: '2026-06-18T09:00:00.000Z' },
+        [],
+      ),
+    ]);
+
+    expect(model.byDomain.agents.items).toEqual([]);
+    expect(model.byDomain.agents.severity).toBeNull();
+    expect(model.byDomain.agents.provenance).toBe('stale');
+    expect(model.byDomain.agents.fetchedAt).toBe('2026-06-18T09:00:00.000Z');
+  });
+
+  it('folds the WORST provenance across a domain (fresh < fixture < stale < error)', () => {
+    const model = composeAttention([
+      freshContributor('runs', { provenance: 'fresh' }),
+      freshContributor('runs', { provenance: 'stale' }),
+      freshContributor('runs', { provenance: 'error' }),
+      freshContributor('runs', { provenance: 'fixture' }),
+    ]);
+
+    expect(model.byDomain.runs.provenance).toBe('error');
+  });
+
+  it('ranks fixture worse than fresh but better than stale', () => {
+    expect(
+      composeAttention([
+        freshContributor('runs', { provenance: 'fresh' }),
+        freshContributor('runs', { provenance: 'fixture' }),
+      ]).byDomain.runs.provenance,
+    ).toBe('fixture');
+    expect(
+      composeAttention([
+        freshContributor('runs', { provenance: 'fixture' }),
+        freshContributor('runs', { provenance: 'stale' }),
+      ]).byDomain.runs.provenance,
+    ).toBe('stale');
+  });
+
+  it('folds the OLDEST (earliest) fetchedAt across a domain', () => {
+    const model = composeAttention([
+      freshContributor('mail', { fetchedAt: '2026-06-18T12:00:00.000Z' }),
+      freshContributor('mail', { fetchedAt: '2026-06-18T08:00:00.000Z' }),
+      freshContributor('mail', { fetchedAt: '2026-06-18T10:00:00.000Z' }),
+    ]);
+
+    expect(model.byDomain.mail.fetchedAt).toBe('2026-06-18T08:00:00.000Z');
+  });
+
+  it('keeps a defined signal over an undefined one, regardless of order', () => {
+    const before = composeAttention([
+      freshContributor('beads', {}),
+      freshContributor('beads', { provenance: 'error', fetchedAt: '2026-06-18T01:00:00.000Z' }),
+    ]);
+    const after = composeAttention([
+      freshContributor('beads', { provenance: 'error', fetchedAt: '2026-06-18T01:00:00.000Z' }),
+      freshContributor('beads', {}),
+    ]);
+
+    expect(before.byDomain.beads.provenance).toBe('error');
+    expect(after.byDomain.beads.provenance).toBe('error');
+    expect(before.byDomain.beads.fetchedAt).toBe('2026-06-18T01:00:00.000Z');
+    expect(after.byDomain.beads.fetchedAt).toBe('2026-06-18T01:00:00.000Z');
+  });
+
+  it('leaves provenance/fetchedAt undefined when no contributor reports them', () => {
+    const model = composeAttention([contributor('runs', [item('run-1', 'runs', 'attention')])]);
+
+    expect(model.byDomain.runs.provenance).toBeUndefined();
+    expect(model.byDomain.runs.fetchedAt).toBeUndefined();
+    // The fold must not disturb the existing counts/severity.
+    expect(model.byDomain.runs.attention).toBe(1);
+    expect(model.byDomain.runs.severity).toBe('attention');
+  });
+});
+
 function contributor(
   domain: AttentionItem['domain'],
   items: readonly AttentionItem[],
@@ -137,6 +231,20 @@ function contributor(
     id: `${domain}-test`,
     domain,
     getItems: () => items,
+  };
+}
+
+function freshContributor(
+  domain: AttentionItem['domain'],
+  freshness: { provenance?: SourceStatus; fetchedAt?: string },
+  items: readonly AttentionItem[] = [],
+): AttentionContributor {
+  return {
+    id: `${domain}-fresh`,
+    domain,
+    getItems: () => items,
+    ...(freshness.provenance !== undefined && { provenance: freshness.provenance }),
+    ...(freshness.fetchedAt !== undefined && { fetchedAt: freshness.fetchedAt }),
   };
 }
 

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -239,19 +239,54 @@ export interface BoardFreshness {
   degraded: readonly { domain: AttentionDomain; provenance: SourceStatus }[];
 }
 
-export function boardFreshness(model: AttentionModel): BoardFreshness {
+export function boardFreshness(
+  model: AttentionModel,
+  nowMs: number,
+  staleAfterMs: number,
+): BoardFreshness {
   let provenance: SourceStatus | undefined;
   let fetchedAt: string | undefined;
   const degraded: { domain: AttentionDomain; provenance: SourceStatus }[] = [];
   for (const domain of ATTENTION_DOMAINS) {
     const summary = model.byDomain[domain];
-    provenance = worseProvenance(provenance, summary.provenance);
+    // gascity-dashboard-fchh blocker 1: most domains' provenance can only ever
+    // be 'fresh'/'error' (they are polled snapshots, not error-reporting), so a
+    // frozen-but-not-erroring read would never degrade off provenance alone.
+    // Derive 'stale' from read AGE at render time — a read older than the
+    // threshold is no longer current, mirroring the runs SourceState.staleAt
+    // convention — so a frozen source flips to the maroon stale state.
+    const effective = effectiveProvenance(
+      summary.provenance,
+      summary.fetchedAt,
+      nowMs,
+      staleAfterMs,
+    );
+    provenance = worseProvenance(provenance, effective);
     fetchedAt = olderFetchedAt(fetchedAt, summary.fetchedAt);
-    if (summary.provenance === 'stale' || summary.provenance === 'error') {
-      degraded.push({ domain, provenance: summary.provenance });
+    if (effective === 'stale' || effective === 'error') {
+      degraded.push({ domain, provenance: effective });
     }
   }
   return { provenance, fetchedAt, degraded };
+}
+
+/** A read's effective provenance, ageing a still-fresh read to 'stale' once it
+ *  crosses the threshold. 'error' (a hard read failure) and an already-'stale'
+ *  source are unchanged; 'fixture' is intentional demo data and never ages. */
+function effectiveProvenance(
+  provenance: SourceStatus | undefined,
+  fetchedAt: string | undefined,
+  nowMs: number,
+  staleAfterMs: number,
+): SourceStatus | undefined {
+  if (provenance === 'error' || provenance === 'stale' || provenance === 'fixture') {
+    return provenance;
+  }
+  if (fetchedAt !== undefined) {
+    const ageMs = nowMs - Date.parse(fetchedAt);
+    if (Number.isFinite(ageMs) && ageMs >= staleAfterMs) return 'stale';
+  }
+  return provenance;
 }
 
 function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -226,6 +226,34 @@ function olderFetchedAt(current: string | undefined, next: string | undefined): 
   return n < c ? next : current;
 }
 
+/**
+ * Board-wide read freshness, folded across every domain summary
+ * (gascity-dashboard-5t0m, Freshness Spine). Drives the one quiet Header
+ * liveness line: `fetchedAt` is the OLDEST read on the board (the line's "as of
+ * N ago"), `provenance` the WORST, and `degraded` the domains whose read is
+ * stale/errored — the only trigger for the line's single maroon glyph+word.
+ */
+export interface BoardFreshness {
+  provenance: SourceStatus | undefined;
+  fetchedAt: string | undefined;
+  degraded: readonly { domain: AttentionDomain; provenance: SourceStatus }[];
+}
+
+export function boardFreshness(model: AttentionModel): BoardFreshness {
+  let provenance: SourceStatus | undefined;
+  let fetchedAt: string | undefined;
+  const degraded: { domain: AttentionDomain; provenance: SourceStatus }[] = [];
+  for (const domain of ATTENTION_DOMAINS) {
+    const summary = model.byDomain[domain];
+    provenance = worseProvenance(provenance, summary.provenance);
+    fetchedAt = olderFetchedAt(fetchedAt, summary.fetchedAt);
+    if (summary.provenance === 'stale' || summary.provenance === 'error') {
+      degraded.push({ domain, provenance: summary.provenance });
+    }
+  }
+  return { provenance, fetchedAt, degraded };
+}
+
 function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {
   return (
     severityRank(a.severity) - severityRank(b.severity) ||

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -304,9 +304,9 @@ function effectiveProvenance(
 // cadence so a healthy board's reads stay current. A read older than the stale
 // threshold is treated as no-longer-current and flips the board liveness line
 // maroon. INVARIANT: REFRESH_INTERVAL_MS < STALE_AFTER_MS with headroom, so a
-// healthy board re-reads ~3x before any domain can age out — only a genuinely
-// wedged/frozen refresh loop crosses the threshold. Mirrors the runs
-// SourceState.staleAt convention (RUNS_STALE_AFTER_MS = 60s).
+// healthy board re-reads ~3x (90s / 30s) before any domain can age out — only a
+// genuinely wedged/frozen refresh loop crosses the threshold. Follows the same
+// fetchedAt + staleAt convention the runs SourceState uses for its own liveness.
 export const ATTENTION_READ_REFRESH_INTERVAL_MS = 30_000;
 export const ATTENTION_READ_STALE_AFTER_MS = 90_000;
 

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -59,9 +59,17 @@ export interface AttentionContributor {
    * read age even when it emits zero items — the one question no item-level
    * signal answers ("is the data CURRENT?", not "is it alarming?"). `provenance`
    * is the cache read's SourceStatus; `fetchedAt` is its ISO read time.
+   *
+   * `staleAt` (gascity-dashboard-fchh) is the ISO instant after which this read
+   * is no longer current — `fetchedAt + ATTENTION_READ_STALE_AFTER_MS`, set ONLY
+   * by polled sources (the cache-read domains). The event-driven runs source
+   * leaves it undefined: its liveness is the gc event stream, not a read age, so
+   * it must not age-flip on a quiet-but-live board. {@link boardFreshness} flips
+   * a domain to `stale` once `now >= staleAt`.
    */
   provenance?: SourceStatus;
   fetchedAt?: string;
+  staleAt?: string;
 }
 
 export interface AttentionDomainSummary {
@@ -78,10 +86,13 @@ export interface AttentionDomainSummary {
    * the WORST provenance (most degraded — `fresh` < `fixture` < `stale` <
    * `error`) and the OLDEST (earliest) `fetchedAt`. Undefined when no contributor
    * reported one. Independent of `severity`: a domain can be calm (no items, null
-   * severity) yet stale — that is exactly the signal this carries.
+   * severity) yet stale — that is exactly the signal this carries. `staleAt` is
+   * the EARLIEST (soonest) stale instant across the domain's polled contributors
+   * (gascity-dashboard-fchh); undefined for event-driven sources that do not age.
    */
   provenance?: SourceStatus;
   fetchedAt?: string;
+  staleAt?: string;
 }
 
 export interface AttentionOverflowGroup {
@@ -126,6 +137,7 @@ export function composeAttention(
       byDomain[contributor.domain],
       contributor.provenance,
       contributor.fetchedAt,
+      contributor.staleAt,
     );
     for (const item of contributor.getItems()) {
       indexedItems.push({ item, index });
@@ -188,19 +200,25 @@ const PROVENANCE_RANK: Record<SourceStatus, number> = {
   error: 3,
 };
 
-/** Fold one contributor's provenance + fetchedAt into a domain summary. */
+/** Fold one contributor's provenance + fetchedAt + staleAt into a domain
+ *  summary. The summary takes the worst provenance, the oldest read time, and
+ *  the soonest stale instant — so a domain goes stale as soon as its earliest
+ *  contributor would. */
 function foldFreshness(
   summary: AttentionDomainSummary,
   provenance: SourceStatus | undefined,
   fetchedAt: string | undefined,
+  staleAt: string | undefined,
 ): AttentionDomainSummary {
   const worst = worseProvenance(summary.provenance, provenance);
   const oldest = olderFetchedAt(summary.fetchedAt, fetchedAt);
+  const soonestStale = olderFetchedAt(summary.staleAt, staleAt);
   return {
     ...summary,
     // exactOptionalPropertyTypes: include each key only when defined.
     ...(worst !== undefined && { provenance: worst }),
     ...(oldest !== undefined && { fetchedAt: oldest }),
+    ...(soonestStale !== undefined && { staleAt: soonestStale }),
   };
 }
 
@@ -239,28 +257,13 @@ export interface BoardFreshness {
   degraded: readonly { domain: AttentionDomain; provenance: SourceStatus }[];
 }
 
-export function boardFreshness(
-  model: AttentionModel,
-  nowMs: number,
-  staleAfterMs: number,
-): BoardFreshness {
+export function boardFreshness(model: AttentionModel, nowMs: number): BoardFreshness {
   let provenance: SourceStatus | undefined;
   let fetchedAt: string | undefined;
   const degraded: { domain: AttentionDomain; provenance: SourceStatus }[] = [];
   for (const domain of ATTENTION_DOMAINS) {
     const summary = model.byDomain[domain];
-    // gascity-dashboard-fchh blocker 1: most domains' provenance can only ever
-    // be 'fresh'/'error' (they are polled snapshots, not error-reporting), so a
-    // frozen-but-not-erroring read would never degrade off provenance alone.
-    // Derive 'stale' from read AGE at render time — a read older than the
-    // threshold is no longer current, mirroring the runs SourceState.staleAt
-    // convention — so a frozen source flips to the maroon stale state.
-    const effective = effectiveProvenance(
-      summary.provenance,
-      summary.fetchedAt,
-      nowMs,
-      staleAfterMs,
-    );
+    const effective = effectiveProvenance(summary, nowMs);
     provenance = worseProvenance(provenance, effective);
     fetchedAt = olderFetchedAt(fetchedAt, summary.fetchedAt);
     if (effective === 'stale' || effective === 'error') {
@@ -270,24 +273,42 @@ export function boardFreshness(
   return { provenance, fetchedAt, degraded };
 }
 
-/** A read's effective provenance, ageing a still-fresh read to 'stale' once it
- *  crosses the threshold. 'error' (a hard read failure) and an already-'stale'
- *  source are unchanged; 'fixture' is intentional demo data and never ages. */
+/**
+ * A domain's effective provenance for the liveness line (gascity-dashboard-fchh
+ * blocker 1). Most polled domains can only ever report `fresh`/`error` from a
+ * single read, so a frozen-but-not-erroring cache would never degrade off
+ * provenance alone. A polled domain therefore carries a `staleAt`
+ * (`fetchedAt + ATTENTION_READ_STALE_AFTER_MS`); once `now >= staleAt` its read
+ * is no longer current and ages to `stale`. `error` and an already-`stale`
+ * source are unchanged; `fixture` is intentional demo data and never ages; the
+ * event-driven runs source has no `staleAt`, so it never age-flips (its liveness
+ * is the gc event stream — see BoardLiveness).
+ */
 function effectiveProvenance(
-  provenance: SourceStatus | undefined,
-  fetchedAt: string | undefined,
+  summary: AttentionDomainSummary,
   nowMs: number,
-  staleAfterMs: number,
 ): SourceStatus | undefined {
+  const { provenance, staleAt } = summary;
   if (provenance === 'error' || provenance === 'stale' || provenance === 'fixture') {
     return provenance;
   }
-  if (fetchedAt !== undefined) {
-    const ageMs = nowMs - Date.parse(fetchedAt);
-    if (Number.isFinite(ageMs) && ageMs >= staleAfterMs) return 'stale';
+  if (staleAt !== undefined) {
+    const staleAtMs = Date.parse(staleAt);
+    if (Number.isFinite(staleAtMs) && nowMs >= staleAtMs) return 'stale';
   }
   return provenance;
 }
+
+// gascity-dashboard-fchh (Freshness Spine, Option B): the polled attention
+// domains (everything except the event-driven runs source) re-read on this
+// cadence so a healthy board's reads stay current. A read older than the stale
+// threshold is treated as no-longer-current and flips the board liveness line
+// maroon. INVARIANT: REFRESH_INTERVAL_MS < STALE_AFTER_MS with headroom, so a
+// healthy board re-reads ~3x before any domain can age out — only a genuinely
+// wedged/frozen refresh loop crosses the threshold. Mirrors the runs
+// SourceState.staleAt convention (RUNS_STALE_AFTER_MS = 60s).
+export const ATTENTION_READ_REFRESH_INTERVAL_MS = 30_000;
+export const ATTENTION_READ_STALE_AFTER_MS = 90_000;
 
 function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {
   return (

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -52,6 +52,16 @@ export interface AttentionContributor {
   id: string;
   domain: AttentionDomain;
   getItems(): readonly AttentionItem[];
+  /**
+   * Read freshness of the source backing this contributor
+   * (gascity-dashboard-5t0m, Freshness Spine). Folded per-domain into
+   * {@link AttentionDomainSummary} so a calm-but-frozen domain still reports its
+   * read age even when it emits zero items — the one question no item-level
+   * signal answers ("is the data CURRENT?", not "is it alarming?"). `provenance`
+   * is the cache read's SourceStatus; `fetchedAt` is its ISO read time.
+   */
+  provenance?: SourceStatus;
+  fetchedAt?: string;
 }
 
 export interface AttentionDomainSummary {
@@ -63,6 +73,15 @@ export interface AttentionDomainSummary {
   /** Badge tier — only ever attention/watch/null; `unavailable` never sets it. */
   severity: BadgeSeverity | null;
   items: readonly AttentionItem[];
+  /**
+   * Freshness folded across this domain's contributors (gascity-dashboard-5t0m):
+   * the WORST provenance (most degraded — `fresh` < `fixture` < `stale` <
+   * `error`) and the OLDEST (earliest) `fetchedAt`. Undefined when no contributor
+   * reported one. Independent of `severity`: a domain can be calm (no items, null
+   * severity) yet stale — that is exactly the signal this carries.
+   */
+  provenance?: SourceStatus;
+  fetchedAt?: string;
 }
 
 export interface AttentionOverflowGroup {
@@ -99,12 +118,21 @@ export function composeAttention(
   let index = 0;
 
   for (const contributor of contributors) {
+    // gascity-dashboard-5t0m: fold the contributor's own read freshness FIRST,
+    // before its items — so a calm contributor (zero items) still records its
+    // age/provenance on the domain summary. The item loop preserves these via
+    // the `...summary` spread.
+    byDomain[contributor.domain] = foldFreshness(
+      byDomain[contributor.domain],
+      contributor.provenance,
+      contributor.fetchedAt,
+    );
     for (const item of contributor.getItems()) {
       indexedItems.push({ item, index });
       const summary = byDomain[item.domain];
       const nextItems = [...summary.items, item];
       byDomain[item.domain] = {
-        domain: item.domain,
+        ...summary,
         attention: summary.attention + (item.severity === 'attention' ? 1 : 0),
         watch: summary.watch + (item.severity === 'watch' ? 1 : 0),
         unavailable: summary.unavailable + (item.severity === 'unavailable' ? 1 : 0),
@@ -147,6 +175,55 @@ function emptyDomainSummaries(): Record<AttentionDomain, AttentionDomainSummary>
 function highestSeverity(current: BadgeSeverity | null, next: BadgeSeverity): BadgeSeverity {
   if (current === 'attention' || next === 'attention') return 'attention';
   return 'watch';
+}
+
+// gascity-dashboard-5t0m: read-freshness fold. "Worst" provenance is the most
+// degraded for the liveness question — a live read (`fresh`) is best; `fixture`
+// is intentional demo data (not live but not broken); `stale` is a real source
+// gone old; `error` is a failed read. Higher rank wins.
+const PROVENANCE_RANK: Record<SourceStatus, number> = {
+  fresh: 0,
+  fixture: 1,
+  stale: 2,
+  error: 3,
+};
+
+/** Fold one contributor's provenance + fetchedAt into a domain summary. */
+function foldFreshness(
+  summary: AttentionDomainSummary,
+  provenance: SourceStatus | undefined,
+  fetchedAt: string | undefined,
+): AttentionDomainSummary {
+  const worst = worseProvenance(summary.provenance, provenance);
+  const oldest = olderFetchedAt(summary.fetchedAt, fetchedAt);
+  return {
+    ...summary,
+    // exactOptionalPropertyTypes: include each key only when defined.
+    ...(worst !== undefined && { provenance: worst }),
+    ...(oldest !== undefined && { fetchedAt: oldest }),
+  };
+}
+
+/** The more-degraded of two provenances (undefined = no signal yet). */
+function worseProvenance(
+  current: SourceStatus | undefined,
+  next: SourceStatus | undefined,
+): SourceStatus | undefined {
+  if (current === undefined) return next;
+  if (next === undefined) return current;
+  return PROVENANCE_RANK[next] > PROVENANCE_RANK[current] ? next : current;
+}
+
+/** The older (earlier) of two ISO read times. Unparsable values lose to a
+ *  parsable one, so a real read time always wins over a malformed marker. */
+function olderFetchedAt(current: string | undefined, next: string | undefined): string | undefined {
+  if (current === undefined) return next;
+  if (next === undefined) return current;
+  const c = Date.parse(current);
+  const n = Date.parse(next);
+  if (!Number.isFinite(n)) return current;
+  if (!Number.isFinite(c)) return next;
+  return n < c ? next : current;
 }
 
 function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -1,11 +1,11 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildRunSummary } from 'gas-city-dashboard-shared';
 import type { RunSummary, SourceState } from 'gas-city-dashboard-shared';
 import { invalidate } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
 import type { OperatorConfig } from '../contexts/OperatorConfigContext';
-import { composeAttention } from './compose';
+import { ATTENTION_READ_REFRESH_INTERVAL_MS, composeAttention } from './compose';
 import type { AgentsAttentionFacts } from './registry';
 import {
   runsFactsFromSource,
@@ -443,6 +443,31 @@ describe('useLiveAttentionContributors', () => {
     expect(mockApi.maintainerTriage).not.toHaveBeenCalled();
     expect(composeAttention(result.current).byDomain.maintainer.attention).toBe(0);
   });
+
+  it('re-reads the polled domains on the visible interval so a healthy board never ages into a false stale (fchh Option B)', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+      renderHook(() => useLiveAttentionContributors([], testOperator, undefined));
+
+      // Let the initial mount reads land.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const afterMount = mockSupervisorApi.listAgents.mock.calls.length;
+      expect(afterMount).toBeGreaterThanOrEqual(1);
+
+      // One refresh interval later, the polled domains re-read — advancing
+      // fetchedAt — so a live-but-quiet board stays fresh instead of aging to the
+      // maroon stale state the way a mount-only read would.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ATTENTION_READ_REFRESH_INTERVAL_MS);
+      });
+      expect(mockSupervisorApi.listAgents.mock.calls.length).toBeGreaterThan(afterMount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('withReadFreshness — cache-read freshness onto facts (gascity-dashboard-fchh)', () => {
@@ -453,14 +478,21 @@ describe('withReadFreshness — cache-read freshness onto facts (gascity-dashboa
     });
   });
 
-  it('maps a landed read with no error to provenance "fresh", preserving other fields', () => {
+  it('maps a landed read to "fresh" with a staleAt = fetchedAt + the stale window, preserving other fields', () => {
     expect(
       withReadFreshness<AgentsAttentionFacts>({ partial: false }, '2026-06-18T12:00:00.000Z', null),
     ).toEqual({
       partial: false,
       provenance: 'fresh',
       fetchedAt: '2026-06-18T12:00:00.000Z',
+      // 2026-06-18T12:00:00 + 90s — the age-flip floor for the liveness line.
+      staleAt: '2026-06-18T12:01:30.000Z',
     });
+  });
+
+  it('attaches NO staleAt to a failed read — an error is already the most degraded state', () => {
+    const facts = withReadFreshness({}, '2026-06-18T12:00:00.000Z', 'boom');
+    expect(facts).not.toHaveProperty('staleAt');
   });
 
   it('omits provenance when there is no error and no fetchedAt yet', () => {

--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -6,7 +6,12 @@ import { invalidate } from '../api/cache';
 import { setActiveCity } from '../api/cityBase';
 import type { OperatorConfig } from '../contexts/OperatorConfigContext';
 import { composeAttention } from './compose';
-import { runsFactsFromSource, useLiveAttentionContributors } from './liveContributors';
+import type { AgentsAttentionFacts } from './registry';
+import {
+  runsFactsFromSource,
+  useLiveAttentionContributors,
+  withReadFreshness,
+} from './liveContributors';
 
 // Operator identity the live hook reads from /config (gascity-dashboard-bhvn).
 const testOperator: OperatorConfig = {
@@ -437,5 +442,34 @@ describe('useLiveAttentionContributors', () => {
 
     expect(mockApi.maintainerTriage).not.toHaveBeenCalled();
     expect(composeAttention(result.current).byDomain.maintainer.attention).toBe(0);
+  });
+});
+
+describe('withReadFreshness — cache-read freshness onto facts (gascity-dashboard-fchh)', () => {
+  it('maps a failed read to provenance "error"', () => {
+    expect(withReadFreshness({}, '2026-06-18T12:00:00.000Z', 'boom')).toEqual({
+      provenance: 'error',
+      fetchedAt: '2026-06-18T12:00:00.000Z',
+    });
+  });
+
+  it('maps a landed read with no error to provenance "fresh", preserving other fields', () => {
+    expect(
+      withReadFreshness<AgentsAttentionFacts>({ partial: false }, '2026-06-18T12:00:00.000Z', null),
+    ).toEqual({
+      partial: false,
+      provenance: 'fresh',
+      fetchedAt: '2026-06-18T12:00:00.000Z',
+    });
+  });
+
+  it('omits provenance when there is no error and no fetchedAt yet', () => {
+    expect(withReadFreshness<AgentsAttentionFacts>({ partial: true }, undefined, null)).toEqual({
+      partial: true,
+    });
+  });
+
+  it('leaves undefined facts untouched', () => {
+    expect(withReadFreshness(undefined, '2026-06-18T12:00:00.000Z', null)).toBeUndefined();
   });
 });

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { type RunSummary, type SourceState } from 'gas-city-dashboard-shared';
+import { type RunSummary, type SourceState, type SourceStatus } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { type OperatorConfig } from '../contexts/OperatorConfigContext';
@@ -19,8 +19,33 @@ import {
   type HealthAttentionFacts,
   type MailAttentionFacts,
   type MaintainerAttentionFacts,
+  type ReadFreshnessFacts,
   type RunsAttentionFacts,
 } from './registry';
+
+/**
+ * Thread a cached source's read freshness onto its facts (gascity-dashboard-5t0m,
+ * Freshness Spine). The runs source carries its own SourceState provenance
+ * (runsFactsFromSource); every other domain reads through useCachedData, whose
+ * read state is just `fetchedAt` + `error` — so a failed refresh reports `error`,
+ * a landed read `fresh`, and the ISO `fetchedAt` carries the real age the
+ * per-domain fold ages off. Returns undefined facts untouched (a domain with no
+ * data yet has no freshness signal).
+ */
+function withReadFreshness<T extends ReadFreshnessFacts>(
+  facts: T | undefined,
+  fetchedAt: string | undefined,
+  error: string | null,
+): T | undefined {
+  if (facts === undefined) return undefined;
+  const provenance: SourceStatus | undefined =
+    error !== null ? 'error' : fetchedAt !== undefined ? 'fresh' : undefined;
+  return {
+    ...facts,
+    ...(provenance !== undefined && { provenance }),
+    ...(fetchedAt !== undefined && { fetchedAt }),
+  };
+}
 
 const ATTENTION_LIST_LIMIT = 1000;
 const ACTIVITY_EVENT_FETCH_LIMIT = 100;
@@ -70,16 +95,40 @@ export function useLiveAttentionContributors(
     () =>
       createAttentionContributors(
         compactFacts({
-          activity: activity.data,
-          agents: agents.data,
-          beads: beads.data,
-          health: health.data,
-          mail: mail.data,
-          maintainer: maintainer.data,
+          // gascity-dashboard-5t0m: thread each cache read's fetchedAt + derived
+          // provenance onto the facts so composeAttention can fold a board-wide
+          // read-age/liveness signal. runs already carries its SourceState
+          // provenance via runsFactsFromSource.
+          activity: withReadFreshness(activity.data, activity.fetchedAt, activity.error),
+          agents: withReadFreshness(agents.data, agents.fetchedAt, agents.error),
+          beads: withReadFreshness(beads.data, beads.fetchedAt, beads.error),
+          health: withReadFreshness(health.data, health.fetchedAt, health.error),
+          mail: withReadFreshness(mail.data, mail.fetchedAt, mail.error),
+          maintainer: withReadFreshness(maintainer.data, maintainer.fetchedAt, maintainer.error),
           runs,
         }),
       ),
-    [activity.data, agents.data, beads.data, health.data, mail.data, maintainer.data, runs],
+    [
+      activity.data,
+      activity.fetchedAt,
+      activity.error,
+      agents.data,
+      agents.fetchedAt,
+      agents.error,
+      beads.data,
+      beads.fetchedAt,
+      beads.error,
+      health.data,
+      health.fetchedAt,
+      health.error,
+      mail.data,
+      mail.fetchedAt,
+      mail.error,
+      maintainer.data,
+      maintainer.fetchedAt,
+      maintainer.error,
+      runs,
+    ],
   );
 }
 

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -32,7 +32,7 @@ import {
  * per-domain fold ages off. Returns undefined facts untouched (a domain with no
  * data yet has no freshness signal).
  */
-function withReadFreshness<T extends ReadFreshnessFacts>(
+export function withReadFreshness<T extends ReadFreshnessFacts>(
   facts: T | undefined,
   fetchedAt: string | undefined,
   error: string | null,

--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -1,14 +1,19 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { type RunSummary, type SourceState, type SourceStatus } from 'gas-city-dashboard-shared';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { type OperatorConfig } from '../contexts/OperatorConfigContext';
 import { useCachedData } from '../hooks/useCachedData';
+import { useVisibleRefresh } from '../hooks/useVisibleRefresh';
 import { listAgentPendingInteractions } from '../supervisor/agentPending';
 import { listSupervisorBeads } from '../supervisor/beadReads';
 import { supervisorApi, supervisorApiForRequestBudget } from '../supervisor/client';
 import { DEFAULT_MAIL_HISTORY_LIMIT, listSupervisorMail } from '../supervisor/mailReads';
-import type { AttentionContributor } from './compose';
+import {
+  ATTENTION_READ_REFRESH_INTERVAL_MS,
+  ATTENTION_READ_STALE_AFTER_MS,
+  type AttentionContributor,
+} from './compose';
 import {
   createAttentionContributors,
   GC_ESCALATION_LABEL,
@@ -29,8 +34,12 @@ import {
  * (runsFactsFromSource); every other domain reads through useCachedData, whose
  * read state is just `fetchedAt` + `error` — so a failed refresh reports `error`,
  * a landed read `fresh`, and the ISO `fetchedAt` carries the real age the
- * per-domain fold ages off. Returns undefined facts untouched (a domain with no
- * data yet has no freshness signal).
+ * per-domain fold ages off. A landed read also gets a `staleAt`
+ * (`fetchedAt + ATTENTION_READ_STALE_AFTER_MS`, gascity-dashboard-fchh) so a
+ * frozen-but-not-erroring poll flips the board liveness line maroon once it ages
+ * past the threshold — these domains re-read on ATTENTION_READ_REFRESH_INTERVAL_MS
+ * (see useLiveAttentionContributors), so a healthy board never reaches it.
+ * Returns undefined facts untouched (a domain with no data yet has no signal).
  */
 export function withReadFreshness<T extends ReadFreshnessFacts>(
   facts: T | undefined,
@@ -40,10 +49,17 @@ export function withReadFreshness<T extends ReadFreshnessFacts>(
   if (facts === undefined) return undefined;
   const provenance: SourceStatus | undefined =
     error !== null ? 'error' : fetchedAt !== undefined ? 'fresh' : undefined;
+  // A staleAt only makes sense for a landed read (no error) — a failed refresh
+  // is already 'error', the most degraded state, so it never needs to age.
+  const staleAt =
+    error === null && fetchedAt !== undefined
+      ? new Date(Date.parse(fetchedAt) + ATTENTION_READ_STALE_AFTER_MS).toISOString()
+      : undefined;
   return {
     ...facts,
     ...(provenance !== undefined && { provenance }),
     ...(fetchedAt !== undefined && { fetchedAt }),
+    ...(staleAt !== undefined && { staleAt }),
   };
 }
 
@@ -90,6 +106,36 @@ export function useLiveAttentionContributors(
     `attention:maintainer:${cacheSuffix}:${maintainerEnabled ? 'enabled' : 'disabled'}`,
     () => fetchMaintainerAttention(cityName, maintainerEnabled),
   );
+
+  // gascity-dashboard-fchh (Option B): unlike the runs source (whose own
+  // subscription re-reads off the gc event stream), these six domains fetch once
+  // through useCachedData and would otherwise freeze at their mount-time read —
+  // so their freshness `staleAt` would age out on a perfectly healthy board.
+  // Re-read them on a slow visible interval (paused when the tab is hidden) so a
+  // live board keeps advancing fetchedAt and only a genuinely wedged refresh ages
+  // a domain to the maroon stale state. useCachedData owns the data/error state;
+  // this just drives the cadence.
+  // Each useCachedData.refresh is stable (keyed on its cache key), so depend on
+  // the functions directly — the callback only changes when a cache key shifts.
+  const { refresh: refreshAgents } = agents;
+  const { refresh: refreshBeads } = beads;
+  const { refresh: refreshMail } = mail;
+  const { refresh: refreshActivity } = activity;
+  const { refresh: refreshHealth } = health;
+  const { refresh: refreshMaintainer } = maintainer;
+  const refreshPolledReads = useCallback(
+    () =>
+      Promise.all([
+        refreshAgents(),
+        refreshBeads(),
+        refreshMail(),
+        refreshActivity(),
+        refreshHealth(),
+        refreshMaintainer(),
+      ]).then(() => undefined),
+    [refreshAgents, refreshBeads, refreshMail, refreshActivity, refreshHealth, refreshMaintainer],
+  );
+  useVisibleRefresh(refreshPolledReads, ATTENTION_READ_REFRESH_INTERVAL_MS);
 
   return useMemo(
     () =>

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -36,6 +36,29 @@ describe('createAttentionContributors', () => {
     expect(new Set(contributors.map((c) => c.id)).size).toBe(ATTENTION_DOMAINS.length);
   });
 
+  it('threads each facts read-freshness onto its contributor and folds it per domain (gascity-dashboard-5t0m)', () => {
+    // A calm domain (agents facts present, no alerting items) must still carry
+    // its read age into byDomain — the spine's whole point.
+    const model = composeAttention(
+      createAttentionContributors({
+        agents: { items: [], provenance: 'stale', fetchedAt: '2026-06-18T09:00:00.000Z' },
+        beads: {
+          decisionLabel: 'needs/stephanie',
+          provenance: 'error',
+          fetchedAt: '2026-06-18T08:00:00.000Z',
+        },
+      }),
+    );
+
+    expect(model.byDomain.agents.severity).toBeNull();
+    expect(model.byDomain.agents.provenance).toBe('stale');
+    expect(model.byDomain.agents.fetchedAt).toBe('2026-06-18T09:00:00.000Z');
+    expect(model.byDomain.beads.provenance).toBe('error');
+    // A domain with no facts at all reports no freshness.
+    expect(model.byDomain.maintainer.provenance).toBeUndefined();
+    expect(model.byDomain.maintainer.fetchedAt).toBeUndefined();
+  });
+
   it('derives health attention from supervisor reachability and critical host pressure', () => {
     const model = composeAttention(
       createAttentionContributors({

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -50,6 +50,14 @@ export type SupervisorHealthState =
 export interface ReadFreshnessFacts {
   provenance?: SourceStatus;
   fetchedAt?: string;
+  /**
+   * ISO instant after which this read is no longer current
+   * (`fetchedAt + ATTENTION_READ_STALE_AFTER_MS`, gascity-dashboard-fchh). Set
+   * only by polled cache-read domains; the event-driven runs source omits it so
+   * it never age-flips. composeAttention folds the soonest `staleAt` per domain;
+   * boardFreshness flips a domain to `stale` once `now >= staleAt`.
+   */
+  staleAt?: string;
 }
 
 export interface HealthAttentionFacts extends ReadFreshnessFacts {
@@ -223,6 +231,7 @@ function withFreshness(
     ...base,
     ...(facts?.provenance !== undefined && { provenance: facts.provenance }),
     ...(facts?.fetchedAt !== undefined && { fetchedAt: facts.fetchedAt }),
+    ...(facts?.staleAt !== undefined && { staleAt: facts.staleAt }),
   };
 }
 

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -39,14 +39,27 @@ export type SupervisorHealthState =
   | { status: 'available'; data: HealthOutputBody }
   | { status: 'unavailable'; error: string };
 
-export interface HealthAttentionFacts {
+/**
+ * Read freshness threaded onto every domain's facts by the live contributor
+ * layer (gascity-dashboard-5t0m, Freshness Spine): the SourceStatus and ISO
+ * `fetchedAt` of the cache read the facts were assembled from. Folded per-domain
+ * into AttentionDomainSummary (worst provenance + oldest fetchedAt) so the board
+ * can answer "is each domain's data CURRENT?" — independent of whether it is
+ * alarming. Every *AttentionFacts extends this so the signal is uniform.
+ */
+export interface ReadFreshnessFacts {
+  provenance?: SourceStatus;
+  fetchedAt?: string;
+}
+
+export interface HealthAttentionFacts extends ReadFreshnessFacts {
   system?: SystemHealth;
   supervisor?: SupervisorHealthState;
   trend?: DoltNomsTrend;
   dashboardError?: string;
 }
 
-export interface RunsAttentionFacts {
+export interface RunsAttentionFacts extends ReadFreshnessFacts {
   /**
    * The bead-derived run summary (gascity-dashboard-2j8e.2). The Runs badge
    * counts genuinely-blocked runs from `summary.blockedLanes` — the same
@@ -57,17 +70,9 @@ export interface RunsAttentionFacts {
    */
   summary?: RunSummary;
   error?: string;
-  /**
-   * Freshness of the runs read these facts were assembled from, threaded by the
-   * live contributor layer. Carried onto `unavailable`-tier items so a degraded
-   * read can be aged rather than rendered as current truth.
-   */
-  provenance?: SourceStatus;
-  /** ISO timestamp of the cache read these facts came from (fetch primitive). */
-  fetchedAt?: string;
 }
 
-export interface AgentsAttentionFacts {
+export interface AgentsAttentionFacts extends ReadFreshnessFacts {
   items?: readonly AgentResponse[];
   pendingInteractions?: readonly AgentPendingInteraction[];
   partial?: boolean;
@@ -75,7 +80,7 @@ export interface AgentsAttentionFacts {
   pendingError?: string;
 }
 
-export interface BeadsAttentionFacts {
+export interface BeadsAttentionFacts extends ReadFreshnessFacts {
   items?: readonly Bead[];
   /**
    * The label marking a bead as a mayor-decision (DASHBOARD_DECISION_LABEL,
@@ -110,14 +115,14 @@ export interface BeadsAttentionFacts {
   escalationsError?: string;
 }
 
-export interface MailAttentionFacts {
+export interface MailAttentionFacts extends ReadFreshnessFacts {
   items?: readonly Message[];
   nowMs?: number;
   partial?: boolean;
   error?: string;
 }
 
-export interface ActivityAttentionFacts {
+export interface ActivityAttentionFacts extends ReadFreshnessFacts {
   deploys?: DeployList;
   deploysError?: string;
   events?: readonly TypedEventStreamEnvelope[];
@@ -126,7 +131,7 @@ export interface ActivityAttentionFacts {
   eventsPartial?: boolean;
 }
 
-export interface MaintainerAttentionFacts {
+export interface MaintainerAttentionFacts extends ReadFreshnessFacts {
   enabled?: boolean;
   triage?: MaintainerTriage;
   nowMs?: number;
@@ -204,60 +209,74 @@ function contributorForDomain(
   }
 }
 
-function healthContributor(facts: HealthAttentionFacts | undefined): AttentionContributor {
+/**
+ * Attach a contributor's read freshness from its facts (gascity-dashboard-5t0m).
+ * composeAttention folds `provenance`/`fetchedAt` per-domain into the summary so
+ * a calm domain still reports its read age. exactOptionalPropertyTypes: include
+ * each key only when defined.
+ */
+function withFreshness(
+  base: { id: string; domain: AttentionDomain; getItems: () => readonly AttentionItem[] },
+  facts: ReadFreshnessFacts | undefined,
+): AttentionContributor {
   return {
-    id: 'health:derived',
-    domain: 'health',
-    getItems: () => deriveHealthAttention(facts),
+    ...base,
+    ...(facts?.provenance !== undefined && { provenance: facts.provenance }),
+    ...(facts?.fetchedAt !== undefined && { fetchedAt: facts.fetchedAt }),
   };
+}
+
+function healthContributor(facts: HealthAttentionFacts | undefined): AttentionContributor {
+  return withFreshness(
+    { id: 'health:derived', domain: 'health', getItems: () => deriveHealthAttention(facts) },
+    facts,
+  );
 }
 
 function runsContributor(facts: RunsAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'runs:derived',
-    domain: 'runs',
-    getItems: () => deriveRunsAttention(facts),
-  };
+  return withFreshness(
+    { id: 'runs:derived', domain: 'runs', getItems: () => deriveRunsAttention(facts) },
+    facts,
+  );
 }
 
 function agentsContributor(facts: AgentsAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'agents:derived',
-    domain: 'agents',
-    getItems: () => deriveAgentsAttention(facts),
-  };
+  return withFreshness(
+    { id: 'agents:derived', domain: 'agents', getItems: () => deriveAgentsAttention(facts) },
+    facts,
+  );
 }
 
 function beadsContributor(facts: BeadsAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'beads:derived',
-    domain: 'beads',
-    getItems: () => deriveBeadsAttention(facts),
-  };
+  return withFreshness(
+    { id: 'beads:derived', domain: 'beads', getItems: () => deriveBeadsAttention(facts) },
+    facts,
+  );
 }
 
 function mailContributor(facts: MailAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'mail:derived',
-    domain: 'mail',
-    getItems: () => deriveMailAttention(facts),
-  };
+  return withFreshness(
+    { id: 'mail:derived', domain: 'mail', getItems: () => deriveMailAttention(facts) },
+    facts,
+  );
 }
 
 function activityContributor(facts: ActivityAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'activity:derived',
-    domain: 'activity',
-    getItems: () => deriveActivityAttention(facts),
-  };
+  return withFreshness(
+    { id: 'activity:derived', domain: 'activity', getItems: () => deriveActivityAttention(facts) },
+    facts,
+  );
 }
 
 function maintainerContributor(facts: MaintainerAttentionFacts | undefined): AttentionContributor {
-  return {
-    id: 'maintainer:derived',
-    domain: 'maintainer',
-    getItems: () => deriveMaintainerAttention(facts),
-  };
+  return withFreshness(
+    {
+      id: 'maintainer:derived',
+      domain: 'maintainer',
+      getItems: () => deriveMaintainerAttention(facts),
+    },
+    facts,
+  );
 }
 
 /** The provenance + fetch timestamp carried onto runs `unavailable` items. */

--- a/frontend/src/components/BoardLiveness.test.tsx
+++ b/frontend/src/components/BoardLiveness.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SourceStatus } from 'gas-city-dashboard-shared';
+import { BoardLiveness } from './BoardLiveness';
+import { AttentionProvider } from '../attention/context';
+import type { AttentionContributor, AttentionDomain } from '../attention/compose';
+import { NowProvider } from '../contexts/NowContext';
+
+afterEach(() => cleanup());
+
+function freshContributor(
+  domain: AttentionDomain,
+  provenance: SourceStatus | undefined,
+  fetchedAt: string | undefined,
+): AttentionContributor {
+  return {
+    id: `${domain}:test`,
+    domain,
+    getItems: () => [],
+    ...(provenance !== undefined && { provenance }),
+    ...(fetchedAt !== undefined && { fetchedAt }),
+  };
+}
+
+function renderLiveness(contributors: readonly AttentionContributor[]) {
+  return render(
+    <NowProvider>
+      <AttentionProvider contributors={contributors}>
+        <BoardLiveness />
+      </AttentionProvider>
+    </NowProvider>,
+  );
+}
+
+const now = () => new Date().toISOString();
+const minutesAgo = (m: number) => new Date(Date.now() - m * 60_000).toISOString();
+
+describe('BoardLiveness (gascity-dashboard-5t0m)', () => {
+  it('reads "all live" in greyscale when every domain read is fresh', () => {
+    renderLiveness([freshContributor('runs', 'fresh', now())]);
+
+    const line = screen.getByRole('status');
+    expect(line.textContent).toMatch(/as of .* ago/);
+    expect(line.textContent).toContain('all live');
+    // One Mark at rest: no maroon mark in the calm state.
+    expect(line.querySelector('.text-accent')).toBeNull();
+  });
+
+  it('turns a single maroon glyph + word naming the stale domain', () => {
+    renderLiveness([
+      freshContributor('runs', 'stale', minutesAgo(5)),
+      freshContributor('mail', 'fresh', now()),
+    ]);
+
+    const line = screen.getByRole('status');
+    expect(line.textContent).toContain('runs stale');
+    const mark = line.querySelector('.text-accent');
+    expect(mark).not.toBeNull();
+    // The word — not just the color — carries the state (Greyscale Test).
+    expect(mark?.textContent).toContain('runs stale');
+  });
+
+  it('phrases an errored read as "unreachable"', () => {
+    renderLiveness([freshContributor('agents', 'error', now())]);
+    expect(screen.getByRole('status').textContent).toContain('agents unreachable');
+  });
+
+  it('counts rather than lists when several domains are stale', () => {
+    renderLiveness([
+      freshContributor('runs', 'stale', minutesAgo(5)),
+      freshContributor('agents', 'error', minutesAgo(3)),
+    ]);
+    expect(screen.getByRole('status').textContent).toContain('2 stale');
+  });
+
+  it('stays silent until a read has landed', () => {
+    const { container } = renderLiveness([freshContributor('runs', undefined, undefined)]);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});

--- a/frontend/src/components/BoardLiveness.test.tsx
+++ b/frontend/src/components/BoardLiveness.test.tsx
@@ -1,12 +1,24 @@
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SourceStatus } from 'gas-city-dashboard-shared';
 import { BoardLiveness } from './BoardLiveness';
 import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor, AttentionDomain } from '../attention/compose';
 import { NowProvider } from '../contexts/NowContext';
+import type { GcEventConnState } from '../hooks/useGcEvents';
 
-afterEach(() => cleanup());
+// The liveness line reads the gc event-stream state via useRunSummary. Drive it
+// from a module-level var the single mock reads, so each test sets it without a
+// re-stub (the unstubAll re-stub no-op gotcha).
+let mockSseState: GcEventConnState = 'open';
+vi.mock('../runs/runSummarySubscription', () => ({
+  useRunSummary: () => ({ sseState: mockSseState }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mockSseState = 'open';
+});
 
 function freshContributor(
   domain: AttentionDomain,
@@ -33,47 +45,65 @@ function renderLiveness(contributors: readonly AttentionContributor[]) {
 }
 
 const now = () => new Date().toISOString();
+const secondsAgo = (s: number) => new Date(Date.now() - s * 1000).toISOString();
 const minutesAgo = (m: number) => new Date(Date.now() - m * 60_000).toISOString();
 
-describe('BoardLiveness (gascity-dashboard-5t0m)', () => {
-  it('reads "all live" in greyscale when every domain read is fresh', () => {
+describe('BoardLiveness (gascity-dashboard-5t0m / fchh)', () => {
+  it('reads "all live" in greyscale when every read is fresh, recent, and the stream is up', () => {
     renderLiveness([freshContributor('runs', 'fresh', now())]);
-
     const line = screen.getByRole('status');
-    expect(line.textContent).toMatch(/as of .* ago/);
     expect(line.textContent).toContain('all live');
-    // One Mark at rest: no maroon mark in the calm state.
-    expect(line.querySelector('.text-accent')).toBeNull();
+    expect(line.querySelector('.text-accent')).toBeNull(); // One Mark at rest: no mark
   });
 
-  it('turns a single maroon glyph + word naming the stale domain', () => {
-    renderLiveness([
-      freshContributor('runs', 'stale', minutesAgo(5)),
-      freshContributor('mail', 'fresh', now()),
-    ]);
-
+  it('flips to maroon on an AGED-stale read — not just on a hard error (blocker 1)', () => {
+    // 'fresh' provenance, but the read is 2 minutes old → past the 60s floor.
+    renderLiveness([freshContributor('agents', 'fresh', minutesAgo(2))]);
     const line = screen.getByRole('status');
-    expect(line.textContent).toContain('runs stale');
-    const mark = line.querySelector('.text-accent');
-    expect(mark).not.toBeNull();
-    // The word — not just the color — carries the state (Greyscale Test).
-    expect(mark?.textContent).toContain('runs stale');
+    expect(line.textContent).toContain('agents stale');
+    expect(line.querySelector('.text-accent')).not.toBeNull();
   });
 
-  it('phrases an errored read as "unreachable"', () => {
-    renderLiveness([freshContributor('agents', 'error', now())]);
-    expect(screen.getByRole('status').textContent).toContain('agents unreachable');
+  it('flips to maroon on an SSE drop even when every read is fresh (blocker 2)', () => {
+    mockSseState = 'closed';
+    renderLiveness([freshContributor('runs', 'fresh', now())]);
+    const line = screen.getByRole('status');
+    expect(line.textContent).toContain('live updates paused');
+    expect(line.querySelector('.text-accent')).not.toBeNull();
   });
 
-  it('counts rather than lists when several domains are stale', () => {
+  it('also degrades on a degraded (not yet closed) stream', () => {
+    mockSseState = 'degraded';
+    renderLiveness([freshContributor('runs', 'fresh', now())]);
+    expect(screen.getByRole('status').querySelector('.text-accent')).not.toBeNull();
+  });
+
+  it('renders the degraded state on a cold all-error outage with no landed read (major 3)', () => {
+    renderLiveness([freshContributor('agents', 'error', undefined)]);
+    const line = screen.getByRole('status');
+    expect(line.textContent).not.toContain('as of'); // no age to show
+    expect(line.textContent).toContain('agents unreachable');
+    expect(line.querySelector('.text-accent')).not.toBeNull();
+  });
+
+  it('labels several degraded domains "N degraded" (mixed stale/error), not "N stale" (minor)', () => {
     renderLiveness([
-      freshContributor('runs', 'stale', minutesAgo(5)),
-      freshContributor('agents', 'error', minutesAgo(3)),
+      freshContributor('agents', 'error', now()),
+      freshContributor('runs', 'fresh', minutesAgo(2)), // aged → stale
     ]);
-    expect(screen.getByRole('status').textContent).toContain('2 stale');
+    const t = screen.getByRole('status').textContent ?? '';
+    expect(t).toContain('2 degraded');
+    expect(t).not.toContain('2 stale');
   });
 
-  it('stays silent until a read has landed', () => {
+  it('phrases a sub-5s read as "just now", never "now ago" (nit)', () => {
+    renderLiveness([freshContributor('runs', 'fresh', secondsAgo(1))]);
+    const t = screen.getByRole('status').textContent ?? '';
+    expect(t).toContain('as of just now');
+    expect(t).not.toContain('now ago');
+  });
+
+  it('stays silent until a read has landed and nothing is wrong', () => {
     const { container } = renderLiveness([freshContributor('runs', undefined, undefined)]);
     expect(container.querySelector('[role="status"]')).toBeNull();
   });

--- a/frontend/src/components/BoardLiveness.test.tsx
+++ b/frontend/src/components/BoardLiveness.test.tsx
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SourceStatus } from 'gas-city-dashboard-shared';
 import { BoardLiveness } from './BoardLiveness';
 import { AttentionProvider } from '../attention/context';
-import type { AttentionContributor, AttentionDomain } from '../attention/compose';
+import {
+  ATTENTION_READ_STALE_AFTER_MS,
+  type AttentionContributor,
+  type AttentionDomain,
+} from '../attention/compose';
 import { NowProvider } from '../contexts/NowContext';
 import type { GcEventConnState } from '../hooks/useGcEvents';
 
@@ -20,17 +24,25 @@ afterEach(() => {
   mockSseState = 'open';
 });
 
+// Mirrors withReadFreshness: a landed (non-error) read carries a staleAt of
+// fetchedAt + the stale window, so age-flip is driven by a real staleAt exactly
+// as the polled domains do in production.
 function freshContributor(
   domain: AttentionDomain,
   provenance: SourceStatus | undefined,
   fetchedAt: string | undefined,
 ): AttentionContributor {
+  const staleAt =
+    provenance !== 'error' && fetchedAt !== undefined
+      ? new Date(Date.parse(fetchedAt) + ATTENTION_READ_STALE_AFTER_MS).toISOString()
+      : undefined;
   return {
     id: `${domain}:test`,
     domain,
     getItems: () => [],
     ...(provenance !== undefined && { provenance }),
     ...(fetchedAt !== undefined && { fetchedAt }),
+    ...(staleAt !== undefined && { staleAt }),
   };
 }
 
@@ -89,7 +101,7 @@ describe('BoardLiveness (gascity-dashboard-5t0m / fchh)', () => {
   it('labels several degraded domains "N degraded" (mixed stale/error), not "N stale" (minor)', () => {
     renderLiveness([
       freshContributor('agents', 'error', now()),
-      freshContributor('runs', 'fresh', minutesAgo(2)), // aged → stale
+      freshContributor('beads', 'fresh', minutesAgo(2)), // polled read aged → stale
     ]);
     const t = screen.getByRole('status').textContent ?? '';
     expect(t).toContain('2 degraded');

--- a/frontend/src/components/BoardLiveness.test.tsx
+++ b/frontend/src/components/BoardLiveness.test.tsx
@@ -69,7 +69,8 @@ describe('BoardLiveness (gascity-dashboard-5t0m / fchh)', () => {
   });
 
   it('flips to maroon on an AGED-stale read — not just on a hard error (blocker 1)', () => {
-    // 'fresh' provenance, but the read is 2 minutes old → past the 60s floor.
+    // 'fresh' provenance, but the read is 2 minutes old → past the 90s stale
+    // floor (ATTENTION_READ_STALE_AFTER_MS).
     renderLiveness([freshContributor('agents', 'fresh', minutesAgo(2))]);
     const line = screen.getByRole('status');
     expect(line.textContent).toContain('agents stale');

--- a/frontend/src/components/BoardLiveness.tsx
+++ b/frontend/src/components/BoardLiveness.tsx
@@ -22,10 +22,6 @@ import { useRunSummary } from '../runs/runSummarySubscription';
 // arbitrates the viewport's single mark — when this line owns it, the "reading
 // as" indicator and the nav badges drop their accent (see Header.tsx).
 
-// Mirrors the runs SourceState.staleAt convention (RUNS_STALE_AFTER_MS). A read
-// older than this is treated as no longer current.
-const LIVENESS_STALE_AFTER_MS = 60_000;
-
 export interface BoardLivenessState {
   /** True when any domain is stale/errored or the event stream is down. */
   degraded: boolean;
@@ -40,7 +36,7 @@ export function useBoardLiveness(): BoardLivenessState {
   const model = useAttentionModel();
   const now = useNow();
   const { sseState } = useRunSummary();
-  const fresh = boardFreshness(model, now, LIVENESS_STALE_AFTER_MS);
+  const fresh = boardFreshness(model, now);
   // A closed/degraded gc event stream means updates have stopped arriving — the
   // board is freezing regardless of what each cached read's provenance says.
   const streamDown = sseState === 'closed' || sseState === 'degraded';

--- a/frontend/src/components/BoardLiveness.tsx
+++ b/frontend/src/components/BoardLiveness.tsx
@@ -1,0 +1,48 @@
+import { useAttentionModel } from '../attention/context';
+import { boardFreshness, type BoardFreshness } from '../attention/compose';
+import { useNow } from '../contexts/NowContext';
+import { formatRelative } from '../hooks/time';
+
+// gascity-dashboard-5t0m (Freshness Spine): ONE quiet board-wide liveness line.
+// It answers the question no badge does — "is the data CURRENT?" (vs the nav
+// badges' "is it alarming?") — so a calm board fed by a dead cache or a dropped
+// stream no longer reads as all-clear. `fetchedAt` is the oldest read on the
+// board; the line ages off it, so a frozen source surfaces as a growing "as of N
+// ago" even before its provenance flips.
+//
+// DESIGN.md: at rest it reads in pure greyscale ("as of 12s ago · all live") and
+// carries NO mark (One Mark at rest). It turns a single maroon glyph + word ONLY
+// when a domain read is stale or errored — the sanctioned Stuck-Maroon status,
+// always paired with a word so it survives the Greyscale Test (the "(!)" glyph +
+// the word carry the state, not the color).
+export function BoardLiveness() {
+  const model = useAttentionModel();
+  const now = useNow();
+  const fresh = boardFreshness(model);
+  // Nothing has loaded yet — no honest age to show, so stay silent.
+  if (fresh.fetchedAt === undefined) return null;
+
+  const age = formatRelative(fresh.fetchedAt, now);
+  return (
+    <span role="status" className="text-label uppercase tracking-wider tnum text-fg-faint">
+      as of {age} ago <span aria-hidden="true">·</span>{' '}
+      {fresh.degraded.length === 0 ? (
+        'all live'
+      ) : (
+        <span className="text-accent">
+          <span aria-hidden="true">(!)</span> {degradedLabel(fresh.degraded)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** A compact phrase for the degraded domains — named when there is one, counted
+ *  when there are several, so the single mark stays one word-group. */
+function degradedLabel(degraded: BoardFreshness['degraded']): string {
+  if (degraded.length === 1) {
+    const only = degraded[0]!;
+    return `${only.domain} ${only.provenance === 'error' ? 'unreachable' : 'stale'}`;
+  }
+  return `${degraded.length} stale`;
+}

--- a/frontend/src/components/BoardLiveness.tsx
+++ b/frontend/src/components/BoardLiveness.tsx
@@ -2,47 +2,91 @@ import { useAttentionModel } from '../attention/context';
 import { boardFreshness, type BoardFreshness } from '../attention/compose';
 import { useNow } from '../contexts/NowContext';
 import { formatRelative } from '../hooks/time';
+import { useRunSummary } from '../runs/runSummarySubscription';
 
 // gascity-dashboard-5t0m (Freshness Spine): ONE quiet board-wide liveness line.
 // It answers the question no badge does — "is the data CURRENT?" (vs the nav
 // badges' "is it alarming?") — so a calm board fed by a dead cache or a dropped
-// stream no longer reads as all-clear. `fetchedAt` is the oldest read on the
-// board; the line ages off it, so a frozen source surfaces as a growing "as of N
-// ago" even before its provenance flips.
+// stream no longer reads as all-clear.
 //
-// DESIGN.md: at rest it reads in pure greyscale ("as of 12s ago · all live") and
-// carries NO mark (One Mark at rest). It turns a single maroon glyph + word ONLY
-// when a domain read is stale or errored — the sanctioned Stuck-Maroon status,
-// always paired with a word so it survives the Greyscale Test (the "(!)" glyph +
-// the word carry the state, not the color).
-export function BoardLiveness() {
+// Three things flip it to the single maroon glyph + word (gascity-dashboard-fchh):
+//   1. a hard read error on any domain;
+//   2. an AGED-stale read — derived from the oldest read's age, not just from a
+//      fetch failure, so a frozen-but-not-erroring cache flips, not just ages;
+//   3. a dropped/degraded gc event stream (sseState) — the live-update path is
+//      down, so the board is freezing whatever the per-read provenance says.
+//
+// DESIGN.md: at rest it reads in pure greyscale ("as of 12s ago · all live") with
+// NO mark (One Mark at rest). When degraded it shows the sanctioned Stuck-Maroon
+// status, ALWAYS paired with a word so it survives the Greyscale Test. The Header
+// arbitrates the viewport's single mark — when this line owns it, the "reading
+// as" indicator and the nav badges drop their accent (see Header.tsx).
+
+// Mirrors the runs SourceState.staleAt convention (RUNS_STALE_AFTER_MS). A read
+// older than this is treated as no longer current.
+const LIVENESS_STALE_AFTER_MS = 60_000;
+
+export interface BoardLivenessState {
+  /** True when any domain is stale/errored or the event stream is down. */
+  degraded: boolean;
+  /** Age phrase of the oldest read ("just now", "12s ago"), or null if no read
+   *  has landed yet (a cold outage shows the degraded copy with no age). */
+  ageLabel: string | null;
+  /** The single glyph+word phrase to show when degraded; '' otherwise. */
+  label: string;
+}
+
+export function useBoardLiveness(): BoardLivenessState {
   const model = useAttentionModel();
   const now = useNow();
-  const fresh = boardFreshness(model);
-  // Nothing has loaded yet — no honest age to show, so stay silent.
-  if (fresh.fetchedAt === undefined) return null;
+  const { sseState } = useRunSummary();
+  const fresh = boardFreshness(model, now, LIVENESS_STALE_AFTER_MS);
+  // A closed/degraded gc event stream means updates have stopped arriving — the
+  // board is freezing regardless of what each cached read's provenance says.
+  const streamDown = sseState === 'closed' || sseState === 'degraded';
+  const degraded = streamDown || fresh.degraded.length > 0;
+  const ageLabel =
+    fresh.fetchedAt === undefined ? null : agePhrase(formatRelative(fresh.fetchedAt, now));
+  return { degraded, ageLabel, label: degraded ? livenessLabel(fresh.degraded, streamDown) : '' };
+}
 
-  const age = formatRelative(fresh.fetchedAt, now);
+export function BoardLiveness() {
+  const { degraded, ageLabel, label } = useBoardLiveness();
+  // Truly nothing to say — no read has landed and nothing is wrong.
+  if (!degraded && ageLabel === null) return null;
+
   return (
     <span role="status" className="text-label uppercase tracking-wider tnum text-fg-faint">
-      as of {age} ago <span aria-hidden="true">·</span>{' '}
-      {fresh.degraded.length === 0 ? (
-        'all live'
-      ) : (
+      {ageLabel !== null && (
+        <>
+          as of {ageLabel} <span aria-hidden="true">·</span>{' '}
+        </>
+      )}
+      {degraded ? (
         <span className="text-accent">
-          <span aria-hidden="true">(!)</span> {degradedLabel(fresh.degraded)}
+          <span aria-hidden="true">(!)</span> {label}
         </span>
+      ) : (
+        'all live'
       )}
     </span>
   );
 }
 
-/** A compact phrase for the degraded domains — named when there is one, counted
- *  when there are several, so the single mark stays one word-group. */
-function degradedLabel(degraded: BoardFreshness['degraded']): string {
+/** "as of N ago", but "just now" for a sub-5s read (formatRelative returns
+ *  'now', so "as of now ago" would be ungrammatical). */
+function agePhrase(relative: string): string {
+  return relative === 'now' ? 'just now' : `${relative} ago`;
+}
+
+/** The single degraded phrase. A dropped stream is the board-level root cause and
+ *  owns the line; otherwise name a lone degraded domain or count several. "N
+ *  degraded" (not "N stale") because the set can mix stale and unreachable. */
+function livenessLabel(degraded: BoardFreshness['degraded'], streamDown: boolean): string {
+  if (streamDown) return 'live updates paused';
   if (degraded.length === 1) {
     const only = degraded[0]!;
     return `${only.domain} ${only.provenance === 'error' ? 'unreachable' : 'stale'}`;
   }
-  return `${degraded.length} stale`;
+  return `${degraded.length} degraded`;
 }

--- a/frontend/src/components/Header.attention.test.tsx
+++ b/frontend/src/components/Header.attention.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AttentionProvider } from '../attention/context';
 import type { AttentionContributor, AttentionItem } from '../attention/compose';
+import { NowProvider } from '../contexts/NowContext';
 import { ThemeProvider } from '../contexts/ThemeContext';
 import { ViewingAsProvider } from '../contexts/ViewingAsContext';
 import { Header } from './Header';
@@ -66,14 +67,16 @@ function renderHeader(contributors: readonly AttentionContributor[]) {
   return render(
     <ThemeProvider>
       <ViewingAsProvider>
-        <AttentionProvider contributors={contributors}>
-          <MemoryRouter
-            initialEntries={['/runs']}
-            future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
-          >
-            <Header />
-          </MemoryRouter>
-        </AttentionProvider>
+        <NowProvider>
+          <AttentionProvider contributors={contributors}>
+            <MemoryRouter
+              initialEntries={['/runs']}
+              future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+            >
+              <Header />
+            </MemoryRouter>
+          </AttentionProvider>
+        </NowProvider>
       </ViewingAsProvider>
     </ThemeProvider>,
   );

--- a/frontend/src/components/Header.attention.test.tsx
+++ b/frontend/src/components/Header.attention.test.tsx
@@ -28,6 +28,13 @@ vi.mock('../supervisor/client', () => ({
   }),
 }));
 
+// gascity-dashboard-fchh: the liveness line reads the event-stream state. Drive
+// it from a module var so a test can force a degraded header.
+let mockSseState = 'open';
+vi.mock('../runs/runSummarySubscription', () => ({
+  useRunSummary: () => ({ sseState: mockSseState }),
+}));
+
 describe('Header attention indicators', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'matchMedia', {
@@ -47,6 +54,22 @@ describe('Header attention indicators', () => {
 
   afterEach(() => {
     cleanup();
+    mockSseState = 'open';
+  });
+
+  it('honors DESIGN.md One Mark — a degraded liveness owns the sole header accent; nav badge defers (fchh major 4)', () => {
+    mockSseState = 'closed'; // degraded liveness owns the mark
+    renderHeader([contributor('runs', [item('run-attn', 'runs', 'attention')])]);
+
+    // The nav attention badge renders its count but in NEUTRAL tone, not accent.
+    const badge = screen.getByLabelText(/Runs: 1 attention item/);
+    expect(badge.className).toContain('text-fg-muted');
+    expect(badge.className).not.toContain('text-accent');
+
+    // Exactly one maroon mark in the header viewport — the liveness line.
+    const accents = document.querySelectorAll('.text-accent');
+    expect(accents.length).toBe(1);
+    expect(screen.getByRole('status').textContent).toContain('live updates paused');
   });
 
   it('rolls up highest severity and count from the shared attention model', async () => {

--- a/frontend/src/components/Header.attention.test.tsx
+++ b/frontend/src/components/Header.attention.test.tsx
@@ -72,6 +72,28 @@ describe('Header attention indicators', () => {
     expect(screen.getByRole('status').textContent).toContain('live updates paused');
   });
 
+  it('keeps an ochre watch badge while a degraded liveness owns the maroon mark (4q60)', () => {
+    mockSseState = 'closed'; // degraded liveness owns the sole maroon mark
+    renderHeader([
+      contributor('runs', [item('run-attn', 'runs', 'attention')]),
+      contributor('mail', [item('mail-watch', 'mail', 'watch')]),
+    ]);
+
+    // The maroon (attention) badge defers to neutral under the One Mark Rule...
+    const attnBadge = screen.getByLabelText(/Runs: 1 attention item/);
+    expect(attnBadge.className).toContain('text-fg-muted');
+    expect(attnBadge.className).not.toContain('text-accent');
+
+    // ...but Caution Ochre is a separate signal and survives: the watch badge
+    // stays text-warn rather than demoting to neutral.
+    const watchBadge = screen.getByLabelText(/Mail: 1 watch item/);
+    expect(watchBadge.className).toContain('text-warn');
+    expect(watchBadge.className).not.toContain('text-fg-muted');
+
+    // Still exactly one maroon mark in the header viewport — the liveness line.
+    expect(document.querySelectorAll('.text-accent').length).toBe(1);
+  });
+
   it('rolls up highest severity and count from the shared attention model', async () => {
     renderHeader([
       contributor('runs', [item('run-1', 'runs', 'attention'), item('run-2', 'runs', 'watch')]),

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { api } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { NavAttentionIndicator } from '../attention/NavAttentionIndicator';
-import { BoardLiveness } from './BoardLiveness';
+import { BoardLiveness, useBoardLiveness } from './BoardLiveness';
 import { useAttentionModel } from '../attention/context';
 import type { AttentionDomain } from '../attention/compose';
 import { useTheme } from '../contexts/ThemeContext';
@@ -57,6 +57,11 @@ export function Header() {
   const { viewingAs } = useViewingAs();
   const { operatorAlias } = useOperatorConfig();
   const attention = useAttentionModel();
+  // gascity-dashboard-fchh major 4 (DESIGN.md One Mark): when the liveness line
+  // is degraded it owns the viewport's single maroon mark, so the other accents
+  // here — the "reading as" indicator and the nav attention badges — drop to
+  // neutral. A frozen/erroring board is the loudest thing on the header.
+  const livenessOwnsMark = useBoardLiveness().degraded;
   const { data: config } = useCachedData('config', () => api.config());
   // City switcher source (gascity-dashboard-ucc). Lists every managed city;
   // selecting one navigates (full reload) to that city's `/city/:name/`
@@ -126,7 +131,11 @@ export function Header() {
             </span>
           )}
           {showReadingAs && (
-            <span className="text-label uppercase tracking-wider text-accent ml-3">
+            <span
+              className={`text-label uppercase tracking-wider ml-3 ${
+                livenessOwnsMark ? 'text-fg-muted' : 'text-accent'
+              }`}
+            >
               · reading as {displayLabel(viewingAs.alias, operatorAlias)}
             </span>
           )}
@@ -152,7 +161,11 @@ export function Header() {
                   >
                     {r.label}
                     {domain !== undefined && (
-                      <NavAttentionIndicator label={r.label} summary={attention.byDomain[domain]} />
+                      <NavAttentionIndicator
+                        label={r.label}
+                        summary={attention.byDomain[domain]}
+                        suppressAccent={livenessOwnsMark}
+                      />
                     )}
                   </NavLink>
                 </li>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { api } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { NavAttentionIndicator } from '../attention/NavAttentionIndicator';
+import { BoardLiveness } from './BoardLiveness';
 import { useAttentionModel } from '../attention/context';
 import type { AttentionDomain } from '../attention/compose';
 import { useTheme } from '../contexts/ThemeContext';
@@ -159,6 +160,8 @@ export function Header() {
             })}
           </ul>
         </nav>
+
+        <BoardLiveness />
 
         <button
           type="button"

--- a/frontend/src/hooks/useVisibleRefresh.test.tsx
+++ b/frontend/src/hooks/useVisibleRefresh.test.tsx
@@ -103,4 +103,78 @@ describe('useVisibleRefresh', () => {
     });
     expect(refresh).toHaveBeenCalledTimes(1);
   });
+
+  it('skips interval ticks while the tab is hidden', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    const refresh = vi.fn(() => Promise.resolve());
+
+    renderHook(() => useVisibleRefresh(refresh, 1_000));
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('re-reads immediately when the tab becomes visible after being hidden past the stale window', async () => {
+    vi.useFakeTimers();
+    const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    const refresh = vi.fn(() => Promise.resolve());
+
+    // Hidden for far longer than any polled domain's stale threshold: the fixed
+    // interval fires repeatedly but tick() bails on document.hidden, so no read
+    // refreshes and every fetchedAt ages out.
+    renderHook(() => useVisibleRefresh(refresh, 1_000));
+    await act(async () => {
+      vi.advanceTimersByTime(120_000);
+    });
+    expect(refresh).not.toHaveBeenCalled();
+
+    // Refocus: the immediate visibilitychange refresh fires BEFORE the next
+    // interval tick, so fetchedAt advances before a stale window can render.
+    hiddenSpy.mockReturnValue(false);
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh when visibilitychange fires while still hidden', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    const refresh = vi.fn(() => Promise.resolve());
+
+    renderHook(() => useVisibleRefresh(refresh, 1_000));
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('clears the interval and visibilitychange listener on unmount', async () => {
+    vi.useFakeTimers();
+    const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    const refresh = vi.fn(() => Promise.resolve());
+
+    const { unmount } = renderHook(() => useVisibleRefresh(refresh, 1_000));
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    // Neither a further interval tick nor a refocus event reaches the unmounted
+    // hook.
+    hiddenSpy.mockReturnValue(true);
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+    hiddenSpy.mockReturnValue(false);
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/hooks/useVisibleRefresh.ts
+++ b/frontend/src/hooks/useVisibleRefresh.ts
@@ -14,7 +14,9 @@ const DEFAULT_MAX_BACKOFF_MS = 60_000;
  * Promise-aware visible polling for refresh callbacks whose data/error state
  * lives elsewhere. This hook deliberately waits for the first interval tick;
  * callers that need an initial load should do that explicitly or use a loader
- * hook such as `useAbortableVisibleRefresh()`.
+ * hook such as `useAbortableVisibleRefresh()`. It does, however, re-read
+ * immediately when the tab returns to the foreground (see the visibilitychange
+ * listener) so reads taken before a long hidden period refresh on refocus.
  */
 export function useVisibleRefresh(
   refresh: () => Promise<void>,
@@ -62,7 +64,22 @@ export function useVisibleRefresh(
     };
 
     const interval = window.setInterval(tick, intervalMs);
-    return () => window.clearInterval(interval);
+
+    // gascity-dashboard-4q60: an ambient dashboard spends most of its life in a
+    // backgrounded tab, where tick() bails on document.hidden — so every polled
+    // read ages past its stale threshold while hidden and no re-read fires. On a
+    // fixed-interval poll alone, refocus would show a false 'stale' mark for up
+    // to one interval until the next tick lands. Re-read the moment the tab
+    // becomes visible so fetchedAt advances before that stale window renders.
+    const onVisibilityChange = () => {
+      if (!document.hidden) tick();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, [enabled, intervalMs, initialBackoffMs, maxBackoffMs]);
 }
 


### PR DESCRIPTION
## Freshness Spine — board-wide liveness off the freshness fold

Surfaces per-domain read-freshness in the attention model and renders a board-wide liveness line in the header, so a viewer can tell at a glance how current the board data is.

Two cohesive commits:
1. **`feat(attention)`** — fold per-domain read freshness into `AttentionDomainSummary` (`compose.ts`), with `fetchedAt` threaded through `liveContributors.ts` and the registry projection.
2. **`feat(header)`** — board-wide liveness line off the freshness fold: new `BoardLiveness.tsx` component + a 3-line `Header.tsx` wire-in.

**Scope:** 9 files / +557 −66, each with tests (`compose.test`, `registry.test`, `BoardLiveness.test`, `Header.attention.test`). Off current `main`.

**Invariants preserved:** shared SSOT wire-shape, 127.0.0.1-only backend bind, Origin allow-list + Vite `changeOrigin`, and the One Mark / greyscale / glyph+word visual contract all untouched. No new supervisor data surfaced.
