### PR TITLE
fix(modal): focus-trap + focus-restore + aria-labelledby for a11y

### DIFF
--- a/frontend/src/components/Modal.test.tsx
+++ b/frontend/src/components/Modal.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Modal } from './Modal';
+
+afterEach(cleanup);
+
+describe('Modal accessibility', () => {
+  it('moves focus into the dialog on open', () => {
+    render(
+      <Modal open onClose={() => {}} title="Peek">
+        body
+      </Modal>,
+    );
+    // The Close button is the first focusable control in the panel.
+    expect(document.activeElement).toBe(screen.getByLabelText('Close'));
+  });
+
+  it('wraps Tab from the last focusable back to the first', () => {
+    render(
+      <Modal open onClose={() => {}} title="Peek" footer={<button>Save</button>}>
+        body
+      </Modal>,
+    );
+    const close = screen.getByLabelText('Close');
+    const save = screen.getByText('Save');
+    save.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(close);
+  });
+
+  it('wraps Shift+Tab from the first focusable to the last', () => {
+    render(
+      <Modal open onClose={() => {}} title="Peek" footer={<button>Save</button>}>
+        body
+      </Modal>,
+    );
+    const close = screen.getByLabelText('Close');
+    const save = screen.getByText('Save');
+    close.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(save);
+  });
+
+  it('restores focus to the opener on close', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const { rerender } = render(
+      <Modal open onClose={() => {}} title="Peek">
+        body
+      </Modal>,
+    );
+    expect(document.activeElement).not.toBe(opener);
+
+    rerender(
+      <Modal open={false} onClose={() => {}} title="Peek">
+        body
+      </Modal>,
+    );
+    expect(document.activeElement).toBe(opener);
+
+    opener.remove();
+  });
+
+  it('focuses the panel itself when there are no focusable controls', () => {
+    render(
+      <Modal open onClose={() => {}} title="Peek">
+        body
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    // The Close button is always present, so suppress it to exercise the
+    // empty-panel fallback the way a read-only modal with no actions would.
+    const close = screen.getByLabelText('Close');
+    close.setAttribute('disabled', '');
+    dialog.querySelector<HTMLElement>('[tabindex="-1"]')?.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(dialog.querySelector('[tabindex="-1"]'));
+  });
+
+  it('labels the dialog via aria-labelledby pointing at the title', () => {
+    render(
+      <Modal open onClose={() => {}} title="Session Peek">
+        body
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy ?? '')?.textContent).toBe('Session Peek');
+  });
+
+  it('still closes on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} title="Peek">
+        body
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Modal.test.tsx
+++ b/frontend/src/components/Modal.test.tsx
@@ -102,4 +102,69 @@ describe('Modal accessibility', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('lets only the topmost of nested modals trap Escape', () => {
+    const onCloseOuter = vi.fn();
+    const onCloseInner = vi.fn();
+    render(
+      <>
+        <Modal open onClose={onCloseOuter} title="Bead detail">
+          outer
+        </Modal>
+        <Modal open onClose={onCloseInner} title="Live run">
+          inner
+        </Modal>
+      </>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    // The inner (last-opened) modal is topmost: it closes, the outer stays put.
+    expect(onCloseInner).toHaveBeenCalledTimes(1);
+    expect(onCloseOuter).not.toHaveBeenCalled();
+  });
+
+  it('traps Tab within the topmost of nested modals only', () => {
+    render(
+      <>
+        <Modal open onClose={() => {}} title="Bead detail" footer={<button>OuterSave</button>}>
+          outer
+        </Modal>
+        <Modal open onClose={() => {}} title="Live run" footer={<button>InnerSave</button>}>
+          inner
+        </Modal>
+      </>,
+    );
+    const innerSave = screen.getByText('InnerSave');
+    innerSave.focus();
+    // Tab from the inner modal's last control wraps to the inner modal's first
+    // control (its Close button), never escaping into the background modal.
+    fireEvent.keyDown(document, { key: 'Tab' });
+    const innerClose = screen.getAllByLabelText('Close')[1];
+    expect(document.activeElement).toBe(innerClose);
+  });
+
+  it('marks the fallback focus target with a visible focus ring', () => {
+    render(
+      <Modal open onClose={() => {}} title="Peek">
+        body
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    const panel = dialog.querySelector<HTMLElement>('[tabindex="-1"]');
+    expect(panel).not.toBeNull();
+    // Focusable fallback target AND visibly indicated: the codebase focus-mark
+    // idiom (DESIGN.md 2px maroon ring), not a bare focus:outline-none.
+    expect(panel?.className).toContain('focus-mark');
+    expect(panel?.className).not.toContain('outline-none');
+  });
+
+  it('preserves a descendant autoFocus instead of moving focus to the first focusable', () => {
+    render(
+      <Modal open onClose={() => {}} title="New message">
+        <input aria-label="To" autoFocus />
+      </Modal>,
+    );
+    // The Close button is the first focusable in DOM order, but a descendant
+    // claimed focus deliberately (as ComposeModal does for "To"), so it wins.
+    expect(document.activeElement).toBe(screen.getByLabelText('To'));
+  });
 });

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,15 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+
+// Controls that can hold keyboard focus inside the dialog. Used for the
+// initial focus move and for the Tab/Shift+Tab wrap-around trap.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 interface ModalProps {
   open: boolean;
@@ -25,14 +36,62 @@ export function Modal({
   footer,
   widthClass = 'max-w-3xl',
 }: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  // Held in a ref so the focus effect keys only on `open` — a changing
+  // onClose identity must not tear down and re-run the trap mid-dialog
+  // (that would restore focus to the opener and snap it back in).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!open) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    const active = document.activeElement;
+    const opener = active instanceof HTMLElement ? active : null;
+
+    // Read the panel fresh each time so a re-mounted node (e.g. a keyed
+    // parent swap) never leaves the trap querying a detached element.
+    const focusables = () => {
+      const panel = panelRef.current;
+      return panel ? Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];
     };
+
+    // Move focus into the dialog so keyboard/AT users leave background controls.
+    const initial = focusables();
+    (initial[0] ?? panelRef.current)?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCloseRef.current();
+        return;
+      }
+      const panel = panelRef.current;
+      if (e.key !== 'Tab' || !panel) return;
+      const items = focusables();
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (!first || !last) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || !panel.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !panel.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
     document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [open, onClose]);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      // Restore focus to whatever opened the dialog, if it's still mounted.
+      if (opener && document.contains(opener)) opener.focus();
+    };
+  }, [open]);
 
   if (!open) return null;
 
