### PR TITLE
refactor(attention): drop the duplicated item-level runs freshness (3ad9)

### DIFF
--- a/frontend/src/attention/AttentionSummaryPanel.test.tsx
+++ b/frontend/src/attention/AttentionSummaryPanel.test.tsx
@@ -58,7 +58,6 @@ describe('AttentionSummaryPanel', () => {
             contributor('runs', [
               item('runs:feed-partial', 'runs', 'unavailable', {
                 title: 'Formula run feed incomplete',
-                provenance: 'stale',
               }),
             ]),
           ]}

--- a/frontend/src/attention/compose.test.ts
+++ b/frontend/src/attention/compose.test.ts
@@ -67,8 +67,8 @@ describe('composeAttention', () => {
     const model = composeAttention([
       contributor('runs', [
         item('run-watch', 'runs', 'watch'),
-        item('run-degraded', 'runs', 'unavailable', { provenance: 'stale' }),
-        item('run-down', 'runs', 'unavailable', { provenance: 'error' }),
+        item('run-degraded', 'runs', 'unavailable'),
+        item('run-down', 'runs', 'unavailable'),
       ]),
     ]);
 
@@ -83,8 +83,8 @@ describe('composeAttention', () => {
   it('never sets the badge severity from unavailable items alone', () => {
     const model = composeAttention([
       contributor('runs', [
-        item('feed-partial', 'runs', 'unavailable', { provenance: 'fresh' }),
-        item('detail-down', 'runs', 'unavailable', { provenance: 'error' }),
+        item('feed-partial', 'runs', 'unavailable'),
+        item('detail-down', 'runs', 'unavailable'),
       ]),
     ]);
 

--- a/frontend/src/attention/compose.ts
+++ b/frontend/src/attention/compose.ts
@@ -33,19 +33,6 @@ export interface AttentionItem {
   current?: boolean;
   actionable?: boolean;
   updatedAt?: string;
-  /**
-   * Freshness of the source this item was derived from. Carried on
-   * `unavailable` items so a badge fed from a stale cache read can be marked
-   * stale rather than rendered as live truth.
-   */
-  provenance?: SourceStatus;
-  /**
-   * ISO timestamp of the cache read this item was derived from (the
-   * useCachedData/cache fetch primitive). Pairs with `provenance` so a consumer
-   * can age a degradation signal — "as of <fetchedAt>, this slice was
-   * unavailable" — instead of treating a long-stale read as current.
-   */
-  fetchedAt?: string;
 }
 
 export interface AttentionContributor {

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -451,10 +451,11 @@ describe('createAttentionContributors', () => {
 
     for (const item of model.byDomain.runs.items) {
       expect(item.severity).toBe('unavailable');
-      // Provenance + fetch timestamp ride along so a stale read can be aged.
-      expect(item.provenance).toBe('stale');
-      expect(item.fetchedAt).toBe('2026-06-06T12:00:00.000Z');
     }
+    // Read freshness is aged via the contributor-level fold on the domain
+    // summary (the single source the board liveness line reads), not per item.
+    expect(model.byDomain.runs.provenance).toBe('stale');
+    expect(model.byDomain.runs.fetchedAt).toBe('2026-06-06T12:00:00.000Z');
   });
 
   it('keeps a total runs read failure as a loud attention signal, not the quiet unavailable tier', () => {

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -288,13 +288,9 @@ function maintainerContributor(facts: MaintainerAttentionFacts | undefined): Att
   );
 }
 
-/** The provenance + fetch timestamp carried onto runs `unavailable` items. */
-type ReadFreshness = { provenance: SourceStatus | undefined; fetchedAt: string | undefined };
-
 function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly AttentionItem[] {
   const items: AttentionItem[] = [];
   if (facts === undefined) return items;
-  const freshness: ReadFreshness = { provenance: facts.provenance, fetchedAt: facts.fetchedAt };
   if (facts.error !== undefined && facts.error.length > 0) {
     items.push(
       domainAttention('runs', {
@@ -319,30 +315,22 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
   // summary-derived degraded reads survive.
   if (summary.lanesPartial === true) {
     items.push(
-      domainUnavailable(
-        'runs',
-        {
-          id: 'runs:partial',
-          title: 'Run list incomplete',
-          href: '/runs',
-        },
-        freshness,
-      ),
+      domainUnavailable('runs', {
+        id: 'runs:partial',
+        title: 'Run list incomplete',
+        href: '/runs',
+      }),
     );
   }
   for (const lane of [...summary.lanes, ...summary.blockedLanes, ...summary.strandedLanes]) {
     if (lane.health.status === 'available') continue;
     items.push(
-      domainUnavailable(
-        'runs',
-        {
-          id: `runs:${lane.id}:health-unavailable`,
-          title: `${lane.title} health unavailable`,
-          summary: lane.health.error,
-          href: runDetailHref(lane.id, lane.scope),
-        },
-        freshness,
-      ),
+      domainUnavailable('runs', {
+        id: `runs:${lane.id}:health-unavailable`,
+        title: `${lane.title} health unavailable`,
+        summary: lane.health.error,
+        href: runDetailHref(lane.id, lane.scope),
+      }),
     );
   }
 
@@ -1072,16 +1060,11 @@ function domainWatch(
 /**
  * A data-unavailability item: a slice of a source could not be read. It reports
  * the degradation WITHOUT inflating or recoloring the domain's nav badge (see
- * AttentionSeverity). `freshness` carries the read's provenance + fetch
- * timestamp so the signal can be aged rather than rendered as current truth.
+ * AttentionSeverity).
  */
 function domainUnavailable(
   domain: AttentionDomain,
-  item: Omit<
-    AttentionItem,
-    'domain' | 'severity' | 'current' | 'actionable' | 'provenance' | 'fetchedAt'
-  >,
-  freshness?: ReadFreshness,
+  item: Omit<AttentionItem, 'domain' | 'severity' | 'current' | 'actionable'>,
 ): AttentionItem {
   return {
     domain,
@@ -1089,8 +1072,6 @@ function domainUnavailable(
     current: true,
     actionable: false,
     ...item,
-    ...(freshness?.provenance === undefined ? {} : { provenance: freshness.provenance }),
-    ...(freshness?.fetchedAt === undefined ? {} : { fetchedAt: freshness.fetchedAt }),
   };
 }
 


### PR DESCRIPTION
Freshness Spine (#138) erosion cleanup. deriveRunsAttention built a local
{provenance,fetchedAt} and threaded it onto each runs `unavailable` item via
domainUnavailable, while the same read freshness is already carried at the
contributor level (withFreshness) and folded per-domain by composeAttention —
two sources of truth that could diverge. No production consumer reads the
item-level copy (BoardLiveness ages the read off the domain-summary fold); only
a test asserted it. Remove the local ReadFreshness construction, the
domainUnavailable freshness params, and the now-unreachable AttentionItem
provenance/fetchedAt fields. The contributor-fold path is the single source.

Tests in the same commit: the runs-unavailable test now asserts the surviving
domain-fold (byDomain.runs.provenance/fetchedAt) instead of the removed
per-item fields; dead fixture freshness fields dropped. Internal-only — no
shared/ wire change, no bind/Origin change, no DESIGN.md change.
