### PR TITLE
feat: Convoy nav tab + /convoy index

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,9 @@ const AmbientHomePage = lazy(() =>
 );
 const BeadsPage = lazy(() => import('./routes/Beads').then((m) => ({ default: m.BeadsPage })));
 const ConvoyPage = lazy(() => import('./routes/Convoy').then((m) => ({ default: m.ConvoyPage })));
+const ConvoyIndexPage = lazy(() =>
+  import('./routes/ConvoyIndex').then((m) => ({ default: m.ConvoyIndex })),
+);
 const MailPage = lazy(() => import('./routes/Mail').then((m) => ({ default: m.MailPage })));
 const FormulaRunDetailPage = lazy(() =>
   import('./routes/FormulaRunDetail').then((m) => ({ default: m.FormulaRunDetailPage })),
@@ -102,6 +105,7 @@ export function App() {
                       <Route path="/agents" element={<AgentsPage />} />
                       <Route path="/agents/:slug" element={<AgentDetailPage />} />
                       <Route path="/beads" element={<BeadsPage />} />
+                      <Route path="/convoy" element={<ConvoyIndexPage />} />
                       <Route path="/convoy/:rootBead" element={<ConvoyPage />} />
                       <Route path="/runs" element={<RunsPage />} />
                       <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -94,9 +94,24 @@ describe('Header mobile nav', () => {
     fireEvent.click(screen.getByRole('button', { name: /menu/i }));
     const dialog = within(screen.getByRole('dialog'));
     // Scope to the dialog: the desktop row keeps its own copy of each link.
-    for (const label of ['Home', 'Agents', 'Beads', 'Runs', 'Mail']) {
+    for (const label of ['Home', 'Agents', 'Beads', 'Runs', 'Convoy', 'Mail']) {
       expect(dialog.getByRole('link', { name: new RegExp(label) })).toBeTruthy();
     }
+  });
+
+  it('gives Convoy a top-level tab pointing at /convoy, ordered between Runs and Mail', () => {
+    // gascity-dashboard-0chv3: the convoy view had no front door — this is it.
+    const { container } = renderHeader();
+    const desktopList = container.querySelector('ul.sm\\:flex') as HTMLElement;
+    expect(desktopList).not.toBeNull();
+    const convoy = within(desktopList).getByRole('link', { name: /Convoy/ });
+    expect(convoy.getAttribute('href')).toBe('/convoy');
+    // Order is explicit (45), so Convoy sits after Runs and before Mail. Assert
+    // the relative order without pinning the full set — registry-driven views may
+    // also be present depending on the async config fetch's timing.
+    const labels = Array.from(desktopList.querySelectorAll('a')).map((a) => a.textContent ?? '');
+    expect(labels.indexOf('Runs')).toBeLessThan(labels.indexOf('Convoy'));
+    expect(labels.indexOf('Convoy')).toBeLessThan(labels.indexOf('Mail'));
   });
 
   it('closes the menu when a route is selected', () => {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -53,7 +53,7 @@ const NAV_ATTENTION_DOMAINS: Readonly<Record<string, AttentionDomain>> = {
 };
 
 // The header is page furniture, not chrome. A small wordmark, the
-// five route names typeset as a row, a textual theme toggle. The
+// route names typeset as a row, a textual theme toggle. The
 // route weight contrast IS the active-state affordance; no underline,
 // no background pill.
 export function Header() {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -36,6 +36,9 @@ const EXPLICIT_ROUTES: ReadonlyArray<NavRoute> = [
   { to: '/agents', label: 'Agents', order: 20 },
   { to: '/beads', label: 'Beads', order: 30 },
   { to: '/runs', label: 'Runs', order: 40 },
+  // gascity-dashboard-0chv3: Convoy gets a real front door between Runs and Mail
+  // (the /convoy index lists active convoy roots; detail stays at /convoy/:root).
+  { to: '/convoy', label: 'Convoy', order: 45 },
   { to: '/mail', label: 'Mail', order: 50 },
 ];
 

--- a/frontend/src/hooks/useConvoyRoots.ts
+++ b/frontend/src/hooks/useConvoyRoots.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { formatApiError } from '../api/client';
+import { loadActiveConvoyRoots, type ConvoyRootsLoad } from '../supervisor/convoyReads';
+
+// Fetch the active-convoy roots for the /convoy index (gascity-dashboard-0chv3).
+//
+// Mirrors useConvoyView: the convoy set changes slowly relative to a session, so
+// this is static-with-explicit-refresh — it loads once on mount and exposes a
+// `refresh` for the page's Refresh control rather than wiring an SSE
+// auto-refresh. There is no `not_found` state: an empty city is the legitimate
+// `ready` state with zero roots, which the page renders as the calm empty
+// notice, not an error.
+
+export type ConvoyRootsState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; load: ConvoyRootsLoad; refreshing: boolean }
+  | { kind: 'failed'; error: string };
+
+export interface UseConvoyRoots {
+  state: ConvoyRootsState;
+  refresh: () => Promise<void>;
+}
+
+export function useConvoyRoots(): UseConvoyRoots {
+  const [state, setState] = useState<ConvoyRootsState>({ kind: 'loading' });
+  // A refresh that resolves after the page unmounted must not setState on a
+  // dead component, so each load checks it is still the live one.
+  const mountedRef = useRef(true);
+
+  const load = useCallback(async (mode: 'initial' | 'refresh'): Promise<void> => {
+    setState((prev) =>
+      mode === 'refresh' && prev.kind === 'ready'
+        ? { ...prev, refreshing: true }
+        : { kind: 'loading' },
+    );
+    try {
+      const result = await loadActiveConvoyRoots();
+      if (mountedRef.current) setState({ kind: 'ready', load: result, refreshing: false });
+    } catch (err) {
+      if (mountedRef.current) {
+        setState({ kind: 'failed', error: formatApiError(err, 'convoy list load failed') });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void load('initial');
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [load]);
+
+  const refresh = useCallback(() => load('refresh'), [load]);
+
+  return { state, refresh };
+}

--- a/frontend/src/hooks/useConvoyRoots.ts
+++ b/frontend/src/hooks/useConvoyRoots.ts
@@ -23,35 +23,43 @@ export interface UseConvoyRoots {
 
 export function useConvoyRoots(): UseConvoyRoots {
   const [state, setState] = useState<ConvoyRootsState>({ kind: 'loading' });
-  // A refresh that resolves after the page unmounted must not setState on a
-  // dead component, so each load checks it is still the live one.
-  const mountedRef = useRef(true);
 
-  const load = useCallback(async (mode: 'initial' | 'refresh'): Promise<void> => {
-    setState((prev) =>
-      mode === 'refresh' && prev.kind === 'ready'
-        ? { ...prev, refreshing: true }
-        : { kind: 'loading' },
-    );
-    try {
-      const result = await loadActiveConvoyRoots();
-      if (mountedRef.current) setState({ kind: 'ready', load: result, refreshing: false });
-    } catch (err) {
-      if (mountedRef.current) {
+  const load = useCallback(
+    async (mode: 'initial' | 'refresh', isCurrent: () => boolean): Promise<void> => {
+      setState((prev) =>
+        mode === 'refresh' && prev.kind === 'ready'
+          ? { ...prev, refreshing: true }
+          : { kind: 'loading' },
+      );
+      try {
+        const result = await loadActiveConvoyRoots();
+        if (isCurrent()) setState({ kind: 'ready', load: result, refreshing: false });
+      } catch (err) {
+        if (!isCurrent()) return;
         setState({ kind: 'failed', error: formatApiError(err, 'convoy list load failed') });
       }
-    }
-  }, []);
+    },
+    [],
+  );
+
+  // The live mount's freshness check. The effect rebinds it per run to a fresh
+  // `() => !cancelled`, so a load — initial OR a refresh() resolving after a
+  // StrictMode unmount/remount — never overwrites the current mount's state with
+  // a stale result. Mirrors useConvoyView's per-effect `cancelled` guard (it has
+  // a liveRootRef because its key can change; this hook has no key, so the guard
+  // is purely mount-generation).
+  const isCurrentRef = useRef<() => boolean>(() => true);
 
   useEffect(() => {
-    mountedRef.current = true;
-    void load('initial');
+    let cancelled = false;
+    isCurrentRef.current = () => !cancelled;
+    void load('initial', () => !cancelled);
     return () => {
-      mountedRef.current = false;
+      cancelled = true;
     };
   }, [load]);
 
-  const refresh = useCallback(() => load('refresh'), [load]);
+  const refresh = useCallback(() => load('refresh', () => isCurrentRef.current()), [load]);
 
   return { state, refresh };
 }

--- a/frontend/src/lib/beadStatusGlyph.ts
+++ b/frontend/src/lib/beadStatusGlyph.ts
@@ -1,0 +1,29 @@
+import type { BeadStatus } from 'gas-city-dashboard-shared';
+
+// Greyscale-neutral bead-status vocabulary for LIST surfaces (the convoy
+// timeline and the /convoy index). A list of many beads must not paint several
+// maroons, so per DESIGN.md's One Mark Rule status here is carried by the glyph
+// and word, never by tone — keeping the list readable under the Greyscale Test.
+// (Single-status surfaces that can afford the accent use StatusBadge instead.)
+
+export interface BeadStatusDisplay {
+  glyph: string;
+  word: string;
+}
+
+export function describeBeadStatus(status: BeadStatus): BeadStatusDisplay {
+  switch (status) {
+    case 'closed':
+      return { glyph: '✓', word: 'closed' };
+    case 'in_progress':
+      return { glyph: '●', word: 'in progress' };
+    case 'blocked':
+      return { glyph: '!', word: 'blocked' };
+    case 'deferred':
+      return { glyph: '∅', word: 'deferred' };
+    case 'open':
+      return { glyph: '·', word: 'open' };
+    default:
+      return { glyph: '·', word: status };
+  }
+}

--- a/frontend/src/routes/Convoy.tsx
+++ b/frontend/src/routes/Convoy.tsx
@@ -1,12 +1,8 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import type {
-  ConvoyStep,
-  ConvoyStepExposure,
-  ConvoyView,
-  BeadStatus,
-} from 'gas-city-dashboard-shared';
+import type { ConvoyStep, ConvoyStepExposure, ConvoyView } from 'gas-city-dashboard-shared';
 import { Button } from '../components/Button';
+import { describeBeadStatus } from '../lib/beadStatusGlyph';
 import { PageHeader } from '../components/PageHeader';
 import { PartialDataNotice } from '../components/PartialDataNotice';
 import { RelatedEntities } from '../components/RelatedEntities';
@@ -179,7 +175,7 @@ function ConvoyTimeline({ exposure }: { exposure: ConvoyStepExposure }) {
 }
 
 function StepRow({ step }: { step: ConvoyStep }) {
-  const status = describeStatus(step.bead.status);
+  const status = describeBeadStatus(step.bead.status);
   return (
     <li className="border-b border-rule pb-3 last:border-b-0">
       <div className="flex items-baseline justify-between gap-3">
@@ -200,29 +196,4 @@ function StepRow({ step }: { step: ConvoyStep }) {
       </div>
     </li>
   );
-}
-
-interface StatusDisplay {
-  glyph: string;
-  word: string;
-}
-
-// Bead-status glyph + word, kept greyscale-neutral so the timeline honors the
-// One Mark Rule: a list of many steps must not paint several maroons. Status is
-// carried by the glyph and word, not tone (DESIGN.md "states have words").
-function describeStatus(status: BeadStatus): StatusDisplay {
-  switch (status) {
-    case 'closed':
-      return { glyph: '✓', word: 'closed' };
-    case 'in_progress':
-      return { glyph: '●', word: 'in progress' };
-    case 'blocked':
-      return { glyph: '!', word: 'blocked' };
-    case 'deferred':
-      return { glyph: '∅', word: 'deferred' };
-    case 'open':
-      return { glyph: '·', word: 'open' };
-    default:
-      return { glyph: '·', word: status };
-  }
 }

--- a/frontend/src/routes/ConvoyIndex.test.tsx
+++ b/frontend/src/routes/ConvoyIndex.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 import type { ConvoyRootsLoad, ConvoyRootSummary } from '../supervisor/convoyReads';
@@ -77,14 +77,29 @@ describe('ConvoyIndex', () => {
     expect(await screen.findByText('name inferred from bead title')).toBeTruthy();
   });
 
-  it('renders the calm empty state when no convoys are active', async () => {
+  it('renders the calm empty state when no convoys are active, with no 0-count synopsis', async () => {
     mockLoad.mockResolvedValue({ partial: false, roots: [] } satisfies ConvoyRootsLoad);
     renderIndex();
 
     expect(await screen.findByText('No active convoys.')).toBeTruthy();
+    // The synopsis is suppressed at zero so it does not echo "0 active convoys."
+    // alongside the body's "No active convoys." (dual-text coherence).
+    expect(screen.queryByText('0 active convoys.')).toBeNull();
   });
 
-  it('shows the partial-truncation notice when the city scan was truncated', async () => {
+  it('qualifies the empty state as bounded when a truncated scan found no roots', async () => {
+    // partial=true means the scan may have hidden roots, so the page must not
+    // claim an absolute zero — it scopes the empty copy to the scanned window
+    // and keeps the truncation notice. (Same lower-bound honesty as the detail.)
+    mockLoad.mockResolvedValue({ partial: true, roots: [] } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    expect(await screen.findByText('No active convoys in the scanned window.')).toBeTruthy();
+    expect(screen.queryByText('No active convoys.')).toBeNull();
+    expect(screen.getByText(/Partial list: the city bead read was truncated/)).toBeTruthy();
+  });
+
+  it('shows the partial-truncation notice and a lower-bound synopsis when truncated', async () => {
     mockLoad.mockResolvedValue({
       partial: true,
       roots: [root()],
@@ -94,6 +109,34 @@ describe('ConvoyIndex', () => {
     // The row still renders; the notice warns the list may be incomplete.
     expect(await screen.findByRole('link', { name: 'mol-focus-review' })).toBeTruthy();
     expect(screen.getByText(/Partial list: the city bead read was truncated/)).toBeTruthy();
+    // The count is a floor under truncation, not an exact total.
+    expect(screen.getByText('At least 1 active convoy.')).toBeTruthy();
+  });
+
+  it('reloads the root list when Refresh is pressed', async () => {
+    mockLoad
+      .mockResolvedValueOnce({
+        partial: false,
+        roots: [root({ rootBeadId: 'gc-root-1', formulaName: 'mol-focus-review' })],
+      } satisfies ConvoyRootsLoad)
+      .mockResolvedValueOnce({
+        partial: false,
+        roots: [
+          root({ rootBeadId: 'gc-root-1', formulaName: 'mol-focus-review' }),
+          root({ rootBeadId: 'gc-root-2', formulaName: 'mol-pr-iterate' }),
+        ],
+      } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    await screen.findByRole('link', { name: 'mol-focus-review' });
+    expect(screen.queryByRole('link', { name: 'mol-pr-iterate' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }));
+
+    // The refresh path (load('refresh', isCurrent)) lands the newer set without
+    // a stale earlier resolution clobbering it.
+    expect(await screen.findByRole('link', { name: 'mol-pr-iterate' })).toBeTruthy();
+    expect(mockLoad).toHaveBeenCalledTimes(2);
   });
 
   it('renders an error line when the scan fails', async () => {

--- a/frontend/src/routes/ConvoyIndex.test.tsx
+++ b/frontend/src/routes/ConvoyIndex.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { ConvoyRootsLoad, ConvoyRootSummary } from '../supervisor/convoyReads';
+import { ConvoyIndex } from './ConvoyIndex';
+
+const mockLoadActiveConvoyRoots = vi.hoisted(() => vi.fn());
+vi.mock('../supervisor/convoyReads', () => ({
+  loadActiveConvoyRoots: mockLoadActiveConvoyRoots,
+}));
+
+const mockLoad = mockLoadActiveConvoyRoots as Mock;
+
+function root(overrides: Partial<ConvoyRootSummary> = {}): ConvoyRootSummary {
+  return {
+    rootBeadId: 'gc-root-1',
+    title: 'root bead 1',
+    status: 'in_progress',
+    formulaName: 'mol-focus-review',
+    formulaNameProvenance: 'metadata',
+    ...overrides,
+  };
+}
+
+function renderIndex() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/convoy']}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <ConvoyIndex />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mockLoad.mockReset();
+});
+
+describe('ConvoyIndex', () => {
+  it('shows a loading line while the bounded scan is in flight', () => {
+    // A pending promise keeps the hook in its loading state.
+    mockLoad.mockReturnValue(new Promise<ConvoyRootsLoad>(() => {}));
+    renderIndex();
+    expect(screen.getByText('Loading convoys.')).toBeTruthy();
+  });
+
+  it('lists each active convoy root as a row linking to its detail page', async () => {
+    mockLoad.mockResolvedValue({
+      partial: false,
+      roots: [
+        root({ rootBeadId: 'gc-root-1', formulaName: 'mol-focus-review', status: 'in_progress' }),
+        root({ rootBeadId: 'gc-root-2', formulaName: 'mol-pr-iterate', status: 'blocked' }),
+      ],
+    } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    const first = await screen.findByRole('link', { name: 'mol-focus-review' });
+    expect(first.getAttribute('href')).toBe('/convoy/gc-root-1');
+    const second = screen.getByRole('link', { name: 'mol-pr-iterate' });
+    expect(second.getAttribute('href')).toBe('/convoy/gc-root-2');
+    // Status reads as a word (greyscale-safe), not by color alone.
+    expect(screen.getByText('in progress')).toBeTruthy();
+    expect(screen.getByText('blocked')).toBeTruthy();
+    // Synopsis counts the active convoys.
+    expect(screen.getByText('2 active convoys.')).toBeTruthy();
+  });
+
+  it('surfaces a title-inferred formula name honestly', async () => {
+    mockLoad.mockResolvedValue({
+      partial: false,
+      roots: [root({ formulaName: 'mol-smoke', formulaNameProvenance: 'title_fallback' })],
+    } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    expect(await screen.findByText('name inferred from bead title')).toBeTruthy();
+  });
+
+  it('renders the calm empty state when no convoys are active', async () => {
+    mockLoad.mockResolvedValue({ partial: false, roots: [] } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    expect(await screen.findByText('No active convoys.')).toBeTruthy();
+  });
+
+  it('shows the partial-truncation notice when the city scan was truncated', async () => {
+    mockLoad.mockResolvedValue({
+      partial: true,
+      roots: [root()],
+    } satisfies ConvoyRootsLoad);
+    renderIndex();
+
+    // The row still renders; the notice warns the list may be incomplete.
+    expect(await screen.findByRole('link', { name: 'mol-focus-review' })).toBeTruthy();
+    expect(screen.getByText(/Partial list: the city bead read was truncated/)).toBeTruthy();
+  });
+
+  it('renders an error line when the scan fails', async () => {
+    mockLoad.mockRejectedValue(new Error('supervisor unreachable'));
+    renderIndex();
+
+    const alert = await screen.findByRole('alert');
+    expect(within(alert).getByText(/supervisor unreachable/)).toBeTruthy();
+  });
+});

--- a/frontend/src/routes/ConvoyIndex.tsx
+++ b/frontend/src/routes/ConvoyIndex.tsx
@@ -23,12 +23,19 @@ export function ConvoyIndex() {
   const loading = state.kind === 'loading';
   const refreshing = ready?.refreshing ?? false;
   const roots = ready?.load.roots ?? [];
+  // A truncated scan may have hidden roots, so every count is a LOWER BOUND
+  // (same honesty bar as the convoy detail page's partial state). The synopsis
+  // qualifies the count and the empty state never claims an absolute zero.
+  const partial = ready?.load.partial ?? false;
 
   return (
     <section>
       <PageHeader
         title="Convoys"
-        synopsis={ready ? convoysSynopsis(roots.length) : undefined}
+        // Only carry a synopsis when there is a count to report — at zero the
+        // body's empty notice is the single, coherent message (no "0 active
+        // convoys." echoing "No active convoys.").
+        synopsis={ready && roots.length > 0 ? convoysSynopsis(roots.length, partial) : undefined}
         meta={
           <Button size="sm" onClick={() => void refresh()} disabled={loading || refreshing}>
             {refreshing ? 'Refreshing' : 'Refresh'}
@@ -53,7 +60,7 @@ export function ConvoyIndex() {
           )}
           {roots.length === 0 ? (
             <p className="text-body text-fg-muted" role="status">
-              No active convoys.
+              {partial ? 'No active convoys in the scanned window.' : 'No active convoys.'}
             </p>
           ) : (
             <ol className="space-y-3">
@@ -68,8 +75,10 @@ export function ConvoyIndex() {
   );
 }
 
-function convoysSynopsis(count: number): string {
-  return count === 1 ? '1 active convoy.' : `${count} active convoys.`;
+function convoysSynopsis(count: number, partial: boolean): string {
+  const noun = count === 1 ? 'active convoy' : 'active convoys';
+  // Under a truncated scan the count is a floor, not the whole set.
+  return partial ? `At least ${count} ${noun}.` : `${count} ${noun}.`;
 }
 
 function ConvoyRootRow({ root }: { root: ConvoyRootSummary }) {

--- a/frontend/src/routes/ConvoyIndex.tsx
+++ b/frontend/src/routes/ConvoyIndex.tsx
@@ -1,0 +1,102 @@
+import { Link } from 'react-router-dom';
+import { Button } from '../components/Button';
+import { PageHeader } from '../components/PageHeader';
+import { PartialDataNotice } from '../components/PartialDataNotice';
+import { describeBeadStatus } from '../lib/beadStatusGlyph';
+import { useConvoyRoots } from '../hooks/useConvoyRoots';
+import type { ConvoyRootSummary } from '../supervisor/convoyReads';
+
+// The /convoy index (gascity-dashboard-0chv3): the front door the detail page
+// never had. It lists the active convoys (graph.v2 run roots still in flight)
+// derived from the same bounded city bead scan the detail page uses, each row
+// linking to the existing /convoy/:rootBead view. Status reads neutral (One Mark
+// Rule: a list must not paint several maroons); the empty city is a calm notice,
+// not an alert.
+
+const TITLE_FALLBACK_TOOLTIP =
+  'name inferred from bead title; supervisor did not set gc.formula on this graph.v2 root';
+
+export function ConvoyIndex() {
+  const { state, refresh } = useConvoyRoots();
+
+  const ready = state.kind === 'ready' ? state : null;
+  const loading = state.kind === 'loading';
+  const refreshing = ready?.refreshing ?? false;
+  const roots = ready?.load.roots ?? [];
+
+  return (
+    <section>
+      <PageHeader
+        title="Convoys"
+        synopsis={ready ? convoysSynopsis(roots.length) : undefined}
+        meta={
+          <Button size="sm" onClick={() => void refresh()} disabled={loading || refreshing}>
+            {refreshing ? 'Refreshing' : 'Refresh'}
+          </Button>
+        }
+      />
+
+      {loading ? (
+        <p className="text-body text-fg-muted italic">Loading convoys.</p>
+      ) : state.kind === 'failed' ? (
+        <p className="text-body text-accent" role="alert">
+          {state.error}
+        </p>
+      ) : ready ? (
+        <>
+          {ready.load.partial && (
+            <PartialDataNotice
+              glyph="◐"
+              label="Partial list: the city bead read was truncated, so some convoys may be missing."
+              title="Raise the fetch window if convoys sit past the bounded read."
+            />
+          )}
+          {roots.length === 0 ? (
+            <p className="text-body text-fg-muted" role="status">
+              No active convoys.
+            </p>
+          ) : (
+            <ol className="space-y-3">
+              {roots.map((root) => (
+                <ConvoyRootRow key={root.rootBeadId} root={root} />
+              ))}
+            </ol>
+          )}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function convoysSynopsis(count: number): string {
+  return count === 1 ? '1 active convoy.' : `${count} active convoys.`;
+}
+
+function ConvoyRootRow({ root }: { root: ConvoyRootSummary }) {
+  const status = describeBeadStatus(root.status);
+  const inferred = root.formulaNameProvenance === 'title_fallback';
+  const name = root.formulaName ?? root.title;
+  return (
+    <li className="border-b border-rule pb-3 last:border-b-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <Link
+          to={`/convoy/${encodeURIComponent(root.rootBeadId)}`}
+          className="focus-mark text-body text-fg hover:text-accent leading-snug min-w-0 break-words"
+        >
+          {name}
+        </Link>
+        <span className="text-label uppercase tracking-wider text-fg-muted shrink-0">
+          <span aria-hidden="true">{status.glyph}</span> {status.word}
+        </span>
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-4 text-label uppercase tracking-wider text-fg-faint">
+        <span className="tnum">{root.rootBeadId}</span>
+        {inferred && (
+          <span className="text-warn" title={TITLE_FALLBACK_TOOLTIP}>
+            name inferred from bead title
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Bead } from 'gas-city-dashboard-shared/gc-supervisor';
 import type { SupervisorBeadList } from './beadReads';
-import { loadConvoyView } from './convoyReads';
+import { loadActiveConvoyRoots, loadConvoyView } from './convoyReads';
+
+const GRAPH_V2_META = {
+  'gc.formula_contract': 'graph.v2',
+  'gc.routed_to': 'city/claude-1',
+} as const;
 
 const mockFetchSupervisorBead = vi.hoisted(() => vi.fn());
 const mockListSupervisorBeads = vi.hoisted(() => vi.fn());
@@ -237,5 +242,79 @@ describe('loadConvoyView', () => {
     const load = await loadConvoyView('root');
 
     expect(load.view.exposure).toEqual({ kind: 'collapsed', reason: 'no_children' });
+  });
+});
+
+describe('loadActiveConvoyRoots', () => {
+  it('keeps only in-flight graph.v2 run roots, sorted newest first', async () => {
+    mockListSupervisorBeads.mockResolvedValue(
+      list([
+        bead('gc-old', {
+          status: 'in_progress',
+          metadata: { ...GRAPH_V2_META },
+          created_at: '2026-06-12T00:00:00Z',
+        }),
+        bead('gc-new', {
+          status: 'blocked',
+          metadata: { ...GRAPH_V2_META },
+          created_at: '2026-06-12T05:00:00Z',
+        }),
+        // Excluded: graph.v2 root but terminal (a finished convoy drops off).
+        bead('gc-done', {
+          status: 'closed',
+          metadata: { ...GRAPH_V2_META },
+          created_at: '2026-06-12T06:00:00Z',
+        }),
+        // Excluded: has the contract label but no run target (not a runnable root).
+        bead('gc-no-target', {
+          status: 'open',
+          metadata: { 'gc.formula_contract': 'graph.v2' },
+        }),
+        // Excluded: an ordinary bead with no convoy contract at all.
+        bead('gc-plain', { status: 'open' }),
+      ]),
+    );
+
+    const { roots, partial } = await loadActiveConvoyRoots();
+
+    expect(roots.map((r) => r.rootBeadId)).toEqual(['gc-new', 'gc-old']);
+    expect(partial).toBe(false);
+  });
+
+  it('resolves the formula name + provenance from the root, falling back to the title', async () => {
+    mockListSupervisorBeads.mockResolvedValue(
+      list([
+        bead('gc-explicit', {
+          status: 'in_progress',
+          metadata: { ...GRAPH_V2_META, 'gc.formula': 'mol-pr-iterate' },
+        }),
+        bead('gc-inferred', {
+          title: 'mol-focus-review',
+          status: 'in_progress',
+          metadata: { ...GRAPH_V2_META },
+        }),
+      ]),
+    );
+
+    const { roots } = await loadActiveConvoyRoots();
+    const byId = new Map(roots.map((r) => [r.rootBeadId, r]));
+    expect(byId.get('gc-explicit')).toMatchObject({
+      formulaName: 'mol-pr-iterate',
+      formulaNameProvenance: 'metadata',
+    });
+    expect(byId.get('gc-inferred')).toMatchObject({
+      formulaName: 'mol-focus-review',
+      formulaNameProvenance: 'title_fallback',
+    });
+  });
+
+  it('propagates the bounded-scan truncation flag so the page can warn', async () => {
+    mockListSupervisorBeads.mockResolvedValue(
+      list([bead('gc-1', { status: 'in_progress', metadata: { ...GRAPH_V2_META } })], {
+        partial: true,
+      }),
+    );
+
+    expect((await loadActiveConvoyRoots()).partial).toBe(true);
   });
 });

--- a/frontend/src/supervisor/convoyReads.test.ts
+++ b/frontend/src/supervisor/convoyReads.test.ts
@@ -317,4 +317,24 @@ describe('loadActiveConvoyRoots', () => {
 
     expect((await loadActiveConvoyRoots()).partial).toBe(true);
   });
+
+  it('excludes a step CHILD bead from the root list — only the run root is a convoy', async () => {
+    // The city-wide scan can surface a graph.v2 run root's step children. A step
+    // bead carries gc.step_ref and a parent, NOT the root's contract+run-target
+    // dual key, so isGraphV2RunRoot must key on that metadata alone and never
+    // mistake a child for a second convoy root (the open-risk the PL flagged).
+    mockListSupervisorBeads.mockResolvedValue(
+      list([
+        bead('gc-root', { status: 'in_progress', metadata: { ...GRAPH_V2_META } }),
+        bead('gc-step', {
+          status: 'open',
+          parent: 'gc-root',
+          metadata: { 'gc.step_ref': 'review.1' },
+        }),
+      ]),
+    );
+
+    const { roots } = await loadActiveConvoyRoots();
+    expect(roots.map((r) => r.rootBeadId)).toEqual(['gc-root']);
+  });
 });

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -1,5 +1,11 @@
-import type { ConvoyView, DashboardBead } from 'gas-city-dashboard-shared';
-import { BEAD_ID_RE, projectConvoyView } from 'gas-city-dashboard-shared';
+import type { ConvoyView, DashboardBead, RunFormulaSource } from 'gas-city-dashboard-shared';
+import {
+  BEAD_ID_RE,
+  isGraphV2RunRoot,
+  isTerminalRunRootStatus,
+  projectConvoyView,
+  resolveRunFormulaIdentity,
+} from 'gas-city-dashboard-shared';
 import { LOG_COMPONENT, logWarn } from '../lib/logging';
 import { fetchBeadSubtreeIds, fetchSupervisorBead, listSupervisorBeads } from './beadReads';
 import { SupervisorApiError } from './client';
@@ -50,6 +56,66 @@ const CONVOY_FETCH_LIMIT = 1_000;
 export interface ConvoyLoad {
   view: ConvoyView;
   partial: boolean;
+}
+
+/** One row of the /convoy index: an active convoy keyed by its root bead. */
+export interface ConvoyRootSummary {
+  rootBeadId: string;
+  title: string;
+  status: string;
+  /** Formula driving the convoy, when the root carries (or implies) one. */
+  formulaName: string | null;
+  /** Provenance of `formulaName` so a title-inferred name can be surfaced honestly. */
+  formulaNameProvenance: RunFormulaSource | null;
+}
+
+export interface ConvoyRootsLoad {
+  roots: readonly ConvoyRootSummary[];
+  /** The bounded city scan was truncated, so a convoy root may be hidden. */
+  partial: boolean;
+}
+
+/**
+ * List the active convoy roots for the /convoy index (gascity-dashboard-0chv3).
+ *
+ * It reuses the SAME bounded city bead scan the detail loader runs, then keeps
+ * only fully-instantiated graph.v2 run roots (`isGraphV2RunRoot`) that are still
+ * in flight (`!isTerminalRunRootStatus`) — so a completed convoy drops off the
+ * front door on its own. `partial` is the raw page-truncation signal: unlike the
+ * detail page (which narrows truncation to a single convoy's subtree), the index
+ * is honestly partial whenever the scan that could surface a NEW root was
+ * truncated. Newest roots sort first.
+ */
+export async function loadActiveConvoyRoots(): Promise<ConvoyRootsLoad> {
+  const list = await listSupervisorBeads({
+    includeClosed: true,
+    includeBookkeeping: true,
+    limit: CONVOY_FETCH_LIMIT,
+  });
+  const roots = normalizeBeads(list.items)
+    .filter((bead) => isGraphV2RunRoot(bead) && !isTerminalRunRootStatus(bead.status))
+    .sort(compareRootsNewestFirst)
+    .map(toRootSummary);
+  return { roots, partial: list.partial };
+}
+
+function toRootSummary(root: DashboardBead): ConvoyRootSummary {
+  const identity = resolveRunFormulaIdentity('route', { root });
+  return {
+    rootBeadId: root.id,
+    title: root.title,
+    status: root.status,
+    formulaName: identity.name,
+    // `formula_detail` is unreachable in route mode (no detail fetch here), so
+    // narrow the source to RunFormulaSource | null without a cast.
+    formulaNameProvenance: identity.source === 'formula_detail' ? null : identity.source,
+  };
+}
+
+/** Newest convoy first; id breaks ties so the order is stable across reads. */
+function compareRootsNewestFirst(a: DashboardBead, b: DashboardBead): number {
+  const byCreated = b.created_at.localeCompare(a.created_at);
+  return byCreated !== 0 ? byCreated : a.id.localeCompare(b.id);
 }
 
 export async function loadConvoyView(rootBeadId: string): Promise<ConvoyLoad> {

--- a/frontend/src/supervisor/convoyReads.ts
+++ b/frontend/src/supervisor/convoyReads.ts
@@ -1,4 +1,9 @@
-import type { ConvoyView, DashboardBead, RunFormulaSource } from 'gas-city-dashboard-shared';
+import type {
+  BeadStatus,
+  ConvoyView,
+  DashboardBead,
+  RunFormulaSource,
+} from 'gas-city-dashboard-shared';
 import {
   BEAD_ID_RE,
   isGraphV2RunRoot,
@@ -62,7 +67,7 @@ export interface ConvoyLoad {
 export interface ConvoyRootSummary {
   rootBeadId: string;
   title: string;
-  status: string;
+  status: BeadStatus;
   /** Formula driving the convoy, when the root carries (or implies) one. */
   formulaName: string | null;
   /** Provenance of `formulaName` so a title-inferred name can be surfaced honestly. */

--- a/shared/src/convoy/projection.test.ts
+++ b/shared/src/convoy/projection.test.ts
@@ -2,7 +2,7 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { DashboardBead } from '../dashboard-beads.js';
-import { projectConvoyView } from './projection.js';
+import { isGraphV2RunRoot, projectConvoyView } from './projection.js';
 
 function bead(id: string, overrides: Partial<DashboardBead> = {}): DashboardBead {
   return {
@@ -15,6 +15,40 @@ function bead(id: string, overrides: Partial<DashboardBead> = {}): DashboardBead
     ...overrides,
   };
 }
+
+describe('isGraphV2RunRoot', () => {
+  test('is true only with the graph.v2 contract AND a run-target key', () => {
+    assert.equal(
+      isGraphV2RunRoot(
+        bead('a', {
+          metadata: { 'gc.formula_contract': 'graph.v2', 'gc.routed_to': 'city/claude-1' },
+        }),
+      ),
+      true,
+    );
+    // The retired gc.run_target key still qualifies a legacy root.
+    assert.equal(
+      isGraphV2RunRoot(
+        bead('b', {
+          metadata: { 'gc.formula_contract': 'graph.v2', 'gc.run_target': 'city/claude-1' },
+        }),
+      ),
+      true,
+    );
+  });
+
+  test('is false without the contract or without a target', () => {
+    assert.equal(isGraphV2RunRoot(bead('c')), false);
+    assert.equal(
+      isGraphV2RunRoot(bead('d', { metadata: { 'gc.routed_to': 'city/claude-1' } })),
+      false,
+    );
+    assert.equal(
+      isGraphV2RunRoot(bead('e', { metadata: { 'gc.formula_contract': 'graph.v2' } })),
+      false,
+    );
+  });
+});
 
 describe('projectConvoyView', () => {
   test('exposes ordered step children with derived progress when the graph is materialized', () => {

--- a/shared/src/convoy/projection.ts
+++ b/shared/src/convoy/projection.ts
@@ -104,16 +104,34 @@ export function projectConvoyView(
   };
 }
 
+/**
+ * Whether `root` is a fully-instantiated graph.v2 run root: it carries the
+ * `gc.formula_contract=graph.v2` label AND a run-target key (`gc.run_target` OR
+ * the current `gc.routed_to`, which the supervisor retired `gc.run_target` for
+ * per gascity #2763). This is the dual-key gate the convoy detail page's
+ * `computeExposure` and the formula-name resolver already use to recognise a
+ * runnable root; the /convoy index reuses it to pick out convoy roots from a
+ * bounded city bead scan. Status is intentionally NOT considered here — a
+ * terminal root is still a graph.v2 root; callers that want only in-flight
+ * convoys layer `isTerminalRunRootStatus` on top.
+ */
+export function isGraphV2RunRoot(root: DashboardBead): boolean {
+  return (
+    metaString(root, FORMULA_CONTRACT_KEY) === GRAPH_V2_CONTRACT &&
+    (metaString(root, RUN_TARGET_KEY) !== undefined ||
+      metaString(root, ROUTED_TO_KEY) !== undefined)
+  );
+}
+
 function computeExposure(
   root: DashboardBead,
   children: readonly DashboardBead[],
 ): ConvoyStepExposure {
   if (children.length === 0) {
-    const isGraphV2Run =
-      metaString(root, FORMULA_CONTRACT_KEY) === GRAPH_V2_CONTRACT &&
-      (metaString(root, RUN_TARGET_KEY) !== undefined ||
-        metaString(root, ROUTED_TO_KEY) !== undefined);
-    return { kind: 'collapsed', reason: isGraphV2Run ? 'graph_v2_root_only' : 'no_children' };
+    return {
+      kind: 'collapsed',
+      reason: isGraphV2RunRoot(root) ? 'graph_v2_root_only' : 'no_children',
+    };
   }
   const statusById = new Map<string, string>([[root.id, root.status]]);
   for (const child of children) statusById.set(child.id, child.status);

--- a/shared/src/runs/formula-name.test.ts
+++ b/shared/src/runs/formula-name.test.ts
@@ -1,7 +1,11 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { resolveRunFormulaIdentity, resolveRunFormulaName } from './formula-name.js';
+import {
+  isTerminalRunRootStatus,
+  resolveRunFormulaIdentity,
+  resolveRunFormulaName,
+} from './formula-name.js';
 import type { RunSnapshotBead } from '../run-snapshot.js';
 
 // Audit finding M3 (run ga-wisp-x0tank): the supervisor retired
@@ -130,5 +134,23 @@ describe('resolveRunFormulaName on gc.routed_to roots (M3)', () => {
 
   test('returns null for terminal routed_to roots', () => {
     assert.equal(resolveRunFormulaName(routedToRoot({ status: 'completed' })), null);
+  });
+});
+
+describe('isTerminalRunRootStatus', () => {
+  // The convoy index uses this to keep its listing to ACTIVE convoys, and the
+  // title fallbacks use it to avoid trusting a retitled closed root's title.
+  for (const status of ['closed', 'completed', 'done', 'failed', 'skipped']) {
+    test(`treats "${status}" as terminal`, () => {
+      assert.equal(isTerminalRunRootStatus(status), true);
+    });
+  }
+
+  test('treats an in-flight status as non-terminal', () => {
+    assert.equal(isTerminalRunRootStatus('in_progress'), false);
+  });
+
+  test('normalizes case and surrounding whitespace before matching', () => {
+    assert.equal(isTerminalRunRootStatus(' CLOSED '), true);
   });
 });

--- a/shared/src/runs/formula-name.ts
+++ b/shared/src/runs/formula-name.ts
@@ -153,7 +153,12 @@ function runFormulaTitleFallback(
   return mode === 'lane' && !title.startsWith('mol-') ? null : title;
 }
 
-function isTerminalRunRootStatus(status: string): boolean {
+/**
+ * Whether a run-root status is terminal (the run is done, not in flight). The
+ * convoy index uses this to keep its listing to ACTIVE convoys; the title
+ * fallbacks here use it to avoid trusting a retitled closed root's title.
+ */
+export function isTerminalRunRootStatus(status: string): boolean {
   switch (status.trim().toLowerCase()) {
     case 'closed':
     case 'completed':


### PR DESCRIPTION
Promotes the **Convoy** view to a top-level nav tab + a `/convoy` index page.

## Why
The Convoy view already existed but was only reachable indirectly — there was no top-level nav entry, so it read as "not there." This adds the front door, closing the discoverability gap.

## Changes
- Convoy nav tab + `/convoy` index (2 commits, 14 files).
- Partial-scan honesty: a truncated scan now reads "At least N / in the scanned window" instead of a false "No active convoys".
- Stale-load race fixed.

## Review
APPROVE via the full PL pipeline (4 reviewers incl. Codex); both prior majors fixed + verified. 2 cosmetic test/async nits parked P3 (non-blocking). Invariants held: no `shared/` wire change, no `127.0.0.1`/Origin/changeOrigin/bind weakening, One-Mark held. Base: main @21a2905 (zero-drift).
