### PR TITLE
test(backend): focused security-boundary unit tests for Host/Origin/CSP + CSRF (8lav)

### DIFF
--- a/backend/test/csrf.test.ts
+++ b/backend/test/csrf.test.ts
@@ -1,0 +1,158 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Express } from 'express';
+
+import { csrfIssueCookie, csrfValidate, getCsrfToken } from '../src/middleware/csrf.js';
+import { withApp, rawRequest } from './helpers/express-harness.js';
+
+// Focused unit coverage for the double-submit CSRF belt (the third defense
+// behind the Host allowlist + Origin check). app.ts mounts csrfValidate on the
+// write router but never asserts its reject branches; this guards that a future
+// edit cannot weaken the timing-safe compare or drop the missing/mismatch
+// rejections.
+
+const TOKEN_HEADER = 'x-csrf-token';
+
+/** Terminal 200 handler so a request that passes validation is observable. */
+function ok(app: Express): void {
+  app.use((_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+}
+
+describe('csrfValidate — double-submit token check on writes', () => {
+  function mount(app: Express): void {
+    app.use(csrfValidate);
+    ok(app);
+  }
+
+  test('exempts safe methods without requiring a token', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        for (const method of ['GET', 'HEAD', 'OPTIONS']) {
+          const res = await rawRequest(url, { method });
+          assert.equal(res.status, 200, `expected ${method} to be exempt`);
+        }
+      },
+    );
+  });
+
+  test('accepts a write whose header token matches the boot token', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { [TOKEN_HEADER]: getCsrfToken() },
+        });
+        assert.equal(res.status, 200);
+      },
+    );
+  });
+
+  test('rejects a write with no CSRF header (403, kind "csrf")', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, { method: 'POST' });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Missing CSRF token', kind: 'csrf' });
+      },
+    );
+  });
+
+  test('rejects a write with an empty CSRF header as missing, not mismatched', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { [TOKEN_HEADER]: '' },
+        });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Missing CSRF token', kind: 'csrf' });
+      },
+    );
+  });
+
+  test('rejects a same-length but different token via the timing-safe compare', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const expected = getCsrfToken();
+        // Same length so the fast length short-circuit cannot fire — this drives
+        // the crypto.timingSafeEqual mismatch branch specifically.
+        const forged = expected.slice(0, -1) + (expected.endsWith('A') ? 'B' : 'A');
+        assert.equal(forged.length, expected.length);
+        assert.notEqual(forged, expected);
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { [TOKEN_HEADER]: forged },
+        });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Invalid CSRF token', kind: 'csrf' });
+      },
+    );
+  });
+
+  test('rejects a wrong-length token without throwing (length short-circuit)', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        // A token of a different byte length must be rejected as invalid, not
+        // crash crypto.timingSafeEqual (which requires equal-length buffers).
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { [TOKEN_HEADER]: 'too-short' },
+        });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Invalid CSRF token', kind: 'csrf' });
+      },
+    );
+  });
+});
+
+describe('csrfIssueCookie — hands the token to the browser on reads', () => {
+  test('sets a JS-readable, SameSite=Strict cookie carrying the boot token on GET', async () => {
+    await withApp(
+      (app) => {
+        app.use(csrfIssueCookie);
+        ok(app);
+      },
+      async ({ url }) => {
+        const res = await rawRequest(url);
+        const cookie = res.headers['set-cookie'];
+        assert.ok(Array.isArray(cookie) && cookie.length === 1, 'one Set-Cookie header');
+        const value = cookie[0];
+        if (value === undefined) throw new Error('Set-Cookie header had no value');
+        assert.ok(value.startsWith(`gascity_admin_csrf=${getCsrfToken()}`));
+        assert.ok(value.includes('Path=/'));
+        assert.ok(value.includes('SameSite=Strict'));
+        assert.ok(value.includes('Max-Age=86400'));
+        // Double-submit requires the cookie be JS-readable, so it is NOT HttpOnly.
+        assert.ok(!/HttpOnly/i.test(value));
+      },
+    );
+  });
+
+  test('does NOT issue the cookie on a write method', async () => {
+    await withApp(
+      (app) => {
+        app.use(csrfIssueCookie);
+        ok(app);
+      },
+      async ({ url }) => {
+        const res = await rawRequest(url, { method: 'POST' });
+        assert.equal(res.headers['set-cookie'], undefined);
+      },
+    );
+  });
+});
+
+describe('getCsrfToken — stable per-process boot token', () => {
+  test('returns the same token across calls', () => {
+    assert.equal(getCsrfToken(), getCsrfToken());
+    assert.ok(getCsrfToken().length > 0);
+  });
+});

