### PR TITLE
refactor(health): extract useHealthSources() hook from Health.tsx

### DIFF
--- a/frontend/src/routes/Health.tsx
+++ b/frontend/src/routes/Health.tsx
@@ -1,106 +1,36 @@
-import { useCallback, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import type {
   DoltNomsTrend,
   LocalToolVersion,
-  LocalToolVersions,
   RigStoreHealth,
   RigStoreHealthReport,
   RigStoreHealthUnavailableReason,
   RigStoreRollup,
-  SupervisorStatusReport,
   SystemHealth,
 } from 'gas-city-dashboard-shared';
-import { api, formatApiError } from '../api/client';
-import { getActiveCity } from '../api/cityBase';
 import { useAttentionModel } from '../attention/context';
 import { attentionSectionProps, prefixedAttentionSeverity } from '../attention/routeHighlight';
 import { Button } from '../components/Button';
 import { PageHeader } from '../components/PageHeader';
 import { StatusBadge, type StatusTone } from '../components/StatusBadge';
-import type {
-  HealthOutputBody,
-  StatusBody,
-  StatusStoreHealth,
-  StatusWorkCounts,
-} from 'gas-city-dashboard-shared/gc-supervisor';
-import { useCachedData } from '../hooks/useCachedData';
-import { useVisibleRefresh } from '../hooks/useVisibleRefresh';
+import type { StatusStoreHealth, StatusWorkCounts } from 'gas-city-dashboard-shared/gc-supervisor';
+import {
+  supervisorStatusStaleCopy,
+  useHealthSources,
+  type LocalToolVersionsState,
+  type SupervisorHealthState,
+  type SupervisorStatusState,
+  type SystemHealthState,
+} from './useHealthSources';
 import { formatHumanSize } from '../lib/format';
 import { formatShortDate } from '../hooks/time';
-import { supervisorApiForRequestBudget } from '../supervisor/client';
-
-const HEALTH_SUPERVISOR_REQUEST_TIMEOUT_MS = 2_500;
 
 export function HealthPage() {
   const attention = useAttentionModel();
-  const cityName = getActiveCity();
-  const systemHealth = useCachedData('health:system', fetchSystemHealth);
-  const supervisorHealth = useCachedData(
-    `health:supervisor:${cityName ?? 'no-city'}`,
-    fetchSupervisorHealth,
-  );
-  const supervisorStatusCache = useCachedData(
-    `health:status:${cityName ?? 'no-city'}`,
-    fetchSupervisorStatus,
-  );
-  const localToolVersions = useCachedData('health:local-tools', fetchLocalToolVersions);
-  const doltNomsTrend = useCachedData(
-    `health:dolt-noms-trend:${cityName ?? 'no-city'}`,
-    fetchDoltNomsTrend,
-  );
-  const rigStoreHealth = useCachedData(
-    `health:rig-store:${cityName ?? 'no-city'}`,
-    fetchRigStoreHealth,
-  );
-  const refreshSystemHealth = systemHealth.refresh;
-  const refreshSupervisorHealth = supervisorHealth.refresh;
-  const refreshSupervisorStatus = supervisorStatusCache.refresh;
-  const refreshLocalToolVersions = localToolVersions.refresh;
-  const refreshDoltNomsTrend = doltNomsTrend.refresh;
-  const refreshRigStoreHealth = rigStoreHealth.refresh;
-  const sourceLoading =
-    systemHealth.loading ||
-    supervisorHealth.loading ||
-    supervisorStatusCache.loading ||
-    localToolVersions.loading ||
-    doltNomsTrend.loading ||
-    rigStoreHealth.loading;
-  const error =
-    [
-      systemHealth.error,
-      supervisorHealth.error,
-      supervisorStatusCache.error,
-      localToolVersions.error,
-      doltNomsTrend.error,
-      rigStoreHealth.error,
-    ]
-      .filter((value): value is string => value !== null)
-      .join('; ') || null;
-  const refresh = useCallback(async () => {
-    await Promise.all([
-      refreshSystemHealth(),
-      refreshSupervisorHealth(),
-      refreshSupervisorStatus(),
-      refreshLocalToolVersions(),
-      refreshDoltNomsTrend(),
-      refreshRigStoreHealth(),
-    ]);
-  }, [
-    refreshDoltNomsTrend,
-    refreshLocalToolVersions,
-    refreshRigStoreHealth,
-    refreshSupervisorHealth,
-    refreshSupervisorStatus,
-    refreshSystemHealth,
-  ]);
-  const healthState = systemHealth.data ?? null;
+  const { sources, loading: sourceLoading, error, refresh } = useHealthSources();
+  const { systemHealth: healthState, supervisor, status, localTools, trend, rigStores } = sources;
   const health = healthState?.status === 'available' ? healthState.data : null;
   const healthError = healthState?.status === 'unavailable' ? healthState.error : null;
-  const supervisor = supervisorHealth.data ?? null;
-  const status = supervisorStatusCache.data ?? null;
-  const localTools = localToolVersions.data ?? null;
-  const trend = doltNomsTrend.data ?? null;
-  const rigStores = rigStoreHealth.data ?? null;
   const rigStoreSummary = rigStores ? rigStoreSummaryStatus(rigStores) : undefined;
   const hasAnyData =
     healthState !== null ||
@@ -118,8 +48,6 @@ export function HealthPage() {
   ]);
   const adminAttention = prefixedAttentionSeverity(attention, 'health', ['health:dashboard-']);
   const doltNomsAttention = prefixedAttentionSeverity(attention, 'health', ['health:dolt-noms-']);
-
-  useVisibleRefresh(refresh, 30_000);
 
   return (
     <section>
@@ -711,147 +639,6 @@ function doltUnavailableCopy(
       return 'supervisor is not reporting store_health; samples resume when it recovers';
     case 'sample_failed':
       return 'latest supervisor status read failed; check the backend log';
-  }
-}
-
-type SupervisorHealthState =
-  | { status: 'available'; data: HealthOutputBody }
-  | { status: 'unavailable'; error: string };
-
-type SystemHealthState =
-  | { status: 'available'; data: SystemHealth }
-  | { status: 'unavailable'; error: string };
-
-type SupervisorStatusState =
-  // `staleReason` is set when the data is the last good snapshot served after a
-  // later sample failed (degraded, not blank) — drives the "showing last sample"
-  // marker on the diagnostics widgets. null means the data is fresh.
-  | {
-      status: 'available';
-      data: StatusBody;
-      staleReason: Extract<SupervisorStatusReport, { available: false }>['reason'] | null;
-    }
-  | { status: 'unavailable'; error: string };
-
-type LocalToolVersionsState =
-  | { status: 'available'; data: LocalToolVersions }
-  | { status: 'unavailable'; error: string };
-
-async function fetchSystemHealth(): Promise<SystemHealthState> {
-  try {
-    return {
-      status: 'available',
-      data: await api.systemHealth(),
-    };
-  } catch (err) {
-    return {
-      status: 'unavailable',
-      error: formatApiError(err, 'dashboard host health unavailable'),
-    };
-  }
-}
-
-async function fetchSupervisorHealth(): Promise<SupervisorHealthState> {
-  const cityName = getActiveCity();
-  if (cityName === null) {
-    throw new Error('Health page loaded before an active city was resolved');
-  }
-  try {
-    return {
-      status: 'available',
-      data: await supervisorApiForRequestBudget(HEALTH_SUPERVISOR_REQUEST_TIMEOUT_MS).cityHealth(
-        cityName,
-      ),
-    };
-  } catch {
-    return {
-      status: 'unavailable',
-      error: 'supervisor health unavailable',
-    };
-  }
-}
-
-function supervisorStatusUnavailableCopy(
-  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
-): string {
-  switch (reason) {
-    case 'not_sampled_yet':
-      return 'supervisor status sample is warming up; data appears after the next backend sample';
-    case 'status_read_failed':
-      return 'latest supervisor status read failed; check the backend log';
-  }
-}
-
-// Stale marker shown above cached diagnostics, mirroring the rig-store-health
-// "Showing the last sample" affordance so a degraded snapshot is never mistaken
-// for a fresh read.
-function supervisorStatusStaleCopy(
-  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
-): string {
-  return `Showing the last sample; refresh failed: ${supervisorStatusUnavailableCopy(reason)}.`;
-}
-
-// gascity-dashboard-4bol: read the dashboard backend's cached /status snapshot
-// (sampled on the background ceiling) instead of racing the slow supervisor on a
-// short interactive budget — live /status runs 10–38s (gastownhall/gascity-dashboard#88).
-// A degraded report still carries the last good status, so the store-thresholds /
-// dolt-usage / beads-usage widgets show real (cached) data with a "stale" marker
-// rather than "supervisor status unavailable".
-async function fetchSupervisorStatus(): Promise<SupervisorStatusState> {
-  try {
-    const report = await api.supervisorStatus();
-    if (report.available) {
-      return { status: 'available', data: report.status, staleReason: null };
-    }
-    if (report.status !== null) {
-      return { status: 'available', data: report.status, staleReason: report.reason };
-    }
-    return {
-      status: 'unavailable',
-      error: supervisorStatusUnavailableCopy(report.reason),
-    };
-  } catch (err) {
-    return {
-      status: 'unavailable',
-      error: formatApiError(err, 'supervisor status unavailable'),
-    };
-  }
-}
-
-async function fetchLocalToolVersions(): Promise<LocalToolVersionsState> {
-  try {
-    return {
-      status: 'available',
-      data: await api.localToolVersions(),
-    };
-  } catch {
-    return {
-      status: 'unavailable',
-      error: 'local tool versions unavailable',
-    };
-  }
-}
-
-async function fetchDoltNomsTrend(): Promise<DoltNomsTrend> {
-  try {
-    return await api.doltTrend();
-  } catch {
-    return {
-      available: false,
-      reason: 'sample_failed',
-      samples: [],
-    };
-  }
-}
-
-async function fetchRigStoreHealth(): Promise<RigStoreHealthReport> {
-  try {
-    return await api.rigStoreHealth();
-  } catch {
-    // Transport-level failure (backend unreachable / 5xx / decode) — a
-    // distinct root cause from the backend's own 'rig_list_failed', so it must
-    // not borrow that reason and point the operator at the supervisor.
-    return { available: false, reason: 'fetch_failed', rigs: [] };
   }
 }
 

--- a/frontend/src/routes/useHealthSources.test.tsx
+++ b/frontend/src/routes/useHealthSources.test.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHealthSources } from './useHealthSources';
+import { invalidate } from '../api/cache';
+
+// The hook owns the Health page's six-source fetch orchestration. These tests
+// exercise that contract directly — independently of the page render — by
+// stubbing the data layer the six fetchers call: the dashboard `api` client
+// and the generated supervisor client. getActiveCity() resolves to `test-city`
+// via the global test setup, so the supervisor fetchers reach a live city.
+
+const mockApi = {
+  systemHealth: vi.fn(),
+  localToolVersions: vi.fn(),
+  doltTrend: vi.fn(),
+  rigStoreHealth: vi.fn(),
+  supervisorStatus: vi.fn(),
+};
+
+vi.mock('../api/client', () => ({
+  api: {
+    systemHealth: (...args: unknown[]) => mockApi.systemHealth(...args),
+    localToolVersions: (...args: unknown[]) => mockApi.localToolVersions(...args),
+    doltTrend: (...args: unknown[]) => mockApi.doltTrend(...args),
+    rigStoreHealth: (...args: unknown[]) => mockApi.rigStoreHealth(...args),
+    supervisorStatus: (...args: unknown[]) => mockApi.supervisorStatus(...args),
+  },
+  formatApiError: (err: unknown, fallback: string) =>
+    err instanceof Error ? err.message : fallback,
+}));
+
+const mockCityHealth = vi.fn();
+vi.mock('../supervisor/client', () => ({
+  supervisorApiForRequestBudget: vi.fn(() => ({ cityHealth: mockCityHealth })),
+}));
+
+const sysHealth = { host: { cpu_count: 8 }, admin: { pid: 1 } };
+const localTools = { gc: { status: 'available', version: 'dev' } };
+const trend = { available: true, reason: null, samples: [] };
+const rigStores = { available: true, rigs: [] };
+const statusBody = { store: {}, work: {} };
+const healthBody = { status: 'ok', city: 'demo-city', version: '1.0.0', uptime_sec: 10 };
+
+function seedAllOk(): void {
+  mockApi.systemHealth.mockResolvedValue(sysHealth);
+  mockApi.localToolVersions.mockResolvedValue(localTools);
+  mockApi.doltTrend.mockResolvedValue(trend);
+  mockApi.rigStoreHealth.mockResolvedValue(rigStores);
+  mockApi.supervisorStatus.mockResolvedValue({
+    available: true,
+    sampledAt: '2026-07-02T00:00:00.000Z',
+    status: statusBody,
+  });
+  mockCityHealth.mockResolvedValue(healthBody);
+}
+
+beforeEach(() => {
+  invalidate('health');
+  vi.clearAllMocks();
+  seedAllOk();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useHealthSources', () => {
+  it('starts loading, then aggregates all six sources on success', async () => {
+    const { result } = renderHook(() => useHealthSources());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const { sources } = result.current;
+    expect(sources.systemHealth).toEqual({ status: 'available', data: sysHealth });
+    expect(sources.supervisor).toEqual({ status: 'available', data: healthBody });
+    expect(sources.status?.status).toBe('available');
+    expect(sources.localTools).toEqual({ status: 'available', data: localTools });
+    expect(sources.trend).toEqual(trend);
+    expect(sources.rigStores).toEqual(rigStores);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('degrades a single source independently without failing the others', async () => {
+    mockCityHealth.mockRejectedValue(new Error('supervisor unreachable'));
+
+    const { result } = renderHook(() => useHealthSources());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const { sources } = result.current;
+    // The failed source resolves to its unavailable state...
+    expect(sources.supervisor).toEqual({
+      status: 'unavailable',
+      error: 'supervisor health unavailable',
+    });
+    // ...while every other source still loads.
+    expect(sources.systemHealth?.status).toBe('available');
+    expect(sources.rigStores).toEqual(rigStores);
+  });
+
+  it('refresh() re-invokes every source fetcher', async () => {
+    const { result } = renderHook(() => useHealthSources());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const before = mockApi.systemHealth.mock.calls.length;
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockApi.systemHealth.mock.calls.length).toBeGreaterThan(before);
+    expect(mockApi.localToolVersions).toHaveBeenCalledTimes(2);
+    expect(mockApi.doltTrend).toHaveBeenCalledTimes(2);
+    expect(mockApi.rigStoreHealth).toHaveBeenCalledTimes(2);
+    expect(mockApi.supervisorStatus).toHaveBeenCalledTimes(2);
+    expect(mockCityHealth).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/routes/useHealthSources.ts
+++ b/frontend/src/routes/useHealthSources.ts
@@ -1,0 +1,260 @@
+import { useCallback } from 'react';
+import type {
+  DoltNomsTrend,
+  LocalToolVersions,
+  RigStoreHealthReport,
+  SupervisorStatusReport,
+  SystemHealth,
+} from 'gas-city-dashboard-shared';
+import type { HealthOutputBody, StatusBody } from 'gas-city-dashboard-shared/gc-supervisor';
+import { api, formatApiError } from '../api/client';
+import { getActiveCity } from '../api/cityBase';
+import { useCachedData } from '../hooks/useCachedData';
+import { useVisibleRefresh } from '../hooks/useVisibleRefresh';
+import { supervisorApiForRequestBudget } from '../supervisor/client';
+
+const HEALTH_SUPERVISOR_REQUEST_TIMEOUT_MS = 2_500;
+
+export type SupervisorHealthState =
+  | { status: 'available'; data: HealthOutputBody }
+  | { status: 'unavailable'; error: string };
+
+export type SystemHealthState =
+  | { status: 'available'; data: SystemHealth }
+  | { status: 'unavailable'; error: string };
+
+export type SupervisorStatusState =
+  // `staleReason` is set when the data is the last good snapshot served after a
+  // later sample failed (degraded, not blank) — drives the "showing last sample"
+  // marker on the diagnostics widgets. null means the data is fresh.
+  | {
+      status: 'available';
+      data: StatusBody;
+      staleReason: Extract<SupervisorStatusReport, { available: false }>['reason'] | null;
+    }
+  | { status: 'unavailable'; error: string };
+
+export type LocalToolVersionsState =
+  | { status: 'available'; data: LocalToolVersions }
+  | { status: 'unavailable'; error: string };
+
+async function fetchSystemHealth(): Promise<SystemHealthState> {
+  try {
+    return {
+      status: 'available',
+      data: await api.systemHealth(),
+    };
+  } catch (err) {
+    return {
+      status: 'unavailable',
+      error: formatApiError(err, 'dashboard host health unavailable'),
+    };
+  }
+}
+
+async function fetchSupervisorHealth(): Promise<SupervisorHealthState> {
+  const cityName = getActiveCity();
+  if (cityName === null) {
+    throw new Error('Health page loaded before an active city was resolved');
+  }
+  try {
+    return {
+      status: 'available',
+      data: await supervisorApiForRequestBudget(HEALTH_SUPERVISOR_REQUEST_TIMEOUT_MS).cityHealth(
+        cityName,
+      ),
+    };
+  } catch {
+    return {
+      status: 'unavailable',
+      error: 'supervisor health unavailable',
+    };
+  }
+}
+
+function supervisorStatusUnavailableCopy(
+  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
+): string {
+  switch (reason) {
+    case 'not_sampled_yet':
+      return 'supervisor status sample is warming up; data appears after the next backend sample';
+    case 'status_read_failed':
+      return 'latest supervisor status read failed; check the backend log';
+  }
+}
+
+// Stale marker shown above cached diagnostics, mirroring the rig-store-health
+// "Showing the last sample" affordance so a degraded snapshot is never mistaken
+// for a fresh read.
+export function supervisorStatusStaleCopy(
+  reason: Extract<SupervisorStatusReport, { available: false }>['reason'],
+): string {
+  return `Showing the last sample; refresh failed: ${supervisorStatusUnavailableCopy(reason)}.`;
+}
+
+// gascity-dashboard-4bol: read the dashboard backend's cached /status snapshot
+// (sampled on the background ceiling) instead of racing the slow supervisor on a
+// short interactive budget — live /status runs 10–38s (gastownhall/gascity-dashboard#88).
+// A degraded report still carries the last good status, so the store-thresholds /
+// dolt-usage / beads-usage widgets show real (cached) data with a "stale" marker
+// rather than "supervisor status unavailable".
+async function fetchSupervisorStatus(): Promise<SupervisorStatusState> {
+  try {
+    const report = await api.supervisorStatus();
+    if (report.available) {
+      return { status: 'available', data: report.status, staleReason: null };
+    }
+    if (report.status !== null) {
+      return { status: 'available', data: report.status, staleReason: report.reason };
+    }
+    return {
+      status: 'unavailable',
+      error: supervisorStatusUnavailableCopy(report.reason),
+    };
+  } catch (err) {
+    return {
+      status: 'unavailable',
+      error: formatApiError(err, 'supervisor status unavailable'),
+    };
+  }
+}
+
+async function fetchLocalToolVersions(): Promise<LocalToolVersionsState> {
+  try {
+    return {
+      status: 'available',
+      data: await api.localToolVersions(),
+    };
+  } catch {
+    return {
+      status: 'unavailable',
+      error: 'local tool versions unavailable',
+    };
+  }
+}
+
+async function fetchDoltNomsTrend(): Promise<DoltNomsTrend> {
+  try {
+    return await api.doltTrend();
+  } catch {
+    return {
+      available: false,
+      reason: 'sample_failed',
+      samples: [],
+    };
+  }
+}
+
+async function fetchRigStoreHealth(): Promise<RigStoreHealthReport> {
+  try {
+    return await api.rigStoreHealth();
+  } catch {
+    // Transport-level failure (backend unreachable / 5xx / decode) — a
+    // distinct root cause from the backend's own 'rig_list_failed', so it must
+    // not borrow that reason and point the operator at the supervisor.
+    return { available: false, reason: 'fetch_failed', rigs: [] };
+  }
+}
+
+/** The six independently-degradable data sources the Health page renders. */
+export interface HealthSources {
+  systemHealth: SystemHealthState | null;
+  supervisor: SupervisorHealthState | null;
+  status: SupervisorStatusState | null;
+  localTools: LocalToolVersionsState | null;
+  trend: DoltNomsTrend | null;
+  rigStores: RigStoreHealthReport | null;
+}
+
+export interface UseHealthSourcesResult {
+  sources: HealthSources;
+  /** True until the first sample of every source has settled at least once. */
+  loading: boolean;
+  /** Aggregated fetcher-level failures (not per-source degradation), or null. */
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Owns the Health page's six-source fetch orchestration: each source loads and
+ * degrades independently (a stale-while-revalidate cache read per source), the
+ * combined loading/error is reduced across them, and a single refresh() fans
+ * out to all six. Foreground polling is wired here (30s) so the page component
+ * stays render-only. Each source degrades to its own `unavailable` state rather
+ * than blanking the page, so one slow/failed source never hides the rest.
+ */
+export function useHealthSources(): UseHealthSourcesResult {
+  const cityName = getActiveCity();
+  const systemHealth = useCachedData('health:system', fetchSystemHealth);
+  const supervisorHealth = useCachedData(
+    `health:supervisor:${cityName ?? 'no-city'}`,
+    fetchSupervisorHealth,
+  );
+  const supervisorStatusCache = useCachedData(
+    `health:status:${cityName ?? 'no-city'}`,
+    fetchSupervisorStatus,
+  );
+  const localToolVersions = useCachedData('health:local-tools', fetchLocalToolVersions);
+  const doltNomsTrend = useCachedData(
+    `health:dolt-noms-trend:${cityName ?? 'no-city'}`,
+    fetchDoltNomsTrend,
+  );
+  const rigStoreHealth = useCachedData(
+    `health:rig-store:${cityName ?? 'no-city'}`,
+    fetchRigStoreHealth,
+  );
+  const refreshSystemHealth = systemHealth.refresh;
+  const refreshSupervisorHealth = supervisorHealth.refresh;
+  const refreshSupervisorStatus = supervisorStatusCache.refresh;
+  const refreshLocalToolVersions = localToolVersions.refresh;
+  const refreshDoltNomsTrend = doltNomsTrend.refresh;
+  const refreshRigStoreHealth = rigStoreHealth.refresh;
+  const loading =
+    systemHealth.loading ||
+    supervisorHealth.loading ||
+    supervisorStatusCache.loading ||
+    localToolVersions.loading ||
+    doltNomsTrend.loading ||
+    rigStoreHealth.loading;
+  const error =
+    [
+      systemHealth.error,
+      supervisorHealth.error,
+      supervisorStatusCache.error,
+      localToolVersions.error,
+      doltNomsTrend.error,
+      rigStoreHealth.error,
+    ]
+      .filter((value): value is string => value !== null)
+      .join('; ') || null;
+  const refresh = useCallback(async () => {
+    await Promise.all([
+      refreshSystemHealth(),
+      refreshSupervisorHealth(),
+      refreshSupervisorStatus(),
+      refreshLocalToolVersions(),
+      refreshDoltNomsTrend(),
+      refreshRigStoreHealth(),
+    ]);
+  }, [
+    refreshDoltNomsTrend,
+    refreshLocalToolVersions,
+    refreshRigStoreHealth,
+    refreshSupervisorHealth,
+    refreshSupervisorStatus,
+    refreshSystemHealth,
+  ]);
+
+  useVisibleRefresh(refresh, 30_000);
+
+  const sources: HealthSources = {
+    systemHealth: systemHealth.data ?? null,
+    supervisor: supervisorHealth.data ?? null,
+    status: supervisorStatusCache.data ?? null,
+    localTools: localToolVersions.data ?? null,
+    trend: doltNomsTrend.data ?? null,
+    rigStores: rigStoreHealth.data ?? null,
+  };
+
+  return { sources, loading, error, refresh };
+}


### PR DESCRIPTION
## What
Extracts a `useHealthSources()` hook out of `Health.tsx`. Behavior-preserving refactor plus a hook test.

## Detail
The six health-source fetchers, their state types, the 2500ms supervisor budget, the cache keys, the `loading` OR-reduction, the `error` join, the `Promise.all` refresh fan-out, and the `useVisibleRefresh(refresh, 30_000)` polling all move verbatim from `Health.tsx` into the hook. `HealthPage` reduces to `useHealthSources()` plus a destructure that preserves the exact bindings the JSX consumes; `supervisorStatusStaleCopy` is exported from the hook and re-imported by `Health.tsx` with identical output.

## Tests
Adds `useHealthSources.test.tsx`, which drives the hook via `renderHook` against a stubbed data layer and asserts three contract behaviors: all six sources aggregate to `available` after an initial `loading`, a single rejecting source degrades only itself to `unavailable` while the rest stay available, and `refresh()` re-invokes all six fetchers.

## Test plan
- `npm run typecheck` (incl. `typecheck:test`), `npm run lint`: green
- `npm --workspace frontend test`: green (1188 tests)
- `npm --workspace frontend run build`: green

Verified merge-clean on current main (5231ab4), behavior-preserving (no dropped fetch or branch). Closes gascity-dashboard-qqymd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
