### PR TITLE
refactor(shared): trim over-exports from the package root barrel

### DIFF
--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -250,9 +250,14 @@ test('shared barrel narrows to only externally-consumed session/link symbols (ga
   assert.equal(typeof parseRef, 'function');
   assert.equal(typeof sanitiseUrl, 'function');
 
-  assert.equal((barrel as Record<string, unknown>)['recordResolution'], undefined);
-  assert.equal((barrel as Record<string, unknown>)['nodeKey'], undefined);
-  assert.equal((barrel as Record<string, unknown>)['matchesSessionTarget'], undefined);
+  // Assert the key is absent from the module namespace, not merely `=== undefined`:
+  // a symbol accidentally exported with the value `undefined` would pass the
+  // latter but is still a barrel leak.
+  const isExported = (name: string): boolean =>
+    Object.prototype.hasOwnProperty.call(barrel, name);
+  assert.equal(isExported('recordResolution'), false);
+  assert.equal(isExported('nodeKey'), false);
+  assert.equal(isExported('matchesSessionTarget'), false);
 });
 
 test('errorMessage normalizes unknown error values for shared client/server reporting', () => {

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -253,8 +253,7 @@ test('shared barrel narrows to only externally-consumed session/link symbols (ga
   // Assert the key is absent from the module namespace, not merely `=== undefined`:
   // a symbol accidentally exported with the value `undefined` would pass the
   // latter but is still a barrel leak.
-  const isExported = (name: string): boolean =>
-    Object.prototype.hasOwnProperty.call(barrel, name);
+  const isExported = (name: string): boolean => Object.prototype.hasOwnProperty.call(barrel, name);
   assert.equal(isExported('recordResolution'), false);
   assert.equal(isExported('nodeKey'), false);
   assert.equal(isExported('matchesSessionTarget'), false);

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -11,14 +11,19 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import {
+  buildRelationIndex,
   CITY_NAME_RE,
   effectiveContextPct,
   errorMessage,
   GC_EVENT_PREFIX,
   makeNodeKey,
+  parseRef,
+  ResolutionRollup,
+  sanitiseUrl,
   SCOPE_REF_RE,
   TRUE_CONTEXT_WINDOWS,
 } from './index.js';
+import * as barrel from './index.js';
 import { CITY_NAME_RE as leafCityNameRe } from './city.js';
 import {
   effectiveContextPct as leafEffectiveContextPct,
@@ -233,6 +238,21 @@ test('shared barrel does not expose dashboard mirror DTOs for direct supervisor 
   assert.doesNotMatch(healthSource, /\bBeadsUsage\b/);
   assert.doesNotMatch(healthSource, /\bConfigComparisonRow\b/);
   assert.equal(exists(new URL('./formula-runs.ts', import.meta.url)), false);
+});
+
+test('shared barrel narrows to only externally-consumed session/link symbols (gascity-dashboard-ox06)', () => {
+  // Runtime reachability is the real contract a consumer sees — source-text
+  // regex on the barrel file is brittle to reformatting and doesn't catch a
+  // symbol re-exported under different syntax, so assert on the barrel's
+  // actual exports rather than how index.ts happens to be written.
+  assert.equal(typeof ResolutionRollup, 'function');
+  assert.equal(typeof buildRelationIndex, 'function');
+  assert.equal(typeof parseRef, 'function');
+  assert.equal(typeof sanitiseUrl, 'function');
+
+  assert.equal((barrel as Record<string, unknown>)['recordResolution'], undefined);
+  assert.equal((barrel as Record<string, unknown>)['nodeKey'], undefined);
+  assert.equal((barrel as Record<string, unknown>)['matchesSessionTarget'], undefined);
 });
 
 test('errorMessage normalizes unknown error values for shared client/server reporting', () => {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -3,7 +3,7 @@
 // `export type *` so importing the package root does not pull in dead JS.
 
 export type * from './snapshot/types.js';
-export { resolveSessionForTarget, matchesSessionTarget, lastSegment } from './session-resolve.js';
+export { resolveSessionForTarget, lastSegment } from './session-resolve.js';
 export * from './run-detail.js';
 export type * from './run-snapshot.js';
 export * from './run-scope.js';
@@ -37,9 +37,11 @@ export * from './runs/stranded.js';
 export * from './bead-id.js';
 export * from './links.js';
 export * from './links/build-link-view.js';
-export * from './links/instrumentation.js';
-export * from './links/node-ref.js';
-export * from './links/relation-index.js';
+// Named exports below, not `export *` — only these symbols have real external
+// consumers (frontend + backend tests). Audit before widening back to `export *`.
+export { ResolutionRollup } from './links/instrumentation.js';
+export { parseRef, sanitiseUrl } from './links/node-ref.js';
+export { buildRelationIndex } from './links/relation-index.js';
 export * from './convoy/projection.js';
 export * from './city.js';
 export * from './operator.js';

--- a/shared/src/run-snapshot.test.ts
+++ b/shared/src/run-snapshot.test.ts
@@ -16,8 +16,10 @@ import { readFileSync } from 'node:fs';
 test('RunSnapshotBead/RunSnapshotDep are aliases of the generated wire types, not hand mirrors', () => {
   const source = readFileSync(new URL('./run-snapshot.ts', import.meta.url), 'utf8');
 
-  assert.doesNotMatch(source, /export interface RunSnapshotBead/);
-  assert.doesNotMatch(source, /export interface RunSnapshotDep/);
-  assert.match(source, /export type RunSnapshotBead = WorkflowBeadResponse;/);
-  assert.match(source, /export type RunSnapshotDep = WorkflowDepResponse;/);
+  // Whitespace-tolerant so a reformat (extra spaces/newlines) can't fail the
+  // guard while the types remain true aliases.
+  assert.doesNotMatch(source, /export\s+interface\s+RunSnapshotBead\b/);
+  assert.doesNotMatch(source, /export\s+interface\s+RunSnapshotDep\b/);
+  assert.match(source, /export\s+type\s+RunSnapshotBead\s*=\s*WorkflowBeadResponse\s*;/);
+  assert.match(source, /export\s+type\s+RunSnapshotDep\s*=\s*WorkflowDepResponse\s*;/);
 });

--- a/shared/src/run-snapshot.test.ts
+++ b/shared/src/run-snapshot.test.ts
@@ -1,0 +1,23 @@
+// Run with: npx tsx --test shared/src/run-snapshot.test.ts
+//
+// gascity-dashboard-ox06: RunSnapshotBead/RunSnapshotDep used to be hand-typed
+// mirrors of the generated supervisor client's WorkflowBeadResponse/
+// WorkflowDepResponse (AGENTS.md forbids mirroring supervisor wire shapes in
+// shared). They are now type aliases of the generated types directly, so a
+// future supervisor schema change surfaces here instead of silently drifting.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Source-text check, not a structural/assignability test: TypeScript's structural
+// typing can't tell a true alias apart from a hand-rolled interface with matching
+// fields, so this is the only way to guard against reintroducing the hand mirror.
+test('RunSnapshotBead/RunSnapshotDep are aliases of the generated wire types, not hand mirrors', () => {
+  const source = readFileSync(new URL('./run-snapshot.ts', import.meta.url), 'utf8');
+
+  assert.doesNotMatch(source, /export interface RunSnapshotBead/);
+  assert.doesNotMatch(source, /export interface RunSnapshotDep/);
+  assert.match(source, /export type RunSnapshotBead = WorkflowBeadResponse;/);
+  assert.match(source, /export type RunSnapshotDep = WorkflowDepResponse;/);
+});

--- a/shared/src/run-snapshot.ts
+++ b/shared/src/run-snapshot.ts
@@ -1,30 +1,22 @@
+import type {
+  WorkflowBeadResponse,
+  WorkflowDepResponse,
+} from './generated/gc-supervisor-client/index.js';
+
 /**
- * Raw dependency edge from gc supervisor's run snapshot endpoint.
- * This mirrors RunDepResponse in the supervisor OpenAPI schema.
+ * Raw dependency edge from gc supervisor's run snapshot endpoint. Rides the
+ * generated WorkflowDepResponse wire shape directly (AGENTS.md: do not
+ * mirror supervisor wire shapes in shared).
  */
-export interface RunSnapshotDep {
-  from: string;
-  to: string;
-  kind?: string;
-}
+export type RunSnapshotDep = WorkflowDepResponse;
 
 /**
  * Raw bead row inside a gc supervisor run snapshot. This is still
- * supervisor wire shape, not the dashboard's display node shape. It mirrors
- * RunBeadResponse in the supervisor OpenAPI schema.
+ * supervisor wire shape, not the dashboard's display node shape. Rides the
+ * generated WorkflowBeadResponse wire shape directly (AGENTS.md: do not
+ * mirror supervisor wire shapes in shared).
  */
-export interface RunSnapshotBead {
-  id: string;
-  title: string;
-  status: string;
-  kind: string;
-  step_ref?: string;
-  attempt?: number;
-  logical_bead_id?: string;
-  scope_ref?: string;
-  assignee?: string;
-  metadata: Record<string, string>;
-}
+export type RunSnapshotBead = WorkflowBeadResponse;
 
 /**
  * Dashboard-normalized gc supervisor snapshot. The current supervisor wire

--- a/shared/src/session-resolve.ts
+++ b/shared/src/session-resolve.ts
@@ -45,7 +45,7 @@ function matchFirst(
  * positions: exact alias, pool, last-segment of alias (split on '/' '.'),
  * or last-segment of session_name (split on '__' '--').
  */
-export function matchesSessionTarget(session: DashboardSession, target: string): boolean {
+function matchesSessionTarget(session: DashboardSession, target: string): boolean {
   if (session.alias === target) return true;
   if (session.pool === target) return true;
   if (session.alias !== undefined && lastSegment(session.alias, ['/', '.']) === target) {


### PR DESCRIPTION
## What
Narrows the `gas-city-dashboard-shared` package-root barrel to the symbols actually imported through the root.

## Detail
Dropped symbols are used only via relative imports inside `shared/src/links/` and `shared/src/session-resolve.ts`, never through the package root, so narrowing the barrel breaks no consumer: `matchesSessionTarget`, `recordResolution`/`ResolutionOutcome`/`ResolutionRecorder`, `ParsedRef`/`ParsedRefType`/`nodeKey`, `IndexBead`/`RelationIndex`. `RunSnapshotDep`/`RunSnapshotBead` become `= WorkflowDepResponse`/`= WorkflowBeadResponse` aliases (still exported). A compile-time-only assignability test is replaced with a stronger runtime barrel-reachability check.

## Verification
Each removed export was grepped across backend/src, frontend/src, shared/src: zero remaining importers. Verified on current main.

## Test plan
- `npm run typecheck` (src + backend/frontend typecheck:test), `npm run lint`: green
- `npm --workspace shared test` (356), backend (618), frontend (1203): green
- `npm --workspace frontend run build`: green

Closes gascity-dashboard-ox06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
