### PR TITLE
fix(deps): bump undici 7.27.2→7.28.0 to clear high-severity audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8515,9 +8515,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Why

A same-day npm advisory marks `undici@<=7.27.2` **high severity**, which trips the CI `npm audit --audit-level=high` step. That step runs inside the "typecheck + tests (node 24)" job with `set -e`, so it fails the **whole job before typecheck/tests run** — red-lighting *every* open dashboard PR (incl. #138 freshness-spine and #140 l4er exposure docs), and main itself if re-run today.

## Fix

Single lockfile-entry bump: `undici 7.27.2 → 7.28.0` (patched latest-7.x). undici is transitive via `jsdom` (`^7.25.0`), which 7.28.0 satisfies — so **no package.json change and no dependency drift**: the diff is 3 lines.

## Verification

- `npm ci` — clean (lockfile ↔ package.json in sync, exit 0)
- `npm audit --audit-level=high` — **passes (exit 0)**; the high advisory is gone (4 moderate remain, all below the gate)
- `undici@7.28.0` resolved in the installed tree

Unblocks the dashboard merge queue. js-yaml (moderate, via @hey-api/openapi-ts) is below the `high` gate and intentionally left alone.