### PR TITLE
fix(convoy): degrade to Unavailable tile instead of blanking the view when the supervisor is slow

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Link, MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 import { ThemeProvider } from './contexts/ThemeContext';
@@ -39,6 +39,22 @@ vi.mock('./routes/ConvoyIndex', () => ({
     throw new Error('convoy render exploded');
   },
 }));
+
+// The convoy detail page throws for one specific root and renders cleanly for
+// another, standing in for a degenerate supervisor shape that crashes the view
+// for convoy root A while root B is healthy (gascity-dashboard-sw1w). Used to
+// pin the route-latch regression: the per-view boundary must reset when the
+// :rootBead param changes, not keep masking B behind A's tripped fallback.
+vi.mock('./routes/Convoy', async () => {
+  const { useParams } = await import('react-router-dom');
+  return {
+    ConvoyPage: () => {
+      const { rootBead } = useParams<{ rootBead: string }>();
+      if (rootBead === 'root-a') throw new Error('convoy root A exploded');
+      return <h1>convoy root {rootBead}</h1>;
+    },
+  };
+});
 
 function LocationProbe() {
   const location = useLocation();
@@ -111,6 +127,40 @@ describe('App routes', () => {
     expect(notice.textContent).toContain('◌');
     // The route stayed mounted at /convoy — the throw was contained, not fatal.
     expect(screen.getByTestId('pathname').textContent).toBe('/convoy');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('resets a tripped convoy-detail boundary when navigating from a throwing root to a healthy one', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 202 })),
+    );
+
+    render(
+      <ThemeProvider>
+        <MemoryRouter
+          initialEntries={['/convoy/root-a']}
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        >
+          <App />
+          {/* A persistent link outside the boundary, mirroring an in-shell
+              step-row link to a healthy convoy root. */}
+          <Link to="/convoy/root-b">to-root-b</Link>
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    // Convoy root A throws -> the per-view boundary degrades to the unavailable tier.
+    expect((await screen.findByRole('alert')).textContent).toContain('Unavailable');
+
+    // Navigating to a HEALTHY root B must clear the tripped boundary (it is keyed
+    // by :rootBead) instead of masking B's good data behind the cached fallback.
+    fireEvent.click(screen.getByRole('link', { name: 'to-root-b' }));
+
+    expect(await screen.findByRole('heading', { name: 'convoy root root-b' })).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
 
     vi.unstubAllGlobals();
   });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -31,6 +31,15 @@ vi.mock('./routes/Runs', () => ({
   RunsPage: () => <h1>Runs route</h1>,
 }));
 
