### PR TITLE
fix(health): accept rig paths that already point at bead stores

### DIFF
--- a/backend/src/routes/rig-store-health.test.ts
+++ b/backend/src/routes/rig-store-health.test.ts
@@ -6,6 +6,7 @@ import {
   issueCountFromChecks,
   parseDoctorChecks,
   probeRigStore,
+  resolveBeadsPath,
   rollupFor,
   storeProblems,
   type RigStoreProbeDeps,
@@ -182,6 +183,24 @@ function depsFor(overrides: Partial<RigStoreProbeDeps> = {}): RigStoreProbeDeps 
 
 const RIG: SupervisorRigDescriptor = { name: 'codeprobe', path: '/home/ds/projects/codeprobe' };
 
+describe('resolveBeadsPath', () => {
+  test('appends .beads to a rig root', () => {
+    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe'), '/home/ds/projects/codeprobe/.beads');
+  });
+
+  test('accepts a path that already points at the store', () => {
+    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/.beads'), '/home/ds/projects/codeprobe/.beads');
+  });
+
+  test('strips a trailing separator on a direct-store path (no permanent downgrade)', () => {
+    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/.beads/'), '/home/ds/projects/codeprobe/.beads');
+  });
+
+  test('strips a trailing separator on a rig root before appending', () => {
+    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/'), '/home/ds/projects/codeprobe/.beads');
+  });
+});
+
 describe('probeRigStore', () => {
   test('healthy server-mode store rolls up ok with endpoint + issue count', async () => {
     const health = await probeRigStore(RIG, depsFor());
@@ -328,6 +347,24 @@ describe('createRigStoreHealthSampler', () => {
     if (report.available) {
       assert.equal(report.rigs[0]?.beadsPath, '/home/ds/projects/codeprobe/.beads');
     }
+  });
+
+  test('safeProbe error-path resolves the store path for a direct-store rig (no .beads/.beads)', async () => {
+    const sampler = createRigStoreHealthSampler({
+      listRigs: async () => [{ name: 'codeprobe', path: '/home/ds/projects/codeprobe/.beads' }],
+      probe: async () => {
+        throw new Error('injected dep blew up');
+      },
+      now: () => '2026-06-06T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+    const report = sampler.report();
+    assert.equal(report.available, true);
+    const rig = report.rigs[0];
+    assert.equal(rig?.beadsPath, '/home/ds/projects/codeprobe/.beads');
+    assert.equal(rig?.rollup, 'down');
+    assert.equal(rig?.reachable, false);
+    assert.match(rig?.note ?? '', /probe failed: injected dep blew up/);
   });
 
   test('rig_list failure keeps the prior snapshot but flips available=false', async () => {

--- a/backend/src/routes/rig-store-health.test.ts
+++ b/backend/src/routes/rig-store-health.test.ts
@@ -195,6 +195,19 @@ describe('probeRigStore', () => {
     assert.deepEqual(health.problems, []);
   });
 
+  test('accepts a rig path that already points at the bead store', async () => {
+    const health = await probeRigStore(
+      { name: 'codeprobe', path: '/home/ds/projects/codeprobe/.beads' },
+      depsFor({
+        statBeads: async (beadsPath) => {
+          assert.equal(beadsPath, '/home/ds/projects/codeprobe/.beads');
+          return true;
+        },
+      }),
+    );
+    assert.equal(health.beadsPath, '/home/ds/projects/codeprobe/.beads');
+  });
+
   test('missing .beads is down + unreachable without probing further', async () => {
     let doctorCalled = false;
     const health = await probeRigStore(
@@ -292,6 +305,29 @@ describe('createRigStoreHealthSampler', () => {
     assert.equal(report.available, true);
     assert.equal(report.rigs.length, 2);
     if (report.available) assert.equal(report.sampledAt, '2026-06-06T00:00:00.000Z');
+  });
+
+  test('samples a rig that already reports the bead-store path', async () => {
+    const sampler = createRigStoreHealthSampler({
+      listRigs: async () => [{ name: 'codeprobe', path: '/home/ds/projects/codeprobe/.beads' }],
+      probe: async (rig) => ({
+        rig: rig.name,
+        beadsPath: rig.path,
+        rollup: 'ok',
+        reachable: true,
+        doltEndpoint: '127.0.0.1:29620',
+        doltConnected: true,
+        issueCount: 1,
+        problems: [],
+      }),
+      now: () => '2026-06-06T00:00:00.000Z',
+    });
+    await sampler.sampleOnce();
+    const report = sampler.report();
+    assert.equal(report.available, true);
+    if (report.available) {
+      assert.equal(report.rigs[0]?.beadsPath, '/home/ds/projects/codeprobe/.beads');
+    }
   });
 
   test('rig_list failure keeps the prior snapshot but flips available=false', async () => {

--- a/backend/src/routes/rig-store-health.test.ts
+++ b/backend/src/routes/rig-store-health.test.ts
@@ -185,19 +185,31 @@ const RIG: SupervisorRigDescriptor = { name: 'codeprobe', path: '/home/ds/projec
 
 describe('resolveBeadsPath', () => {
   test('appends .beads to a rig root', () => {
-    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe'), '/home/ds/projects/codeprobe/.beads');
+    assert.equal(
+      resolveBeadsPath('/home/ds/projects/codeprobe'),
+      '/home/ds/projects/codeprobe/.beads',
+    );
   });
 
   test('accepts a path that already points at the store', () => {
-    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/.beads'), '/home/ds/projects/codeprobe/.beads');
+    assert.equal(
+      resolveBeadsPath('/home/ds/projects/codeprobe/.beads'),
+      '/home/ds/projects/codeprobe/.beads',
+    );
   });
 
   test('strips a trailing separator on a direct-store path (no permanent downgrade)', () => {
-    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/.beads/'), '/home/ds/projects/codeprobe/.beads');
+    assert.equal(
+      resolveBeadsPath('/home/ds/projects/codeprobe/.beads/'),
+      '/home/ds/projects/codeprobe/.beads',
+    );
   });
 
   test('strips a trailing separator on a rig root before appending', () => {
-    assert.equal(resolveBeadsPath('/home/ds/projects/codeprobe/'), '/home/ds/projects/codeprobe/.beads');
+    assert.equal(
+      resolveBeadsPath('/home/ds/projects/codeprobe/'),
+      '/home/ds/projects/codeprobe/.beads',
+    );
   });
 });
 

--- a/backend/src/routes/rig-store-health.ts
+++ b/backend/src/routes/rig-store-health.ts
@@ -15,10 +15,12 @@ import type { ExecResult } from '../exec.js';
 import { recordAudit } from '../audit.js';
 import { LOG_COMPONENT, errorMessage, logWarn } from '../logging.js';
 
-// Per-rig bead-store + dolt health (gascity-dashboard-u6d0). Each rig owns its
-// own embedded-dolt `.beads` store, so — unlike the supervisor's single
-// city-level store_health — this is a dashboard-local probe of host state:
-//   1. `.beads` present on disk            → reachable
+// Per-rig bead-store + dolt health (gascity-dashboard-u6d0). Older rigs report
+// the rig root and store the beads data in `/.beads`; newer DoltLite-backed
+// setups can report the bead-store path directly. Unlike the supervisor's
+// single city-level store_health, this is a dashboard-local probe of host
+// state:
+//   1. bead store present on disk         → reachable
 //   2. dolt-server.port + TCP connect      → dolt sql-server up + endpoint
 //   3. `bd doctor --json` (read-only)      → schema drift / integrity / count
 // rolled up to one red/green-per-rig tone. The probe runs on a periodic
@@ -195,7 +197,7 @@ export async function probeRigStore(
   rig: SupervisorRigDescriptor,
   deps: RigStoreProbeDeps,
 ): Promise<RigStoreHealth> {
-  const beadsPath = path.join(rig.path, '.beads');
+  const beadsPath = resolveBeadsPath(rig.path);
   const reachable = await deps.statBeads(beadsPath);
   if (!reachable) {
     return {
@@ -253,6 +255,10 @@ export async function probeRigStore(
     problems,
     ...(note !== undefined ? { note } : {}),
   };
+}
+
+function resolveBeadsPath(rigPath: string): string {
+  return path.basename(rigPath) === '.beads' ? rigPath : path.join(rigPath, '.beads');
 }
 
 // ── Sampler ──────────────────────────────────────────────────────────────

--- a/backend/src/routes/rig-store-health.ts
+++ b/backend/src/routes/rig-store-health.ts
@@ -257,8 +257,32 @@ export async function probeRigStore(
   };
 }
 
-function resolveBeadsPath(rigPath: string): string {
-  return path.basename(rigPath) === '.beads' ? rigPath : path.join(rigPath, '.beads');
+// One-shot guard: log the first time a rig reports its bead-store path directly
+// so the DoltLite direct-store premise is confirmable in production, without
+// spamming the warn stream on every sample cycle (gascity-dashboard-ahwg).
+let directStoreLogged = false;
+
+/**
+ * Resolve a rig's untrusted supervisor path to its bead-store directory. Older
+ * rigs report the rig root (store lives at `<root>/.beads`); DoltLite rigs can
+ * report the store path directly. Trailing separators are stripped first so a
+ * `/foo/.beads/` path is recognised as the store and returns a clean path,
+ * rather than being re-nested to `/foo/.beads/.beads`. This is the single
+ * definition shared by the happy path and safeProbe's error fallback.
+ */
+export function resolveBeadsPath(rigPath: string): string {
+  const normalized = rigPath.replace(/\/+$/, '');
+  if (path.basename(normalized) === '.beads') {
+    if (!directStoreLogged) {
+      directStoreLogged = true;
+      logWarn(
+        LOG_COMPONENT.rigStoreHealth,
+        `rig reported a bead-store path directly (direct-store rig class); using as-is: ${normalized}`,
+      );
+    }
+    return normalized;
+  }
+  return path.join(normalized, '.beads');
 }
 
 // ── Sampler ──────────────────────────────────────────────────────────────
@@ -367,7 +391,7 @@ async function safeProbe(
   } catch (err) {
     return {
       rig: rig.name,
-      beadsPath: path.join(rig.path, '.beads'),
+      beadsPath: resolveBeadsPath(rig.path),
       rollup: 'down',
       reachable: false,
       doltEndpoint: null,


### PR DESCRIPTION
## Problem
On DoltLite-backed city setups, the supervisor can report the bead-store path directly instead of only a rig root. The rig-store-health probe unconditionally appended `/.beads` to the rig path, so the health sampler probed the wrong location and reported bad store health for these rigs.

## Root cause
`backend/src/routes/rig-store-health.ts` assumed every rig path was a rig root and always joined `/.beads` onto it, ignoring the case where the descriptor already points at the bead store.

## Fix
Resolve the bead-store path from the rig descriptor before probing: append `/.beads` only when the path is a legacy rig root, and use the path as-is when it already points at a bead store.

## Testing
- `npm run typecheck` (shared, backend, frontend, plus test tsconfigs) — clean
- backend `npm test` — 613 tests / 118 suites pass, including new regression coverage in `rig-store-health.test.ts` for both the direct bead-store path and the sampler path

🤖 Generated with [Claude Code](https://claude.com/claude-code)