### PR TITLE
test(supervisor): cover untested frontend edge modules (eventSignals, sessionReads, agentPending, useConvoyView)

### DIFF
--- a/frontend/src/hooks/useConvoyView.test.tsx
+++ b/frontend/src/hooks/useConvoyView.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ConvoyLoad } from '../supervisor/convoyReads';
+import { SupervisorApiError } from '../supervisor/client';
+import { useConvoyView } from './useConvoyView';
+
+const mockLoadConvoyView = vi.hoisted(() => vi.fn());
+
+vi.mock('../supervisor/convoyReads', () => ({
+  loadConvoyView: mockLoadConvoyView,
+}));
+
+function convoyLoad(rootBeadId: string): ConvoyLoad {
+  return {
+    view: {
+      rootBeadId,
+      root: { id: rootBeadId, title: `root ${rootBeadId}`, status: 'in_progress' },
+      progress: { closed: 0, total: 0 },
+      exposure: { kind: 'collapsed', reason: 'no_children' },
+    },
+    partial: false,
+  } as unknown as ConvoyLoad;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('useConvoyView', () => {
+  it('stays idle when no root bead id is supplied', () => {
+    const { result } = renderHook(() => useConvoyView(null));
+    expect(result.current.state).toEqual({ kind: 'idle' });
+    expect(mockLoadConvoyView).not.toHaveBeenCalled();
+  });
+
+  it('stays idle for an empty root bead id without hitting the loader', () => {
+    const { result } = renderHook(() => useConvoyView(''));
+    expect(result.current.state).toEqual({ kind: 'idle' });
+    expect(mockLoadConvoyView).not.toHaveBeenCalled();
+  });
+
+  it('loads the convoy view and lands in ready on success', async () => {
+    mockLoadConvoyView.mockResolvedValue(convoyLoad('root-1'));
+
+    const { result } = renderHook(() => useConvoyView('root-1'));
+
+    await waitFor(() => expect(result.current.state.kind).toBe('ready'));
+    expect(mockLoadConvoyView).toHaveBeenCalledWith('root-1');
+    if (result.current.state.kind !== 'ready') throw new Error('expected ready');
+    expect(result.current.state.refreshing).toBe(false);
+    expect(result.current.state.load.view.rootBeadId).toBe('root-1');
+  });
+
+  it('surfaces a 404 as the distinct not_found state', async () => {
+    mockLoadConvoyView.mockRejectedValue(new SupervisorApiError(404, 'no such convoy', undefined));
+
+    const { result } = renderHook(() => useConvoyView('ghost'));
+
+    await waitFor(() => expect(result.current.state.kind).toBe('not_found'));
+  });
+
+  it('surfaces any non-404 error as the failed state with a formatted message', async () => {
+    mockLoadConvoyView.mockRejectedValue(new SupervisorApiError(500, 'boom', undefined));
+
+    const { result } = renderHook(() => useConvoyView('root-1'));
+
+    await waitFor(() => expect(result.current.state.kind).toBe('failed'));
+    if (result.current.state.kind !== 'failed') throw new Error('expected failed');
+    expect(result.current.state.error).toContain('boom');
+  });
+
+  it('reloads on root bead id change', async () => {
+    mockLoadConvoyView.mockImplementation(async (id: string) => convoyLoad(id));
+
+    const { result, rerender } = renderHook(({ id }) => useConvoyView(id), {
+      initialProps: { id: 'root-1' },
+    });
+    await waitFor(() => expect(result.current.state.kind).toBe('ready'));
+
+    rerender({ id: 'root-2' });
+    await waitFor(() => {
+      expect(result.current.state.kind).toBe('ready');
+      if (result.current.state.kind !== 'ready') throw new Error('expected ready');
+      expect(result.current.state.load.view.rootBeadId).toBe('root-2');
+    });
+    expect(mockLoadConvoyView).toHaveBeenCalledWith('root-2');
+  });
+
+  it('marks the existing view refreshing during a manual refresh, then ready again', async () => {
+    mockLoadConvoyView.mockResolvedValueOnce(convoyLoad('root-1'));
+    const { result } = renderHook(() => useConvoyView('root-1'));
+    await waitFor(() => expect(result.current.state.kind).toBe('ready'));
+
+    let release: (load: ConvoyLoad) => void = () => {};
+    mockLoadConvoyView.mockReturnValueOnce(
+      new Promise<ConvoyLoad>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    let refreshDone: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshDone = result.current.refresh();
+    });
+
+    await waitFor(() => {
+      if (result.current.state.kind !== 'ready') throw new Error('expected ready');
+      expect(result.current.state.refreshing).toBe(true);
+    });
+
+    await act(async () => {
+      release(convoyLoad('root-1'));
+      await refreshDone;
+    });
+
+    if (result.current.state.kind !== 'ready') throw new Error('expected ready');
+    expect(result.current.state.refreshing).toBe(false);
+  });
+
+  it('is a no-op refresh when there is no active root bead id', async () => {
+    const { result } = renderHook(() => useConvoyView(null));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockLoadConvoyView).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/supervisor/agentPending.test.ts
+++ b/frontend/src/supervisor/agentPending.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentResponse,
+  PendingInteraction,
+  SessionPendingResponse,
+  SessionResponse,
+} from 'gas-city-dashboard-shared/gc-supervisor';
+import { setActiveCity } from '../api/cityBase';
+import {
+  GC_MUTATION_HEADERS,
+  resetSupervisorApiForTests,
+  setSupervisorApiForTests,
+  type SupervisorApi,
+} from './client';
+import {
+  attachCommand,
+  listAgentPendingInteractions,
+  respondToAgentPendingInteraction,
+} from './agentPending';
+
+function agent(name: string, sessionName?: string): AgentResponse {
+  return {
+    name,
+    available: true,
+    running: true,
+    state: 'idle',
+    suspended: false,
+    ...(sessionName === undefined ? {} : { session: { name: sessionName, attached: false } }),
+  };
+}
+
+function session(id: string, sessionName: string): SessionResponse {
+  return {
+    id,
+    template: 'claude',
+    session_name: sessionName,
+    title: id,
+    state: 'running',
+    created_at: '2026-06-28T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+  };
+}
+
+function pending(requestId: string): PendingInteraction {
+  return { kind: 'permission', request_id: requestId };
+}
+
+const baseApi: SupervisorApi = {
+  baseUrl: '/gc-supervisor',
+  health: vi.fn(),
+  cityHealth: vi.fn(),
+  cityStatus: vi.fn(),
+  listCities: vi.fn(),
+  listAgents: vi.fn(),
+  listRigs: vi.fn(),
+  listBeads: vi.fn(),
+  listEvents: vi.fn(),
+  getBead: vi.fn(),
+  beadsGraph: vi.fn(),
+  createBead: vi.fn(),
+  updateBead: vi.fn(),
+  closeBead: vi.fn(),
+  nudgeAgent: vi.fn(),
+  agentPrime: vi.fn(),
+  sling: vi.fn(),
+  formulaFeed: vi.fn(),
+  listMail: vi.fn(),
+  markMailRead: vi.fn(),
+  markMailUnread: vi.fn(),
+  archiveMail: vi.fn(),
+  replyMail: vi.fn(),
+  sendMail: vi.fn(),
+  mailThread: vi.fn(),
+  cityEventStreamUrl: vi.fn(),
+  sessionStreamUrl: vi.fn(),
+  listSessions: vi.fn(),
+  sessionPending: vi.fn(),
+  respondSession: vi.fn(),
+  sessionTranscript: vi.fn(),
+  workflowRun: vi.fn(),
+  formulaDetail: vi.fn(),
+  mutationHeaders: () => ({ ...GC_MUTATION_HEADERS }),
+};
+
+beforeEach(() => {
+  setActiveCity('test-city');
+});
+
+afterEach(() => {
+  resetSupervisorApiForTests();
+});
+
+describe('attachCommand', () => {
+  it('leaves a safe agent name unquoted', () => {
+    expect(attachCommand('claude-1')).toBe('gc agent attach claude-1');
+    expect(attachCommand('rig/dir:claude_2.codex')).toBe('gc agent attach rig/dir:claude_2.codex');
+  });
+
+  it('single-quotes a name containing whitespace', () => {
+    expect(attachCommand('my agent')).toBe("gc agent attach 'my agent'");
+  });
+
+  it('single-quotes and escapes shell metacharacters (injection-adjacent)', () => {
+    // The displayed command must be paste-safe: a name carrying shell control
+    // characters cannot break out of the single-quoted token.
+    expect(attachCommand('a;rm -rf /')).toBe("gc agent attach 'a;rm -rf /'");
+    expect(attachCommand('$(whoami)')).toBe("gc agent attach '$(whoami)'");
+    expect(attachCommand('a`id`b')).toBe("gc agent attach 'a`id`b'");
+  });
+
+  it('escapes embedded single quotes with the close-escape-reopen idiom', () => {
+    // The only way a single-quote can appear inside a single-quoted string.
+    expect(attachCommand("a'b")).toBe("gc agent attach 'a'\\''b'");
+  });
+
+  it('quotes the empty string rather than emitting a bare token', () => {
+    expect(attachCommand('')).toBe("gc agent attach ''");
+  });
+});
+
+describe('listAgentPendingInteractions', () => {
+  it('returns one entry per agent whose session has a pending interaction', async () => {
+    const sessionPending = vi.fn(
+      async (_city: string, sessionId: string): Promise<SessionPendingResponse> => ({
+        supported: true,
+        pending: pending(`req-${sessionId}`),
+      }),
+    );
+    setSupervisorApiForTests({ ...baseApi, sessionPending });
+
+    const result = await listAgentPendingInteractions(
+      [agent('claude-1', 'tmux-1')],
+      [session('sess-1', 'tmux-1')],
+    );
+
+    expect(sessionPending).toHaveBeenCalledWith('test-city', 'sess-1');
+    expect(result).toEqual([
+      {
+        agentName: 'claude-1',
+        sessionId: 'sess-1',
+        sessionName: 'tmux-1',
+        pending: pending('req-sess-1'),
+      },
+    ]);
+  });
+
+  it('skips an agent with no bound session', async () => {
+    const sessionPending = vi.fn();
+    setSupervisorApiForTests({ ...baseApi, sessionPending });
+
+    const result = await listAgentPendingInteractions([agent('claude-1')], []);
+
+    expect(result).toEqual([]);
+    expect(sessionPending).not.toHaveBeenCalled();
+  });
+
+  it('skips an agent whose session name resolves to no live session id', async () => {
+    const sessionPending = vi.fn();
+    setSupervisorApiForTests({ ...baseApi, sessionPending });
+
+    const result = await listAgentPendingInteractions(
+      [agent('claude-1', 'tmux-ghost')],
+      [session('sess-1', 'tmux-1')],
+    );
+
+    expect(result).toEqual([]);
+    expect(sessionPending).not.toHaveBeenCalled();
+  });
+
+  it('drops candidates whose session reports no pending interaction', async () => {
+    const sessionPending = vi.fn(
+      async (_city: string, sessionId: string): Promise<SessionPendingResponse> =>
+        sessionId === 'sess-1' ? { supported: true } : { supported: true, pending: pending('req') },
+    );
+    setSupervisorApiForTests({ ...baseApi, sessionPending });
+
+    const result = await listAgentPendingInteractions(
+      [agent('claude-1', 'tmux-1'), agent('claude-2', 'tmux-2')],
+      [session('sess-1', 'tmux-1'), session('sess-2', 'tmux-2')],
+    );
+
+    expect(result.map((item) => item.agentName)).toEqual(['claude-2']);
+  });
+
+  it('ignores wire sessions that carry no session_name when indexing', async () => {
+    const sessionPending = vi.fn(
+      async (): Promise<SessionPendingResponse> => ({ supported: true, pending: pending('req') }),
+    );
+    setSupervisorApiForTests({ ...baseApi, sessionPending });
+    const nameless = {
+      ...session('sess-2', 'tmux-1'),
+      session_name: undefined,
+    } as unknown as SessionResponse;
+
+    const result = await listAgentPendingInteractions(
+      [agent('claude-1', 'tmux-1')],
+      [session('sess-1', 'tmux-1'), nameless],
+    );
+
+    // The named session wins the index; the nameless one is never reachable.
+    expect(result).toEqual([
+      {
+        agentName: 'claude-1',
+        sessionId: 'sess-1',
+        sessionName: 'tmux-1',
+        pending: pending('req'),
+      },
+    ]);
+  });
+});
+
+describe('respondToAgentPendingInteraction', () => {
+  it('routes the response to the active city and session', async () => {
+    const respondSession = vi.fn(async () => ({ id: 'sess-1' }) as never);
+    setSupervisorApiForTests({ ...baseApi, respondSession });
+
+    await respondToAgentPendingInteraction('sess-1', { request_id: 'req-1', action: 'allow' });
+
+    expect(respondSession).toHaveBeenCalledWith('test-city', 'sess-1', {
+      request_id: 'req-1',
+      action: 'allow',
+    });
+  });
+});

--- a/frontend/src/supervisor/eventSignals.test.ts
+++ b/frontend/src/supervisor/eventSignals.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { TypedEventStreamEnvelope } from 'gas-city-dashboard-shared/gc-supervisor';
+import { supervisorEventDetail, supervisorEventSignal } from './eventSignals';
+
+// The attention/watch classification drives the supervisor event badge. These
+// sets are pinned here so dropping, renaming, or reclassifying a supervisor
+// event type fails a test instead of silently changing what the badge surfaces
+// (gascity-dashboard-afeo). The lists are the EXPECTED membership, duplicated on
+// purpose — the test is the second copy that catches an edit to the source set.
+const ATTENTION_TYPES = [
+  'gc.store.maintenance.failed',
+  'order.failed',
+  'request.failed',
+  'session.crashed',
+  'session.stranded',
+  'session.work_query_failed',
+  'supervisor.shutdown_requested',
+] as const;
+
+const WATCH_TYPES = [
+  'events.rotated',
+  'session.quarantined',
+  'session.suspended',
+  'supervisor.fs_pressure.skipped_tick',
+] as const;
+
+// Minimal envelope carrying only the fields the classifier reads (type) plus
+// the optional detail fields. The wire shape is a discriminated union over
+// dozens of variants; this loader only ever reads `type`, `message`, `subject`,
+// so a structural fixture cast to the union type is the honest minimum.
+function envelope(
+  type: string,
+  detail: { message?: string; subject?: string } = {},
+): TypedEventStreamEnvelope {
+  return {
+    type,
+    actor: 'supervisor',
+    seq: 1,
+    ts: '2026-06-28T00:00:00Z',
+    payload: {},
+    ...detail,
+  } as unknown as TypedEventStreamEnvelope;
+}
+
+describe('supervisorEventSignal', () => {
+  it.each(ATTENTION_TYPES)('classifies %s as attention', (type) => {
+    expect(supervisorEventSignal(envelope(type))).toBe('attention');
+  });
+
+  it.each(WATCH_TYPES)('classifies %s as watch', (type) => {
+    expect(supervisorEventSignal(envelope(type))).toBe('watch');
+  });
+
+  it('classifies any unmapped type as a plain event', () => {
+    for (const type of ['bead.closed', 'mail.sent', 'session.updated', 'controller.started']) {
+      expect(supervisorEventSignal(envelope(type))).toBe('event');
+    }
+  });
+
+  it('does not cross-classify a watch type as attention or vice versa', () => {
+    // Guards against a future edit that adds a type to both sets: attention is
+    // checked first, so a watch type leaking into the attention set would flip
+    // here while its watch test above still passed.
+    for (const type of WATCH_TYPES) {
+      expect(supervisorEventSignal(envelope(type))).not.toBe('attention');
+    }
+    for (const type of ATTENTION_TYPES) {
+      expect(supervisorEventSignal(envelope(type))).not.toBe('watch');
+    }
+  });
+});
+
+describe('supervisorEventDetail', () => {
+  it('prefers the message when present', () => {
+    expect(
+      supervisorEventDetail(
+        envelope('order.failed', { message: 'order blew up', subject: 'ord-1' }),
+      ),
+    ).toBe('order blew up');
+  });
+
+  it('falls back to the subject when no message', () => {
+    expect(supervisorEventDetail(envelope('order.failed', { subject: 'ord-1' }))).toBe('ord-1');
+  });
+
+  it('falls back to the type when neither message nor subject is set', () => {
+    expect(supervisorEventDetail(envelope('order.failed'))).toBe('order.failed');
+  });
+});

--- a/frontend/src/supervisor/sessionReads.test.ts
+++ b/frontend/src/supervisor/sessionReads.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ListBodySessionResponse,
+  OutputTurn,
+  SessionResponse,
+  SessionTranscriptGetResponse,
+} from 'gas-city-dashboard-shared/gc-supervisor';
+import type { DashboardSession } from 'gas-city-dashboard-shared';
+import { setActiveCity } from '../api/cityBase';
+import {
+  resetSupervisorApiForTests,
+  setSupervisorApiForTests,
+  GC_MUTATION_HEADERS,
+  type SupervisorApi,
+} from './client';
+import {
+  fetchSupervisorSessionTranscript,
+  listSupervisorSessions,
+  normalizeSessions,
+  sessionTranscriptView,
+} from './sessionReads';
+
+// The required wire fields a SessionResponse always carries; the optional ones
+// are layered on per-test to exercise the include-only-when-defined branches.
+function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: 'sess-1',
+    template: 'claude',
+    session_name: 'tmux-1',
+    title: 'Session One',
+    state: 'running',
+    created_at: '2026-06-28T00:00:00Z',
+    attached: false,
+    running: true,
+    provider: 'claude',
+    ...overrides,
+  };
+}
+
+function turn(text: string, role = 'assistant'): OutputTurn {
+  return { role, text };
+}
+
+function sessionList(items: SessionResponse[]): ListBodySessionResponse {
+  return { items, total: items.length };
+}
+
+function normalizeOne(overrides: Partial<SessionResponse> = {}): DashboardSession {
+  const [result] = normalizeSessions(sessionList([session(overrides)]));
+  if (result === undefined) throw new Error('expected exactly one normalized session');
+  return result;
+}
+
+const baseApi: SupervisorApi = {
+  baseUrl: '/gc-supervisor',
+  health: vi.fn(),
+  cityHealth: vi.fn(),
+  cityStatus: vi.fn(),
+  listCities: vi.fn(),
+  listAgents: vi.fn(),
+  listRigs: vi.fn(),
+  listBeads: vi.fn(),
+  listEvents: vi.fn(),
+  getBead: vi.fn(),
+  beadsGraph: vi.fn(),
+  createBead: vi.fn(),
+  updateBead: vi.fn(),
+  closeBead: vi.fn(),
+  nudgeAgent: vi.fn(),
+  agentPrime: vi.fn(),
+  sling: vi.fn(),
+  formulaFeed: vi.fn(),
+  listMail: vi.fn(),
+  markMailRead: vi.fn(),
+  markMailUnread: vi.fn(),
+  archiveMail: vi.fn(),
+  replyMail: vi.fn(),
+  sendMail: vi.fn(),
+  mailThread: vi.fn(),
+  cityEventStreamUrl: vi.fn(),
+  sessionStreamUrl: vi.fn(),
+  listSessions: vi.fn(),
+  sessionPending: vi.fn(),
+  respondSession: vi.fn(),
+  sessionTranscript: vi.fn(),
+  workflowRun: vi.fn(),
+  formulaDetail: vi.fn(),
+  mutationHeaders: () => ({ ...GC_MUTATION_HEADERS }),
+};
+
+beforeEach(() => {
+  setActiveCity('test-city');
+});
+
+afterEach(() => {
+  resetSupervisorApiForTests();
+});
+
+describe('normalizeSessions', () => {
+  it('maps every required field across the list', () => {
+    const result = normalizeSessions(sessionList([session({ id: 'a' }), session({ id: 'b' })]));
+
+    expect(result.map((s) => s.id)).toEqual(['a', 'b']);
+    expect(result[0]).toMatchObject({
+      id: 'a',
+      template: 'claude',
+      session_name: 'tmux-1',
+      title: 'Session One',
+      state: 'running',
+      created_at: '2026-06-28T00:00:00Z',
+      attached: false,
+      running: true,
+      provider: 'claude',
+    });
+  });
+
+  it('treats a missing items array as an empty list', () => {
+    expect(normalizeSessions({} as ListBodySessionResponse)).toEqual([]);
+  });
+
+  it('omits optional keys entirely when the wire field is undefined', () => {
+    const result = normalizeOne();
+
+    // Absence must be a missing key, not an explicit `undefined` value — the
+    // DashboardSession contract treats these as optional, and a spurious
+    // `alias: undefined` would defeat `'alias' in session` consumers.
+    for (const key of [
+      'alias',
+      'reason',
+      'display_name',
+      'last_active',
+      'rig',
+      'pool',
+      'agent_kind',
+      'model',
+      'context_pct',
+      'context_window',
+      'activity',
+    ]) {
+      expect(key in result).toBe(false);
+    }
+  });
+
+  it('carries every optional field through when the wire field is present', () => {
+    const result = normalizeOne({
+      alias: 'claude-1',
+      reason: 'city-stop',
+      display_name: 'Claude Code',
+      last_active: '2026-06-28T01:00:00Z',
+      rig: 'gascity-dashboard',
+      pool: 'default',
+      agent_kind: 'pool',
+      model: 'opus',
+      context_pct: 42,
+      context_window: 200000,
+      activity: 'thinking',
+    });
+
+    expect(result).toMatchObject({
+      alias: 'claude-1',
+      reason: 'city-stop',
+      display_name: 'Claude Code',
+      last_active: '2026-06-28T01:00:00Z',
+      rig: 'gascity-dashboard',
+      pool: 'default',
+      agent_kind: 'pool',
+      model: 'opus',
+      context_pct: 42,
+      context_window: 200000,
+      activity: 'thinking',
+    });
+  });
+
+  it('preserves a falsy-but-present optional field (context_pct: 0)', () => {
+    // `!== undefined` is the right guard, not truthiness — a 0% context window
+    // is a real value and must survive normalization.
+    const result = normalizeOne({ context_pct: 0 });
+    expect('context_pct' in result).toBe(true);
+    expect(result.context_pct).toBe(0);
+  });
+});
+
+describe('sessionTranscriptView', () => {
+  function transcript(
+    overrides: Partial<SessionTranscriptGetResponse> = {},
+  ): SessionTranscriptGetResponse {
+    return { turns: [], ...overrides } as SessionTranscriptGetResponse;
+  }
+
+  it('sums total_chars over the turn texts', () => {
+    const view = sessionTranscriptView(
+      transcript({ turns: [turn('abc'), turn('de'), turn('')] }),
+      '2026-06-28T02:00:00Z',
+    );
+
+    expect(view.total_chars).toBe(5);
+    expect(view.turns).toHaveLength(3);
+    expect(view.captured_at).toBe('2026-06-28T02:00:00Z');
+    expect(view.truncated).toBe(false);
+  });
+
+  it('defaults turns to an empty array and total_chars to 0 when turns are null', () => {
+    const view = sessionTranscriptView(
+      { turns: null } as unknown as SessionTranscriptGetResponse,
+      '2026-06-28T02:00:00Z',
+    );
+
+    expect(view.turns).toEqual([]);
+    expect(view.total_chars).toBe(0);
+  });
+
+  it('stamps captured_at from the wall clock when no value is supplied', () => {
+    const before = Date.now();
+    const view = sessionTranscriptView(transcript({ turns: [turn('hi')] }));
+    const captured = Date.parse(view.captured_at);
+
+    expect(Number.isNaN(captured)).toBe(false);
+    expect(captured).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('supervisor session read wrappers', () => {
+  it('lists sessions for the active city', async () => {
+    const listSessions = vi.fn(async () => ({ items: [session()], total: 1 }));
+    setSupervisorApiForTests({ ...baseApi, listSessions });
+
+    const result = await listSupervisorSessions();
+
+    expect(listSessions).toHaveBeenCalledWith('test-city');
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('fetches a transcript and derives the view on the real edge', async () => {
+    const sessionTranscript = vi.fn(async () => transcriptResponse());
+    setSupervisorApiForTests({ ...baseApi, sessionTranscript });
+
+    const view = await fetchSupervisorSessionTranscript('sess-1');
+
+    expect(sessionTranscript).toHaveBeenCalledWith('test-city', 'sess-1');
+    expect(view.total_chars).toBe(7);
+    expect(view.truncated).toBe(false);
+  });
+
+  function transcriptResponse(): SessionTranscriptGetResponse {
+    return { turns: [turn('hello '), turn('x')] } as SessionTranscriptGetResponse;
+  }
+});


### PR DESCRIPTION
Adds unit coverage for four previously-untested supervisor frontend edge modules: `eventSignals`, `sessionReads`, `agentPending`, and the `useConvoyView` hook. Test-only and invariant-safe — no production code or wire-shape changes.

From the 2026-06-29 dashboard deep-audit, which flagged these as the spots where a silent regression would slip through uncaught.

**Test plan**
- New tests pass locally (branch-ready @742621f).
- CI: `typecheck:test` + the snap harness run on this PR.
