### PR TITLE
feat: Epic entry point — Epics filter on Beads

### DIFF
--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -217,6 +217,24 @@ describe('BeadsPage', () => {
     expect(screen.queryByText(/match the current search or filter/i)).toBeNull();
   });
 
+  it('rig-scopes the epic empty copy — both body and synopsis say "No epics on {rig}"', async () => {
+    // A rig with tasks but zero epics must NOT read as "No beads on {rig}." (the
+    // rig has beads) nor as an unscoped "No epics on the queue". Under the epic
+    // filter the empty body and the synopsis both scope to the rig and the epic
+    // object type.
+    boardBeads = [sampleBead()]; // a task on the rig, but no epic
+    renderPage('/beads?type=epic');
+    await screen.findByText('No epics on the queue right now.');
+
+    fireEvent.change(screen.getByLabelText(/rig filter/i), { target: { value: 'east' } });
+
+    // Both the empty-state body and the PageHeader synopsis carry the rig-scoped,
+    // epic-typed copy — no "No beads on east." object-type/false-empty signal.
+    const scoped = await screen.findAllByText('No epics on east.');
+    expect(scoped.length).toBe(2);
+    expect(screen.queryByText('No beads on east.')).toBeNull();
+  });
+
   it('preserves an existing bead param when the Epics entry point turns the filter ON', async () => {
     // The entry point's param-preservation contract: a deep-linked bead
     // selection must survive flipping the epic filter on.

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -10,6 +10,9 @@ import type { SupervisorBead } from '../supervisor/beadReads';
 
 const PROJECT = 'gascity';
 const beadQueries: URLSearchParams[] = [];
+// The board payload the GET handler serves; a test may narrow it (e.g. drop the
+// epic) before rendering to exercise the genuinely-empty epic branch.
+let boardBeads: SupervisorBead[] = [];
 const supervisorWrites: Array<{
   method: string;
   path: string;
@@ -20,6 +23,7 @@ beforeEach(() => {
   setActiveCity('test-city');
   beadQueries.length = 0;
   supervisorWrites.length = 0;
+  boardBeads = [sampleBead(), sampleEpic()];
   invalidate('beads:board:');
   invalidate('sessions');
   invalidate('agents');
@@ -31,9 +35,7 @@ beforeEach(() => {
       const method = requestMethod(input, init);
       if (url.pathname === '/gc-supervisor/v0/city/test-city/beads' && method === 'GET') {
         beadQueries.push(url.searchParams);
-        return jsonResponse(
-          beadListPayload(url.searchParams.has('type') ? [] : [sampleBead(), sampleEpic()]),
-        );
+        return jsonResponse(beadListPayload(url.searchParams.has('type') ? [] : boardBeads));
       }
       if (url.pathname === '/gc-supervisor/v0/city/test-city/beads' && method === 'POST') {
         supervisorWrites.push({
@@ -189,17 +191,47 @@ describe('BeadsPage', () => {
     expect(screen.getByText(/showing epics only/i)).toBeTruthy();
     const clear = screen.getByRole('link', { name: /^clear$/i });
     expect(clear.getAttribute('href')).toBe('/beads');
+    // The synopsis must NOT read as a truncated fetch: the epic filter is a
+    // client-side narrowing, so "Showing 1 of 2" would be a false positive.
+    expect(screen.getByText('1 open.')).toBeTruthy();
+    expect(screen.queryByText(/showing 1 of 2/i)).toBeNull();
   });
 
-  it('shows a calm epic-specific empty state when the epic filter matches nothing', async () => {
+  it('names epics in the search/filter empty copy, distinct from the genuinely-empty copy', async () => {
     renderPage('/beads?type=epic');
     await screen.findByText('Sample epic');
-    // Narrow the search so no epic matches: the empty copy names epics, not a
-    // generic "no beads", so the operator knows the filter is the cause.
+    // A search that no epic matches is the search/filter branch, not the
+    // genuinely-empty one — the copy must say so rather than imply no epics exist.
     fireEvent.change(screen.getByLabelText(/search beads/i), {
       target: { value: 'no-such-epic-xyz' },
     });
-    expect(await screen.findByText('No epics on the queue right now.')).toBeTruthy();
+    expect(await screen.findByText('No epics match the current search or filter.')).toBeTruthy();
+  });
+
+  it('shows the genuinely-empty epic copy when the board has no epics at all', async () => {
+    boardBeads = [sampleBead()]; // task only — no epic on the board
+    renderPage('/beads?type=epic');
+
+    await screen.findByText('No epics on the queue right now.');
+    // Not the search/filter copy: no search or chip is active here.
+    expect(screen.queryByText(/match the current search or filter/i)).toBeNull();
+  });
+
+  it('preserves an existing bead param when the Epics entry point turns the filter ON', async () => {
+    // The entry point's param-preservation contract: a deep-linked bead
+    // selection must survive flipping the epic filter on.
+    renderPage('/beads?bead=gascity-0001');
+
+    const epicsLink = await screen.findByRole('link', { name: /^epics$/i });
+    expect(epicsLink.getAttribute('href')).toBe('/beads?bead=gascity-0001&type=epic');
+  });
+
+  it('preserves an existing bead param when the Clear control turns the filter OFF', async () => {
+    renderPage('/beads?bead=gascity-0001&type=epic');
+
+    await screen.findByText('Sample epic');
+    const clear = screen.getByRole('link', { name: /^clear$/i });
+    expect(clear.getAttribute('href')).toBe('/beads?bead=gascity-0001');
   });
 
   it('requests direct supervisor current engineering beads without type fan-out or closed history', async () => {

--- a/frontend/src/routes/Beads.test.tsx
+++ b/frontend/src/routes/Beads.test.tsx
@@ -31,7 +31,9 @@ beforeEach(() => {
       const method = requestMethod(input, init);
       if (url.pathname === '/gc-supervisor/v0/city/test-city/beads' && method === 'GET') {
         beadQueries.push(url.searchParams);
-        return jsonResponse(beadListPayload(url.searchParams.has('type') ? [] : [sampleBead()]));
+        return jsonResponse(
+          beadListPayload(url.searchParams.has('type') ? [] : [sampleBead(), sampleEpic()]),
+        );
       }
       if (url.pathname === '/gc-supervisor/v0/city/test-city/beads' && method === 'POST') {
         supervisorWrites.push({
@@ -156,6 +158,48 @@ describe('BeadsPage', () => {
     expect(screen.queryByRole('table')).toBeNull();
     expect(screen.queryByRole('radiogroup', { name: /view/i })).toBeNull();
     expect(screen.getByRole('button', { name: /new bead/i })).toBeTruthy();
+  });
+
+  it('exposes a visible Epics entry point that deep-links to the epic-filtered board', async () => {
+    // gascity-dashboard-a0vak: epics are otherwise only findable by scanning the
+    // board, so the Beads surface carries an Epics affordance that deep-links to
+    // /beads?type=epic — no second top-level nav tab.
+    renderPage();
+
+    await screen.findByText('Sample bead');
+    const epicsLink = screen.getByRole('link', { name: /^epics$/i });
+    expect(epicsLink.getAttribute('href')).toBe('/beads?type=epic');
+    // Not active on the unfiltered board.
+    expect(epicsLink.getAttribute('aria-current')).toBeNull();
+    expect(screen.queryByText(/showing epics only/i)).toBeNull();
+    // Both the task and the epic are on the unfiltered board.
+    expect(screen.getByText('Sample epic')).toBeTruthy();
+  });
+
+  it('filters the board to epics on the ?type=epic deep link, with a clear control', async () => {
+    renderPage('/beads?type=epic');
+
+    // Only the epic renders; the task bead is filtered out.
+    expect(await screen.findByText('Sample epic')).toBeTruthy();
+    expect(screen.queryByText('Sample bead')).toBeNull();
+    // The entry point reads active and a textual notice + Clear are present.
+    const epicsLink = screen.getByRole('link', { name: /^epics$/i });
+    expect(epicsLink.getAttribute('aria-current')).toBe('true');
+    expect(epicsLink.getAttribute('href')).toBe('/beads');
+    expect(screen.getByText(/showing epics only/i)).toBeTruthy();
+    const clear = screen.getByRole('link', { name: /^clear$/i });
+    expect(clear.getAttribute('href')).toBe('/beads');
+  });
+
+  it('shows a calm epic-specific empty state when the epic filter matches nothing', async () => {
+    renderPage('/beads?type=epic');
+    await screen.findByText('Sample epic');
+    // Narrow the search so no epic matches: the empty copy names epics, not a
+    // generic "no beads", so the operator knows the filter is the cause.
+    fireEvent.change(screen.getByLabelText(/search beads/i), {
+      target: { value: 'no-such-epic-xyz' },
+    });
+    expect(await screen.findByText('No epics on the queue right now.')).toBeTruthy();
   });
 
   it('requests direct supervisor current engineering beads without type fan-out or closed history', async () => {
@@ -370,6 +414,20 @@ function sampleBead(): SupervisorBead {
     status: 'open',
     priority: 0,
     issue_type: 'task',
+    assignee: 'mayor',
+    labels: [],
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function sampleEpic(): SupervisorBead {
+  return {
+    id: `${PROJECT}-0007`,
+    title: 'Sample epic',
+    description: 'A tracking epic.',
+    status: 'open',
+    priority: 0,
+    issue_type: 'epic',
     assignee: 'mayor',
     labels: [],
     created_at: '2026-01-01T00:00:00Z',

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   GC_EVENT_PREFIX,
   isBlockedStatus,
@@ -56,6 +56,9 @@ interface ActionMessage {
   text: string;
 }
 
+// The bead issue_type the /beads?type=epic entry point filters to.
+const EPIC_ISSUE_TYPE = 'epic';
+
 export const BEAD_CHIPS: ReadonlyArray<FilterChip<SupervisorBead>> = [
   { id: 'open', label: 'open', match: (b) => isOpenStatus(b.status) },
   { id: 'in_progress', label: 'in progress', match: (b) => isInFlightStatus(b.status) },
@@ -77,6 +80,21 @@ export function BeadsPage() {
   const cityCacheKey = cityName ?? 'no-city';
   const [searchParams] = useSearchParams();
   const selectedBeadParam = normalizeSelectedBeadParam(searchParams.get('bead'));
+  // gascity-dashboard-a0vak: the visible Epic entry point. Epics are ordinary
+  // beads (issue_type='epic') folded into the board, so an operator who never
+  // thinks to scan for them can't find them. A deep-linkable `?type=epic`
+  // narrows the board to epics — same client-side filter register as the rig
+  // and status controls, not a new top-level nav tab (the minimal-nav set is a
+  // DESIGN.md rule). `buildBeadsHref` preserves any other params (e.g. an open
+  // bead modal) while flipping the epic filter.
+  const epicOnly = searchParams.get('type') === EPIC_ISSUE_TYPE;
+  const buildBeadsHref = (toEpics: boolean): string => {
+    const next = new URLSearchParams(searchParams);
+    if (toEpics) next.set('type', EPIC_ISSUE_TYPE);
+    else next.delete('type');
+    const query = next.toString();
+    return query.length > 0 ? `/beads?${query}` : '/beads';
+  };
   const [rigFilter, setRigFilter] = useState<string>(RIG_FILTER_ALL);
   // Closed beads dwarf the open queue (~199.7K closed vs ~1K open on this
   // city), so scanning them on every load makes the `task` query spike and
@@ -165,7 +183,10 @@ export function BeadsPage() {
     }
   }, [dispatchRigOptions, rigFilter]);
 
-  const filteredRows = rows;
+  const filteredRows = useMemo(
+    () => (epicOnly ? rows.filter((bead) => bead.issue_type === EPIC_ISSUE_TYPE) : rows),
+    [epicOnly, rows],
+  );
 
   const filters = useListFilters<SupervisorBead>({
     viewKey: 'beads',
@@ -437,6 +458,17 @@ export function BeadsPage() {
             </button>
           </p>
         )}
+        {epicOnly && (
+          <p role="status">
+            Showing epics only.{' '}
+            <Link
+              to={buildBeadsHref(false)}
+              className="text-fg-muted hover:text-fg focus-mark underline decoration-dotted underline-offset-2 rounded-sm"
+            >
+              Clear
+            </Link>
+          </p>
+        )}
         {actionMessage && (
           <p
             className={actionMessage.tone === 'error' ? 'text-accent' : 'text-fg-muted'}
@@ -465,6 +497,19 @@ export function BeadsPage() {
             onToggle={toggleStatusChip}
             legend="Status"
           />
+          <span className="flex items-baseline gap-2 text-label">
+            <span className="uppercase tracking-wider text-fg-muted">Type</span>
+            <Link
+              to={buildBeadsHref(!epicOnly)}
+              aria-current={epicOnly ? 'true' : undefined}
+              className={[
+                'uppercase tracking-wider focus-mark transition-colors duration-150 ease-out-quart',
+                epicOnly ? 'text-fg font-semibold' : 'text-fg-muted hover:text-fg',
+              ].join(' ')}
+            >
+              Epics
+            </Link>
+          </span>
           {dispatchRigOptions.length > 1 && (
             <label className="flex items-baseline gap-2 text-label">
               <span className="uppercase tracking-wider text-fg-muted">Rig</span>
@@ -490,9 +535,11 @@ export function BeadsPage() {
         <p className="text-body text-fg-muted italic">Loading beads.</p>
       ) : matched.length === 0 ? (
         <p className="text-body text-fg-muted italic">
-          {filters.search.length > 0 || filters.activeChipIds.size > 0
-            ? 'No beads match the current search or filter.'
-            : 'Nothing on the queue right now.'}
+          {epicOnly
+            ? 'No epics on the queue right now.'
+            : filters.search.length > 0 || filters.activeChipIds.size > 0
+              ? 'No beads match the current search or filter.'
+              : 'Nothing on the queue right now.'}
         </p>
       ) : (
         <div className="space-y-12">

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -381,8 +381,15 @@ export function BeadsPage() {
   );
 
   const synopsis = useMemo(
-    () => (hasLoadedBoard ? buildSynopsis(filteredRows, totalShown, rigFilter) : 'Loading beads.'),
-    [filteredRows, hasLoadedBoard, totalShown, rigFilter],
+    () =>
+      hasLoadedBoard
+        ? // The "Showing N of M" clause compares the displayed set against the
+          // server-returned total to flag a truncated fetch. The epic filter is
+          // a CLIENT-side narrowing, not a truncation, so under it the total is
+          // the epic count — otherwise every epic view reads as "3 of 1000".
+          buildSynopsis(filteredRows, epicOnly ? filteredRows.length : totalShown, rigFilter)
+        : 'Loading beads.',
+    [epicOnly, filteredRows, hasLoadedBoard, totalShown, rigFilter],
   );
 
   const isTruncated =
@@ -504,7 +511,9 @@ export function BeadsPage() {
               aria-current={epicOnly ? 'true' : undefined}
               className={[
                 'uppercase tracking-wider focus-mark transition-colors duration-150 ease-out-quart',
-                epicOnly ? 'text-fg font-semibold' : 'text-fg-muted hover:text-fg',
+                epicOnly
+                  ? 'text-fg font-semibold underline decoration-fg underline-offset-4'
+                  : 'text-fg-muted hover:text-fg',
               ].join(' ')}
             >
               Epics
@@ -535,10 +544,12 @@ export function BeadsPage() {
         <p className="text-body text-fg-muted italic">Loading beads.</p>
       ) : matched.length === 0 ? (
         <p className="text-body text-fg-muted italic">
-          {epicOnly
-            ? 'No epics on the queue right now.'
-            : filters.search.length > 0 || filters.activeChipIds.size > 0
-              ? 'No beads match the current search or filter.'
+          {filters.search.length > 0 || filters.activeChipIds.size > 0
+            ? epicOnly
+              ? 'No epics match the current search or filter.'
+              : 'No beads match the current search or filter.'
+            : epicOnly
+              ? 'No epics on the queue right now.'
               : 'Nothing on the queue right now.'}
         </p>
       ) : (

--- a/frontend/src/routes/Beads.tsx
+++ b/frontend/src/routes/Beads.tsx
@@ -387,7 +387,12 @@ export function BeadsPage() {
           // server-returned total to flag a truncated fetch. The epic filter is
           // a CLIENT-side narrowing, not a truncation, so under it the total is
           // the epic count — otherwise every epic view reads as "3 of 1000".
-          buildSynopsis(filteredRows, epicOnly ? filteredRows.length : totalShown, rigFilter)
+          buildSynopsis(
+            filteredRows,
+            epicOnly ? filteredRows.length : totalShown,
+            rigFilter,
+            epicOnly,
+          )
         : 'Loading beads.',
     [epicOnly, filteredRows, hasLoadedBoard, totalShown, rigFilter],
   );
@@ -549,7 +554,9 @@ export function BeadsPage() {
               ? 'No epics match the current search or filter.'
               : 'No beads match the current search or filter.'
             : epicOnly
-              ? 'No epics on the queue right now.'
+              ? rigFilter !== RIG_FILTER_ALL
+                ? `No epics on ${rigFilter}.`
+                : 'No epics on the queue right now.'
               : 'Nothing on the queue right now.'}
         </p>
       ) : (
@@ -746,8 +753,14 @@ export function buildSynopsis(
   filtered: ReadonlyArray<SupervisorBead>,
   totalShown: number,
   rigFilter: string,
+  epicOnly = false,
 ): string {
-  if (rigFilter !== RIG_FILTER_ALL && filtered.length === 0) return `No beads on ${rigFilter}.`;
+  if (rigFilter !== RIG_FILTER_ALL && filtered.length === 0) {
+    // Under the epic filter an empty rig means "no epics here" — it does NOT
+    // imply the rig has no beads (it may have many tasks), and the object type
+    // is epics, not beads.
+    return epicOnly ? `No epics on ${rigFilter}.` : `No beads on ${rigFilter}.`;
+  }
   const open = filtered.filter((bead) => isOpenStatus(bead.status)).length;
   const inProgress = filtered.filter((bead) => isInFlightStatus(bead.status)).length;
   const blocked = filtered.filter((bead) => isBlockedStatus(bead.status)).length;


### PR DESCRIPTION
Adds an **Epics** in-page filter on the Beads view — surfacing epics as a first-class, discoverable lens.

## Why
Closes the other half of the "I didn't know it existed" nav gap: epics had no discoverable entry point. This is a client-side filter on Beads (minimal-nav — deliberately NOT a new top-level tab).

## Changes
- Epics filter on Beads (3 commits, 2 files).
- Fix: stacking epic + rig filters showed a false "No beads on <rig>" — now correctly "No epics on <rig>".

## Review
APPROVE. PL-verified: Beads tests 60/60, `typecheck:test` clean. Invariants held: client-side filter, no `shared/` DTO change, no backend/bind/Origin change. Base: main @21a2905 (zero-drift).
