### PR TITLE
fix: surface recent reef agent activity

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -256,9 +256,13 @@ licenses it; outside this route, nothing here applies.
   drill-down targets.
 - **Provider telemetry is never guessed.** `activity: in-turn` is the only fact
   that may be called working. A live session whose provider omits turn activity
-  is labelled "activity unknown," never idle or working. Its detail card explains that
-  turn activity is not reported by the provider. Its calm visual pose reflects
-  the absence of turn evidence, not a claim that the agent has stopped.
+  is labelled "activity unknown," never idle or working. When the provider
+  explicitly reports idle and `last_active` is less than sixty seconds old, the
+  calm fish is labelled "active just now." This is a recency statement, not a
+  claim that work is still in progress. For an unknown-activity session, the
+  detail card explains that turn activity is not reported by the provider. Its
+  calm visual pose reflects the absence of turn evidence, not a claim that the
+  agent has stopped.
 - **Visible morsels are practical targets.** Every rendered bead is hoverable
   and clickable at a stable screen-space distance at overview, LOD1, and LOD2.
   Hit testing uses the same LOD-thinning predicate as painting, so an invisible

--- a/frontend/src/aquarium/contracts.ts
+++ b/frontend/src/aquarium/contracts.ts
@@ -62,7 +62,7 @@ export interface FishEntity {
   species: FishSpecies;
   isMayor: boolean;
   pose: AquariumPose;
-  /** caption state word, e.g. "working", "awaiting input" */
+  /** caption activity/state word, e.g. "working", "active just now", "awaiting input" */
   poseWord: string;
   /** the provider does not expose authoritative in-turn/idle activity */
   turnActivityUnavailable?: true;

--- a/frontend/src/aquarium/derive/fish.test.ts
+++ b/frontend/src/aquarium/derive/fish.test.ts
@@ -110,6 +110,18 @@ describe('buildFish — session-backed fish', () => {
     expect(fish[0]?.pose).toBe('working');
   });
 
+  it('keeps the calm pose but labels recently completed activity active just now', () => {
+    const s = session({
+      session_name: 'sess-1',
+      id: 'gc-1',
+      activity: 'idle',
+      last_active: new Date(NOW - 30_000).toISOString(),
+    });
+    const { fish } = buildFish(inputs({ sessions: [s] }));
+    expect(fish[0]?.pose).toBe('idle');
+    expect(fish[0]?.poseWord).toBe('active just now');
+  });
+
   it('carries a distress pose verbatim, joined agent<->session via agent.session.name', () => {
     const s = session({ session_name: 'sess-1', id: 'gc-1', activity: 'in-turn' });
     const a = agent({

--- a/frontend/src/aquarium/derive/fish.ts
+++ b/frontend/src/aquarium/derive/fish.ts
@@ -139,7 +139,7 @@ function fishFromSession(
     species,
     isMayor,
     pose,
-    poseWord: poseWordForSession(pose, session),
+    poseWord: poseWordForSession(pose, session, nowMs),
     ...(turnActivityUnavailable(pose, session) ? { turnActivityUnavailable: true } : {}),
     bellyPct: effectiveContextPct(session),
     homeKey: homeKeyFor(isMayor, session.rig, rigs),

--- a/frontend/src/aquarium/derive/pose.test.ts
+++ b/frontend/src/aquarium/derive/pose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AgentNeedsYou } from 'gas-city-dashboard-shared';
 import {
   ASLEEP_THRESHOLD_MS,
+  RECENT_ACTIVITY_WINDOW_MS,
   derivePose,
   isDistressPose,
   poseWord,
@@ -52,11 +53,15 @@ describe('derivePose', () => {
       ),
     ).toBe('idle');
     expect(
-      poseWordForSession('idle', {
-        state: 'active',
-        running: true,
-        last_active: '2026-07-12T09:35:49.000Z',
-      }),
+      poseWordForSession(
+        'idle',
+        {
+          state: 'active',
+          running: true,
+          last_active: '2026-07-12T09:35:49.000Z',
+        },
+        NOW,
+      ),
     ).toBe('activity unknown');
   });
 
@@ -107,27 +112,92 @@ describe('poseWord', () => {
 
   it('does not present liveness as a competing work-state when turn activity is unknown', () => {
     expect(
-      poseWordForSession('idle', {
-        state: 'active',
-      }),
+      poseWordForSession(
+        'idle',
+        {
+          state: 'active',
+        },
+        NOW,
+      ),
     ).toBe('activity unknown');
   });
 
   it('uses the same activity-unknown label for a running session with no turn signal', () => {
     expect(
-      poseWordForSession('idle', {
-        state: 'running',
-        running: true,
-      }),
+      poseWordForSession(
+        'idle',
+        {
+          state: 'running',
+          running: true,
+        },
+        NOW,
+      ),
     ).toBe('activity unknown');
   });
 
   it('keeps an explicit provider idle signal authoritative', () => {
     expect(
-      poseWordForSession('idle', {
-        activity: 'idle',
-        state: 'active',
-      }),
+      poseWordForSession(
+        'idle',
+        {
+          activity: 'idle',
+          state: 'active',
+        },
+        NOW,
+      ),
     ).toBe('idle');
+  });
+
+  it('labels an explicitly idle session active just now inside the recency window', () => {
+    expect(
+      poseWordForSession(
+        'idle',
+        {
+          activity: 'idle',
+          state: 'active',
+          last_active: new Date(NOW - RECENT_ACTIVITY_WINDOW_MS + 1).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe('active just now');
+  });
+
+  it('returns to idle at the recency boundary and rejects future timestamps', () => {
+    expect(
+      poseWordForSession(
+        'idle',
+        {
+          activity: 'idle',
+          state: 'active',
+          last_active: new Date(NOW - RECENT_ACTIVITY_WINDOW_MS).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe('idle');
+    expect(
+      poseWordForSession(
+        'idle',
+        {
+          activity: 'idle',
+          state: 'active',
+          last_active: new Date(NOW + 1).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe('idle');
+  });
+
+  it('keeps missing turn telemetry unknown even when last_active is recent', () => {
+    expect(
+      poseWordForSession(
+        'idle',
+        {
+          state: 'active',
+          running: true,
+          last_active: new Date(NOW - 1).toISOString(),
+        },
+        NOW,
+      ),
+    ).toBe('activity unknown');
   });
 });

--- a/frontend/src/aquarium/derive/pose.ts
+++ b/frontend/src/aquarium/derive/pose.ts
@@ -9,6 +9,8 @@ import type { AquariumPose } from '../contracts';
 
 /** A session idles into 'asleep' once this much time has passed with no activity. */
 export const ASLEEP_THRESHOLD_MS = 3_600_000;
+/** Keep a completed, explicitly observed turn visible through one 30s poll cycle. */
+export const RECENT_ACTIVITY_WINDOW_MS = 60_000;
 
 const POSE_WORD: Readonly<Record<AquariumPose, string>> = {
   working: 'working',
@@ -31,8 +33,13 @@ export function poseWord(pose: AquariumPose): string {
  * session list. An active process with no activity field is not evidence of
  * either an idle or an in-turn agent, so say exactly what is known.
  */
-export function poseWordForSession(pose: AquariumPose, session: PoseSessionFacts): string {
+export function poseWordForSession(
+  pose: AquariumPose,
+  session: PoseSessionFacts,
+  nowMs: number,
+): string {
   if (turnActivityUnavailable(pose, session)) return 'activity unknown';
+  if (pose === 'idle' && wasRecentlyActive(session, nowMs)) return 'active just now';
   return poseWord(pose);
 }
 
@@ -49,6 +56,16 @@ function isLiveWithoutTurnActivity(session: PoseSessionFacts): boolean {
     (activity === undefined || activity.length === 0) &&
     (session.running === true || state === 'active' || state === 'running')
   );
+}
+
+function wasRecentlyActive(session: PoseSessionFacts, nowMs: number): boolean {
+  if (session.activity?.trim().toLowerCase() !== 'idle' || session.last_active === undefined) {
+    return false;
+  }
+  const lastActiveMs = Date.parse(session.last_active);
+  if (Number.isNaN(lastActiveMs)) return false;
+  const elapsedMs = nowMs - lastActiveMs;
+  return elapsedMs >= 0 && elapsedMs < RECENT_ACTIVITY_WINDOW_MS;
 }
 
 const CALM_POSES: ReadonlySet<AquariumPose> = new Set(['working', 'idle', 'asleep']);

--- a/frontend/src/aquarium/page/useAquariumData.test.ts
+++ b/frontend/src/aquarium/page/useAquariumData.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GC_EVENT_PREFIX } from 'gas-city-dashboard-shared';
 import { invalidate } from '../../api/cache';
 import {
   GC_MUTATION_HEADERS,
@@ -8,6 +9,8 @@ import {
   type SupervisorApi,
 } from '../../supervisor/client';
 import { useAquariumData } from './useAquariumData';
+
+const eventSources: FakeEventSource[] = [];
 
 const baseApi: SupervisorApi = {
   baseUrl: '/gc-supervisor',
@@ -71,9 +74,31 @@ afterEach(() => {
   invalidate('rigs');
   invalidate('aquarium:');
   vi.unstubAllGlobals();
+  eventSources.length = 0;
 });
 
 describe('useAquariumData (live mode)', () => {
+  it('refreshes session activity immediately after a mail event', async () => {
+    vi.stubGlobal('EventSource', FakeEventSource);
+    const listSessions = vi.fn(async () => ({ items: [], total: 0 }));
+    setSupervisorApiForTests({
+      ...baseApi,
+      listSessions,
+      listBeads: vi.fn(async () => ({ items: [], total: 0 })),
+    });
+
+    const { result } = renderHook(() => useAquariumData(null));
+    await waitFor(() => expect(result.current.dataState).toBe('complete'));
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      eventSources[0]?.open();
+      eventSources[0]?.emitNamed('event', JSON.stringify({ type: `${GC_EVENT_PREFIX.mail}sent` }));
+    });
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+  });
+
   it('fans out one bounded bead read per canonical rig name into beadsByRig', async () => {
     // No real EventSource in jsdom; useGcEventRefresh degrades to 'closed'
     // without one, which is fine — this test only cares about beadsByRig.
@@ -330,3 +355,44 @@ describe('useAquariumData (fixture mode)', () => {
     expect(result.current.manifest).toBeNull();
   });
 });
+
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readyState = FakeEventSource.CONNECTING;
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  constructor(readonly url: string | URL) {
+    eventSources.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = FakeEventSource.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  emitNamed(type: string, data: string): void {
+    const event = new MessageEvent<string>(type, { data });
+    this.listeners.get(type)?.forEach((listener) => listener(event));
+    if (type === 'message') this.onmessage?.(event);
+  }
+}

--- a/frontend/src/aquarium/page/useAquariumData.ts
+++ b/frontend/src/aquarium/page/useAquariumData.ts
@@ -119,7 +119,9 @@ export function useAquariumData(fixtureKind: FixtureKind | null): AquariumDataRe
 
   useVisibleRefresh(refresh, ATTENTION_READ_REFRESH_INTERVAL_MS, { enabled: !isFixture });
   const sseState = useGcEventRefresh(
-    isFixture ? [] : [GC_EVENT_PREFIX.session, GC_EVENT_PREFIX.bead, 'agent.'],
+    isFixture
+      ? []
+      : [GC_EVENT_PREFIX.session, GC_EVENT_PREFIX.bead, GC_EVENT_PREFIX.mail, 'agent.'],
     () => void refresh(),
   );
 

--- a/shared/src/operator.ts
+++ b/shared/src/operator.ts
@@ -1,5 +1,6 @@
 export const GC_EVENT_PREFIX = {
   bead: 'bead.',
+  mail: 'mail.',
   session: 'session.',
 } as const;
 


### PR DESCRIPTION
## Summary

- Refresh Reef session data when city mail events arrive, catching brief turns that the 30-second poll can miss.
- Label an explicitly idle session active just now for 60 seconds using authoritative last_active data while keeping its calm visual pose.
- Preserve activity unknown for providers without turn telemetry and reserve working for activity: in-turn.
- Document the truthfulness contract and add unit plus hook-integration regression coverage.

## Why

The supervisor derives session activity from the provider transcript tail. A brief tool turn can start and finish between Reef polls, so the fish can read idle immediately after visible work. Provider transcript observations intentionally do not enter the durable city event bus, so this fix uses the existing last_active field and existing mail events instead of inventing a parallel activity feed.

## Test plan

- npm run typecheck
- npm run lint
- npm run format:check
- npm --workspace frontend run build
- npm run openapi:gc-supervisor:check
- npm --workspace frontend run test:coverage (1,792 tests; 86.42% statement coverage)
- npm --workspace shared test (357 tests)
- Browser QA with a mocked recent session: active just now rendered with no page errors
- Live Reef browser QA: gascity-dashboard PL rendered active just now with no page errors