### PR TITLE
feat(sse): client idle-watchdog degrades a silently half-open stream (934a)

### DIFF
--- a/frontend/src/hooks/useGcEvents.test.tsx
+++ b/frontend/src/hooks/useGcEvents.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, renderHook } from '@testing-library/react';
 import { GC_EVENT_PREFIX } from 'gas-city-dashboard-shared';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { reportClientError } from '../lib/clientErrorReporting';
-import { useGcEventRefresh } from './useGcEvents';
+import { SSE_IDLE_WATCHDOG_MS, useGcEventRefresh } from './useGcEvents';
 
 const eventSources: FakeEventSource[] = [];
 const mockReportClientError = reportClientError as Mock;
@@ -219,6 +219,89 @@ describe('useGcEventRefresh', () => {
       });
       // No reconnect after teardown.
       expect(eventSources).toHaveLength(1);
+    });
+  });
+
+  describe('idle-watchdog (half-open detection)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    const emitEvent = () =>
+      act(() => eventSources[0]?.emitNamed('event', JSON.stringify({ type: 'bead.updated' })));
+
+    it('flips an open-but-silent stream to degraded once the idle window elapses', () => {
+      const { result } = renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()));
+      act(() => eventSources[0]?.open());
+      expect(result.current).toBe('open');
+
+      // Just before the window closes the stream still reads live.
+      act(() => {
+        vi.advanceTimersByTime(SSE_IDLE_WATCHDOG_MS - 1);
+      });
+      expect(result.current).toBe('open');
+
+      // At the window edge a silently half-open socket degrades to ochre.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current).toBe('degraded');
+    });
+
+    it('keeps a continuously-active stream open — each event re-arms the watchdog', () => {
+      const { result } = renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()));
+      act(() => eventSources[0]?.open());
+
+      // An event arriving just shy of every window keeps resetting the timer,
+      // so the stream never trips the watchdog across several windows.
+      for (let i = 0; i < 3; i++) {
+        act(() => {
+          vi.advanceTimersByTime(SSE_IDLE_WATCHDOG_MS - 1);
+        });
+        emitEvent();
+        expect(result.current).toBe('open');
+      }
+    });
+
+    it('recovers to open when an event arrives after the watchdog degraded it', () => {
+      const { result } = renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()));
+      act(() => eventSources[0]?.open());
+
+      act(() => {
+        vi.advanceTimersByTime(SSE_IDLE_WATCHDOG_MS);
+      });
+      expect(result.current).toBe('degraded');
+
+      // A real event proves the socket is alive again: liveness recovers.
+      emitEvent();
+      expect(result.current).toBe('open');
+    });
+
+    it('does not fire the watchdog after the stream errors and closes', () => {
+      const { result } = renderHook(() => useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()));
+      act(() => eventSources[0]?.open());
+      act(() => eventSources[0]?.error());
+      expect(result.current).toBe('closed');
+
+      // The idle timer was cleared on close, so advancing past the window must
+      // not resurrect a stale 'degraded' over the real 'closed'/reconnect state.
+      act(() => {
+        vi.advanceTimersByTime(SSE_IDLE_WATCHDOG_MS);
+      });
+      expect(result.current).not.toBe('degraded');
+    });
+
+    it('cancels the watchdog on unmount so no state update lands after teardown', () => {
+      const { result, unmount } = renderHook(() =>
+        useGcEventRefresh([GC_EVENT_PREFIX.bead], vi.fn()),
+      );
+      act(() => eventSources[0]?.open());
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(SSE_IDLE_WATCHDOG_MS);
+      });
+      // No throw and the last observed state is the pre-unmount 'open'.
+      expect(result.current).toBe('open');
     });
   });
 

