### PR TITLE
test(convoy): 0chv3 review nits — semantic Header anchor + refresh gen guard (7snrm)

### DIFF
--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -101,15 +101,19 @@ describe('Header mobile nav', () => {
 
   it('gives Convoy a top-level tab pointing at /convoy, ordered between Runs and Mail', () => {
     // gascity-dashboard-0chv3: the convoy view had no front door — this is it.
-    const { container } = renderHeader();
-    const desktopList = container.querySelector('ul.sm\\:flex') as HTMLElement;
-    expect(desktopList).not.toBeNull();
-    const convoy = within(desktopList).getByRole('link', { name: /Convoy/ });
+    renderHeader();
+    // Anchor on the semantic primary nav, not the responsive `sm:flex` utility
+    // class (an implementation detail). The mobile menu is a separate labelled
+    // nav, so this scopes cleanly to the desktop row.
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    const convoy = within(nav).getByRole('link', { name: /Convoy/ });
     expect(convoy.getAttribute('href')).toBe('/convoy');
     // Order is explicit (45), so Convoy sits after Runs and before Mail. Assert
     // the relative order without pinning the full set — registry-driven views may
     // also be present depending on the async config fetch's timing.
-    const labels = Array.from(desktopList.querySelectorAll('a')).map((a) => a.textContent ?? '');
+    const labels = within(nav)
+      .getAllByRole('link')
+      .map((link) => link.textContent ?? '');
     expect(labels.indexOf('Runs')).toBeLessThan(labels.indexOf('Convoy'));
     expect(labels.indexOf('Convoy')).toBeLessThan(labels.indexOf('Mail'));
   });

--- a/frontend/src/hooks/useConvoyRoots.test.ts
+++ b/frontend/src/hooks/useConvoyRoots.test.ts
@@ -1,0 +1,71 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { ConvoyRootsLoad, ConvoyRootSummary } from '../supervisor/convoyReads';
+import { useConvoyRoots } from './useConvoyRoots';
+
+const mockLoadActiveConvoyRoots = vi.hoisted(() => vi.fn());
+vi.mock('../supervisor/convoyReads', () => ({
+  loadActiveConvoyRoots: mockLoadActiveConvoyRoots,
+}));
+const mockLoad = mockLoadActiveConvoyRoots as Mock;
+
+function rootsLoad(id: string): ConvoyRootsLoad {
+  return {
+    partial: false,
+    roots: [
+      {
+        rootBeadId: id,
+        title: id,
+        status: 'in_progress',
+        formulaName: id,
+        formulaNameProvenance: 'metadata',
+      } satisfies ConvoyRootSummary,
+    ],
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  cleanup();
+  mockLoad.mockReset();
+});
+
+describe('useConvoyRoots', () => {
+  it('lands the latest-issued refresh even when an earlier one resolves later', async () => {
+    const r1 = deferred<ConvoyRootsLoad>();
+    const r2 = deferred<ConvoyRootsLoad>();
+    mockLoad
+      .mockResolvedValueOnce(rootsLoad('gc-initial')) // initial mount load
+      .mockReturnValueOnce(r1.promise) // refresh generation 1
+      .mockReturnValueOnce(r2.promise); // refresh generation 2 (supersedes 1)
+
+    const { result } = renderHook(() => useConvoyRoots());
+    await waitFor(() => expect(result.current.state.kind).toBe('ready'));
+
+    // Two overlapping refreshes (bypassing the UI's disabled-while-loading guard).
+    await act(async () => {
+      void result.current.refresh();
+      void result.current.refresh();
+    });
+
+    // The later-issued refresh resolves first and lands…
+    await act(async () => {
+      r2.resolve(rootsLoad('gc-r2'));
+    });
+    // …and the earlier one resolving LAST is ignored, not last-resolve-wins.
+    await act(async () => {
+      r1.resolve(rootsLoad('gc-r1'));
+    });
+
+    const state = result.current.state;
+    if (state.kind !== 'ready') throw new Error(`expected ready, got ${state.kind}`);
+    expect(state.load.roots.map((root) => root.rootBeadId)).toEqual(['gc-r2']);
+  });
+});

--- a/frontend/src/hooks/useConvoyRoots.ts
+++ b/frontend/src/hooks/useConvoyRoots.ts
@@ -59,7 +59,17 @@ export function useConvoyRoots(): UseConvoyRoots {
     };
   }, [load]);
 
-  const refresh = useCallback(() => load('refresh', () => isCurrentRef.current()), [load]);
+  // Per-request generation for refresh(). Each call supersedes the previous one,
+  // so two overlapping refreshes resolve in ISSUE order (latest wins) rather than
+  // last-resolve-wins. Unreachable through the UI today — the Refresh control is
+  // disabled while a load is in flight and refresh() has no other caller — but it
+  // makes the hook correct-by-construction for any future caller, and composes
+  // with (does not replace) the mount-liveness guard above.
+  const refreshGenRef = useRef(0);
+  const refresh = useCallback(() => {
+    const generation = (refreshGenRef.current += 1);
+    return load('refresh', () => isCurrentRef.current() && generation === refreshGenRef.current);
+  }, [load]);
 
   return { state, refresh };
 }


### PR DESCRIPTION
## Summary
Addresses the 0chv3 convoy review nits: move the Header nav test assertion onto a semantic `getByRole('navigation',{name:'Primary'})` anchor (off the Tailwind class), and add a per-request generation guard to `useConvoyRoots.refresh()` for latest-wins. Frontend-only, invariant-safe.

## Changes
- `frontend/src/components/Header.test.tsx` — semantic nav anchor
- `frontend/src/hooks/useConvoyRoots.ts` — refresh() generation guard
- `frontend/src/hooks/useConvoyRoots.test.ts` — mutation-biting guard tests

## Test plan
- typecheck (src+test), workspace tests (1118, +1 new), lint --max-warnings=0, prettier — green

---
Review record (dashboard multi-reviewer pipeline, pre-merge): **APPROVE / 0 findings** — code-reviewer + security-reviewer + typescript-reviewer + Codex, unanimous clean. CI parity green (typecheck src+test, workspace tests, lint --max-warnings=0, prettier). Approved for merge by maintainer (Stephanie) GO.
