### PR TITLE
test: drop dead formulaFeed mock, pin runs error-path provenance

### DIFF
--- a/frontend/src/attention/liveContributors.test.tsx
+++ b/frontend/src/attention/liveContributors.test.tsx
@@ -56,7 +56,6 @@ const mockApi = vi.hoisted(() => ({
 
 const mockSupervisorApi = vi.hoisted(() => ({
   cityHealth: vi.fn(),
-  formulaFeed: vi.fn(),
   listAgents: vi.fn(),
   listBeads: vi.fn(),
   listEvents: vi.fn(),
@@ -90,7 +89,6 @@ describe('useLiveAttentionContributors', () => {
       mockApi.maintainerTriage,
       mockApi.systemHealth,
       mockSupervisorApi.cityHealth,
-      mockSupervisorApi.formulaFeed,
       mockSupervisorApi.listAgents,
       mockSupervisorApi.listBeads,
       mockSupervisorApi.listEvents,
@@ -101,24 +99,6 @@ describe('useLiveAttentionContributors', () => {
       fn.mockReset();
     }
 
-    mockSupervisorApi.formulaFeed.mockResolvedValue({
-      partial: false,
-      items: [
-        {
-          id: 'run-1',
-          root_bead_id: 'B-root',
-          root_store_ref: 'city:B-root',
-          scope_kind: 'city',
-          scope_ref: 'test-city',
-          started_at: '2026-05-29T20:00:00.000Z',
-          status: 'failed',
-          target: 'mayor',
-          title: 'Failed run',
-          type: 'formula',
-          updated_at: '2026-05-29T20:05:00.000Z',
-        },
-      ],
-    });
     mockSupervisorApi.listAgents.mockResolvedValue({
       total: 1,
       items: [

--- a/frontend/src/attention/registry.test.ts
+++ b/frontend/src/attention/registry.test.ts
@@ -469,6 +469,10 @@ describe('createAttentionContributors', () => {
     expect(model.byDomain.runs.attention).toBe(1);
     expect(model.byDomain.runs.unavailable).toBe(0);
     expect(model.byDomain.runs.items[0]?.id).toBe('runs:unavailable');
+    // The read-freshness provenance still threads through on the error path —
+    // the loud runs:unavailable item does not shadow the 'error' read state the
+    // board liveness line folds from byDomain.runs (gascity-dashboard-5t0m).
+    expect(model.byDomain.runs.provenance).toBe('error');
   });
 
   it('counts an agent awaiting an input decision as needs-you', () => {


### PR DESCRIPTION
Test-only. Deleted formulaFeed mock confirmed dead (zero prod + zero test refs remain); new assertion pins runs error-path provenance = real coverage gain. Dashboard PL review: APPROVE.

Dashboard PL review: merge-ready, conflict-free vs main, invariant-safe.