--- a/frontend/src/hooks/useGcEvents.ts
+++ b/frontend/src/hooks/useGcEvents.ts
@@ -37,6 +37,24 @@ const CONNECTING_GRACE_MS = 2_000;
 const DEFAULT_COALESCE_MS = 2_500;
 
 /**
+ * Idle-watchdog window. An EventSource can silently half-open — the TCP socket
+ * stays up, no `onerror` fires, the server just stops emitting — leaving
+ * `sseState` stuck at 'open' while the data behind it freezes (gascity-dashboard-934a).
+ * When no event of any kind (open, named, malformed) arrives within this window
+ * we flip to 'degraded' (the existing ochre tier — One-Mark safe, not a second
+ * primary mark) so liveness stops reading a dead stream as live.
+ *
+ * The window is deliberately conservative. The gc supervisor does not yet emit a
+ * periodic heartbeat (that real-time detector is the deferred, mayor-owned
+ * upstream follow-up), so on a quiet-but-healthy city the only events are real
+ * activity. A short window would false-degrade a normally-idle runs board; this
+ * 5-minute bound trades slower half-open detection for not crying wolf during
+ * ordinary lulls. Once the server heartbeat lands this drops to a small multiple
+ * of the heartbeat interval.
+ */
+export const SSE_IDLE_WATCHDOG_MS = 300_000;
+
+/**
  * Subscribe to gc events. When an event whose type starts with any of
  * `prefixes` arrives, `onMatch` is invoked. Designed for "refresh this
  * panel when its underlying data changed" — pass refresh().
@@ -78,6 +96,7 @@ export function useGcEventRefresh(
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let connectGraceTimer: ReturnType<typeof setTimeout> | null = null;
+    let idleWatchdog: ReturnType<typeof setTimeout> | null = null;
     let retryDelayMs = 1_000;
     let malformedEventReported = false;
 
@@ -85,6 +104,22 @@ export function useGcEventRefresh(
       if (connectGraceTimer === null) return;
       clearTimeout(connectGraceTimer);
       connectGraceTimer = null;
+    };
+    const clearIdleWatchdog = () => {
+      if (idleWatchdog === null) return;
+      clearTimeout(idleWatchdog);
+      idleWatchdog = null;
+    };
+    // Arm (or re-arm) the half-open detector. Called whenever the stream is
+    // proven live — on open and on every received event — so a continuously
+    // active stream never trips it; only true silence past the window does.
+    const armIdleWatchdog = () => {
+      clearIdleWatchdog();
+      idleWatchdog = setTimeout(() => {
+        if (cancelled) return;
+        idleWatchdog = null;
+        setState('degraded');
+      }, SSE_IDLE_WATCHDOG_MS);
     };
     const reportMalformedEventOnce = (reason: string) => {
       if (malformedEventReported) return;
@@ -135,11 +170,13 @@ export function useGcEventRefresh(
       connectGraceTimer = setTimeout(() => {
         if (cancelled || es !== source || source.readyState === EventSourceCtor.CLOSED) return;
         setState('open');
+        armIdleWatchdog();
       }, CONNECTING_GRACE_MS);
       es.onopen = () => {
         if (cancelled) return;
         clearConnectGraceTimer();
         setState('open');
+        armIdleWatchdog();
         retryDelayMs = 1_000;
       };
       // gc supervisor sends events with `event: event` (the event NAME
@@ -150,6 +187,9 @@ export function useGcEventRefresh(
       // names them.
       const handleData = (msg: MessageEvent<string>) => {
         if (cancelled) return;
+        // Any received frame — even a malformed one — proves the socket is
+        // still delivering, so reset the half-open detector before dispatch.
+        armIdleWatchdog();
         let parsed: unknown = null;
         try {
           parsed = JSON.parse(msg.data);
@@ -183,6 +223,7 @@ export function useGcEventRefresh(
       es.onerror = () => {
         if (cancelled) return;
         clearConnectGraceTimer();
+        clearIdleWatchdog();
         setState('closed');
         es?.close();
         es = null;
@@ -200,6 +241,7 @@ export function useGcEventRefresh(
       cancelled = true;
       if (retryTimer) clearTimeout(retryTimer);
       clearConnectGraceTimer();
+      clearIdleWatchdog();
       if (coalesceTimerRef.current) {
         clearTimeout(coalesceTimerRef.current);
         coalesceTimerRef.current = null;


### PR DESCRIPTION
An EventSource can half-open silently: the TCP socket stays up, no onerror
fires, the server just stops emitting. sseState stayed 'open', no event ran
onSseMatch/runRefresh, and runs (which carries no staleAt and has no
independent poll) froze while still reading as live.

Arm an idle-watchdog in useGcEventRefresh: on open, and on every received
frame, (re)start a timer; if no event of any kind arrives within
SSE_IDLE_WATCHDOG_MS, flip sseState to 'degraded' — the existing ochre tier
(One-Mark safe, not a second primary mark). Reset on each event, recover to
'open' when one lands, and clear on error/close and unmount.

Scope is client-only per the resolved bead direction: no server-side
heartbeat dependency (that real-time detector is the deferred, mayor-owned
gc-supervisor follow-up). The 5-minute window is deliberately conservative
so a normally-idle runs board does not false-degrade; it tightens to a
small multiple of the heartbeat interval once the server heartbeat lands.
No shared/ wire change, no bind/Origin change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