+// The convoy index render throws — standing in for an unanticipated partial or
+// degenerate supervisor shape that slips past the data layer under store
+// slowness (gascity-dashboard-sw1w). The per-view boundary must catch it.
+vi.mock('./routes/ConvoyIndex', () => ({
+  ConvoyIndex: () => {
+    throw new Error('convoy render exploded');
+  },
+}));
+
 function LocationProbe() {
   const location = useLocation();
   return <output data-testid="pathname">{location.pathname}</output>;
@@ -86,5 +95,23 @@ describe('App routes', () => {
 
     expect(await screen.findByRole('heading', { name: 'Runs route' })).toBeTruthy();
     expect(screen.getByTestId('pathname').textContent).toBe('/runs');
+  });
+
+  it('degrades a throwing convoy view to the per-view unavailable tier, not a whole-app crash', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 202 })),
+    );
+
+    renderAt('/convoy');
+
+    const notice = await screen.findByRole('alert');
+    expect(notice.textContent).toContain('Unavailable');
+    expect(notice.textContent).toContain('◌');
+    // The route stayed mounted at /convoy — the throw was contained, not fatal.
+    expect(screen.getByTestId('pathname').textContent).toBe('/convoy');
+
+    vi.unstubAllGlobals();
   });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -78,6 +78,12 @@ function renderAt(path: string) {
 describe('App routes', () => {
   afterEach(() => {
     cleanup();
+    // Guarantee stub/spy cleanup even if a test throws before its own cleanup:
+    // restoreAllMocks reverts spyOn spies (console.error), unstubAllGlobals
+    // reverts stubGlobal (fetch). Without this a mid-test throw leaks them into
+    // later files in the same Vitest worker.
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   beforeEach(() => {
@@ -127,8 +133,6 @@ describe('App routes', () => {
     expect(notice.textContent).toContain('◌');
     // The route stayed mounted at /convoy — the throw was contained, not fatal.
     expect(screen.getByTestId('pathname').textContent).toBe('/convoy');
-
-    vi.unstubAllGlobals();
   });
 
   it('resets a tripped convoy-detail boundary when navigating from a throwing root to a healthy one', async () => {
@@ -161,7 +165,5 @@ describe('App routes', () => {
 
     expect(await screen.findByRole('heading', { name: 'convoy root root-b' })).toBeTruthy();
     expect(screen.queryByRole('alert')).toBeNull();
-
-    vi.unstubAllGlobals();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useMemo, type ReactNode } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { api } from './api/client';
 import { AttentionProvider } from './attention/context';
 import { useLiveAttentionContributors } from './attention/liveContributors';
@@ -35,6 +35,21 @@ const FormulaRunDetailPage = lazy(() =>
   import('./routes/FormulaRunDetail').then((m) => ({ default: m.FormulaRunDetailPage })),
 );
 const RunsPage = lazy(() => import('./routes/Runs').then((m) => ({ default: m.RunsPage })));
+
+// The convoy detail boundary is keyed by the :rootBead param. React Router
+// reuses a route's element across param-only navigations, so a single boundary
+// instance would keep its tripped "unavailable" latch when the operator follows
+// a step-row link from a throwing convoy root A to a healthy root B, masking B's
+// good data until manual Retry. Keying by rootBead gives each root its own
+// boundary instance, so the latch resets on navigation.
+function ConvoyDetailRoute(): ReactNode {
+  const { rootBead } = useParams<{ rootBead: string }>();
+  return (
+    <ViewErrorBoundary key={rootBead ?? ''} view="convoy detail">
+      <ConvoyPage />
+    </ViewErrorBoundary>
+  );
+}
 
 export function App() {
   // NowProvider lives at the App root because useFaviconSignal (R8) is
@@ -120,14 +135,7 @@ export function App() {
                           </ViewErrorBoundary>
                         }
                       />
-                      <Route
-                        path="/convoy/:rootBead"
-                        element={
-                          <ViewErrorBoundary view="convoy detail">
-                            <ConvoyPage />
-                          </ViewErrorBoundary>
-                        }
-                      />
+                      <Route path="/convoy/:rootBead" element={<ConvoyDetailRoute />} />
                       <Route path="/runs" element={<RunsPage />} />
                       <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
                       <Route path="/mail" element={<MailPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { api } from './api/client';
 import { AttentionProvider } from './attention/context';
 import { useLiveAttentionContributors } from './attention/liveContributors';
 import { Layout } from './components/Layout';
+import { ViewErrorBoundary } from './components/ViewErrorBoundary';
 import { NowProvider } from './contexts/NowContext';
 import {
   OperatorConfigProvider,
@@ -105,8 +106,28 @@ export function App() {
                       <Route path="/agents" element={<AgentsPage />} />
                       <Route path="/agents/:slug" element={<AgentDetailPage />} />
                       <Route path="/beads" element={<BeadsPage />} />
-                      <Route path="/convoy" element={<ConvoyIndexPage />} />
-                      <Route path="/convoy/:rootBead" element={<ConvoyPage />} />
+                      {/* The convoy views compose a city-wide bead scan and a
+                  client-side graph projection (gascity-dashboard-sw1w). Their
+                  data layer already degrades a failing/slow fetch to an honest
+                  state, but a per-view boundary keeps an unanticipated
+                  render throw under supervisor store slowness from bubbling to
+                  the app-root crash page and taking down the whole dashboard. */}
+                      <Route
+                        path="/convoy"
+                        element={
+                          <ViewErrorBoundary view="convoy index">
+                            <ConvoyIndexPage />
+                          </ViewErrorBoundary>
+                        }
+                      />
+                      <Route
+                        path="/convoy/:rootBead"
+                        element={
+                          <ViewErrorBoundary view="convoy detail">
+                            <ConvoyPage />
+                          </ViewErrorBoundary>
+                        }
+                      />
                       <Route path="/runs" element={<RunsPage />} />
                       <Route path="/runs/:runId" element={<FormulaRunDetailPage />} />
                       <Route path="/mail" element={<MailPage />} />

--- a/frontend/src/components/ViewErrorBoundary.test.tsx
+++ b/frontend/src/components/ViewErrorBoundary.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+import { ViewErrorBoundary } from './ViewErrorBoundary';
+
+function BrokenChild(): never {
+  throw new Error('convoy render exploded');
+}
+
+// A child whose throwing is driven by external state (not self-consumed during
+// render, so React's double-invoke is harmless), letting a test flip the
+// transient off and observe Retry remounting the subtree cleanly.
+function FlakyChild({ gate }: { gate: { shouldThrow: boolean } }) {
+  if (gate.shouldThrow) throw new Error('transient store slowness');
+  return <p>convoy contents</p>;
+}
+
+describe('ViewErrorBoundary', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders its children when they do not throw', () => {
+    render(
+      <ViewErrorBoundary view="convoy">
+        <p>convoy contents</p>
+      </ViewErrorBoundary>,
+    );
+    expect(screen.getByText('convoy contents')).toBeTruthy();
+  });
+
+  it('degrades a child render throw to a glyph+word unavailable tier instead of failing the whole app', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 202 })),
+    );
+
+    // The view boundary sits INSIDE the app-root boundary, exactly as App.tsx
+    // wires it: a single view's throw must stop here, not replace the dashboard.
+    render(
+      <ErrorBoundary>
+        <ViewErrorBoundary view="convoy">
+          <BrokenChild />
+        </ViewErrorBoundary>
+      </ErrorBoundary>,
+    );
+
+    const notice = screen.getByRole('alert');
+    expect(notice.textContent).toContain('Unavailable');
+    // Greyscale-readable: the state is carried by a glyph + the word, not tone.
+    expect(notice.textContent).toContain('◌');
+    // The app-root crash page must NOT have taken over the whole dashboard.
+    expect(screen.queryByText('Dashboard view failed.')).toBeNull();
+  });
+
+  it('reports the underlying error to the local dashboard log rather than swallowing it', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 202 }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    render(
+      <ViewErrorBoundary view="convoy">
+        <BrokenChild />
+      </ViewErrorBoundary>,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/client-errors',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          component: 'ViewErrorBoundary',
+          operation: 'convoy',
+          message: 'convoy render exploded',
+        }),
+      }),
+    );
+  });
+
+  it('retries by remounting the subtree, clearing a transient failure', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 202 })),
+    );
+    const gate = { shouldThrow: true };
+
+    render(
+      <ViewErrorBoundary view="convoy">
+        <FlakyChild gate={gate} />
+      </ViewErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('Unavailable');
+
+    // The transient slowness clears, then the operator retries the view.
+    gate.shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(screen.getByText('convoy contents')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/frontend/src/components/ViewErrorBoundary.test.tsx
+++ b/frontend/src/components/ViewErrorBoundary.test.tsx
@@ -19,6 +19,9 @@ describe('ViewErrorBoundary', () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    // restoreAllMocks reverts spyOn spies but NOT stubGlobal; unstub the fetch
+    // stub explicitly so it cannot leak into later files in the same worker.
+    vi.unstubAllGlobals();
   });
 
   it('renders its children when they do not throw', () => {

--- a/frontend/src/components/ViewErrorBoundary.tsx
+++ b/frontend/src/components/ViewErrorBoundary.tsx
@@ -24,7 +24,11 @@ interface ViewErrorBoundaryState {
 // (never swallowed), and Retry remounts the subtree so transient slowness
 // clears without a full-page reload. Greyscale-readable per DESIGN.md (the
 // state is carried by a glyph and the word, not by tone) and non-counting (no
-// maroon mark — One Mark Rule unaffected).
+// maroon mark, so the One Mark Rule is unaffected).
+//
+// The neutral grey is deliberate and distinct from the convoy DATA layer's
+// Stuck Maroon "failed" tier: a render crash is an unexpected fault in the view
+// itself, mirroring the app-root ErrorBoundary, not a counted domain signal.
 export class ViewErrorBoundary extends Component<ViewErrorBoundaryProps, ViewErrorBoundaryState> {
   override state: ViewErrorBoundaryState = { failed: false };
 
@@ -47,7 +51,7 @@ export class ViewErrorBoundary extends Component<ViewErrorBoundaryProps, ViewErr
       return (
         <section className="space-y-3" role="alert">
           <p className="text-body text-fg-muted">
-            <span aria-hidden="true">◌</span> Unavailable. This view could not be rendered — the
+            <span aria-hidden="true">◌</span> Unavailable. This view could not be rendered; the
             supervisor store may be slow or returning partial data. The error was reported to the
             local dashboard log.
           </p>

--- a/frontend/src/components/ViewErrorBoundary.tsx
+++ b/frontend/src/components/ViewErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { errorMessage } from 'gas-city-dashboard-shared';
+import { reportClientError } from '../lib/clientErrorReporting';
+
+interface ViewErrorBoundaryProps {
+  /** Short name of the wrapped view — surfaced in the dashboard error log. */
+  view: string;
+  children: ReactNode;
+}
+
+interface ViewErrorBoundaryState {
+  failed: boolean;
+}
+
+// A per-view error boundary. When one view's render throws — e.g. an
+// unanticipated partial or degenerate supervisor shape that slips past the data
+// layer's guards while the dolt store is slow — this degrades THAT view to a
+// calm, DESIGN-compliant "unavailable" tier (glyph + word + a retry affordance)
+// instead of letting the throw bubble to the app-root ErrorBoundary, which
+// replaces the WHOLE dashboard with the generic crash page.
+//
+// It is defense-in-depth, not a substitute for handling errors at the data
+// edge: the underlying error is still REPORTED to the local dashboard log
+// (never swallowed), and Retry remounts the subtree so transient slowness
+// clears without a full-page reload. Greyscale-readable per DESIGN.md (the
+// state is carried by a glyph and the word, not by tone) and non-counting (no
+// maroon mark — One Mark Rule unaffected).
+export class ViewErrorBoundary extends Component<ViewErrorBoundaryProps, ViewErrorBoundaryState> {
+  override state: ViewErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): ViewErrorBoundaryState {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: unknown, _errorInfo: ErrorInfo): void {
+    void reportClientError({
+      component: 'ViewErrorBoundary',
+      operation: this.props.view,
+      message: errorMessage(error),
+    });
+  }
+
+  private readonly retry = (): void => this.setState({ failed: false });
+
+  override render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <section className="space-y-3" role="alert">
+          <p className="text-body text-fg-muted">
+            <span aria-hidden="true">◌</span> Unavailable. This view could not be rendered — the
+            supervisor store may be slow or returning partial data. The error was reported to the
+            local dashboard log.
+          </p>
+          <button
+            type="button"
+            onClick={this.retry}
+            className="text-label uppercase tracking-wider text-fg-faint hover:text-fg focus-mark"
+          >
+            Retry
+          </button>
+        </section>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## What

Isolate the Convoy view behind a per-view error boundary so a render throw degrades to a clean "Unavailable" tile (glyph + word, with refresh) instead of blanking the whole operator view. Also clears an A→B route-latch where navigating between convoys left a stale detail boundary.

## Why

When the supervisor is slow to answer, the Convoy view could throw mid-render and take the entire operator view down with it. Root cause of the slowness is upstream: the supervisor's memory-aggregation cold-recompute path (`/v0/city/<city>/status` returns in ~1.7ms warm but 60-90s cold, then the client kills it at the timeout), tracked as gascity#2740. Raw dolt is fast (~35ms); this is the aggregation logic, not database latency.

That upstream fix is separate. This PR is the dashboard-side hardening for those timeout windows: a boundary that contains the throw to one tile and keeps the rest of the view usable. It strictly improves the view and cannot regress it; when Convoy renders normally, behavior is unchanged.

## Changes

- `frontend/src/components/ViewErrorBoundary.tsx` (new) — per-view error boundary rendering a DESIGN-compliant "Unavailable" tier.
- `frontend/src/App.tsx` — wrap the Convoy view; key the detail boundary by `rootBead` so A→B navigation clears the latch.
- Tests: `ViewErrorBoundary.test.tsx` (new) + `App.test.tsx` coverage for the boundary and the route-latch fix.

Frontend-only, +286/-5 across 4 files.

## Test plan

- `npm run build`, `npm run typecheck` (incl. `typecheck:test`), eslint, prettier — green.
- New unit tests cover: boundary catches a render throw and shows the Unavailable tile; refresh path; A→B nav clears the prior detail boundary.
- Reviewed by code + security + typescript + Codex passes — zero blockers. One minor glyph nit tracked as a follow-up.
