### PR TITLE
chore(frontend): remove stale freshness comments

### DIFF
--- a/frontend/src/attention/liveContributors.ts
+++ b/frontend/src/attention/liveContributors.ts
@@ -184,9 +184,8 @@ export function useLiveAttentionContributors(
  * the same selectBlockedRuns the /runs page renders — so reading the page's exact
  * source object makes the badge and the page agree by construction, not merely by
  * shared selector (gascity-dashboard-2j8e.7). The source's own status flows
- * through as provenance and is carried onto `unavailable`-tier items so a
- * degraded read can be aged rather than rendered as current truth; `fetchedAt`
- * carries the exact read time for any age comparison.
+ * through as provenance and `fetchedAt` carries the exact read time, so the read
+ * can be aged rather than rendered as current truth.
  */
 export function runsFactsFromSource(
   source: SourceState<RunSummary> | undefined,

--- a/frontend/src/attention/registry.ts
+++ b/frontend/src/attention/registry.ts
@@ -309,7 +309,7 @@ function deriveRunsAttention(facts: RunsAttentionFacts | undefined): readonly At
   // dash-ygj + gascity-dashboard-2j8e.2: degraded runs reads land in the
   // `unavailable` tier, which BadgeSeverity excludes — so a partial fan-out and
   // any lane whose health could not be read surface as quiet, non-counting items
-  // (never a badge number) and ride read freshness so a stale read can be aged.
+  // (never a badge number).
   // The formula feed is no longer a source (it produced the gc-1920 phantom roots
   // and flapped 6<->13), so #91's feed-derived emitters are gone; only the
   // summary-derived degraded reads survive.


### PR DESCRIPTION
Comment-only cleanup (2 frontend files). No executable change; surviving comments verified accurate. Dashboard PL review: APPROVE, invariants intact.

Dashboard PL review: merge-ready, conflict-free vs main, invariant-safe.