### PR TITLE
feat(mobile): mobile-first responsive pass + dedicated phone layouts

### DIFF
--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AttentionProvider } from '../attention/context';
+import { NowProvider } from '../contexts/NowContext';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { ViewingAsProvider } from '../contexts/ViewingAsContext';
+import { Header } from './Header';
+
+vi.mock('../api/client', () => ({
+  api: {
+    config: vi.fn(async () => ({
+      cityName: 'test-city',
+      defaultView: null,
+      enabledModules: [],
+      readOnly: false,
+    })),
+  },
+}));
+
+vi.mock('../supervisor/client', () => ({
+  supervisorApi: () => ({
+    listCities: vi.fn(async () => ({
+      items: [{ name: 'test-city', path: '/srv/test-city', running: true }],
+      total: 1,
+    })),
+  }),
+}));
+
+vi.mock('../runs/runSummarySubscription', () => ({
+  useRunSummary: () => ({ sseState: 'open' }),
+}));
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderHeader() {
+  return render(
+    <ThemeProvider>
+      <ViewingAsProvider>
+        <NowProvider>
+          <AttentionProvider contributors={[]}>
+            <MemoryRouter
+              initialEntries={['/runs']}
+              future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+            >
+              <Header />
+            </MemoryRouter>
+          </AttentionProvider>
+        </NowProvider>
+      </ViewingAsProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('Header mobile nav', () => {
+  it('keeps the inline nav row but hides it below sm (desktop unchanged)', () => {
+    const { container } = renderHeader();
+    // The desktop row is the ul that becomes a flex row at sm:; on phones it is
+    // hidden in favor of the hamburger menu.
+    const desktopList = container.querySelector('ul.sm\\:flex');
+    expect(desktopList).not.toBeNull();
+    expect(desktopList?.className).toContain('hidden');
+  });
+
+  it('exposes a hamburger button that is hidden from sm: up', () => {
+    renderHeader();
+    const button = screen.getByRole('button', { name: /menu/i });
+    expect(button.className).toContain('sm:hidden');
+    // Closed by default — no dialog yet.
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('opens the nav menu with every route when the hamburger is tapped', () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: /menu/i }));
+    const dialog = within(screen.getByRole('dialog'));
+    // Scope to the dialog: the desktop row keeps its own copy of each link.
+    for (const label of ['Home', 'Agents', 'Beads', 'Runs', 'Mail']) {
+      expect(dialog.getByRole('link', { name: new RegExp(label) })).toBeTruthy();
+    }
+  });
+
+  it('closes the menu when a route is selected', () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: /menu/i }));
+    const dialog = within(screen.getByRole('dialog'));
+    fireEvent.click(dialog.getByRole('link', { name: /Agents/ }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AttentionProvider } from '../attention/context';
 import { NowProvider } from '../contexts/NowContext';
@@ -104,6 +104,42 @@ describe('Header mobile nav', () => {
     fireEvent.click(screen.getByRole('button', { name: /menu/i }));
     const dialog = within(screen.getByRole('dialog'));
     fireEvent.click(dialog.getByRole('link', { name: /Agents/ }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes the menu on any route change, not just menu-link clicks (e.g. back/forward)', () => {
+    // The Header is outside <Routes>, so a navigation that does not originate
+    // from a menu link (browser back, a link elsewhere) must still dismiss the
+    // open menu rather than strand the scrim over the next page.
+    function Harness() {
+      const navigate = useNavigate();
+      return (
+        <>
+          <button onClick={() => navigate('/agents')}>navigate elsewhere</button>
+          <Header />
+        </>
+      );
+    }
+    render(
+      <ThemeProvider>
+        <ViewingAsProvider>
+          <NowProvider>
+            <AttentionProvider contributors={[]}>
+              <MemoryRouter
+                initialEntries={['/runs']}
+                future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+              >
+                <Harness />
+              </MemoryRouter>
+            </AttentionProvider>
+          </NowProvider>
+        </ViewingAsProvider>
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    // Navigate without touching a menu link.
+    fireEvent.click(screen.getByRole('button', { name: /navigate elsewhere/i }));
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { Modal } from './Modal';
 import { api } from '../api/client';
@@ -103,6 +103,14 @@ export function Header() {
   // behind a hamburger that opens the routes in the shared Modal. Both layouts
   // render the same routes through navItem so they cannot drift.
   const [menuOpen, setMenuOpen] = useState(false);
+
+  // The Header lives in Layout, outside <Routes>, so its state survives SPA
+  // navigation. Menu-link clicks close the menu themselves, but a back/forward
+  // or any navigation that doesn't originate from a menu link would otherwise
+  // leave the dialog + scrim stranded over the next page. Close on route change.
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
 
   const navItem = (r: NavRoute, sizeClass: string, onClick?: () => void) => {
     const domain = NAV_ATTENTION_DOMAINS[r.to];

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -217,7 +217,7 @@ export function Header() {
       </div>
 
       <Modal open={menuOpen} onClose={() => setMenuOpen(false)} title="Menu" widthClass="max-w-xs">
-        <nav id="mobile-nav-menu" aria-label="Primary">
+        <nav id="mobile-nav-menu" aria-label="Mobile navigation">
           <ul className="flex flex-col gap-y-3">
             {ROUTES.map((r) => navItem(r, 'text-headline', () => setMenuOpen(false)))}
           </ul>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
+import { Modal } from './Modal';
 import { api } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
 import { NavAttentionIndicator } from '../attention/NavAttentionIndicator';
@@ -98,6 +99,40 @@ export function Header() {
   // the header indicator only makes sense inside the mail surface.
   const showReadingAs = !viewingAs.isOperator && pathname.startsWith('/mail');
 
+  // On phones the inline route row stacks to several lines, so it collapses
+  // behind a hamburger that opens the routes in the shared Modal. Both layouts
+  // render the same routes through navItem so they cannot drift.
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const navItem = (r: NavRoute, sizeClass: string, onClick?: () => void) => {
+    const domain = NAV_ATTENTION_DOMAINS[r.to];
+    return (
+      <li key={r.to}>
+        <NavLink
+          to={r.to}
+          end={r.end ?? false}
+          onClick={onClick}
+          className={({ isActive }: { isActive: boolean }) =>
+            [
+              sizeClass,
+              'transition-colors duration-150 ease-out-quart focus-mark',
+              isActive ? 'text-fg font-semibold' : 'text-fg-muted font-medium hover:text-fg',
+            ].join(' ')
+          }
+        >
+          {r.label}
+          {domain !== undefined && (
+            <NavAttentionIndicator
+              label={r.label}
+              summary={attention.byDomain[domain]}
+              suppressAccent={livenessOwnsMark}
+            />
+          )}
+        </NavLink>
+      </li>
+    );
+  };
+
   return (
     <header className="border-b border-rule">
       <div className="max-w-dashboard mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-baseline gap-x-6 lg:gap-x-8 gap-y-2 flex-wrap">
@@ -141,38 +176,25 @@ export function Header() {
           )}
         </div>
 
-        <nav className="flex-1">
-          <ul className="flex items-baseline gap-x-5 lg:gap-x-7 gap-y-1 flex-wrap">
-            {ROUTES.map((r) => {
-              const domain = NAV_ATTENTION_DOMAINS[r.to];
-              return (
-                <li key={r.to}>
-                  <NavLink
-                    to={r.to}
-                    end={r.end ?? false}
-                    className={({ isActive }: { isActive: boolean }) =>
-                      [
-                        'text-title transition-colors duration-150 ease-out-quart focus-mark',
-                        isActive
-                          ? 'text-fg font-semibold'
-                          : 'text-fg-muted font-medium hover:text-fg',
-                      ].join(' ')
-                    }
-                  >
-                    {r.label}
-                    {domain !== undefined && (
-                      <NavAttentionIndicator
-                        label={r.label}
-                        summary={attention.byDomain[domain]}
-                        suppressAccent={livenessOwnsMark}
-                      />
-                    )}
-                  </NavLink>
-                </li>
-              );
-            })}
+        <nav className="flex-1" aria-label="Primary">
+          {/* Desktop: the route names typeset as a row. Hidden on phones, where
+              the hamburger below opens the same routes in a Modal. */}
+          <ul className="hidden sm:flex items-baseline gap-x-5 lg:gap-x-7 gap-y-1 flex-wrap">
+            {ROUTES.map((r) => navItem(r, 'text-title'))}
           </ul>
         </nav>
+
+        <button
+          type="button"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open menu"
+          aria-haspopup="dialog"
+          aria-expanded={menuOpen}
+          {...(menuOpen ? { 'aria-controls': 'mobile-nav-menu' } : {})}
+          className="sm:hidden ml-auto text-fg-muted hover:text-fg transition-colors duration-150 ease-out-quart focus-mark text-lg leading-none"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
 
         <BoardLiveness />
 
@@ -185,6 +207,14 @@ export function Header() {
           {resolved === 'dark' ? 'Light' : 'Dark'}
         </button>
       </div>
+
+      <Modal open={menuOpen} onClose={() => setMenuOpen(false)} title="Menu" widthClass="max-w-xs">
+        <nav id="mobile-nav-menu" aria-label="Primary">
+          <ul className="flex flex-col gap-y-3">
+            {ROUTES.map((r) => navItem(r, 'text-headline', () => setMenuOpen(false)))}
+          </ul>
+        </nav>
+      </Modal>
     </header>
   );
 }

--- a/frontend/src/components/PageHeader.test.tsx
+++ b/frontend/src/components/PageHeader.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PageHeader } from './PageHeader';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PageHeader', () => {
+  it('renders the title as the level-1 page heading', () => {
+    render(<PageHeader title="Formula Runs" />);
+    expect(screen.getByRole('heading', { level: 1, name: 'Formula Runs' })).toBeTruthy();
+  });
+
+  it('scales the heading mobile-first: Headline on phones, Display from sm up', () => {
+    render(<PageHeader title="Formula Runs" />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    // Base (mobile) renders the smaller Headline step so the title does not
+    // dominate a ~390px viewport; it grows to Display at sm: and up.
+    expect(heading.className).toContain('text-headline');
+    expect(heading.className).toContain('sm:text-display');
+    // The unconditional Display step would re-dominate mobile, so it must not
+    // be applied without a breakpoint prefix.
+    expect(heading.className).not.toMatch(/(^|\s)text-display(\s|$)/);
+  });
+
+  it('renders the optional synopsis and meta slot', () => {
+    render(<PageHeader title="Runs" synopsis="3 active" meta={<span>live</span>} />);
+    expect(screen.getByText('3 active')).toBeTruthy();
+    expect(screen.getByText('live')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -18,9 +18,7 @@ export function PageHeader({ title, synopsis, meta, className = '' }: PageHeader
       className={`grid grid-cols-1 items-start gap-x-6 gap-y-4 mb-10 md:grid-cols-[minmax(0,1fr)_auto] md:items-end ${className}`}
     >
       <div className="min-w-0 space-y-2">
-        <h1 className="text-display font-semibold tracking-tighter text-fg leading-[1.05]">
-          {title}
-        </h1>
+        <h1 className="text-headline sm:text-display font-semibold text-fg">{title}</h1>
         {synopsis && <p className="text-body text-fg-muted max-w-prose">{synopsis}</p>}
       </div>
       {meta && (

--- a/frontend/src/components/Table.test.tsx
+++ b/frontend/src/components/Table.test.tsx
@@ -43,7 +43,11 @@ describe('Table', () => {
     expect(list.className).toContain('sm:hidden');
     const items = within(list).getAllByRole('listitem');
     expect(items).toHaveLength(2);
-    const tableWrapper = screen.getByRole('table').parentElement;
+    // The table sits in the overflow-x-auto wrapper, hidden below sm:. Query the
+    // wrapper by its own class rather than walking parentElement, so the test is
+    // robust to changes in the wrapper's nesting depth.
+    const table = screen.getByRole('table');
+    const tableWrapper = table.closest('div.overflow-x-auto');
     expect(tableWrapper?.className).toContain('hidden');
     expect(tableWrapper?.className).toContain('sm:block');
   });

--- a/frontend/src/components/Table.test.tsx
+++ b/frontend/src/components/Table.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Table, type TableColumn } from './Table';
+
+interface Row {
+  id: string;
+  name: string;
+  state: string;
+}
+
+const columns: ReadonlyArray<TableColumn<Row>> = [
+  { key: 'name', label: 'Name', render: (r) => r.name },
+  { key: 'state', label: 'State', render: (r) => r.state },
+];
+
+const rows: Row[] = [
+  { id: 'a', name: 'alpha', state: 'idle' },
+  { id: 'b', name: 'bravo', state: 'busy' },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Table', () => {
+  it('renders only the table (no mobile list) when mobileRow is not provided', () => {
+    render(<Table columns={columns} rows={rows} rowKey={(r) => r.id} />);
+    expect(screen.getByRole('table')).toBeTruthy();
+    expect(screen.queryByRole('list')).toBeNull();
+  });
+
+  it('renders a dedicated stacked mobile list when mobileRow is provided', () => {
+    render(
+      <Table
+        columns={columns}
+        rows={rows}
+        rowKey={(r) => r.id}
+        mobileRow={(r) => <span>{r.name}</span>}
+      />,
+    );
+    const list = screen.getByRole('list');
+    // The mobile list shows below sm:, the table from sm: up.
+    expect(list.className).toContain('sm:hidden');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    const tableWrapper = screen.getByRole('table').parentElement;
+    expect(tableWrapper?.className).toContain('hidden');
+    expect(tableWrapper?.className).toContain('sm:block');
+  });
+
+  it('shows the empty message in the mobile list when there are no rows', () => {
+    render(
+      <Table
+        columns={columns}
+        rows={[]}
+        rowKey={(r) => r.id}
+        empty="No agents"
+        mobileRow={(r) => <span>{r.name}</span>}
+      />,
+    );
+    const list = screen.getByRole('list');
+    expect(within(list).getByText('No agents')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -29,6 +29,12 @@ interface TableProps<T> {
   rowProps?: (row: T) => HTMLAttributes<HTMLTableRowElement>;
   empty?: ReactNode;
   initialSort?: SortState | null;
+  // A column-grid table cannot fit a ~390px phone without horizontal scroll, so
+  // when this is provided the same rows render as a dedicated stacked list below
+  // sm: (each row a typographic block separated by a hairline, never a card per
+  // DESIGN.md), and the table itself shows from sm: up. The list reuses the same
+  // sorted rows, rowKey, onRowClick, and rowProps as the table.
+  mobileRow?: (row: T) => ReactNode;
 }
 
 export function Table<T>({
@@ -39,6 +45,7 @@ export function Table<T>({
   rowProps,
   empty,
   initialSort,
+  mobileRow,
 }: TableProps<T>) {
   const [sort, setSort] = useState<SortState | null>(initialSort ?? null);
 
@@ -67,8 +74,8 @@ export function Table<T>({
     });
   };
 
-  return (
-    <div className="overflow-x-auto">
+  const tableBlock = (
+    <div className={`overflow-x-auto${mobileRow ? ' hidden sm:block' : ''}`}>
       <table className="w-full text-body tnum">
         <thead>
           <tr className="border-b border-rule text-label uppercase tracking-wider text-fg-muted">
@@ -139,5 +146,34 @@ export function Table<T>({
         </tbody>
       </table>
     </div>
+  );
+
+  if (!mobileRow) return tableBlock;
+
+  return (
+    <>
+      <ul role="list" className="sm:hidden divide-y divide-rule">
+        {sortedRows.length === 0 ? (
+          <li className="py-10 text-center text-fg-muted italic">{empty ?? 'No data'}</li>
+        ) : (
+          sortedRows.map((row) => {
+            const { className: rowClassName = '', ...extraRowProps } = rowProps?.(row) ?? {};
+            return (
+              <li
+                {...(extraRowProps as HTMLAttributes<HTMLLIElement>)}
+                key={rowKey(row)}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                className={`py-4 transition-colors duration-150 ease-out-quart ${
+                  onRowClick ? 'cursor-pointer hover:bg-surface-tint' : ''
+                } ${rowClassName}`}
+              >
+                {mobileRow(row)}
+              </li>
+            );
+          })
+        )}
+      </ul>
+      {tableBlock}
+    </>
   );
 }

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -160,6 +160,11 @@ export function Table<T>({
             const { className: rowClassName = '', ...extraRowProps } = rowProps?.(row) ?? {};
             return (
               <li
+                // rowProps is typed for <tr>; in practice it carries only data-*
+                // attributes (attentionDataProps), valid on any element, so this
+                // cast is a type concession, not a runtime hazard. A type-safe
+                // fix means narrowing attentionDataProps + GroupedTable across
+                // all callers — out of scope for this PR.
                 {...(extraRowProps as HTMLAttributes<HTMLLIElement>)}
                 key={rowKey(row)}
                 onClick={onRowClick ? () => onRowClick(row) : undefined}

--- a/frontend/src/routes/Activity.test.tsx
+++ b/frontend/src/routes/Activity.test.tsx
@@ -166,8 +166,11 @@ describe('ActivityPage', () => {
   it('renders deploy and commit activity without using supervisor mirrors', async () => {
     renderPage('/activity');
 
-    expect(await screen.findByText('stage: frontend')).toBeTruthy();
-    expect(screen.getByText('wire activity route')).toBeTruthy();
+    const deployTable = await screen.findByRole('table', { name: /deploy history/i });
+    expect(within(deployTable).getByText('stage: frontend')).toBeTruthy();
+    expect(
+      within(screen.getByRole('table', { name: /git commits/i })).getByText('wire activity route'),
+    ).toBeTruthy();
     expect(fetchCalls.some((call) => call.path === '/api/builds')).toBe(true);
     expect(fetchCalls.some((call) => call.path === '/api/git/commits')).toBe(true);
     expect(fetchCalls.some((call) => call.path === '/api/city/test-city/snapshot')).toBe(false);
@@ -178,8 +181,8 @@ describe('ActivityPage', () => {
       eventId: 'activity:event:42:session.crashed',
     });
 
-    const eventText = await screen.findByText('session.crashed');
-    const row = eventText.closest('tr');
+    const table = await screen.findByRole('table', { name: /supervisor events/i });
+    const row = within(table).getByText('session.crashed').closest('tr');
     expect(row?.getAttribute('data-attention-severity')).toBe('attention');
   });
 
@@ -231,8 +234,8 @@ describe('ActivityPage', () => {
       deploys: true,
     });
 
-    const deployText = await screen.findByText('stage: frontend');
-    const row = deployText.closest('tr');
+    const table = await screen.findByRole('table', { name: /deploy history/i });
+    const row = within(table).getByText('stage: frontend').closest('tr');
     expect(row?.getAttribute('data-attention-severity')).toBe('attention');
   });
 
@@ -250,9 +253,43 @@ describe('ActivityPage', () => {
 
     renderPage('/activity');
 
-    expect(await screen.findByText('stage: frontend')).toBeTruthy();
-    expect(screen.getByText('wire activity route')).toBeTruthy();
+    const deployTable = await screen.findByRole('table', { name: /deploy history/i });
+    expect(within(deployTable).getByText('stage: frontend')).toBeTruthy();
+    expect(
+      within(screen.getByRole('table', { name: /git commits/i })).getByText('wire activity route'),
+    ).toBeTruthy();
     expect(screen.getAllByText(/event history unavailable/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders a dedicated mobile stacked layout below sm for each activity section', async () => {
+    renderPage('/activity');
+
+    const eventsList = await screen.findByRole('list', { name: /supervisor events/i });
+    expect(eventsList.className).toContain('sm:hidden');
+    expect(within(eventsList).getByText('session.crashed')).toBeTruthy();
+
+    // The desktop table is hidden below sm: and shows from sm: up, so the two
+    // layouts never paint at once.
+    const eventsTable = screen.getByRole('table', { name: /supervisor events/i });
+    expect(eventsTable.parentElement?.className).toContain('hidden');
+    expect(eventsTable.parentElement?.className).toContain('sm:block');
+
+    expect(
+      within(screen.getByRole('list', { name: /deploy history/i })).getByText('stage: frontend'),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByRole('list', { name: /git commits/i })).getByText('wire activity route'),
+    ).toBeTruthy();
+  });
+
+  it('carries attention severity onto the mobile stacked event row', async () => {
+    renderPage('/activity?mode=events', {
+      eventId: 'activity:event:42:session.crashed',
+    });
+
+    const list = await screen.findByRole('list', { name: /supervisor events/i });
+    const item = within(list).getByText('session.crashed').closest('li');
+    expect(item?.getAttribute('data-attention-severity')).toBe('attention');
   });
 });
 

--- a/frontend/src/routes/Activity.tsx
+++ b/frontend/src/routes/Activity.tsx
@@ -1,10 +1,15 @@
-import type { DeployList, DeployRecord, GitCommit, GitCommitList } from 'gas-city-dashboard-shared';
-import type { ReactNode } from 'react';
+import type { DeployList, DeployRecord, GitCommitList } from 'gas-city-dashboard-shared';
+import { Fragment, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
+import type { BadgeSeverity } from '../attention/compose';
 import { useAttentionModel } from '../attention/context';
-import { attentionRowProps, resourceAttentionSeverity } from '../attention/routeHighlight';
+import {
+  attentionListItemProps,
+  attentionRowProps,
+  resourceAttentionSeverity,
+} from '../attention/routeHighlight';
 import { Button } from '../components/Button';
 import { PageHeader } from '../components/PageHeader';
 import { StatusBadge, type StatusTone } from '../components/StatusBadge';
@@ -383,63 +388,56 @@ function EventsSection({
           Event history incomplete{partialErrors.length > 0 ? `: ${partialErrors.join('; ')}` : '.'}
         </p>
       )}
-      <ActivityTable label="Supervisor events">
-        <thead>
-          <tr className="border-b border-rule text-label uppercase tracking-wider text-fg-muted">
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Time
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Signal
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Type
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Subject
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Detail
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.length === 0 ? (
-            <EmptyRow colSpan={5}>
-              {loading
-                ? 'Reading supervisor events.'
-                : error !== undefined
-                  ? 'Event history unavailable.'
-                  : filterActive
-                    ? 'No supervisor events match these filters.'
-                    : 'No supervisor events in this window.'}
-            </EmptyRow>
-          ) : (
-            items.map((event, index) => (
-              <tr
-                // Audit-forwarded events all arrive at seq 0; index breaks ties.
-                key={`${event.seq}:${event.type}:${index}`}
-                {...attentionRowProps(attentionSeverity(event))}
-                className={`border-b border-rule ${
-                  attentionRowProps(attentionSeverity(event)).className ?? ''
-                }`}
-              >
-                <td className="py-3 pr-6 align-baseline text-fg-muted">
-                  <TimeStamp ts={event.ts} />
-                </td>
-                <td className="py-3 pr-6 align-baseline">
-                  <EventSignalBadge signal={supervisorEventSignal(event)} />
-                </td>
-                <td className="py-3 pr-6 align-baseline font-medium text-fg">{event.type}</td>
-                <td className="py-3 pr-6 align-baseline text-fg-muted">{event.subject ?? '·'}</td>
-                <td className="py-3 pr-6 align-baseline text-fg-muted">
-                  {supervisorEventDetail(event)}
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </ActivityTable>
+      <ActivityRecordTable
+        label="Supervisor events"
+        rows={items}
+        // Audit-forwarded events all arrive at seq 0; index breaks ties.
+        rowKey={(event, index) => `${event.seq}:${event.type}:${index}`}
+        attentionSeverity={attentionSeverity}
+        columns={[
+          {
+            key: 'time',
+            label: 'Time',
+            render: (event) => (
+              <span className="text-fg-muted">
+                <TimeStamp ts={event.ts} />
+              </span>
+            ),
+          },
+          {
+            key: 'signal',
+            label: 'Signal',
+            render: (event) => <EventSignalBadge signal={supervisorEventSignal(event)} />,
+          },
+          {
+            key: 'type',
+            label: 'Type',
+            primary: true,
+            render: (event) => <span className="font-medium text-fg">{event.type}</span>,
+          },
+          {
+            key: 'subject',
+            label: 'Subject',
+            render: (event) => <span className="text-fg-muted">{event.subject ?? '·'}</span>,
+          },
+          {
+            key: 'detail',
+            label: 'Detail',
+            render: (event) => (
+              <span className="text-fg-muted">{supervisorEventDetail(event)}</span>
+            ),
+          },
+        ]}
+        empty={
+          loading
+            ? 'Reading supervisor events.'
+            : error !== undefined
+              ? 'Event history unavailable.'
+              : filterActive
+                ? 'No supervisor events match these filters.'
+                : 'No supervisor events in this window.'
+        }
+      />
     </ActivitySection>
   );
 }
@@ -466,46 +464,35 @@ function DeploysSection({
           Deploy history unavailable: {error}.
         </p>
       )}
-      <ActivityTable label="Deploy history">
-        <thead>
-          <tr className="border-b border-rule text-label uppercase tracking-wider text-fg-muted">
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Time
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Status
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Detail
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.length === 0 ? (
-            <EmptyRow colSpan={3}>
-              {loading ? 'Reading deploy history.' : 'No deploy records in this window.'}
-            </EmptyRow>
-          ) : (
-            items.map((deploy) => (
-              <tr
-                key={`${deploy.at}:${deploy.detail}`}
-                {...attentionRowProps(attentionSeverity(deploy))}
-                className={`border-b border-rule ${
-                  attentionRowProps(attentionSeverity(deploy)).className ?? ''
-                }`}
-              >
-                <td className="py-3 pr-6 align-baseline text-fg-muted">
-                  <TimeStamp ts={deploy.at} />
-                </td>
-                <td className="py-3 pr-6 align-baseline">
-                  <DeployStatusBadge deploy={deploy} />
-                </td>
-                <td className="py-3 pr-6 align-baseline text-fg-muted">{deploy.detail}</td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </ActivityTable>
+      <ActivityRecordTable
+        label="Deploy history"
+        rows={items}
+        rowKey={(deploy) => `${deploy.at}:${deploy.detail}`}
+        attentionSeverity={attentionSeverity}
+        columns={[
+          {
+            key: 'time',
+            label: 'Time',
+            render: (deploy) => (
+              <span className="text-fg-muted">
+                <TimeStamp ts={deploy.at} />
+              </span>
+            ),
+          },
+          {
+            key: 'status',
+            label: 'Status',
+            render: (deploy) => <DeployStatusBadge deploy={deploy} />,
+          },
+          {
+            key: 'detail',
+            label: 'Detail',
+            primary: true,
+            render: (deploy) => <span className="text-fg-muted">{deploy.detail}</span>,
+          },
+        ]}
+        empty={loading ? 'Reading deploy history.' : 'No deploy records in this window.'}
+      />
     </ActivitySection>
   );
 }
@@ -527,47 +514,40 @@ function CommitsSection({
           Git commits unavailable: {error}.
         </p>
       )}
-      <ActivityTable label="Git commits">
-        <thead>
-          <tr className="border-b border-rule text-label uppercase tracking-wider text-fg-muted">
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Time
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Commit
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Author
-            </th>
-            <th scope="col" className="pb-3 pr-6 text-left font-medium">
-              Subject
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.length === 0 ? (
-            <EmptyRow colSpan={4}>
-              {loading ? 'Reading git commits.' : 'No commits in this window.'}
-            </EmptyRow>
-          ) : (
-            items.map((commit) => <CommitRow key={commit.sha} commit={commit} />)
-          )}
-        </tbody>
-      </ActivityTable>
+      <ActivityRecordTable
+        label="Git commits"
+        rows={items}
+        rowKey={(commit) => commit.sha}
+        columns={[
+          {
+            key: 'time',
+            label: 'Time',
+            render: (commit) => (
+              <span className="text-fg-muted">
+                <TimeStamp ts={commit.date} />
+              </span>
+            ),
+          },
+          {
+            key: 'commit',
+            label: 'Commit',
+            render: (commit) => <span className="font-medium text-fg">{commit.short_sha}</span>,
+          },
+          {
+            key: 'author',
+            label: 'Author',
+            render: (commit) => <span className="text-fg-muted">{commit.author}</span>,
+          },
+          {
+            key: 'subject',
+            label: 'Subject',
+            primary: true,
+            render: (commit) => <span className="text-fg-muted">{commit.subject}</span>,
+          },
+        ]}
+        empty={loading ? 'Reading git commits.' : 'No commits in this window.'}
+      />
     </ActivitySection>
-  );
-}
-
-function CommitRow({ commit }: { commit: GitCommit }) {
-  return (
-    <tr className="border-b border-rule">
-      <td className="py-3 pr-6 align-baseline text-fg-muted">
-        <TimeStamp ts={commit.date} />
-      </td>
-      <td className="py-3 pr-6 align-baseline font-medium text-fg">{commit.short_sha}</td>
-      <td className="py-3 pr-6 align-baseline text-fg-muted">{commit.author}</td>
-      <td className="py-3 pr-6 align-baseline text-fg-muted">{commit.subject}</td>
-    </tr>
   );
 }
 
@@ -595,23 +575,115 @@ function ActivitySection({
   );
 }
 
-function ActivityTable({ children, label }: { children: ReactNode; label: string }) {
-  return (
-    <div className="overflow-x-auto">
-      <table aria-label={label} className="w-full text-body tnum">
-        {children}
-      </table>
-    </div>
-  );
+// A typeset record list rendered two ways from one column model so the layouts
+// cannot drift: the column grid table from sm: up, and — because that grid
+// cannot fit a ~390px phone without an internal horizontal scroll — a dedicated
+// stacked list below sm: (each record a typographic block separated by a
+// hairline, never a card per DESIGN.md's Flat Page Rule). On mobile, columns
+// marked `primary` lead as the headline; the rest fall to a label·value grid.
+interface ActivityColumn<T> {
+  key: string;
+  label: string;
+  render: (row: T) => ReactNode;
+  primary?: boolean;
 }
 
-function EmptyRow({ children, colSpan }: { children: ReactNode; colSpan: number }) {
+function ActivityRecordTable<T>({
+  attentionSeverity,
+  columns,
+  empty,
+  label,
+  rowKey,
+  rows,
+}: {
+  attentionSeverity?: (row: T) => BadgeSeverity | null;
+  columns: ReadonlyArray<ActivityColumn<T>>;
+  empty: ReactNode;
+  label: string;
+  rowKey: (row: T, index: number) => string;
+  rows: ReadonlyArray<T>;
+}) {
+  const primaryColumns = columns.filter((col) => col.primary === true);
+  const detailColumns = columns.filter((col) => col.primary !== true);
+
   return (
-    <tr>
-      <td colSpan={colSpan} className="py-10 text-center text-fg-muted italic">
-        {children}
-      </td>
-    </tr>
+    <>
+      <ul role="list" aria-label={label} className="divide-y divide-rule sm:hidden">
+        {rows.length === 0 ? (
+          <li className="py-10 text-center text-fg-muted italic">{empty}</li>
+        ) : (
+          rows.map((row, index) => {
+            const { className = '', ...severityProps } = attentionListItemProps(
+              attentionSeverity?.(row) ?? null,
+            );
+            return (
+              <li
+                {...severityProps}
+                key={rowKey(row, index)}
+                className={`space-y-2 py-4 ${className}`}
+              >
+                {primaryColumns.map((col) => (
+                  <div key={col.key}>{col.render(row)}</div>
+                ))}
+                {detailColumns.length > 0 && (
+                  <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-1">
+                    {detailColumns.map((col) => (
+                      <Fragment key={col.key}>
+                        <dt className="text-label uppercase tracking-wider text-fg-faint">
+                          {col.label}
+                        </dt>
+                        <dd className="min-w-0">{col.render(row)}</dd>
+                      </Fragment>
+                    ))}
+                  </dl>
+                )}
+              </li>
+            );
+          })
+        )}
+      </ul>
+      <div className="hidden overflow-x-auto sm:block">
+        <table aria-label={label} className="w-full text-body tnum">
+          <thead>
+            <tr className="border-b border-rule text-label uppercase tracking-wider text-fg-muted">
+              {columns.map((col) => (
+                <th key={col.key} scope="col" className="pb-3 pr-6 text-left font-medium">
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="py-10 text-center text-fg-muted italic">
+                  {empty}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, index) => {
+                const { className = '', ...severityProps } = attentionRowProps(
+                  attentionSeverity?.(row) ?? null,
+                );
+                return (
+                  <tr
+                    {...severityProps}
+                    key={rowKey(row, index)}
+                    className={`border-b border-rule ${className}`}
+                  >
+                    {columns.map((col) => (
+                      <td key={col.key} className="py-3 pr-6 align-baseline">
+                        {col.render(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/routes/Activity.tsx
+++ b/frontend/src/routes/Activity.tsx
@@ -1,5 +1,5 @@
 import type { DeployList, DeployRecord, GitCommitList } from 'gas-city-dashboard-shared';
-import { Fragment, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { api, formatApiError } from '../api/client';
 import { getActiveCity } from '../api/cityBase';
@@ -617,25 +617,26 @@ function ActivityRecordTable<T>({
               attentionSeverity?.(row) ?? null,
             );
             return (
-              <li
-                {...severityProps}
-                key={rowKey(row, index)}
-                className={`space-y-2 py-4 ${className}`}
-              >
+              <li {...severityProps} key={rowKey(row, index)} className={`py-3 ${className}`}>
                 {primaryColumns.map((col) => (
-                  <div key={col.key}>{col.render(row)}</div>
+                  <div key={col.key} className="text-body">
+                    {col.render(row)}
+                  </div>
                 ))}
                 {detailColumns.length > 0 && (
-                  <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-1">
+                  // Compact meta: the detail columns collapse to one wrapping
+                  // line of values (no per-field labels — a timestamp, badge, or
+                  // subject reads as itself), separated by spacing rather than
+                  // glyphs so a record stays ~2 lines on a phone instead of one
+                  // label·value row per column. Status badges already carry their
+                  // own glyph, so an added separator would double up.
+                  <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-0.5 text-label text-fg-muted">
                     {detailColumns.map((col) => (
-                      <Fragment key={col.key}>
-                        <dt className="text-label uppercase tracking-wider text-fg-faint">
-                          {col.label}
-                        </dt>
-                        <dd className="min-w-0">{col.render(row)}</dd>
-                      </Fragment>
+                      <span key={col.key} className="min-w-0 break-words">
+                        {col.render(row)}
+                      </span>
                     ))}
-                  </dl>
+                  </div>
                 )}
               </li>
             );

--- a/frontend/src/routes/Agents.render.test.tsx
+++ b/frontend/src/routes/Agents.render.test.tsx
@@ -222,13 +222,16 @@ describe('AgentsPage (post-ay6 regressions)', () => {
 
     // mayor has no rig (cross-rig orchestration) → the label is just the
     // alias, rendered as a Link.
-    const mayorLink = await screen.findByRole('link', { name: /mayor/i });
+    // The roster renders twice (a phone stacked list + the sm: table, CSS-
+    // toggled but both in the DOM), so scope roster assertions to the table.
+    const roster = within(await screen.findByRole('table'));
+    const mayorLink = await roster.findByRole('link', { name: /mayor/i });
     expect(mayorLink).toBeDefined();
     expect(mayorLink.textContent).toBe('mayor');
     expect(fetchUrls()).toContain('/gc-supervisor/v0/city/test-city/agents');
     expect(fetchUrls()).not.toContain('/api/city/test-city/agents');
     // display_name appears as secondary muted text — present but not the link.
-    expect(screen.getByText('Claude (Account 5)')).toBeDefined();
+    expect(roster.getByText('Claude (Account 5)')).toBeDefined();
   });
 
   it('boots with the running checkbox checked and renders in-rig agents as "rig · agent"', async () => {
@@ -284,15 +287,17 @@ describe('AgentsPage (post-ay6 regressions)', () => {
     expect(runningCheckbox.checked).toBe(true);
 
     // The running agent is shown with the restored 'rig · agent' label.
-    const runningLink = await screen.findByRole('link', { name: /polecat-1/i });
+    // Scope to the table; the phone stacked list duplicates the same rows.
+    const roster = within(await screen.findByRole('table'));
+    const runningLink = await roster.findByRole('link', { name: /polecat-1/i });
     expect(runningLink.textContent).toBe('gascity-packs · polecat-1');
 
     // The asleep agent is hidden by the default-on running filter.
-    expect(screen.queryByRole('link', { name: /polecat-2/i })).toBeNull();
+    expect(roster.queryByRole('link', { name: /polecat-2/i })).toBeNull();
 
     // Unchecking the box reveals the full roster (asleep agent appears).
     fireEvent.click(runningCheckbox);
-    const sleepingLink = await screen.findByRole('link', { name: /polecat-2/i });
+    const sleepingLink = await roster.findByRole('link', { name: /polecat-2/i });
     expect(sleepingLink.textContent).toBe('gascity-packs · polecat-2');
   });
 
@@ -331,10 +336,12 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    // Wait for the row to load.
-    await screen.findByRole('link', { name: /mayor/i });
+    // Wait for the row to load. Scope to the table; the phone stacked list
+    // duplicates the same Peek control.
+    const roster = within(await screen.findByRole('table'));
+    await roster.findByRole('link', { name: /mayor/i });
 
-    const peekButton = await screen.findByRole('button', { name: /peek/i });
+    const peekButton = await roster.findByRole('button', { name: /peek/i });
     fireEvent.click(peekButton);
 
     // The peek modal must hit supervisor transcript for gc-2568 — NOT
@@ -367,12 +374,14 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('needs you')).toBeTruthy();
+    // Scope to the table; the phone stacked list duplicates the roster row.
+    const roster = within(await screen.findByRole('table'));
+    expect(await roster.findByText('needs you')).toBeTruthy();
     // The prompt shows in both the "Needs you" section and the roster row.
-    expect(within(screen.getByRole('table')).getByText('Approve deployment?')).toBeTruthy();
+    expect(roster.getByText('Approve deployment?')).toBeTruthy();
     expect(fetchUrls()).toContain('/gc-supervisor/v0/city/test-city/session/gc-2568/pending');
 
-    fireEvent.click(screen.getByRole('button', { name: /copy attach/i }));
+    fireEvent.click(roster.getByRole('button', { name: /copy attach/i }));
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith('gc agent attach mayor');
@@ -388,9 +397,11 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('needs you')).toBeTruthy();
+    // Scope to the table; the phone stacked list duplicates the Deny control.
+    const roster = within(await screen.findByRole('table'));
+    expect(await roster.findByText('needs you')).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: /deny/i }));
+    fireEvent.click(roster.getByRole('button', { name: /deny/i }));
 
     await screen.findByText('responded to mayor');
 
@@ -417,16 +428,17 @@ describe('AgentsPage (post-ay6 regressions)', () => {
       </MemoryRouter>,
     );
 
-    const table = await screen.findByRole('table');
-    expect(await within(table).findByText('Approve deployment?')).toBeTruthy();
+    // Scope to the table; the phone stacked list duplicates these controls.
+    const roster = within(await screen.findByRole('table'));
+    expect(await roster.findByText('Approve deployment?')).toBeTruthy();
 
-    const approve = screen.getByRole('button', { name: /approve/i }) as HTMLButtonElement;
-    const deny = screen.getByRole('button', { name: /deny/i }) as HTMLButtonElement;
+    const approve = roster.getByRole('button', { name: /approve/i }) as HTMLButtonElement;
+    const deny = roster.getByRole('button', { name: /deny/i }) as HTMLButtonElement;
     expect(approve.disabled).toBe(true);
     expect(deny.disabled).toBe(true);
     expect(approve.getAttribute('title')).toBe('Read-only mode: mutations are disabled');
     // The affordance carries words, not just a dimmed control (DESIGN.md §States).
-    expect(screen.getByText('Read-only')).toBeTruthy();
+    expect(roster.getByText('Read-only')).toBeTruthy();
 
     // The disabled control must not reach the supervisor respond mutation.
     fireEvent.click(deny);

--- a/frontend/src/routes/Agents.tsx
+++ b/frontend/src/routes/Agents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   GC_EVENT_PREFIX,
@@ -552,6 +552,34 @@ export function AgentsPage() {
         rowProps={rowProps}
         empty={emptyMessage}
         initialSort={{ key: 'last_active', dir: 'desc' }}
+        // Phone layout: the six-column roster cannot fit ~390px, so each agent
+        // renders as a stacked typographic block (name, then State/Activity/
+        // Context/Last active as label·value rows, then the actions). Reuses the
+        // column render fns so the two layouts can't drift.
+        mobileRow={(r) => {
+          const cell = (key: string) => columns.find((c) => c.key === key)?.render(r);
+          return (
+            <div className="space-y-2">
+              {cell('name')}
+              <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-1">
+                {(
+                  [
+                    ['State', 'state'],
+                    ['Activity', 'activity'],
+                    ['Context', 'context'],
+                    ['Last active', 'last_active'],
+                  ] as const
+                ).map(([label, key]) => (
+                  <Fragment key={key}>
+                    <dt className="text-label uppercase tracking-wider text-fg-faint">{label}</dt>
+                    <dd className="min-w-0 text-right">{cell(key)}</dd>
+                  </Fragment>
+                ))}
+              </dl>
+              {cell('actions')}
+            </div>
+          );
+        }}
       />
 
       <Modal

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -312,7 +312,9 @@ function KvList({ children }: { children: ReactNode }) {
   // Two-column typeset list. Label left, value right, hairlines
   // between rows. Tabular numerals for value alignment.
   return (
-    <dl className="grid grid-cols-[max-content_1fr] gap-x-8 gap-y-3 max-w-prose">{children}</dl>
+    <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-8 gap-y-3 max-w-prose">
+      {children}
+    </dl>
   );
 }
 
@@ -321,7 +323,7 @@ function Kv({ label, value, tone }: { label: string; value: string; tone?: 'warn
   return (
     <>
       <dt className="text-body text-fg-muted">{label}</dt>
-      <dd className={`text-body tnum font-medium ${valueColor}`}>{value}</dd>
+      <dd className={`min-w-0 break-words text-body tnum font-medium ${valueColor}`}>{value}</dd>
     </>
   );
 }
@@ -355,7 +357,7 @@ function ToolVersionsTable({ state }: { state: LocalToolVersionsState | null }) 
     { label: 'dolt', tool: state.data.dolt },
   ];
   return (
-    <div className="grid grid-cols-[1fr_max-content] gap-x-8 gap-y-3 max-w-prose">
+    <div className="grid grid-cols-[minmax(0,1fr)_max-content] gap-x-8 gap-y-3 max-w-prose">
       <div className="text-label uppercase tracking-wider text-fg-muted">Tool</div>
       <div className="text-label uppercase tracking-wider text-fg-muted text-right">Installed</div>
       {rows.map((row) => (
@@ -466,7 +468,7 @@ function RigStoreRow({ rig }: { rig: RigStoreHealth }) {
         <span className="text-body font-medium text-fg">{rig.rig}</span>
         <StatusBadge tone={status.tone} label={status.label} />
       </div>
-      <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1">
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-6 gap-y-1">
         <Kv
           label="Dolt server"
           value={rigDoltServerValue(rig)}
@@ -481,7 +483,7 @@ function RigStoreRow({ rig }: { rig: RigStoreHealth }) {
           {rig.problems.map((p) => (
             <li
               key={`${p.category}/${p.name}`}
-              className={`text-label ${p.status === 'error' ? 'text-accent' : 'text-warn'}`}
+              className={`text-label break-words ${p.status === 'error' ? 'text-accent' : 'text-warn'}`}
             >
               {p.name}: {p.message}
             </li>
@@ -553,7 +555,7 @@ function ConfigComparison({ comparison }: { comparison: DiagnosticDatum<ConfigCo
   return (
     <div className="space-y-2">
       {comparison.stale !== undefined && <StaleNote message={comparison.stale} />}
-      <div className="grid grid-cols-[1fr_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
+      <div className="grid grid-cols-[minmax(0,1fr)_max-content_max-content] gap-x-8 gap-y-3 max-w-prose">
         <div className="text-label uppercase tracking-wider text-fg-muted">Setting</div>
         <div className="text-label uppercase tracking-wider text-fg-muted text-right">
           Recommended

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -107,6 +107,25 @@ describe('resolveTailnetDevServer', () => {
     process.env.DEV_TAILNET_PORT = '70000';
     expect(() => resolveTailnetDevServer()).toThrow(/DEV_TAILNET_PORT/);
   });
+
+  it('throws on a leading-numeric DEV_TAILNET_PORT instead of partial-parsing it', () => {
+    // Number.parseInt('5174abc') would be 5174; the strict parse must reject it.
+    process.env.DEV_TAILNET_HOST = 'host.example.ts.net';
+    process.env.DEV_TAILNET_PORT = '5174abc';
+    expect(() => resolveTailnetDevServer()).toThrow(/DEV_TAILNET_PORT/);
+  });
+
+  it('throws on a wildcard/sentinel DEV_TAILNET_HOST that would widen the host guard', () => {
+    for (const bad of ['*', 'true', '0.0.0.0', 'localhost']) {
+      process.env.DEV_TAILNET_HOST = bad;
+      expect(() => resolveTailnetDevServer(), bad).toThrow(/DEV_TAILNET_HOST/);
+    }
+  });
+
+  it('trims surrounding whitespace from DEV_TAILNET_HOST', () => {
+    process.env.DEV_TAILNET_HOST = '  host.example.ts.net  ';
+    expect(resolveTailnetDevServer()).toMatchObject({ allowedHosts: ['host.example.ts.net'] });
+  });
 });
 
 interface ProxyRequestDouble {

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from 'vitest';
-import viteConfig, { BACKEND_TARGET, configureBackendDevProxy } from '../vite.config';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import viteConfig, {
+  BACKEND_TARGET,
+  configureBackendDevProxy,
+  resolveTailnetDevServer,
+} from '../vite.config';
 
 describe('vite dev proxy config', () => {
   it('rewrites Origin for both dashboard api and supervisor transport writes', () => {
@@ -58,6 +62,50 @@ describe('vite dev proxy config', () => {
     listener(proxyReq);
 
     expect(proxyReq.setHeader).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveTailnetDevServer', () => {
+  afterEach(() => {
+    delete process.env.DEV_TAILNET_HOST;
+    delete process.env.DEV_TAILNET_PORT;
+  });
+
+  it('returns no overrides when DEV_TAILNET_HOST is unset (default loopback dev)', () => {
+    expect(resolveTailnetDevServer()).toEqual({});
+  });
+
+  it('returns no overrides when DEV_TAILNET_HOST is empty', () => {
+    process.env.DEV_TAILNET_HOST = '';
+    expect(resolveTailnetDevServer()).toEqual({});
+  });
+
+  it('allows the tailnet host and points HMR at the default serve port over wss', () => {
+    process.env.DEV_TAILNET_HOST = 'host.example.ts.net';
+    expect(resolveTailnetDevServer()).toEqual({
+      allowedHosts: ['host.example.ts.net'],
+      hmr: { protocol: 'wss', host: 'host.example.ts.net', clientPort: 5174 },
+    });
+  });
+
+  it('honors an explicit DEV_TAILNET_PORT for the HMR client port', () => {
+    process.env.DEV_TAILNET_HOST = 'host.example.ts.net';
+    process.env.DEV_TAILNET_PORT = '8443';
+    expect(resolveTailnetDevServer()).toMatchObject({
+      hmr: { clientPort: 8443 },
+    });
+  });
+
+  it('throws on a non-numeric DEV_TAILNET_PORT rather than silently defaulting', () => {
+    process.env.DEV_TAILNET_HOST = 'host.example.ts.net';
+    process.env.DEV_TAILNET_PORT = 'not-a-port';
+    expect(() => resolveTailnetDevServer()).toThrow(/DEV_TAILNET_PORT/);
+  });
+
+  it('throws on an out-of-range DEV_TAILNET_PORT', () => {
+    process.env.DEV_TAILNET_HOST = 'host.example.ts.net';
+    process.env.DEV_TAILNET_PORT = '70000';
+    expect(() => resolveTailnetDevServer()).toThrow(/DEV_TAILNET_PORT/);
   });
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -71,12 +71,28 @@ type TailnetDevServer = {
 };
 
 export function resolveTailnetDevServer(): TailnetDevServer | Record<string, never> {
-  const host = process.env.DEV_TAILNET_HOST;
+  const host = process.env.DEV_TAILNET_HOST?.trim();
   if (host === undefined || host.length === 0) return {};
-  const rawPort = process.env.DEV_TAILNET_PORT;
-  const clientPort = rawPort === undefined ? DEV_PORT : Number.parseInt(rawPort, 10);
+  // The host becomes the sole entry in Vite's allowedHosts (its DNS-rebinding
+  // guard) and hmr.host. Require a real hostname so an operator typo like `*`,
+  // `true`, or `0.0.0.0` fails loudly here instead of silently widening the
+  // guard from one explicit tailnet name to "any host". A tailnet FQDN always
+  // has a dotted suffix and no wildcard. Mirrors DEV_BACKEND_TARGET's
+  // validate-at-load style above.
+  if (!/^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(host)) {
+    throw new Error(
+      `DEV_TAILNET_HOST must be a hostname (e.g. host.tailnet.ts.net); got ${JSON.stringify(host)}`,
+    );
+  }
+  // Strict port parse: Number.parseInt('5174abc') is 5174, which would silently
+  // accept malformed input; require an all-digits string so bad values throw.
+  const rawPort = process.env.DEV_TAILNET_PORT?.trim();
+  const clientPort =
+    rawPort === undefined ? DEV_PORT : /^\d+$/.test(rawPort) ? Number(rawPort) : NaN;
   if (!Number.isInteger(clientPort) || clientPort < 1 || clientPort > 65535) {
-    throw new Error(`DEV_TAILNET_PORT must be a valid port; got ${JSON.stringify(rawPort)}`);
+    throw new Error(
+      `DEV_TAILNET_PORT must be a valid port; got ${JSON.stringify(process.env.DEV_TAILNET_PORT)}`,
+    );
   }
   return { allowedHosts: [host], hmr: { protocol: 'wss', host, clientPort } };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -53,12 +53,41 @@ export function configureBackendDevProxy(proxy: BackendDevProxy): void {
   });
 }
 
+const DEV_PORT = 5174;
+
+// Optional tailnet exposure for mobile dev/QA over `tailscale serve`. The dev
+// server still binds 127.0.0.1 only — `tailscale serve` bridges the tailnet to
+// loopback — so this never widens the listener. When DEV_TAILNET_HOST is set we
+// (1) add that host to Vite's allowlist (its DNS-rebinding guard otherwise
+// answers a non-loopback Host with "Blocked request") and (2) point the HMR
+// client at the TLS serve endpoint so hot reload survives the proxy. Unset →
+// zero effect on normal loopback dev. While set, HMR targets the tailnet origin,
+// so iterate from the phone (or another serve port) rather than loopback.
+type TailnetDevServer = {
+  // Vite's ServerOptions types allowedHosts as string[] (mutable), so this is a
+  // fresh per-call array, never shared mutable state.
+  allowedHosts: string[];
+  hmr: { protocol: 'wss'; host: string; clientPort: number };
+};
+
+export function resolveTailnetDevServer(): TailnetDevServer | Record<string, never> {
+  const host = process.env.DEV_TAILNET_HOST;
+  if (host === undefined || host.length === 0) return {};
+  const rawPort = process.env.DEV_TAILNET_PORT;
+  const clientPort = rawPort === undefined ? DEV_PORT : Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(clientPort) || clientPort < 1 || clientPort > 65535) {
+    throw new Error(`DEV_TAILNET_PORT must be a valid port; got ${JSON.stringify(rawPort)}`);
+  }
+  return { allowedHosts: [host], hmr: { protocol: 'wss', host, clientPort } };
+}
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5174,
+    port: DEV_PORT,
     strictPort: true,
     host: '127.0.0.1',
+    ...resolveTailnetDevServer(),
     proxy: {
       '/api': {
         target: BACKEND_TARGET,


### PR DESCRIPTION
## Summary

Makes the dashboard usable on a phone. It was desktop-first (1280px ambient layout): the nav stacked to 3–4 lines, the Agents roster and Activity tables forced horizontal scrolling, Health overflowed the viewport, and page titles dominated small screens. This is a mobile-first responsive pass plus dedicated mobile layouts for the table-heavy views, all kept within the DESIGN.md "Reading Room" contract (flat, typographic, warm paper, One Mark). Desktop is unchanged throughout — every change is gated below `sm:`.

Tracked under epic `gascity-dashboard-vy0w`.

## What's in it

- **Dev tailnet config** (`feat(dev)`): env-gated `DEV_TAILNET_HOST`/`DEV_TAILNET_PORT` in `vite.config.ts` so the dev server can be reached from a phone over `tailscale serve` (Vite still binds loopback; the serve bridges it). Zero effect when unset — this is the affordance that made on-device testing possible.
- **PageHeader scale**: page titles render Headline-size on phones, Display from `sm:` up, instead of a 40px title eating half the viewport.
- **Agents roster**: a new opt-in `Table.mobileRow` renders the six-column roster as a stacked typographic list below `sm:` (hairline-separated rows, **no cards** per the Flat Page Rule), table from `sm:` up. Reuses the column render fns so the two layouts can't drift.
- **Health**: fixed horizontal document overflow (a long unbreakable rig-store token + `1fr` grid tracks that wouldn't shrink) via `break-words` + `minmax(0,1fr)`.
- **Header nav → hamburger**: below `sm:` the route row collapses behind a ☰ that opens the routes in the shared `Modal` (paper panel + scrim, Escape / click-outside / select-to-close, no glass). One `navItem` helper drives both the desktop row and the menu, so routes/active-state/attention counts stay in sync.
- **Activity**: the three bespoke event/deploy/commit tables fold into one data-driven `ActivityRecordTable` (stacked list below `sm:`, table from `sm:`). Records are compact — a headline plus one wrapping meta line of values — roughly halving the page height (~18.7k → ~9.5k px at 390px) with no horizontal scroll.

## Test plan

- `npm run typecheck` (src + test): pass
- `npm run lint` / `npm run format:check`: clean
- `npm --workspace frontend run build`: pass
- `npm run openapi:gc-supervisor:check`: no drift
- `npm audit --audit-level=high`: pass
- Full frontend suite: **1084 passing** (new tests ship with each change: PageHeader, Table.mobileRow mechanism, Header menu, Activity stacked layout, plus Agents roster assertions re-scoped for the dual desktop/mobile DOM, and `resolveTailnetDevServer` unit tests)
- Verified live at 390px (and 320px for overflow, `sm:`/desktop for the table fallbacks) via headless screenshots: no horizontal scroll on any main view; Agents/Activity stack; Health fits; hamburger opens/closes; desktop row intact.

## Notes for review

- The hamburger drawer is the one element that leans on `Modal` (an overlay/panel) rather than the flat default — chosen deliberately by the operator over a flat word-disclosure; kept opaque paper + scrim, no glassmorphism.
- Known data residue (not layout, identical on desktop): Activity events often carry the same value for `subject` and `detail`, so the compact meta line can show it twice. De-duping is a candidate follow-up.
