### PR TITLE
fix(deploy): MemoryDenyWriteExecute=true core-dumps Node 24 at V8 isolate init

### DIFF
--- a/deploy/gas-city-dashboard.service
+++ b/deploy/gas-city-dashboard.service
@@ -48,7 +48,12 @@ ProtectControlGroups=true
 RestrictAddressFamilies=AF_UNIX AF_INET
 RestrictNamespaces=true
 LockPersonality=true
-MemoryDenyWriteExecute=true
+# NOT MemoryDenyWriteExecute=true: V8's JIT allocates writable-then-executable
+# pages at isolate init (v8::base::OS::SetPermissions), so MDWE core-dumps node
+# before main() — "Check failed: 12 == (*__errno_location ())" and
+# status=5/TRAP on Node 24. W^X for the dashboard would require a JITless
+# node build; until then this directive must stay off.
+MemoryDenyWriteExecute=false
 SystemCallArchitectures=native
 
 [Install]


### PR DESCRIPTION
The shipped systemd unit sets `MemoryDenyWriteExecute=true`, which denies the writable+executable `mprotect` V8's JIT needs when creating the first isolate.  On Node 24 (the documented runtime) the service never reaches `main()`:

```
# Fatal error in , line 0
# Check failed: 12 == (*__errno_location ()).
...
3: 0x2723e56 v8::base::OS::SetPermissions(...)
8: 0xc30cc6 v8::Isolate::Initialize(...)
...
gas-city-dashboard.service: Main process exited, code=dumped, status=5/TRAP
```

Hit this deploying the unit verbatim on Ubuntu with Node 24.15.0 (repro: `systemctl --user enable --now gas-city-dashboard.service` on any host, the service core-dumps before binding).  This PR flips the directive to `=false` with a comment explaining why, so the next operator doesn't have to rediscover it from a core dump.  Every other hardening directive is kept.

Sibling data point from the same deploy landed on #88 (cold formulas/feed scan timing).