### PR TITLE
refactor(audit-2026-06-28): fallbackPhase ZFC doc, selectOneMark single-pass, HealthPage split, runSummary error log (xubc)

### DIFF
--- a/backend/src/views/modules/maintainer/triage.ts
+++ b/backend/src/views/modules/maintainer/triage.ts
@@ -398,35 +398,53 @@ export function computeHasInFlightPr(items: TriageItem[]): void {
  *
  * Extracted from composeEnvelope so the GET overlay (gascity-dashboard-9qs)
  * can re-run the winnow after splicing slung-state onto items at serve
- * time. Mutates each item's is_marked in place.
+ * time.
+ *
+ * The winner is resolved purely (selectMarkWinner — no mutation), then a
+ * single pass sets is_marked = (item is the winner) on every item. The
+ * decision and the assignment are no longer split across provisional-set
+ * then multiple clearing passes (audit-2026-06-28 #5). Immutability note:
+ * this still writes is_marked in place rather than returning new objects,
+ * because the item references are shared — collectItems() hands back the
+ * very objects held inside the rendered envelope tiers, and applySlungOverlay
+ * is by contract an in-place envelope mutator; returning fresh objects here
+ * would orphan the envelope's references and drop the maroon ● at render.
  *
  * Callers must have already populated tier + triage_score on every item
  * AND set the provisional is_marked from classifyItem / isMarkCandidate.
- * Items whose is_marked is already false are passed over.
  */
 export function selectOneMark(items: TriageItem[]): void {
-  // (1) Drop candidate issues whose in-flight PR is in view so the eye
-  // lands on the action (the PR), not the problem.
-  const issueNumbersWithInFlightPrSet = issueNumbersWithInFlightPr(items);
+  const winner = selectMarkWinner(items);
   for (const item of items) {
-    if (item.kind === 'issue' && issueNumbersWithInFlightPrSet.has(item.number)) {
-      item.is_marked = false;
-    }
+    item.is_marked = item === winner;
   }
+}
 
-  // (2) Pick the top scorer among the surviving candidates. Uses
-  // sortScore so a vetted item wins the mark over an unvetted item
-  // with a higher heuristic score (vetted is the stronger signal).
+/**
+ * Pure winner resolution for the One Mark Rule — reads provisional is_marked
+ * + scores and returns the single item that should carry the maroon ● (or
+ * null when nothing qualifies). No mutation, so the decision is testable and
+ * the assignment lives in exactly one place (selectOneMark).
+ */
+function selectMarkWinner(items: TriageItem[]): TriageItem | null {
+  // (1) Candidate set: provisionally-marked items, minus any issue whose
+  // in-flight PR is in view — the eye should land on the action (the PR),
+  // not the problem.
+  const issueNumbersWithInFlightPrSet = issueNumbersWithInFlightPr(items);
+  const isCandidate = (item: TriageItem): boolean =>
+    item.is_marked && !(item.kind === 'issue' && issueNumbersWithInFlightPrSet.has(item.number));
+
+  // (2) Top scorer among the survivors. Uses sortScore so a vetted item wins
+  // the mark over an unvetted item with a higher heuristic score (vetted is
+  // the stronger signal).
   let topMark: TriageItem | null = null;
   for (const item of items) {
-    if (!item.is_marked) continue;
+    if (!isCandidate(item)) continue;
     if (topMark === null || sortScore(item) > sortScore(topMark)) {
       topMark = item;
     }
   }
-  for (const item of items) {
-    if (item.is_marked && item !== topMark) item.is_marked = false;
-  }
+  if (topMark === null) return null;
 
   // (3) Legacy parent-transfer (PR → parent issue): when the winning mark
   // is a PR, the mark belongs on the parent issue ONLY when there is no
@@ -434,25 +452,24 @@ export function selectOneMark(items: TriageItem[]): void {
   // open action item (merged / closed), so the eye should fall back to
   // the still-open problem.
   //
-  // gascity-dashboard-443: the guard is keyed on the step-(1) in-flight
+  // gascity-dashboard-443: the guard is keyed on the candidate in-flight
   // set, NOT on `parent.is_marked`. The previous `parent.is_marked` check
   // was structurally wrong in two ways:
-  //   - It is unconditionally dead today: step (2) clears is_marked on
-  //     every non-topMark item, so the parent is always unmarked here.
+  //   - It was unconditionally dead: the winnow cleared is_marked on every
+  //     non-topMark item, so the parent was always unmarked at this point.
   //   - It points the wrong direction for the forward-defense case the
   //     block claims to handle. If isMarkCandidate is ever extended to
-  //     mark issues directly, a parent issue that was the top scorer in
-  //     step (2) would arrive with is_marked=true and WRONGLY trigger a
-  //     transfer from a winning in-flight PR to its parent issue —
-  //     re-introducing the exact bs2 regression (the mark must stay on
-  //     the action item, the PR).
+  //     mark issues directly, a parent issue that was the top scorer would
+  //     arrive with is_marked=true and WRONGLY trigger a transfer from a
+  //     winning in-flight PR to its parent issue — re-introducing the exact
+  //     bs2 regression (the mark must stay on the action item, the PR).
   //
   // Keying on `issueNumbersWithInFlightPr` makes the intent explicit and
   // direction-correct: an issue with an in-flight PR NEVER receives the
-  // mark (bs2), regardless of which item won step (2). The transfer fires
-  // only for a parent with no in-flight PR (its linking PR is the merged /
-  // closed topMark) and which is not itself the top scorer.
-  if (topMark !== null && topMark.kind === 'pr' && topMark.linked_numbers.length > 0) {
+  // mark (bs2), regardless of which item is the top scorer. The transfer
+  // fires only for a parent with no in-flight PR (its linking PR is the
+  // merged / closed topMark) and which is not itself the top scorer.
+  if (topMark.kind === 'pr' && topMark.linked_numbers.length > 0) {
     for (const linkedNum of topMark.linked_numbers) {
       const parent = items.find((i) => i.kind === 'issue' && i.number === linkedNum);
       if (
@@ -460,12 +477,11 @@ export function selectOneMark(items: TriageItem[]): void {
         parent !== topMark &&
         !issueNumbersWithInFlightPrSet.has(parent.number)
       ) {
-        topMark.is_marked = false;
-        parent.is_marked = true;
-        break;
+        return parent;
       }
     }
   }
+  return topMark;
 }
 
 function composeEnvelope(repo: string, items: TriageItem[]): MaintainerTriage {

--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -109,7 +109,6 @@ export function HealthPage() {
     localTools !== null ||
     trend !== null ||
     rigStores !== null;
-  const hostHealthStatus = health ? hostStatus(health) : undefined;
   const supervisorAttention = prefixedAttentionSeverity(attention, 'health', [
     'health:supervisor-',
   ]);
@@ -145,89 +144,21 @@ export function HealthPage() {
 
       {hasAnyData ? (
         <div className="space-y-12">
-          <Section
-            title="Supervisor"
-            attention={supervisorAttention}
-            {...(supervisor ? { status: supervisorStatus(supervisor) } : {})}
-          >
-            {supervisor === null ? (
-              <p className="text-body text-fg-muted italic">Loading supervisor state.</p>
-            ) : supervisor.status === 'available' ? (
-              <KvList>
-                {/* izgc F7/F8: city + version are optional per supervisor's
-                    OpenAPI. Absence is itself a wire-drift signal — render
-                    in 'warn' tone rather than coalescing to a glanceable
-                    em-dash, so the operator notices the regression. */}
-                {supervisor.data.city !== undefined ? (
-                  <Kv label="City" value={supervisor.data.city} />
-                ) : (
-                  <Kv label="City" value="not reported by supervisor" tone="warn" />
-                )}
-                {supervisor.data.version !== undefined ? (
-                  <Kv label="Version" value={supervisor.data.version} />
-                ) : (
-                  <Kv label="Version" value="not reported by supervisor" tone="warn" />
-                )}
-                <Kv label="Uptime" value={formatDuration(supervisor.data.uptime_sec)} />
-                <Kv label="Status" value={supervisor.data.status} />
-              </KvList>
-            ) : (
-              <p className="text-body text-accent">
-                Supervisor not reachable. The dashboard shell stays up; live data is stale.
-              </p>
-            )}
-          </Section>
+          <SupervisorSection supervisor={supervisor} attention={supervisorAttention} />
 
-          <Section
-            title="Host"
+          <HostSection
+            healthState={healthState}
+            health={health}
+            healthError={healthError}
             attention={hostAttention}
-            {...(hostHealthStatus ? { status: hostHealthStatus } : {})}
-          >
-            {healthState === null ? (
-              <p className="text-body text-fg-muted italic">Loading dashboard host health.</p>
-            ) : health === null ? (
-              <p className="text-body text-accent">
-                Dashboard host health unavailable{healthError ? `: ${healthError}` : ''}.
-              </p>
-            ) : (
-              <KvList>
-                <Kv label="CPUs" value={health.host.cpu_count.toString()} />
-                <Kv
-                  label="Load (1m, 5m, 15m)"
-                  value={`${health.host.load_avg_1.toFixed(2)}, ${health.host.load_avg_5.toFixed(2)}, ${health.host.load_avg_15.toFixed(2)}`}
-                  {...(health.host.load_avg_1 > health.host.cpu_count
-                    ? { tone: 'warn' as const }
-                    : {})}
-                />
-                <Kv
-                  label="Memory free"
-                  value={`${formatHumanSize(health.host.free_mem_bytes)} of ${formatHumanSize(health.host.total_mem_bytes)}`}
-                  {...(health.host.free_mem_bytes / health.host.total_mem_bytes < 0.1
-                    ? { tone: 'warn' as const }
-                    : {})}
-                />
-                <Kv label="Host uptime" value={formatDuration(health.host.uptime_sec)} />
-              </KvList>
-            )}
-          </Section>
+          />
 
-          <Section title="Admin process" attention={adminAttention}>
-            {healthState === null ? (
-              <p className="text-body text-fg-muted italic">Loading dashboard process health.</p>
-            ) : health === null ? (
-              <p className="text-body text-accent">
-                Dashboard process health unavailable{healthError ? `: ${healthError}` : ''}.
-              </p>
-            ) : (
-              <KvList>
-                <Kv label="PID" value={health.admin.pid.toString()} />
-                <Kv label="Uptime" value={formatDuration(health.admin.uptime_sec)} />
-                <Kv label="RSS" value={formatHumanSize(health.admin.rss_bytes)} />
-                <Kv label="Heap used" value={formatHumanSize(health.admin.heap_used_bytes)} />
-                <Kv label="Node" value={health.admin.node_version} />
-              </KvList>
-            )}
-          </Section>
+          <AdminProcessSection
+            healthState={healthState}
+            health={health}
+            healthError={healthError}
+            attention={adminAttention}
+          />
 
           <Section title="Tool versions">
             <ToolVersionsTable state={localTools} />
@@ -252,30 +183,163 @@ export function HealthPage() {
             <ConfigComparison comparison={configComparisonOf(status)} />
           </Section>
 
-          <Section
-            title="Dolt-noms · 24 h"
-            attention={doltNomsAttention}
-            meta={trend && trend.samples.length > 0 ? `${trend.samples.length} samples` : undefined}
-          >
-            {trend === null ? (
-              <p className="text-body text-fg-muted italic">Loading.</p>
-            ) : !trend.available ? (
-              <p className="text-body text-fg-muted italic">
-                Dolt-noms metric unavailable: {doltUnavailableCopy(trend.reason)}.
-              </p>
-            ) : trend.samples.length === 0 ? (
-              <p className="text-body text-fg-muted italic">
-                No samples yet. Backend just started; next sample in ten minutes or less.
-              </p>
-            ) : (
-              <Sparkline samples={trend.samples} />
-            )}
-          </Section>
+          <DoltNomsSection trend={trend} attention={doltNomsAttention} />
         </div>
       ) : (
         <p className="text-body text-fg-muted italic">Loading.</p>
       )}
     </section>
+  );
+}
+
+function SupervisorSection({
+  supervisor,
+  attention,
+}: {
+  supervisor: SupervisorHealthState | null;
+  attention: ReturnType<typeof prefixedAttentionSeverity>;
+}) {
+  return (
+    <Section
+      title="Supervisor"
+      attention={attention}
+      {...(supervisor ? { status: supervisorStatus(supervisor) } : {})}
+    >
+      {supervisor === null ? (
+        <p className="text-body text-fg-muted italic">Loading supervisor state.</p>
+      ) : supervisor.status === 'available' ? (
+        <KvList>
+          {/* izgc F7/F8: city + version are optional per supervisor's
+              OpenAPI. Absence is itself a wire-drift signal — render
+              in 'warn' tone rather than coalescing to a glanceable
+              em-dash, so the operator notices the regression. */}
+          {supervisor.data.city !== undefined ? (
+            <Kv label="City" value={supervisor.data.city} />
+          ) : (
+            <Kv label="City" value="not reported by supervisor" tone="warn" />
+          )}
+          {supervisor.data.version !== undefined ? (
+            <Kv label="Version" value={supervisor.data.version} />
+          ) : (
+            <Kv label="Version" value="not reported by supervisor" tone="warn" />
+          )}
+          <Kv label="Uptime" value={formatDuration(supervisor.data.uptime_sec)} />
+          <Kv label="Status" value={supervisor.data.status} />
+        </KvList>
+      ) : (
+        <p className="text-body text-accent">
+          Supervisor not reachable. The dashboard shell stays up; live data is stale.
+        </p>
+      )}
+    </Section>
+  );
+}
+
+function HostSection({
+  healthState,
+  health,
+  healthError,
+  attention,
+}: {
+  healthState: SystemHealthState | null;
+  health: SystemHealth | null;
+  healthError: string | null;
+  attention: ReturnType<typeof prefixedAttentionSeverity>;
+}) {
+  const hostHealthStatus = health ? hostStatus(health) : undefined;
+  return (
+    <Section
+      title="Host"
+      attention={attention}
+      {...(hostHealthStatus ? { status: hostHealthStatus } : {})}
+    >
+      {healthState === null ? (
+        <p className="text-body text-fg-muted italic">Loading dashboard host health.</p>
+      ) : health === null ? (
+        <p className="text-body text-accent">
+          Dashboard host health unavailable{healthError ? `: ${healthError}` : ''}.
+        </p>
+      ) : (
+        <KvList>
+          <Kv label="CPUs" value={health.host.cpu_count.toString()} />
+          <Kv
+            label="Load (1m, 5m, 15m)"
+            value={`${health.host.load_avg_1.toFixed(2)}, ${health.host.load_avg_5.toFixed(2)}, ${health.host.load_avg_15.toFixed(2)}`}
+            {...(health.host.load_avg_1 > health.host.cpu_count ? { tone: 'warn' as const } : {})}
+          />
+          <Kv
+            label="Memory free"
+            value={`${formatHumanSize(health.host.free_mem_bytes)} of ${formatHumanSize(health.host.total_mem_bytes)}`}
+            {...(health.host.free_mem_bytes / health.host.total_mem_bytes < 0.1
+              ? { tone: 'warn' as const }
+              : {})}
+          />
+          <Kv label="Host uptime" value={formatDuration(health.host.uptime_sec)} />
+        </KvList>
+      )}
+    </Section>
+  );
+}
+
+function AdminProcessSection({
+  healthState,
+  health,
+  healthError,
+  attention,
+}: {
+  healthState: SystemHealthState | null;
+  health: SystemHealth | null;
+  healthError: string | null;
+  attention: ReturnType<typeof prefixedAttentionSeverity>;
+}) {
+  return (
+    <Section title="Admin process" attention={attention}>
+      {healthState === null ? (
+        <p className="text-body text-fg-muted italic">Loading dashboard process health.</p>
+      ) : health === null ? (
+        <p className="text-body text-accent">
+          Dashboard process health unavailable{healthError ? `: ${healthError}` : ''}.
+        </p>
+      ) : (
+        <KvList>
+          <Kv label="PID" value={health.admin.pid.toString()} />
+          <Kv label="Uptime" value={formatDuration(health.admin.uptime_sec)} />
+          <Kv label="RSS" value={formatHumanSize(health.admin.rss_bytes)} />
+          <Kv label="Heap used" value={formatHumanSize(health.admin.heap_used_bytes)} />
+          <Kv label="Node" value={health.admin.node_version} />
+        </KvList>
+      )}
+    </Section>
+  );
+}
+
+function DoltNomsSection({
+  trend,
+  attention,
+}: {
+  trend: DoltNomsTrend | null;
+  attention: ReturnType<typeof prefixedAttentionSeverity>;
+}) {
+  return (
+    <Section
+      title="Dolt-noms · 24 h"
+      attention={attention}
+      meta={trend && trend.samples.length > 0 ? `${trend.samples.length} samples` : undefined}
+    >
+      {trend === null ? (
+        <p className="text-body text-fg-muted italic">Loading.</p>
+      ) : !trend.available ? (
+        <p className="text-body text-fg-muted italic">
+          Dolt-noms metric unavailable: {doltUnavailableCopy(trend.reason)}.
+        </p>
+      ) : trend.samples.length === 0 ? (
+        <p className="text-body text-fg-muted italic">
+          No samples yet. Backend just started; next sample in ten minutes or less.
+        </p>
+      ) : (
+        <Sparkline samples={trend.samples} />
+      )}
+    </Section>
   );
 }
 

--- a/frontend/src/runs/runSummarySubscription.tsx
+++ b/frontend/src/runs/runSummarySubscription.tsx
@@ -1,5 +1,6 @@
 import {
   GC_EVENT_PREFIX,
+  errorMessage,
   type RunSummary,
   type SourceAvailableState,
   type SourceState,
@@ -7,6 +8,7 @@ import {
 } from 'gas-city-dashboard-shared';
 import { createContext, useCallback, useContext, useEffect, useRef, type ReactNode } from 'react';
 import { getActiveCity } from '../api/cityBase';
+import { LOG_COMPONENT, logWarn } from '../lib/logging';
 import { useCachedData } from '../hooks/useCachedData';
 import { useGcEventRefresh, type GcEventConnState } from '../hooks/useGcEvents';
 import {
@@ -179,7 +181,10 @@ export function useRunSummarySubscription(): RunSummarySubscription {
     const refreshKey = cityName ?? 'no-city';
     if (fullRefreshKeyRef.current === refreshKey) return;
     fullRefreshKeyRef.current = refreshKey;
-    void refresh().catch(() => {
+    void refresh().catch((err: unknown) => {
+      // Log before clearing the key so a persistently-failing first-upgrade
+      // leaves a diagnostic trail instead of silently re-arming forever.
+      logWarn(LOG_COMPONENT.runs, `run-summary full refresh failed: ${errorMessage(err)}`);
       fullRefreshKeyRef.current = null;
     });
   }, [cityName, refresh, runs]);
@@ -239,7 +244,10 @@ export function useRunSummarySubscription(): RunSummarySubscription {
     // SSE-driven bursts take the CHEAP path (active-only + merged history); the
     // wide scan is reserved for the manual Refresh button and the one-time
     // first-upgrade.
-    void cheapRefresh().catch(() => {
+    void cheapRefresh().catch((err: unknown) => {
+      // Log before resetting so a persistently-failing SSE-driven refresh leaves
+      // a diagnostic trail rather than churning silently every event.
+      logWarn(LOG_COMPONENT.runs, `run-summary event refresh failed: ${errorMessage(err)}`);
       // Reset on error so the next event retries instead of being silently
       // dropped for the rest of the debounce window.
       lastRefreshAtRef.current = 0;

--- a/shared/src/runs/phaseMapping.ts
+++ b/shared/src/runs/phaseMapping.ts
@@ -298,6 +298,16 @@ const INTAKE_STAGE_TOKENS: ReadonlySet<string> = new Set([
  * full description+metadata dump, and drops the incidental-matching needles
  * ('gate', 'human', 'merge', 'close', 'report', 'work', 'fix', 'code') that
  * collapsed real runs onto late phases. Conservative: 'active' when ambiguous.
+ *
+ * ZFC boundary (audit-2026-06-28 #3): this is render-time UI presentation, not
+ * AI-orchestration — the ZFC ban on hardcoded semantic classifiers carves out
+ * UI/hot paths, and no model is in the loop at synchronous render. The keyword
+ * scan is a last-resort DISPLAY hint, reached only after the structural,
+ * gc.step_id-based `structuredPhase` returns null (legacy / pre-step-id runs);
+ * it gates no action, fails safe to the neutral 'active' label when ambiguous,
+ * and is already narrowed to step-identity text with the false-positive needles
+ * removed. Kept (not deleted) so unstructured runs still show a best-effort
+ * phase instead of always rendering 'active'.
  */
 function fallbackPhase(issues: RunIssue[]): PhaseMapping {
   if (stepSignalContainsAny(issues, ['approval', 'approved', 'finalize-scope'])) {


### PR DESCRIPTION
## Summary
Audit-2026-06-28 cleanup: document the `fallbackPhase` choice as a deliberate ZFC default, make `selectOneMark` a single-pass selector, split the Health page into smaller components, and add an error log on the run-summary path. No behavior change to the wire contract.

## Changes
- `backend/src/views/modules/maintainer/triage.ts` — selectOneMark single-pass
- `frontend/src/routes/Health.tsx` — HealthPage component split
- `frontend/src/runs/runSummarySubscription.tsx` — runSummary error log
- `shared/src/runs/phaseMapping.ts` — additive phase mapping + fallbackPhase ZFC doc (reviewed invariant-safe: additive, no wire-shape break)

## Test plan
- typecheck (src+test), workspace tests, lint --max-warnings=0, prettier — green

---
Review record (dashboard multi-reviewer pipeline, pre-merge): **APPROVE / 0 findings** — code-reviewer + security-reviewer + typescript-reviewer + Codex, unanimous clean. CI parity green (typecheck src+test, workspace tests, lint --max-warnings=0, prettier). Approved for merge by maintainer (Stephanie) GO.