--- a/backend/test/helpers/express-harness.ts
+++ b/backend/test/helpers/express-harness.ts
@@ -1,0 +1,92 @@
+// Shared harness for focused middleware tests (security.ts, csrf.ts).
+//
+// These middleware guard the bind/Host/Origin/CSRF invariants, so the tests
+// must drive them through a real express app — a hand-mocked req/res would not
+// prove the middleware behaves when wired the way app.ts wires it. The host
+// allowlist in particular keys off the raw `Host` header, which the WHATWG
+// fetch (undici) forbids callers from setting. `node:http.request` lets us set
+// `Host` (and any method/Origin) verbatim, so we drive the app with it instead
+// of `fetch`.
+
+import http, { type IncomingHttpHeaders } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+export interface RunningApp {
+  url: string;
+  close(): Promise<void>;
+}
+
+/** Start an express app the caller has configured, bound to 127.0.0.1:0. */
+export async function startApp(configure: (app: express.Express) => void): Promise<RunningApp> {
+  const app = express();
+  configure(app);
+  const server = await new Promise<Server>((resolve) => {
+    const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+/** Run `fn` against a freshly configured app and always tear the server down. */
+export async function withApp<T>(
+  configure: (app: express.Express) => void,
+  fn: (app: RunningApp) => Promise<T>,
+): Promise<T> {
+  const app = await startApp(configure);
+  try {
+    return await fn(app);
+  } finally {
+    await app.close();
+  }
+}
+
+export interface RawRequestOptions {
+  method?: string;
+  /** Verbatim request headers, including normally-protected ones like `Host`. */
+  headers?: Record<string, string>;
+}
+
+export interface RawResponse {
+  status: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+/**
+ * Issue a raw HTTP request that can carry an arbitrary `Host`/`Origin` header.
+ * `fetch` cannot set `Host`, which is exactly the header the DNS-rebinding
+ * defense inspects, so the security tests rely on this.
+ */
+export function rawRequest(url: string, options: RawRequestOptions = {}): Promise<RawResponse> {
+  const target = new URL(url);
+  const { method = 'GET', headers = {} } = options;
+  return new Promise<RawResponse>((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: target.hostname,
+        port: target.port,
+        path: target.pathname + target.search,
+        method,
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}

--- a/backend/test/security.test.ts
+++ b/backend/test/security.test.ts
@@ -1,0 +1,248 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Express } from 'express';
+
+import {
+  hostHeaderAllowlistFactory,
+  originCheck,
+  securityHeaders,
+} from '../src/middleware/security.js';
+import { withApp, rawRequest } from './helpers/express-harness.js';
+
+// Focused unit coverage for the DNS-rebinding / clickjacking / content-type
+// defenses (invariants #2/#3 — the 127.0.0.1-only posture). app.ts wires these
+// for real but never asserts their reject branches; this is the guard that a
+// future edit cannot silently widen the allowlist or drop the CSP.
+
+/** Terminal 200 handler so a middleware that calls next() is observable. */
+function ok(app: Express): void {
+  app.use((_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+}
+
+// The configured port is only used to BUILD the allowed-origin strings; it is
+// independent of the ephemeral port the test server actually binds.
+const ORIGIN_PORT = 8081;
+
+describe('hostHeaderAllowlistFactory — Host allowlist (DNS-rebinding defense)', () => {
+  test('allows the always-on localhost floor', async () => {
+    await withApp(
+      (app) => {
+        app.use(hostHeaderAllowlistFactory());
+        ok(app);
+      },
+      async ({ url }) => {
+        for (const host of ['127.0.0.1', 'localhost', '127.0.0.1:8081', 'LOCALHOST']) {
+          const res = await rawRequest(url, { headers: { Host: host } });
+          assert.equal(res.status, 200, `expected allow for Host: ${host}`);
+        }
+      },
+    );
+  });
+
+  test('rejects a foreign Host with 421 Misdirected Request', async () => {
+    await withApp(
+      (app) => {
+        app.use(hostHeaderAllowlistFactory());
+        ok(app);
+      },
+      async ({ url }) => {
+        const res = await rawRequest(url, { headers: { Host: 'evil.example.com' } });
+        assert.equal(res.status, 421);
+        assert.equal(res.body, 'Host not allowed');
+      },
+    );
+  });
+
+  test('rejects a request with no Host header at all with 421 (no next)', () => {
+    // HTTP/1.1 clients always send a Host, so this `host === null` branch is
+    // only reachable by invoking the middleware directly. It is the floor of
+    // the defense: a header-less request must never fall through to next().
+    const mw = hostHeaderAllowlistFactory();
+    let nexted = false;
+    let sentStatus = 0;
+    let sentBody: unknown;
+    const res = {
+      status(code: number) {
+        sentStatus = code;
+        return res;
+      },
+      type() {
+        return res;
+      },
+      send(body: unknown) {
+        sentBody = body;
+        return res;
+      },
+    };
+    mw({ headers: {} } as never, res as never, () => {
+      nexted = true;
+    });
+    assert.equal(nexted, false, 'a host-less request must not pass through');
+    assert.equal(sentStatus, 421);
+    assert.equal(sentBody, 'Host not allowed');
+  });
+
+  test('ADMIN_EXTRA_ALLOWED_HOSTS widens the floor, case-insensitively, and nothing else', async () => {
+    await withApp(
+      (app) => {
+        app.use(hostHeaderAllowlistFactory(['my-vm', '192.168.1.58']));
+        ok(app);
+      },
+      async ({ url }) => {
+        // The explicitly-added LAN names pass...
+        for (const host of ['my-vm', 'MY-VM', '192.168.1.58', 'my-vm:5174']) {
+          const res = await rawRequest(url, { headers: { Host: host } });
+          assert.equal(res.status, 200, `expected allow for widened Host: ${host}`);
+        }
+        // ...but an un-listed host still fails closed.
+        const denied = await rawRequest(url, { headers: { Host: 'other-vm' } });
+        assert.equal(denied.status, 421);
+      },
+    );
+  });
+});
+
+describe('originCheck — Origin guard on state-changing methods', () => {
+  function mount(app: Express, extra: ReadonlyArray<string> = []): void {
+    app.use(originCheck(ORIGIN_PORT, extra));
+    ok(app);
+  }
+
+  test('exempts safe methods regardless of Origin', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        for (const method of ['GET', 'HEAD', 'OPTIONS']) {
+          const res = await rawRequest(url, {
+            method,
+            headers: { Origin: 'http://evil.example.com' },
+          });
+          // HEAD has no body but still reports the status; all must pass.
+          assert.equal(res.status, 200, `expected ${method} to be exempt`);
+        }
+      },
+    );
+  });
+
+  test('allows a same-origin write (127.0.0.1 and localhost forms)', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        for (const origin of [
+          `http://127.0.0.1:${ORIGIN_PORT}`,
+          `http://localhost:${ORIGIN_PORT}`,
+        ]) {
+          const res = await rawRequest(url, { method: 'POST', headers: { Origin: origin } });
+          assert.equal(res.status, 200, `expected allow for Origin: ${origin}`);
+        }
+      },
+    );
+  });
+
+  test('rejects a foreign Origin on a write with 403 + kind "origin"', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { Origin: 'http://evil.example.com' },
+        });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Origin not allowed', kind: 'origin' });
+      },
+    );
+  });
+
+  test('rejects a write with NO Origin header (non-browser / forged) with 403', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, { method: 'POST' });
+        assert.equal(res.status, 403);
+        assert.deepEqual(JSON.parse(res.body), { error: 'Origin not allowed', kind: 'origin' });
+      },
+    );
+  });
+
+  test('rejects a write whose Origin matches an allowed host but the WRONG port', async () => {
+    await withApp(
+      (app) => mount(app),
+      async ({ url }) => {
+        const res = await rawRequest(url, {
+          method: 'POST',
+          headers: { Origin: `http://127.0.0.1:${ORIGIN_PORT + 1}` },
+        });
+        assert.equal(res.status, 403);
+      },
+    );
+  });
+
+  test('extra allowed hosts widen the Origin allowlist on the configured port', async () => {
+    await withApp(
+      (app) => mount(app, ['my-vm']),
+      async ({ url }) => {
+        const allowed = await rawRequest(url, {
+          method: 'POST',
+          headers: { Origin: `http://my-vm:${ORIGIN_PORT}` },
+        });
+        assert.equal(allowed.status, 200);
+        // Same host on a different port is still rejected.
+        const wrongPort = await rawRequest(url, {
+          method: 'POST',
+          headers: { Origin: `http://my-vm:${ORIGIN_PORT + 1}` },
+        });
+        assert.equal(wrongPort.status, 403);
+      },
+    );
+  });
+});
+
+describe('securityHeaders — CSP + clickjacking + sniff lockdown', () => {
+  test('sets the fixed defense headers and a locked-down CSP', async () => {
+    await withApp(
+      (app) => {
+        app.use(securityHeaders());
+        ok(app);
+      },
+      async ({ url }) => {
+        const res = await rawRequest(url);
+        assert.equal(res.headers['x-frame-options'], 'DENY');
+        assert.equal(res.headers['x-content-type-options'], 'nosniff');
+        assert.equal(res.headers['referrer-policy'], 'no-referrer');
+        const csp = res.headers['content-security-policy'];
+        assert.equal(typeof csp, 'string');
+        const directives = (csp as string).split('; ');
+        // The invariants the CSP exists to hold: no foreign script/connect, no
+        // framing, no base-tag hijack, same-origin forms only.
+        assert.ok(directives.includes("default-src 'self'"));
+        assert.ok(directives.includes("object-src 'none'"));
+        assert.ok(directives.includes("frame-ancestors 'none'"));
+        assert.ok(directives.includes("base-uri 'none'"));
+        assert.ok(directives.includes("form-action 'self'"));
+        assert.ok(directives.includes("connect-src 'self'"));
+        // The theme-boot inline script is pinned by hash, not 'unsafe-inline'.
+        const scriptSrc = directives.find((d) => d.startsWith('script-src '));
+        assert.ok(scriptSrc?.includes("'self'"));
+        assert.ok(scriptSrc?.includes("'sha256-"));
+        assert.ok(!scriptSrc?.includes("'unsafe-inline'"));
+      },
+    );
+  });
+
+  test('extra connect-src values are appended to self, never replacing it', async () => {
+    await withApp(
+      (app) => {
+        app.use(securityHeaders(['https://supervisor.example:9000']));
+        ok(app);
+      },
+      async ({ url }) => {
+        const res = await rawRequest(url);
+        const csp = res.headers['content-security-policy'] as string;
+        const directives = csp.split('; ');
+        assert.ok(directives.includes("connect-src 'self' https://supervisor.example:9000"));
+      },
+    );
+  });
+});


