### PR TITLE
docs(exposure): external-exposure hardening guide (lv4k — deploy + #2578 verify + rate-limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,18 @@ non-zero exit always means a real regression.
 
 All knobs are environment variables. See [`backend/src/config.ts`](backend/src/config.ts) for the authoritative list.
 
-| Variable                    | Default                  | Purpose                                                                                                                                  |
-| --------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                      | `8081`                   | TCP port the dashboard listens on                                                                                                        |
+| Variable                    | Default                  | Purpose                                                                                                                                                                                              |
+| --------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                      | `8081`                   | TCP port the dashboard listens on                                                                                                                                                                    |
 | `HOST`                      | `127.0.0.1`              | Ignored — the backend always binds loopback. Expose beyond localhost via your own auth proxy that rewrites `Host`+`Origin` to loopback — see the [Exposure runbook](specs/architecture/exposure.md). |
-| `ADMIN_EXTRA_ALLOWED_HOSTS` | (empty)                  | CSV of extra hostnames allowed in the `Host:` header (e.g. `my-vm,192.168.1.58`). The floor `127.0.0.1` / `localhost` is always allowed. |
-| `GC_SUPERVISOR_URL`         | `http://127.0.0.1:8372`  | gc supervisor API base URL.                                                                                                              |
-| `GC_CITY_NAME`              | `racoon-city`            | Name of the city this dashboard manages. One dashboard per city.                                                                         |
-| `MODULES_ENABLED`           | (empty)                  | CSV of optional first-party modules to mount, e.g. `maintainer`. Core views always mount.                                                |
-| `DEFAULT_VIEW`              | (empty)                  | Optional module/view id to use as the city default route.                                                                                |
-| `ADMIN_AUDIT_LOG_PATH`      | `$HOME/.gc/events.jsonl` | Where state-changing actions append audit entries.                                                                                       |
-| `ADMIN_FRONTEND_DIST`       | `../frontend/dist`       | Path to built frontend assets.                                                                                                           |
-| `ADMIN_DASHBOARD_DISABLED`  | `0`                      | Kill switch. Set to `1` to refuse to start.                                                                                              |
+| `ADMIN_EXTRA_ALLOWED_HOSTS` | (empty)                  | CSV of extra hostnames allowed in the `Host:` header (e.g. `my-vm,192.168.1.58`). The floor `127.0.0.1` / `localhost` is always allowed.                                                             |
+| `GC_SUPERVISOR_URL`         | `http://127.0.0.1:8372`  | gc supervisor API base URL.                                                                                                                                                                          |
+| `GC_CITY_NAME`              | `racoon-city`            | Name of the city this dashboard manages. One dashboard per city.                                                                                                                                     |
+| `MODULES_ENABLED`           | (empty)                  | CSV of optional first-party modules to mount, e.g. `maintainer`. Core views always mount.                                                                                                            |
+| `DEFAULT_VIEW`              | (empty)                  | Optional module/view id to use as the city default route.                                                                                                                                            |
+| `ADMIN_AUDIT_LOG_PATH`      | `$HOME/.gc/events.jsonl` | Where state-changing actions append audit entries.                                                                                                                                                   |
+| `ADMIN_FRONTEND_DIST`       | `../frontend/dist`       | Path to built frontend assets.                                                                                                                                                                       |
+| `ADMIN_DASHBOARD_DISABLED`  | `0`                      | Kill switch. Set to `1` to refuse to start.                                                                                                                                                          |
 
 For local dev a `.env.local` is convenient (not auto-loaded; source it explicitly):
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ All knobs are environment variables. See [`backend/src/config.ts`](backend/src/c
 | Variable                    | Default                  | Purpose                                                                                                                                  |
 | --------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                      | `8081`                   | TCP port the dashboard listens on                                                                                                        |
-| `HOST`                      | `127.0.0.1`              | Ignored — the backend always binds loopback. Expose beyond localhost via your own auth proxy (see Security model).                       |
+| `HOST`                      | `127.0.0.1`              | Ignored — the backend always binds loopback. Expose beyond localhost via your own auth proxy that rewrites `Host`+`Origin` to loopback — see the [Exposure runbook](specs/architecture/exposure.md). |
 | `ADMIN_EXTRA_ALLOWED_HOSTS` | (empty)                  | CSV of extra hostnames allowed in the `Host:` header (e.g. `my-vm,192.168.1.58`). The floor `127.0.0.1` / `localhost` is always allowed. |
 | `GC_SUPERVISOR_URL`         | `http://127.0.0.1:8372`  | gc supervisor API base URL.                                                                                                              |
 | `GC_CITY_NAME`              | `racoon-city`            | Name of the city this dashboard manages. One dashboard per city.                                                                         |
@@ -129,7 +129,7 @@ Built for **single-operator** use on a **trusted network**.
 - **Content Security Policy** — `script-src 'self'` plus a hash for the static theme bootstrap, no arbitrary inline scripts, no `eval`.
 - **Exec whitelist** — every shell-out is enumerated explicitly in [`backend/src/exec.ts`](backend/src/exec.ts). There is no general-purpose command execution path.
 
-**Exposing beyond localhost is operator-owned.** The default needs zero config and ships no auth. To reach the dashboard remotely you front it with your **own** authenticated proxy (nginx/Caddy/Tailscale Serve/Cloudflare Access/etc.) — the dashboard stays on loopback. Optionally enable the server-enforced read-only gate (`DASHBOARD_READONLY=1`), keep the gc supervisor loopback-only and patched, and rate-limit at your proxy. Full runbook: [`specs/architecture/exposure.md`](specs/architecture/exposure.md).
+**Exposing beyond localhost is operator-owned.** The default needs zero config and ships no auth. To reach the dashboard remotely you front it with your **own** authenticated proxy (nginx/Caddy/Tailscale Serve/Cloudflare Access/etc.) — the dashboard stays on loopback. The front **must rewrite `Host` → `127.0.0.1` and `Origin` → `http://127.0.0.1:<port>`** before forwarding; forwarding the public values 403s every write and (if you "fix" it via `ADMIN_EXTRA_ALLOWED_HOSTS`) weakens the Origin belt — it is the #1 misconfiguration. Optionally enable the server-enforced read-only gate (`DASHBOARD_READONLY=1`), keep the gc supervisor loopback-only and patched, and rate-limit at your proxy. Full runbook: [`specs/architecture/exposure.md`](specs/architecture/exposure.md).
 
 Full threat model: [`specs/architecture/security.md`](specs/architecture/security.md).
 

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -179,6 +179,131 @@ The tunnel forwards the client's `Origin`, so pair it with `DASHBOARD_READONLY=1
 (reads only, `Origin` check exempt). For read/write exposure, add a Cloudflare
 Transform Rule that sets `Origin: http://127.0.0.1:8082` on requests to the host.
 
+## Rate-limiting at the front
+
+The dashboard has **no rate limiter of its own**. The only back-pressure in the
+codebase is a global four-slot semaphore around host shell-outs
+(`MAX_CONCURRENT = 4` in `backend/src/exec-core.ts`) — it serialises
+`git`/`gh`/`bd` reads, not HTTP requests, and it is per-process, not per-IP. HTTP
+requests, and especially long-lived streams, hit no ceiling at all.
+
+This limiting belongs **at the BYO front, never in transit.** The
+`/gc-supervisor/*` proxy is transport-only by contract — it forwards bytes and
+nothing else. Putting a rate policy inside it would couple the dashboard to a
+supervisor concern it must not own (the same reason `DASHBOARD_READONLY` gates
+verbs at the proxy's _edge_, not its body). Enforce every limit below at the
+authenticated front, where identity is already known.
+
+### The exhaustion vector: long-lived streams
+
+A request-per-second limiter is necessary but not sufficient, because the
+dashboard's costliest traffic is **streams that stay open**, not requests that
+return. Each one pins a socket and a file descriptor for its whole lifetime, so a
+handful of identities holding many streams exhausts the host long before any
+req/s ceiling notices — one stream is a _single_ request that never completes.
+This is the scoping review's risk #7: "resource exhaustion against the supervisor
+via open proxy GETs — long-lived SSE event/session streams especially."
+
+The streams to bound:
+
+- `GET /api/maintainer/events` — the dashboard's own SSE channel
+  (`text/event-stream`, 30 s heartbeats), registered in an **unbounded**
+  in-memory client set.
+- `GET /gc-supervisor/v0/city/{city}/events` and `…/events/stream` — the
+  supervisor event streams, proxied through verbatim.
+- `GET /gc-supervisor/v0/city/{city}/session/{id}/stream` — one open stream
+  **per session view**, so a single operator with several sessions open already
+  holds several.
+
+All are `GET`s, so all cross the wire even under `DASHBOARD_READONLY=1`. A
+concurrent-connection cap — not a request-rate limit — is what bounds them.
+
+### The three knobs
+
+| Knob                            | What it bounds                                       | Recommended start, per identity |
+| ------------------------------- | --------------------------------------------------- | ------------------------------- |
+| Per-identity request rate       | reconnect storms, abusive polling, write floods     | 10 req/s, burst 30              |
+| Concurrent-connection cap       | held-open SSE — the real exhaustion vector          | 15 connections                  |
+| GET-rate ceiling                | the only verb that crosses in read-only mode        | 20 req/s, burst 50              |
+
+These are starting points for a one-operator (or small, known team) control
+plane — scale them by the number of real operators, not by anticipated load. The
+request rate is the overall per-identity ceiling; the GET-rate ceiling is a
+deliberately looser sub-limit you raise above it **only for `GET`/`HEAD`**, since
+under `DASHBOARD_READONLY=1` reads are the entire (and cheap, polling-heavy)
+surface. Key every limit on the **authenticated identity** the front already
+established
+(basic-auth user, forward-auth `Remote-User`, the Access email), falling back to
+client IP only where no identity header exists. A browser tab holds roughly the
+maintainer stream plus one supervisor event stream plus one stream per open
+session, so 15 concurrent connections leaves headroom for a couple of tabs;
+tighten toward 5 for a strict single-tab operator.
+
+### Concrete limits per front
+
+**nginx** — `limit_req` for rate, `limit_conn` for the stream cap, both keyed on
+the basic-auth user:
+
+```nginx
+# These two zone directives live in the http{} context (the conf.d files nginx
+# includes are already inside http{}) — NOT inside server{}, where nginx rejects
+# them with "directive is not allowed here".
+limit_req_zone  $remote_user zone=gcd_req:10m  rate=10r/s;
+limit_conn_zone $remote_user zone=gcd_conn:10m;
+
+server {
+    # …TLS + auth_basic from the nginx recipe above…
+    location / {
+        limit_req  zone=gcd_req burst=30 nodelay;   # per-identity request rate
+        limit_conn gcd_conn 15;                      # concurrent-connection cap (bounds SSE)
+        # …proxy_pass + Host/Origin rewrite + proxy_buffering off…
+    }
+}
+```
+
+`limit_conn` is the load-bearing one here: it counts a held-open SSE stream as a
+live connection, which a `limit_req` ceiling never sees.
+
+**Caddy** — standard Caddy ships **no** rate limiting; add the third-party
+[`caddy-ratelimit`](https://github.com/mholt/caddy-ratelimit) module via a custom
+`xcaddy` build, then key on the forward-auth identity. `rate_limit` is a handler
+directive — place it inside the `dash.example.com { … }` site block from the
+Caddy recipe above:
+
+```caddy
+rate_limit {
+    zone gcd {
+        key    {http.request.header.Remote-User}
+        events 600                                 # 600 per window…
+        window 60s                                 # …i.e. ~10 req/s per identity
+    }
+}
+```
+
+Caddy has no native concurrent-connection cap; if you need to bound streams
+precisely, terminate the cap with an nginx hop on the host or rely on the tight
+request rate plus the small, authenticated audience.
+
+**Tailscale Serve** — no rate-limiting primitive; tailnet ACLs gate **who**
+connects, not how fast. For a small, trusted tailnet running
+`DASHBOARD_READONLY=1`, that membership boundary is usually enough. If you need
+hard rate or connection caps, put an nginx hop on the host behind `tailscale
+serve` and apply the nginx limits above.
+
+**Cloudflare Access** — add a WAF **Rate Limiting Rule** at the edge, keyed on
+`cf-access-authenticated-user-email` so the budget is per operator, not shared
+across the team's egress IP:
+
+```
+When  http.request.uri.path contains "/"
+Rate  > 600 requests per 60s per cf-access-authenticated-user-email
+Then  Block (or Managed Challenge)
+```
+
+Cloudflare also enforces edge connection limits, but the rule above plus Access
+identity is the per-identity ceiling; note that rate-limiting-rule counts are
+plan-limited on the free tier.
+
 ## Hardening checklist when exposing
 
 Before you point an authenticated front at it:
@@ -217,7 +342,10 @@ Before you point an authenticated front at it:
    dashboard's loopback hard-bind covers the default case, but once you put a
    proxy in front, a fail-open proxy is the whole exposure.
 4. **Rate-limit at your proxy.** The dashboard has no per-IP throttle of its
-   own (only an in-process semaphore); apply limits at the authenticated edge.
+   own (only the in-process exec semaphore); apply a per-identity request rate,
+   a concurrent-connection cap, and a GET-rate ceiling at the authenticated edge
+   — see [Rate-limiting at the front](#rate-limiting-at-the-front), with the
+   concurrent-connection cap doing the load-bearing work against long-lived SSE.
 5. **Keep `ADMIN_EXTRA_ALLOWED_HOSTS` minimal.** Add only the `Host` value your
    proxy actually forwards. The `127.0.0.1` / `localhost` floor is always
    allowed; everything else is an opt-in you should keep as small as possible.

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -9,6 +9,18 @@ This guide is the deployment counterpart to the posture spec
 test invariants that block merge; this file is the operator runbook for the one
 decision the dashboard deliberately leaves to you — network exposure.
 
+Two absolutes frame everything below:
+
+- **No exposure without auth.** There is no supported way to put the raw port on
+  a network. If a request can reach the dashboard, an authenticated front must
+  have let it through first.
+- **Read-only is the inner belt, not the auth boundary.** `DASHBOARD_READONLY=1`
+  and the loopback bind shrink the blast radius if the front is breached; they
+  log nobody in. The auth front is the boundary — and it protects the
+  **dashboard**, not the gc supervisor, which stays unauthenticated on loopback
+  (any other process or user on the host reaches it directly, with or without
+  the dashboard).
+
 ## Default posture (zero configuration)
 
 Out of the box, with no flags and no config file:
@@ -45,6 +57,37 @@ Tailscale **Funnel** of the raw port — Funnel publishes to the public internet
 with no auth in front. Tailscale **Serve** (tailnet-only) is fine; Funnel is
 not.
 
+## The load-bearing rewrite: `Host` **and** `Origin`
+
+This is the single most common misconfiguration — get it right before anything
+else. Your front must rewrite **two** request headers to loopback before it
+forwards to the backend:
+
+| Header   | Rewrite to                | Why it is required                                                                                                                                                                                              |
+| -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Host`   | `127.0.0.1`               | The host-header allow-list (`middleware/security.ts`) rejects any other value — the DNS-rebinding floor. Applies to **every** request, GETs included.                                                          |
+| `Origin` | `http://127.0.0.1:<port>` | `originCheck` requires the `Origin` on every state-changing request (anything but `GET`/`HEAD`/`OPTIONS`) to be exactly the backend's own loopback origin. The browser sends the *public* origin (`https://dash.example.com`); un-rewritten, every write `403`s with `{"kind":"origin"}`. |
+
+`<port>` is the **backend's bound port** — `8082` for the systemd production
+listener, `8081` for `npm run dev:backend` — **not** your proxy's public `443`.
+The backend wants its own loopback origin, whatever port the client actually
+reached.
+
+**Do not "fix" the write `403` by adding your public host to
+`ADMIN_EXTRA_ALLOWED_HOSTS`.** That widens both the host-header and the `Origin`
+allow-lists to your public name, silently dismantling the DNS-rebinding floor
+and the Origin belt — the two controls you are exposing *behind*. Rewrite the
+headers at the proxy instead, and keep `ADMIN_EXTRA_ALLOWED_HOSTS` empty.
+
+Only a front where you control request headers — **nginx** or **Caddy** below —
+can rewrite `Origin`, so only those carry **writes**. The identity-scoped fronts
+(Tailscale Serve, Cloudflare Access) forward the client's `Origin`; run them with
+`DASHBOARD_READONLY=1`, where the supervisor write surface is already closed and
+only `GET`/`HEAD` reads — exempt from the `Origin` check — cross the wire, so the
+missing rewrite costs nothing. For read/write exposure, front with nginx or Caddy, or add
+a platform header-transform (e.g. Cloudflare Transform Rules) that sets
+`Origin: http://127.0.0.1:<port>`.
+
 ## Recipes
 
 Four concrete fronts, one per common environment. All assume the dashboard is
@@ -54,9 +97,11 @@ Each terminates TLS and authenticates at the front, then proxies over loopback.
 Pair every one of them with `DASHBOARD_READONLY=1` and the
 [hardening checklist](#hardening-checklist-when-exposing) below.
 
-Forwarding `Host: 127.0.0.1` keeps the backend host-allowlist satisfied without
-touching `ADMIN_EXTRA_ALLOWED_HOSTS`; the SSE streams (`/gc-supervisor/**`
-events, `/api` event stream) need response buffering off or they stall.
+Each rewrites `Host` (and, on the header-controlling fronts, `Origin`) to
+loopback per [the load-bearing rewrite](#the-load-bearing-rewrite-host-and-origin)
+above — without touching `ADMIN_EXTRA_ALLOWED_HOSTS`. The SSE streams
+(`/gc-supervisor/**` events, `/api` event stream) need response buffering off or
+they stall.
 
 ### nginx — basic-auth reverse proxy
 
@@ -74,7 +119,8 @@ server {
         auth_basic_user_file /etc/nginx/.gcd-htpasswd;   # fails closed: no file → 403
 
         proxy_pass         http://127.0.0.1:8082;
-        proxy_set_header   Host 127.0.0.1;               # satisfy the host-allowlist
+        proxy_set_header   Host   127.0.0.1;                  # host-allowlist (every request)
+        proxy_set_header   Origin http://127.0.0.1:8082;     # originCheck (writes); backend port, not 443
         proxy_http_version 1.1;
         proxy_set_header   Connection "";                # keep SSE connections open
         proxy_buffering    off;                          # stream events un-buffered
@@ -95,8 +141,9 @@ dash.example.com {
     }
 
     reverse_proxy 127.0.0.1:8082 {
-        header_up Host 127.0.0.1     # satisfy the host-allowlist
-        flush_interval -1            # never buffer SSE
+        header_up Host   127.0.0.1                 # host-allowlist (every request)
+        header_up Origin http://127.0.0.1:8082     # originCheck (writes); backend port, not 443
+        flush_interval -1                          # never buffer SSE
     }
 }
 ```
@@ -112,6 +159,10 @@ tailscale serve status      # must list the :8082 mapping
 tailscale funnel status     # must show NOTHING for this port
 ```
 
+Serve forwards the client's `Origin`, so writes would fail the `Origin` check.
+Run it with `DASHBOARD_READONLY=1` (the recommended pairing) and that is moot —
+the supervisor write surface is closed and only `GET`/`HEAD` reads cross the wire.
+
 ### Cloudflare Access — zero-trust gateway
 
 ```bash
@@ -123,6 +174,10 @@ cloudflared tunnel --hostname dash.example.com --url http://127.0.0.1:8082
 #    Cloudflare's edge BEFORE traffic reaches the tunnel; an unauthenticated
 #    request never reaches the host.
 ```
+
+The tunnel forwards the client's `Origin`, so pair it with `DASHBOARD_READONLY=1`
+(reads only, `Origin` check exempt). For read/write exposure, add a Cloudflare
+Transform Rule that sets `Origin: http://127.0.0.1:8082` on requests to the host.
 
 ## Hardening checklist when exposing
 

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -2,7 +2,8 @@
 
 How to reach this dashboard from anywhere other than the machine it runs on.
 The short version: **you front it with your own authenticated proxy; the
-dashboard itself stays on loopback and ships no auth.**
+dashboard itself stays on loopback and ships no auth.** This surfaces live city
+data — gate it behind your auth front before any request can reach it.
 
 This guide is the deployment counterpart to the posture spec
 [`security.md`](./security.md). That file enumerates the controls and the
@@ -46,10 +47,14 @@ to the dashboard over loopback:
 your client ──TLS+auth──▶ your proxy (auth/SSO/allowlist) ──▶ 127.0.0.1:<port> dashboard
 ```
 
-Any authenticated front works — a reverse proxy with basic-auth or
-forward-auth (nginx, Caddy), a tailnet-scoped share (Tailscale Serve), or a
-zero-trust gateway (Cloudflare Access), among others. The dashboard does not
-care which; it only ever sees a loopback connection.
+Any authenticated front works for **read-only** exposure — a reverse proxy with
+basic-auth or forward-auth (nginx, Caddy), a tailnet-scoped share (Tailscale
+Serve), or a zero-trust gateway (Cloudflare Access), among others. **Read/write
+exposure is narrower:** only a front that rewrites `Origin` (nginx or Caddy, per
+[the load-bearing rewrite](#the-load-bearing-rewrite-host-and-origin) below)
+carries writes; the identity-scoped fronts forward the client's public `Origin`
+and must run `DASHBOARD_READONLY=1`. Either way the dashboard only ever sees a
+loopback connection.
 
 **Never put the raw port on a public interface.** That means no `0.0.0.0`
 bind (the backend refuses it anyway), no port-forward of the listener, and no
@@ -63,10 +68,10 @@ This is the single most common misconfiguration — get it right before anything
 else. Your front must rewrite **two** request headers to loopback before it
 forwards to the backend:
 
-| Header   | Rewrite to                | Why it is required                                                                                                                                                                                              |
-| -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Host`   | `127.0.0.1`               | The host-header allow-list (`middleware/security.ts`) rejects any other value — the DNS-rebinding floor. Applies to **every** request, GETs included.                                                          |
-| `Origin` | `http://127.0.0.1:<port>` | `originCheck` requires the `Origin` on every state-changing request (anything but `GET`/`HEAD`/`OPTIONS`) to be exactly the backend's own loopback origin. The browser sends the *public* origin (`https://dash.example.com`); un-rewritten, every write `403`s with `{"kind":"origin"}`. |
+| Header   | Rewrite to                | Why it is required                                                                                                                                                                                                                                                                        |
+| -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Host`   | `127.0.0.1`               | The host-header allow-list (`middleware/security.ts`) rejects any other value with **`421 Misdirected Request`** — the DNS-rebinding floor. Applies to **every** request, GETs included.                                                                                                  |
+| `Origin` | `http://127.0.0.1:<port>` | `originCheck` requires the `Origin` on every state-changing request (anything but `GET`/`HEAD`/`OPTIONS`) to be exactly the backend's own loopback origin. The browser sends the _public_ origin (`https://dash.example.com`); un-rewritten, every write `403`s with `{"kind":"origin"}`. |
 
 `<port>` is the **backend's bound port** — `8082` for the systemd production
 listener, `8081` for `npm run dev:backend` — **not** your proxy's public `443`.
@@ -76,7 +81,7 @@ reached.
 **Do not "fix" the write `403` by adding your public host to
 `ADMIN_EXTRA_ALLOWED_HOSTS`.** That widens both the host-header and the `Origin`
 allow-lists to your public name, silently dismantling the DNS-rebinding floor
-and the Origin belt — the two controls you are exposing *behind*. Rewrite the
+and the Origin belt — the two controls you are exposing _behind_. Rewrite the
 headers at the proxy instead, and keep `ADMIN_EXTRA_ALLOWED_HOSTS` empty.
 
 Only a front where you control request headers — **nginx** or **Caddy** below —
@@ -142,11 +147,15 @@ dash.example.com {
 
     reverse_proxy 127.0.0.1:8082 {
         header_up Host   127.0.0.1                 # host-allowlist (every request)
-        header_up Origin http://127.0.0.1:8082     # originCheck (writes); backend port, not 443
+        header_up Origin http://127.0.0.1:8082     # SETS/replaces Origin (not append); backend port, not 443
         flush_interval -1                          # never buffer SSE
     }
 }
 ```
+
+`header_up` with a replacement value **sets** the header — it overwrites the
+browser's public `Origin` rather than appending a second one — and requires
+**Caddy v2.4+**.
 
 ### Tailscale Serve — tailnet-only
 
@@ -182,10 +191,9 @@ Transform Rule that sets `Origin: http://127.0.0.1:8082` on requests to the host
 ## Rate-limiting at the front
 
 The dashboard has **no rate limiter of its own**. The only back-pressure in the
-codebase is a global four-slot semaphore around host shell-outs
-(`MAX_CONCURRENT = 4` in `backend/src/exec-core.ts`) — it serialises
-`git`/`gh`/`bd` reads, not HTTP requests, and it is per-process, not per-IP. HTTP
-requests, and especially long-lived streams, hit no ceiling at all.
+codebase is a small in-process exec semaphore around host shell-outs — it
+serialises `git`/`gh`/`bd` reads, not HTTP requests, and it is per-process, not
+per-IP. HTTP requests, and especially long-lived streams, hit no ceiling at all.
 
 This limiting belongs **at the BYO front, never in transit.** The
 `/gc-supervisor/*` proxy is transport-only by contract — it forwards bytes and
@@ -201,8 +209,8 @@ dashboard's costliest traffic is **streams that stay open**, not requests that
 return. Each one pins a socket and a file descriptor for its whole lifetime, so a
 handful of identities holding many streams exhausts the host long before any
 req/s ceiling notices — one stream is a _single_ request that never completes.
-This is the scoping review's risk #7: "resource exhaustion against the supervisor
-via open proxy GETs — long-lived SSE event/session streams especially."
+Resource exhaustion against the supervisor via open proxy `GET`s — long-lived SSE
+event/session streams especially — is the headline exposure risk here.
 
 The streams to bound:
 
@@ -220,11 +228,11 @@ concurrent-connection cap — not a request-rate limit — is what bounds them.
 
 ### The three knobs
 
-| Knob                            | What it bounds                                       | Recommended start, per identity |
-| ------------------------------- | --------------------------------------------------- | ------------------------------- |
-| Per-identity request rate       | reconnect storms, abusive polling, write floods     | 10 req/s, burst 30              |
-| Concurrent-connection cap       | held-open SSE — the real exhaustion vector          | 15 connections                  |
-| GET-rate ceiling                | the only verb that crosses in read-only mode        | 20 req/s, burst 50              |
+| Knob                      | What it bounds                                  | Recommended start, per identity |
+| ------------------------- | ----------------------------------------------- | ------------------------------- |
+| Per-identity request rate | reconnect storms, abusive polling, write floods | 10 req/s, burst 30              |
+| Concurrent-connection cap | held-open SSE — the real exhaustion vector      | 15 connections                  |
+| GET-rate ceiling          | the only verb that crosses in read-only mode    | 20 req/s, burst 50              |
 
 These are starting points for a one-operator (or small, known team) control
 plane — scale them by the number of real operators, not by anticipated load. The
@@ -241,15 +249,22 @@ tighten toward 5 for a strict single-tab operator.
 
 ### Concrete limits per front
 
-**nginx** — `limit_req` for rate, `limit_conn` for the stream cap, both keyed on
-the basic-auth user:
+**nginx** — `limit_req` for rate, `limit_conn` for the stream cap, keyed on the
+client address (see the note below on why not the identity):
 
 ```nginx
 # These two zone directives live in the http{} context (the conf.d files nginx
 # includes are already inside http{}) — NOT inside server{}, where nginx rejects
 # them with "directive is not allowed here".
-limit_req_zone  $remote_user zone=gcd_req:10m  rate=10r/s;
-limit_conn_zone $remote_user zone=gcd_conn:10m;
+#
+# Keyed on $binary_remote_addr, NOT $remote_user: limit_req/limit_conn run in
+# nginx's preaccess phase, BEFORE auth_basic populates $remote_user, so a
+# $remote_user key is empty here and collapses to one shared per-server bucket.
+# Per-identity limiting needs a post-auth mechanism — rate-limit at your
+# SSO/forward-auth layer, or emit the identity from an auth subrequest and key on
+# that. Per-address is the honest nginx-native limit.
+limit_req_zone  $binary_remote_addr zone=gcd_req:10m  rate=10r/s;
+limit_conn_zone $binary_remote_addr zone=gcd_conn:10m;
 
 server {
     # …TLS + auth_basic from the nginx recipe above…
@@ -370,6 +385,7 @@ Before you point an authenticated front at it:
      | grep -q withHostAllowing \
      && echo ">= #2578 ✅" || echo "PRE-#2578 ❌ — redeploy before exposing"
    ```
+
 3. **Your proxy must not fail-open.** If the auth backend is unreachable, the
    front must deny — never pass the request through unauthenticated. The
    dashboard's loopback hard-bind covers the default case, but once you put a
@@ -379,9 +395,13 @@ Before you point an authenticated front at it:
    a concurrent-connection cap, and a GET-rate ceiling at the authenticated edge
    — see [Rate-limiting at the front](#rate-limiting-at-the-front), with the
    concurrent-connection cap doing the load-bearing work against long-lived SSE.
-5. **Keep `ADMIN_EXTRA_ALLOWED_HOSTS` minimal.** Add only the `Host` value your
-   proxy actually forwards. The `127.0.0.1` / `localhost` floor is always
-   allowed; everything else is an opt-in you should keep as small as possible.
+5. **Leave `ADMIN_EXTRA_ALLOWED_HOSTS` empty.** The supported path rewrites
+   `Host` to `127.0.0.1` at the front (see [the load-bearing
+   rewrite](#the-load-bearing-rewrite-host-and-origin)), so the proxy forwards a
+   loopback `Host` and there is nothing to add. Widening the allow-list to your
+   public name dismantles the DNS-rebinding floor and the `Origin` belt — the two
+   controls you are exposing behind — so never do it; rewrite the headers at the
+   front instead.
 
 ## What the dashboard deliberately does not provide
 

--- a/specs/architecture/exposure.md
+++ b/specs/architecture/exposure.md
@@ -336,7 +336,40 @@ Before you point an authenticated front at it:
 2. **Keep the gc supervisor on loopback and patched.** The read-only gate sits
    _upstream_ of the supervisor, so it only protects requests that go through
    the dashboard. The supervisor's own port (`:8372` by default) must not be
-   independently reachable, and it must carry the host-header rebinding fix.
+   independently reachable, and it must carry the host-header rebinding fix
+   (gascity **#2578**, _"Harden supervisor Host handling and request audit"_,
+   merged 2026-06-06). Confirm your **deployed** build carries it before you
+   expose — a build that predates #2578 is a hard blocker, not a note.
+
+   **Behavioral check (preferred — needs no source checkout).** #2578 makes the
+   supervisor reject a Host header that is not loopback or allow-listed with
+   `421 host_not_allowed`. Probe the live supervisor directly:
+
+   ```bash
+   # Disallowed Host MUST be rejected — proves the rebinding guard is live:
+   curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: evil.example.com' \
+     http://127.0.0.1:8372/health        # expect 421 (host_not_allowed)
+   # Loopback Host still passes:
+   curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: 127.0.0.1:8372' \
+     http://127.0.0.1:8372/health        # expect 200
+   ```
+
+   A `200` for the first probe means the deployed build is **pre-#2578** —
+   stop, redeploy the supervisor, do not expose.
+
+   **Build-id audit (for the source-tree-keeping operator).** `/health` reports
+   the deployed commit as `build_id`. Check the deployed tree itself for the
+   fix's distinctive symbol rather than resolving #2578 by commit subject — the
+   merge has been rebased more than once, so two commits share that subject and
+   only one is an ancestor of any given build, which makes a `git log --grep`
+   lookup unreliable:
+
+   ```bash
+   build_id=$(curl -fsS http://127.0.0.1:8372/health | grep -o '"build_id":"[^"]*"' | cut -d'"' -f4)
+   git -C <gascity-source> show "$build_id:internal/api/middleware.go" \
+     | grep -q withHostAllowing \
+     && echo ">= #2578 ✅" || echo "PRE-#2578 ❌ — redeploy before exposing"
+   ```
 3. **Your proxy must not fail-open.** If the auth backend is unreachable, the
    front must deny — never pass the request through unauthenticated. The
    dashboard's loopback hard-bind covers the default case, but once you put a


### PR DESCRIPTION
## External-exposure hardening docs (lv4k)

The deploy/exposure guide for running the dashboard safely behind a user-provided auth reverse-proxy, under the model-1a posture (safe-by-default + BYO auth, no built-in auth, read-only inner belt). Docs-only — no code, no invariant touched.

Bundles the three lv4k doc deliverables into one exposure.md story:
- **Deploy guide** — BYO auth reverse-proxy + `DASHBOARD_READONLY=1`; the load-bearing `Host → 127.0.0.1` + `Origin → loopback` rewrite (with a Caddy snippet); explicit "no exposure without auth" and "read-only is the inner belt, not the auth boundary."
- **#2578 verification gate** — confirm the deployed supervisor build is at/after the host-header-hardening merge before exposing (the deployed build verified ≥ #2578).
- **Rate-limit guidance** — at the BYO front (per-identity limits, SSE connection cap), never in-transport.

Carries one proportionate data-sensitivity line: an exposed read-only instance surfaces live city data — gate it behind your auth front.

Review: passed `/gascity-dashboard-review-pr` (3 Claude reviewers + Codex), all majors resolved (read-only/read-write compat qualified, no allow-list widening, nginx `$binary_remote_addr` keying). No bind / Origin / changeOrigin weakening.
