### PR TITLE
fix(attention): route degraded beads/mail reads to the non-counting unavailable tier (m1gi)

### DIFF
--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -933,6 +933,52 @@ describe('createAttentionContributors', () => {
     const ids = model.byDomain.beads.items.map((item) => item.id);
     expect(ids).toContain('beads:decisions-unavailable');
     expect(ids).toContain('beads:B-1:escalated');
+    // gascity-dashboard-m1gi: the failed decision-queue READ rides the
+    // non-counting unavailable tier; only the real escalation inflates the badge.
+    expect(model.byDomain.beads.attention).toBe(1);
+    expect(model.byDomain.beads.unavailable).toBe(1);
+  });
+
+  it('keeps a beads-list read failure in the non-counting unavailable tier — a 503 does not inflate the badge (gascity-dashboard-m1gi)', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: { decisionLabel: NEEDS_STEPHANIE_LABEL, error: 'bead list unavailable: 503' },
+      }),
+    );
+
+    expect(model.byDomain.beads.attention).toBe(0);
+    expect(model.byDomain.beads.watch).toBe(0);
+    expect(model.byDomain.beads.unavailable).toBe(1);
+    expect(model.byDomain.beads.severity).toBeNull();
+    expect(model.byDomain.beads.items[0]?.id).toBe('beads:unavailable');
+  });
+
+  it('keeps an escalation-queue read failure in the non-counting unavailable tier (gascity-dashboard-m1gi)', () => {
+    const model = composeAttention(
+      createAttentionContributors({
+        beads: {
+          decisionLabel: NEEDS_STEPHANIE_LABEL,
+          escalationsError: 'escalation queue unavailable: ECONNREFUSED',
+        },
+      }),
+    );
+
+    expect(model.byDomain.beads.attention).toBe(0);
+    expect(model.byDomain.beads.unavailable).toBe(1);
+    expect(model.byDomain.beads.severity).toBeNull();
+    expect(model.byDomain.beads.items[0]?.id).toBe('beads:escalations-unavailable');
+  });
+
+  it('keeps a mail read failure in the non-counting unavailable tier — a 503 does not inflate the badge (gascity-dashboard-m1gi)', () => {
+    const model = composeAttention(
+      createAttentionContributors({ mail: { error: 'mail unavailable: 503' } }),
+    );
+
+    expect(model.byDomain.mail.attention).toBe(0);
+    expect(model.byDomain.mail.watch).toBe(0);
+    expect(model.byDomain.mail.unavailable).toBe(1);
+    expect(model.byDomain.mail.severity).toBeNull();
+    expect(model.byDomain.mail.items[0]?.id).toBe('mail:unavailable');
   });
 
   it('derives maintainer attention from needs-you, awaiting-triage, and blocked slung facts', () => {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -446,9 +446,14 @@ function deriveAgentsAttention(facts: AgentsAttentionFacts | undefined): readonl
 function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly AttentionItem[] {
   const items: AttentionItem[] = [];
   if (facts === undefined) return items;
+  // gascity-dashboard-m1gi: a failed bead READ is a data degradation, not
+  // operator-actionable work, so it lands in the non-counting `unavailable`
+  // tier (like agents:unavailable / runs:partial) — the item still renders so
+  // the operator sees the source is down, but a 503 never inflates the nav
+  // badge or spends the One-Mark maroon on a fetch that merely failed.
   if (facts.error !== undefined && facts.error.length > 0) {
     items.push(
-      domainAttention('beads', {
+      domainUnavailable('beads', {
         id: 'beads:unavailable',
         title: 'Bead data unavailable',
         summary: facts.error,
@@ -467,7 +472,7 @@ function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly 
   }
   if (facts.decisionsError !== undefined && facts.decisionsError.length > 0) {
     items.push(
-      domainAttention('beads', {
+      domainUnavailable('beads', {
         id: 'beads:decisions-unavailable',
         title: 'Decision queue unavailable',
         summary: facts.decisionsError,
@@ -477,7 +482,7 @@ function deriveBeadsAttention(facts: BeadsAttentionFacts | undefined): readonly 
   }
   if (facts.escalationsError !== undefined && facts.escalationsError.length > 0) {
     items.push(
-      domainAttention('beads', {
+      domainUnavailable('beads', {
         id: 'beads:escalations-unavailable',
         title: 'Escalation queue unavailable',
         summary: facts.escalationsError,
@@ -600,9 +605,12 @@ function mayorDecisionAttention(bead: Bead): AttentionItem {
 function deriveMailAttention(facts: MailAttentionFacts | undefined): readonly AttentionItem[] {
   const items: AttentionItem[] = [];
   if (facts === undefined) return items;
+  // gascity-dashboard-m1gi: a failed mail READ is a degradation, not actionable
+  // mail, so it rides the non-counting `unavailable` tier (see beads above) —
+  // visible, but a 503 never inflates the Mail badge.
   if (facts.error !== undefined && facts.error.length > 0) {
     items.push(
-      domainAttention('mail', {
+      domainUnavailable('mail', {
         id: 'mail:unavailable',
         title: 'Mail data unavailable',
         summary: facts.error,


### PR DESCRIPTION
A failed beads-list / decision-queue / escalation-queue / mail READ was
emitted via domainAttention (severity=attention, BADGE-COUNTING), so a 503
inflated that nav badge and spent the One-Mark maroon on a fetch that merely
failed — the 'board lies' symptom this rig exists to prevent. agents already
routes the identical 'read failed' concept through the non-counting
`unavailable` tier (agents:unavailable / agents:pending-unavailable), and the
tier's documented purpose (issue-88/dash-ygj) + DESIGN.md One Mark Rule both
say a degraded read should surface WITHOUT inflating or recoloring the badge.

Verified intent first: the codebase carried two tested-opposite conventions
for a degraded read (agents=quiet, runs:unavailable=loud). The quiet tier still
RENDERS the item (visible, muted), so the operator is never left blind — the
only thing loud added was badge inflation + a maroon, exactly what One Mark
wants kept rare. Resolved beads/mail toward the quiet convention.

beads:unavailable, beads:decisions-unavailable, beads:escalations-unavailable,
and mail:unavailable now use domainUnavailable. Regression tests assert a 503
lands in the non-counting tier (attention=0, severity=null) and that a real
escalation still counts alongside a failed decision-queue read. Frontend-only;
no shared/ wire change, no bind/Origin change, no new DESIGN.md primary mark.

Out of scope (noted for follow-up): runs:unavailable + activity:deploys-unavailable
remain loud (runs has an explicit 'not left blind' test); beads:partial/mail:partial
remain watch-tier.
