### PR TITLE
test(backend): strengthen CSP/CSRF/HEAD-cookie security assertions

### DIFF
--- a/backend/test/csrf.test.ts
+++ b/backend/test/csrf.test.ts
@@ -136,6 +136,28 @@ describe('csrfIssueCookie — hands the token to the browser on reads', () => {
     );
   });
 
+  test('also issues the cookie on HEAD (csrf.ts treats HEAD like GET)', async () => {
+    await withApp(
+      (app) => {
+        app.use(csrfIssueCookie);
+        ok(app);
+      },
+      async ({ url }) => {
+        // HEAD shares the read path in csrfIssueCookie, so a SPA that probes
+        // with HEAD before its first GET must still receive the token. A HEAD
+        // response carries no body but the Set-Cookie header is still present.
+        const res = await rawRequest(url, { method: 'HEAD' });
+        const cookie = res.headers['set-cookie'];
+        assert.ok(Array.isArray(cookie) && cookie.length === 1, 'one Set-Cookie header on HEAD');
+        const value = cookie[0];
+        if (value === undefined) throw new Error('Set-Cookie header had no value');
+        assert.ok(value.startsWith(`gascity_admin_csrf=${getCsrfToken()}`));
+        assert.ok(value.includes('SameSite=Strict'));
+        assert.ok(!/HttpOnly/i.test(value));
+      },
+    );
+  });
+
   test('does NOT issue the cookie on a write method', async () => {
     await withApp(
       (app) => {

--- a/backend/test/express-harness.test.ts
+++ b/backend/test/express-harness.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { rawRequest, withApp } from './helpers/express-harness.js';
+
+describe('rawRequest — fail-fast timeout guard', () => {
+  test('rejects with a timeout error when a middleware branch never responds', async () => {
+    await withApp(
+      (app) => {
+        // A stalled branch: it never sends a response and never calls next, so
+        // without the guard the request would hang until the whole suite times
+        // out. The guard must reject fast with a clear reason instead.
+        app.use((_req, _res, _next) => {
+          /* intentionally never responds */
+        });
+      },
+      async ({ url }) => {
+        await assert.rejects(
+          () => rawRequest(url, { timeoutMs: 50 }),
+          /rawRequest timed out after 50ms/,
+        );
+      },
+    );
+  });
+
+  test('a normal response settles before the timeout and clears the timer', async () => {
+    await withApp(
+      (app) => {
+        app.get('/', (_req, res) => res.status(204).end());
+      },
+      async ({ url }) => {
+        // A short ceiling still resolves cleanly for a fast handler — proving the
+        // timer is cleared on success and does not reject a healthy request.
+        const res = await rawRequest(url, { timeoutMs: 1_000 });
+        assert.equal(res.status, 204);
+      },
+    );
+  });
+});

--- a/backend/test/helpers/express-harness.ts
+++ b/backend/test/helpers/express-harness.ts
@@ -45,10 +45,18 @@ export async function withApp<T>(
   }
 }
 
+// Fail-fast ceiling for a single raw request. These are localhost middleware
+// tests that resolve in single-digit milliseconds; if one blows past this, a
+// middleware branch has stalled and we want the runner to fail with a clear
+// error rather than hang until the whole suite times out.
+const RAW_REQUEST_TIMEOUT_MS = 5_000;
+
 export interface RawRequestOptions {
   method?: string;
   /** Verbatim request headers, including normally-protected ones like `Host`. */
   headers?: Record<string, string>;
+  /** Override the {@link RAW_REQUEST_TIMEOUT_MS} fail-fast ceiling. */
+  timeoutMs?: number;
 }
 
 export interface RawResponse {
@@ -64,7 +72,7 @@ export interface RawResponse {
  */
 export function rawRequest(url: string, options: RawRequestOptions = {}): Promise<RawResponse> {
   const target = new URL(url);
-  const { method = 'GET', headers = {} } = options;
+  const { method = 'GET', headers = {}, timeoutMs = RAW_REQUEST_TIMEOUT_MS } = options;
   return new Promise<RawResponse>((resolve, reject) => {
     const req = http.request(
       {
@@ -75,18 +83,33 @@ export function rawRequest(url: string, options: RawRequestOptions = {}): Promis
         headers,
       },
       (res) => {
+        // A mid-stream socket error must reject, not leave the request dangling
+        // on a promise that never settles (the runner would hang on it).
+        res.on('error', (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
         const chunks: Buffer[] = [];
         res.on('data', (chunk: Buffer) => chunks.push(chunk));
-        res.on('end', () =>
+        res.on('end', () => {
+          clearTimeout(timer);
           resolve({
             status: res.statusCode ?? 0,
             headers: res.headers,
             body: Buffer.concat(chunks).toString('utf8'),
-          }),
-        );
+          });
+        });
       },
     );
-    req.on('error', reject);
+    // Fail fast on a stalled middleware branch: destroy the request, which
+    // surfaces through the 'error' handler below with a clear timeout reason.
+    const timer = setTimeout(() => {
+      req.destroy(new Error(`rawRequest timed out after ${timeoutMs}ms: ${method} ${url}`));
+    }, timeoutMs);
+    req.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
     req.end();
   });
 }

--- a/backend/test/security.test.ts
+++ b/backend/test/security.test.ts
@@ -222,11 +222,20 @@ describe('securityHeaders — CSP + clickjacking + sniff lockdown', () => {
         assert.ok(directives.includes("base-uri 'none'"));
         assert.ok(directives.includes("form-action 'self'"));
         assert.ok(directives.includes("connect-src 'self'"));
-        // The theme-boot inline script is pinned by hash, not 'unsafe-inline'.
-        const scriptSrc = directives.find((d) => d.startsWith('script-src '));
-        assert.ok(scriptSrc?.includes("'self'"));
-        assert.ok(scriptSrc?.includes("'sha256-"));
-        assert.ok(!scriptSrc?.includes("'unsafe-inline'"));
+        // style-src/img-src are part of the lockdown too: inline styles are
+        // allowed (Tailwind/theme), images only same-origin + data: URIs. Pin
+        // them so a directive drop is caught, not silently widened.
+        assert.ok(directives.includes("style-src 'self' 'unsafe-inline'"));
+        assert.ok(directives.includes("img-src 'self' data:"));
+        // The theme-boot inline script is pinned by EXACT hash, not 'unsafe-inline'.
+        // Matching the full directive (not just the 'sha256-' prefix) catches both
+        // a hash drift and a widening — an added 'unsafe-inline' or extra source
+        // changes the string, so it would no longer be an exact element here.
+        assert.ok(
+          directives.includes(
+            "script-src 'self' 'sha256-UwUdbc/TSVCB3Er6sM8M1BP5Fk3RrQVkswCUvEjf08g='",
+          ),
+        );
       },
     );
   });


### PR DESCRIPTION
Backend test/harness-only (4 files). New CSP/CSRF/HEAD-cookie assertions bind verified prod behavior (exact script-src sha pin, SameSite=Strict). Harness timeout uses req.destroy(Error)+clearTimeout in all paths (surfaces a real error, no swallow). 127.0.0.1:0 bind unchanged. Dashboard PL review: APPROVE. (LOW out-of-scope: pre-existing connect-src test is substring not exact-match.)

Dashboard PL review: merge-ready, conflict-free vs main, invariant-safe.