### PR TITLE
refactor(backend): delete dead link re-export shims, point tests at shared (enhp)

### DIFF
--- a/backend/src/links/build-link-view.ts
+++ b/backend/src/links/build-link-view.ts
@@ -1,2 +1,0 @@
-export { buildLinkView } from 'gas-city-dashboard-shared';
-export type { BuildLinkViewOptions } from 'gas-city-dashboard-shared';

--- a/backend/src/links/instrumentation.ts
+++ b/backend/src/links/instrumentation.ts
@@ -1,2 +1,0 @@
-export { recordResolution, ResolutionRollup } from 'gas-city-dashboard-shared';
-export type { ResolutionOutcome, ResolutionRecorder } from 'gas-city-dashboard-shared';

--- a/backend/src/links/node-ref.ts
+++ b/backend/src/links/node-ref.ts
@@ -1,2 +1,0 @@
-export { nodeKey, parseRef, sanitiseUrl } from 'gas-city-dashboard-shared';
-export type { ParsedRef, ParsedRefType } from 'gas-city-dashboard-shared';

--- a/backend/src/links/relation-index.ts
+++ b/backend/src/links/relation-index.ts
@@ -1,2 +1,0 @@
-export { buildRelationIndex } from 'gas-city-dashboard-shared';
-export type { IndexBead, RelationIndex } from 'gas-city-dashboard-shared';

--- a/backend/test/links-build-view.test.ts
+++ b/backend/test/links-build-view.test.ts
@@ -1,10 +1,12 @@
 import type { DashboardBead, DashboardSession, LinkNode } from 'gas-city-dashboard-shared';
+import {
+  buildLinkView,
+  buildRelationIndex,
+  parseRef,
+  ResolutionRollup,
+} from 'gas-city-dashboard-shared';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { buildLinkView } from '../src/links/build-link-view.js';
-import { ResolutionRollup } from '../src/links/instrumentation.js';
-import { parseRef } from '../src/links/node-ref.js';
-import { buildRelationIndex } from '../src/links/relation-index.js';
 
 function bead(id: string, metadata: Record<string, string> = {}): DashboardBead {
   return {

--- a/backend/test/links-node-ref.test.ts
+++ b/backend/test/links-node-ref.test.ts
@@ -1,6 +1,6 @@
+import { parseRef, sanitiseUrl } from 'gas-city-dashboard-shared';
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseRef, sanitiseUrl } from '../src/links/node-ref.js';
 
 describe('parseRef', () => {
   test('parses pr/<n> and issue/<n>', () => {

--- a/backend/test/links-relation-index.test.ts
+++ b/backend/test/links-relation-index.test.ts
@@ -1,8 +1,7 @@
 import type { DashboardBead, DashboardSession } from 'gas-city-dashboard-shared';
-import { makeNodeKey } from 'gas-city-dashboard-shared';
+import { buildRelationIndex, makeNodeKey } from 'gas-city-dashboard-shared';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { buildRelationIndex } from '../src/links/relation-index.js';
 
 // R1 + RK1 unit tests for the backend relation index.
 


### PR DESCRIPTION
backend/src/links/{build-link-view,instrumentation,node-ref,relation-index}.ts
were 2-line pure re-exports of gas-city-dashboard-shared with zero importers
in backend/src or frontend/src — the only real consumer
(frontend/src/supervisor/entityLinks.ts) already imports from shared directly.
The three links-*.test.ts suites reached the shared link logic only through
this dead indirection.

Delete the four shim files and re-point the test imports straight at
gas-city-dashboard-shared, preserving all coverage with no shared wire-shape
change (import path only).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
