### PR TITLE
fix(mobile): close the hamburger menu when the viewport widens past sm: (nb0b)

### DIFF
--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AttentionProvider } from '../attention/context';
@@ -140,6 +140,45 @@ describe('Header mobile nav', () => {
     expect(screen.getByRole('dialog')).toBeTruthy();
     // Navigate without touching a menu link.
     fireEvent.click(screen.getByRole('button', { name: /navigate elsewhere/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes the open menu when the viewport widens past the sm: breakpoint', () => {
+    // The hamburger is sm:hidden in CSS, but the open state is React state. When
+    // a phone-width viewport widens back to >=640px the desktop nav row returns
+    // and the Modal + scrim would otherwise stay stranded over it. Capture the
+    // change handler the Header registers on the (min-width: 640px) query so the
+    // test can drive the crossing directly — scoped to that query so the theme
+    // provider's prefers-color-scheme listener is not also triggered.
+    const widthChangeHandlers: Array<(e: MediaQueryListEvent) => void> = [];
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        addEventListener: (_type: string, handler: (e: MediaQueryListEvent) => void) => {
+          if (query.includes('min-width')) widthChangeHandlers.push(handler);
+        },
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    // Simulate the viewport crossing to >=640px (the sm: breakpoint), where the
+    // desktop nav row reappears.
+    act(() => {
+      for (const handler of widthChangeHandlers) {
+        handler({ matches: true } as MediaQueryListEvent);
+      }
+    });
+
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -112,6 +112,21 @@ export function Header() {
     setMenuOpen(false);
   }, [pathname]);
 
+  // The hamburger is `sm:hidden`, but `menuOpen` is React state, not CSS — so a
+  // viewport that widens past the sm: breakpoint while the menu is open brings
+  // the desktop nav row back (`hidden sm:flex`) with the Modal + scrim still
+  // stranded over it. Close the menu the moment we cross to >=640px so the
+  // dialog never outlives the phone layout that justifies it. <640px crossings
+  // never reopen it — the operator must tap the hamburger again.
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 640px)');
+    const onChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setMenuOpen(false);
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
   const navItem = (r: NavRoute, sizeClass: string, onClick?: () => void) => {
     const domain = NAV_ATTENTION_DOMAINS[r.to];
     return (


### PR DESCRIPTION
PR #144 residual major (flagged by code-reviewer + Codex, rollup
gascity-dashboard-1ind/vy0w). The mobile nav Modal only closed on route
change, so widening a <640px viewport back past the sm: breakpoint with
the menu open left the desktop nav row (`hidden sm:flex`) reappearing
while the Modal + scrim stayed stranded over it — contradicting
"desktop unchanged" for tablet/resizable windows.

Add a matchMedia('(min-width: 640px)') change listener in Header that
calls setMenuOpen(false) on the cross to >=640px (the moment the desktop
nav reappears). <640px crossings never reopen the menu. Ships a Header
test in the same commit driving the captured change handler to >=640px
and asserting the dialog closes; the handler capture is scoped to the
min-width query so the ThemeProvider's prefers-color-scheme listener is
untouched.

No shared/ wire change, no bind/Origin change, no DESIGN.md contract
change (One Mark Rule already satisfied).