### PR DESCRIPTION
Adds focused unit coverage for the two security-boundary middleware the
DEEP_AUDIT flagged as untested — the invariants the rig exists to protect
(127.0.0.1 bind, Host/Origin allowlist, CSRF) — and which nothing else guards:

- security.test.ts: hostHeaderAllowlistFactory (allowed floor; foreign Host
  -> 421; host-less request -> 421 via direct call; ADMIN_EXTRA_ALLOWED_HOSTS
  widening, case-insensitive, fail-closed), originCheck (safe-method exempt;
  same-origin allow; foreign/missing Origin on a write -> 403; wrong-port
  reject; extra-host widening), securityHeaders (locked-down CSP directives,
  hash-pinned script-src with no unsafe-inline, connect-src append).
- csrf.test.ts: csrfValidate (safe-method exempt; valid double-submit; missing
  and empty header -> Missing; same-length-different token through the
  crypto.timingSafeEqual mismatch branch; wrong-length without crash ->
  Invalid), csrfIssueCookie (JS-readable SameSite=Strict cookie on GET, none
  on writes), getCsrfToken stability.
- test/helpers/express-harness.ts: shared real-express + raw-HTTP harness.
  Raw node:http is required because WHATWG fetch forbids setting Host, the
  exact header the DNS-rebinding defense inspects.

The other audit targets (supervisor-read-allowlist traversal, run-scope
parsers, city-dispatch async-reject) already have equivalent focused unit
tests in main; not duplicated. Test-only — no source change needed; every
invariant branch holds. Full CI parity: build:shared, typecheck src+test,
lint, 603/603 backend tests.
