### PR TITLE
fix(convoy): drop the colliding unavailable-tier glyph, carry state by word

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -130,7 +130,9 @@ describe('App routes', () => {
 
     const notice = await screen.findByRole('alert');
     expect(notice.textContent).toContain('Unavailable');
-    expect(notice.textContent).toContain('◌');
+    // The unavailable tier is glyph-less and must not reuse ◌ (the `waiting`
+    // statusGlyph), so one mark keeps one meaning (gascity-dashboard-xdzm).
+    expect(notice.textContent).not.toContain('◌');
     // The route stayed mounted at /convoy — the throw was contained, not fatal.
     expect(screen.getByTestId('pathname').textContent).toBe('/convoy');
   });

--- a/frontend/src/components/ViewErrorBoundary.test.tsx
+++ b/frontend/src/components/ViewErrorBoundary.test.tsx
@@ -33,7 +33,7 @@ describe('ViewErrorBoundary', () => {
     expect(screen.getByText('convoy contents')).toBeTruthy();
   });
 
-  it('degrades a child render throw to a glyph+word unavailable tier instead of failing the whole app', () => {
+  it('degrades a child render throw to a word-carried unavailable tier instead of failing the whole app', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal(
       'fetch',
@@ -51,9 +51,12 @@ describe('ViewErrorBoundary', () => {
     );
 
     const notice = screen.getByRole('alert');
+    // Greyscale-readable: the state is carried by the word (glyph-less, like the
+    // app-root ErrorBoundary), not tone.
     expect(notice.textContent).toContain('Unavailable');
-    // Greyscale-readable: the state is carried by a glyph + the word, not tone.
-    expect(notice.textContent).toContain('◌');
+    // Must NOT reuse ◌ — that glyph means the `waiting` run-node status
+    // (statusGlyph), so it would give one mark two meanings (gascity-dashboard-xdzm).
+    expect(notice.textContent).not.toContain('◌');
     // The app-root crash page must NOT have taken over the whole dashboard.
     expect(screen.queryByText('Dashboard view failed.')).toBeNull();
   });

--- a/frontend/src/components/ViewErrorBoundary.tsx
+++ b/frontend/src/components/ViewErrorBoundary.tsx
@@ -15,7 +15,7 @@ interface ViewErrorBoundaryState {
 // A per-view error boundary. When one view's render throws — e.g. an
 // unanticipated partial or degenerate supervisor shape that slips past the data
 // layer's guards while the dolt store is slow — this degrades THAT view to a
-// calm, DESIGN-compliant "unavailable" tier (glyph + word + a retry affordance)
+// calm, DESIGN-compliant "unavailable" tier (the word + a retry affordance)
 // instead of letting the throw bubble to the app-root ErrorBoundary, which
 // replaces the WHOLE dashboard with the generic crash page.
 //
@@ -23,8 +23,9 @@ interface ViewErrorBoundaryState {
 // edge: the underlying error is still REPORTED to the local dashboard log
 // (never swallowed), and Retry remounts the subtree so transient slowness
 // clears without a full-page reload. Greyscale-readable per DESIGN.md (the
-// state is carried by a glyph and the word, not by tone) and non-counting (no
-// maroon mark, so the One Mark Rule is unaffected).
+// state is carried by the word, not by tone; glyph-less like the app-root
+// ErrorBoundary so it adds no mark to the run/bead status glyph vocabulary) and
+// non-counting (no maroon mark, so the One Mark Rule is unaffected).
 //
 // The neutral grey is deliberate and distinct from the convoy DATA layer's
 // Stuck Maroon "failed" tier: a render crash is an unexpected fault in the view
@@ -51,9 +52,8 @@ export class ViewErrorBoundary extends Component<ViewErrorBoundaryProps, ViewErr
       return (
         <section className="space-y-3" role="alert">
           <p className="text-body text-fg-muted">
-            <span aria-hidden="true">◌</span> Unavailable. This view could not be rendered; the
-            supervisor store may be slow or returning partial data. The error was reported to the
-            local dashboard log.
+            Unavailable. This view could not be rendered; the supervisor store may be slow or
+            returning partial data. The error was reported to the local dashboard log.
           </p>
           <button
             type="button"


### PR DESCRIPTION
## What
Drops the `◌` glyph from the `ViewErrorBoundary` unavailable-tier fallback; the state is carried by the word plus `role="alert"`.

## Why
The `◌` glyph collides with the run/bead status glyph vocabulary. Going glyph-less, like the app-root `ErrorBoundary`, keeps the boundary greyscale-readable per DESIGN.md and adds no mark to the status glyph set. No maroon mark, so the One Mark Rule is unaffected.

## Test plan
- `npm run typecheck`, `npm run lint`: green
- `ViewErrorBoundary.test.tsx` + `App.test.tsx`: green (fallback renders, error still reported, Retry remounts)

Closes gascity-dashboard-xdzm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
