### PR TITLE
test(security): pin isSafeRelativeGitPath branch coverage (muva)

### DIFF
--- a/backend/src/runs/diff.ts
+++ b/backend/src/runs/diff.ts
@@ -13,7 +13,11 @@ import {
 } from '../exec.js';
 import { MAX_RUN_DIFF_BYTES } from '../exec-core.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
-import { classifyRunDiffFile, isReviewableRunDiffPath } from './run-diff-policy.js';
+import {
+  classifyRunDiffFile,
+  isReviewableRunDiffPath,
+  isSafeRelativeGitPath,
+} from './run-diff-policy.js';
 
 const MAX_UNTRACKED_PATCH_FILES = 50;
 const MAX_UNTRACKED_FILE_DIFF_BYTES = 96 * 1024;
@@ -339,15 +343,6 @@ function isReviewablePatchBlock(block: string): boolean {
   const match = /^diff --git a\/(.+) b\/(.+)$/.exec(header);
   if (!match) return true;
   return isReviewableRunDiffPath(match[1] ?? '') && isReviewableRunDiffPath(match[2] ?? '');
-}
-
-function isSafeRelativeGitPath(filePath: string): boolean {
-  return (
-    filePath.length > 0 &&
-    !filePath.startsWith('/') &&
-    !filePath.includes('\0') &&
-    !filePath.split('/').includes('..')
-  );
 }
 
 function isChangedFile(value: RunChangedFile | null): value is RunChangedFile {

--- a/backend/src/runs/run-diff-policy.ts
+++ b/backend/src/runs/run-diff-policy.ts
@@ -22,6 +22,20 @@ export function normalizeGitDiffPath(filePath: string): string {
   return filePath.replace(/^"?[ab]\//, '').replace(/"$/, '');
 }
 
+// Defense-in-depth guard for paths handed to a `git diff` shell-out in the
+// untracked-patch pass. Git only ever emits repo-relative paths, so in normal
+// operation every path passes; the guard fails closed if a compromised or
+// malformed git output ever yields an absolute path, a `..` escape, or an
+// embedded NUL — none of which a legitimate relative in-repo path carries.
+export function isSafeRelativeGitPath(filePath: string): boolean {
+  return (
+    filePath.length > 0 &&
+    !filePath.startsWith('/') &&
+    !filePath.includes('\0') &&
+    !filePath.split('/').includes('..')
+  );
+}
+
 export function classifyRunDiffFile(filePath: string): RunChangedFileKind {
   const lower = normalizeGitDiffPath(filePath).toLowerCase();
   if (

--- a/backend/test/run-diff-policy.test.ts
+++ b/backend/test/run-diff-policy.test.ts
@@ -4,6 +4,7 @@ import {
   RUN_REVIEWABLE_PATHS,
   classifyRunDiffFile,
   isReviewableRunDiffPath,
+  isSafeRelativeGitPath,
 } from '../src/runs/run-diff-policy.js';
 
 describe('run diff reviewability policy', () => {
@@ -35,5 +36,47 @@ describe('run diff reviewability policy', () => {
     assert.equal(classifyRunDiffFile('docs/readme.md'), 'docs');
     assert.equal(classifyRunDiffFile('package.json'), 'config');
     assert.equal(classifyRunDiffFile('assets/logo.png'), 'other');
+  });
+});
+
+describe('untracked git path safety guard', () => {
+  // `isSafeRelativeGitPath` gates paths fed to the untracked-patch `git diff`
+  // shell-out. Git itself only emits repo-relative paths, so the reject branches
+  // are unreachable through normal git output — they exist as defense-in-depth
+  // against compromised/malformed git output and are only exercisable directly.
+  // Each rejection below isolates exactly one branch: neuter that branch and
+  // only its case flips, so every assertion is mutation-biting.
+  test('accepts ordinary repo-relative untracked paths', () => {
+    for (const filePath of [
+      'src/index.ts',
+      'docs/plan.md',
+      '.runtime/session_id',
+      'a/b/c/deep.txt',
+      'file-with..dots-but-no-segment.ts',
+    ]) {
+      assert.equal(isSafeRelativeGitPath(filePath), true, `expected safe: ${filePath}`);
+    }
+  });
+
+  test('rejects the empty path (length-0 branch)', () => {
+    assert.equal(isSafeRelativeGitPath(''), false);
+  });
+
+  test('rejects an absolute path (leading-slash branch)', () => {
+    assert.equal(isSafeRelativeGitPath('/etc/passwd'), false);
+    assert.equal(isSafeRelativeGitPath('/tmp/evil'), false);
+  });
+
+  test('rejects an embedded NUL byte (null-byte branch)', () => {
+    assert.equal(isSafeRelativeGitPath('src/app.ts\0.png'), false);
+    assert.equal(isSafeRelativeGitPath('\0'), false);
+  });
+
+  test('rejects a `..` escape segment without flagging `..` substrings', () => {
+    // The split('/').includes('..') branch matches a whole `..` segment only —
+    // a literal `..` inside a filename (asserted safe above) must still pass.
+    assert.equal(isSafeRelativeGitPath('../outside'), false);
+    assert.equal(isSafeRelativeGitPath('src/../../escape'), false);
+    assert.equal(isSafeRelativeGitPath('a/b/..'), false);
   });
 });


### PR DESCRIPTION
## Summary
Pins branch coverage for the `isSafeRelativeGitPath` traversal guard used by the runs-diff path. Extracts the policy check into `run-diff-policy.ts` and adds tests asserting each accept/reject branch of the safe-relative-path rule, so a future change to the guard can't silently widen what paths are accepted.

## Changes
- `backend/src/runs/diff.ts` — route the path check through the policy helper
- `backend/src/runs/run-diff-policy.ts` — `isSafeRelativeGitPath` policy helper
- `backend/test/run-diff-policy.test.ts` — branch-coverage tests for accept/reject cases

## Test plan
- `npm run typecheck` (src + test), workspace tests, eslint `--max-warnings=0`, prettier — all green
- Reviewed by the dashboard multi-reviewer pipeline (code-reviewer + security-reviewer + typescript-reviewer + Codex): APPROVE, 0 findings; invariant-safe (no shared wire-shape / bind / Origin / DESIGN changes)
