### PR TITLE
fix(gitignore): re-ignore the auto-regenerating search-sessions skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ credentials.*
 # ...but never the nested git worktrees agents create under .claude/ — those are
 # full checkouts (with node_modules) that must not be tracked or formatted.
 .claude/worktrees/
+# ...nor session-runtime skills that regenerate on every session-active cycle
+# (search-sessions rewrites SKILL.md each wake) — the !.claude/** un-ignore would
+# otherwise surface them as a perpetually-dirty tree and block every worker claim.
+.claude/skills/search-sessions/
 !.agents/
 !.agents/**
 .scorecard/


### PR DESCRIPTION
## What
Re-ignores `.claude/skills/search-sessions/`, a session-runtime skill the runtime rewrites on every wake.

## Why
The `!.claude/**` un-ignore surfaces that directory as a perpetually-dirty working tree, which blocks every worker claim (the claim hook refuses a dirty shared tree). Re-ignoring it after the allow-list, exactly like the existing `.claude/worktrees/` line, keeps the tree clean without giving up the `.claude/` allow-list for real project files.

## Test plan
`.gitignore`-only change; no code, no gate impact. CI passes trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