@@ -40,16 +99,21 @@ export function Modal({
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby={titleId}
       className="fixed inset-0 z-50 flex items-start sm:items-center justify-center bg-fg/30 p-3 sm:p-6"
       onClick={onClose}
     >
       <div
-        className={`w-full ${widthClass} bg-surface border border-rule rounded-md flex flex-col max-h-[90vh]`}
+        ref={panelRef}
+        tabIndex={-1}
+        className={`w-full ${widthClass} bg-surface border border-rule rounded-md flex flex-col max-h-[90vh] focus:outline-none`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-rule">
           <div className="min-w-0">
-            <h2 className="text-title font-semibold text-fg truncate">{title}</h2>
+            <h2 id={titleId} className="text-title font-semibold text-fg truncate">
+              {title}
+            </h2>
             {caption && (
               <p className="text-label uppercase tracking-wider text-fg-muted mt-1 truncate">
                 {caption}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -64,8 +64,7 @@ export function Modal({
     const preFocused = document.activeElement;
     const descendantHasFocus =
       preFocused instanceof HTMLElement && !!panelRef.current?.contains(preFocused);
-    const opener =
-      !descendantHasFocus && preFocused instanceof HTMLElement ? preFocused : null;
+    const opener = !descendantHasFocus && preFocused instanceof HTMLElement ? preFocused : null;
 
     // Read the panel fresh each time so a re-mounted node (e.g. a keyed
     // parent swap) never leaves the trap querying a detached element.

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -11,6 +11,13 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
+// Stack of open Modal instances, most-recently-opened last. Every Modal binds a
+// document-level Tab/Escape handler, so nested modals (bead detail -> live-run,
+// bead detail -> close confirm) would otherwise all fire on one keypress. The
+// handler consults this stack and no-ops unless it belongs to the topmost modal.
+const modalStack: number[] = [];
+let nextModalId = 0;
+
 interface ModalProps {
   open: boolean;
   onClose: () => void;
@@ -46,8 +53,19 @@ export function Modal({
 
   useEffect(() => {
     if (!open) return;
-    const active = document.activeElement;
-    const opener = active instanceof HTMLElement ? active : null;
+    const id = ++nextModalId;
+    modalStack.push(id);
+    const isTopmost = () => modalStack[modalStack.length - 1] === id;
+
+    // A descendant may claim focus deliberately (e.g. ComposeModal autoFocuses
+    // its "To" field). When it already holds focus, honor it: don't yank focus
+    // to the first focusable, and don't treat that descendant as the opener to
+    // restore to on close.
+    const preFocused = document.activeElement;
+    const descendantHasFocus =
+      preFocused instanceof HTMLElement && !!panelRef.current?.contains(preFocused);
+    const opener =
+      !descendantHasFocus && preFocused instanceof HTMLElement ? preFocused : null;
 
     // Read the panel fresh each time so a re-mounted node (e.g. a keyed
     // parent swap) never leaves the trap querying a detached element.
@@ -56,11 +74,16 @@ export function Modal({
       return panel ? Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];
     };
 
-    // Move focus into the dialog so keyboard/AT users leave background controls.
-    const initial = focusables();
-    (initial[0] ?? panelRef.current)?.focus();
+    // Move focus into the dialog so keyboard/AT users leave background controls,
+    // unless a descendant already claimed it.
+    if (!descendantHasFocus) {
+      const initial = focusables();
+      (initial[0] ?? panelRef.current)?.focus();
+    }
 
     const handleKey = (e: KeyboardEvent) => {
+      // Only the topmost modal traps Tab/Escape; background modals stay inert.
+      if (!isTopmost()) return;
       if (e.key === 'Escape') {
         onCloseRef.current();
         return;
@@ -88,6 +111,8 @@ export function Modal({
     document.addEventListener('keydown', handleKey);
     return () => {
       document.removeEventListener('keydown', handleKey);
+      const idx = modalStack.indexOf(id);
+      if (idx !== -1) modalStack.splice(idx, 1);
       // Restore focus to whatever opened the dialog, if it's still mounted.
       if (opener && document.contains(opener)) opener.focus();
     };
@@ -106,7 +131,7 @@ export function Modal({
       <div
         ref={panelRef}
         tabIndex={-1}
-        className={`w-full ${widthClass} bg-surface border border-rule rounded-md flex flex-col max-h-[90vh] focus:outline-none`}
+        className={`w-full ${widthClass} bg-surface border border-rule rounded-md flex flex-col max-h-[90vh] focus-mark`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-rule">


### PR DESCRIPTION
## Summary

- The shared `Modal` component only listened for Escape — keyboard and assistive-tech users could tab past the dialog into background controls.
- On open, focus now moves into the panel (first focusable control, or the panel itself if none), Tab/Shift+Tab is trapped within it, and focus is restored to the opener on close.
- `role="dialog"` is now labelled via `aria-labelledby` pointing at the title.
- Fixes all `Modal` consumers: Session Peek, `BeadDetailModal`, `BeadLiveRunModal`, `ComposeModal`, mobile hamburger nav.

## Test plan

- [x] `Modal.test.tsx` covers: initial focus move, Tab wrap-around, Shift+Tab wrap-around, focus restore to opener on close, fallback focus on panel when no focusable controls, `aria-labelledby` wiring, Escape still closes.
- [ ] Manual keyboard-only pass through Session Peek and Compose modal to confirm no visual regression.