### PR TITLE
fix: allow Reef rig reads in readonly mode

### DIFF
--- a/backend/src/routes/supervisor-read-allowlist.ts
+++ b/backend/src/routes/supervisor-read-allowlist.ts
@@ -29,6 +29,7 @@ const READ_ENDPOINT_TEMPLATES = [
   '/v0/city/{cityName}/health',
   '/v0/city/{cityName}/mail',
   '/v0/city/{cityName}/mail/thread/{id}',
+  '/v0/city/{cityName}/rigs',
   '/v0/city/{cityName}/sessions',
   '/v0/city/{cityName}/session/{id}/pending',
   '/v0/city/{cityName}/session/{id}/stream',

--- a/backend/test/supervisor-read-allowlist.test.ts
+++ b/backend/test/supervisor-read-allowlist.test.ts
@@ -19,6 +19,7 @@ describe('supervisor read allowlist', () => {
       '/v0/city/test-city/health',
       '/v0/city/test-city/mail',
       '/v0/city/test-city/mail/thread/m1',
+      '/v0/city/test-city/rigs',
       '/v0/city/test-city/sessions',
       '/v0/city/test-city/session/s1/pending',
       '/v0/city/test-city/session/s1/stream',


### PR DESCRIPTION
## Summary

- allow the supervisor `/v0/city/{cityName}/rigs` read through the read-only proxy
- cover the route in the supervisor read-allowlist regression test

The Reef view requests rig data. Without this allowlist entry, Reef returns a 404 when the dashboard runs with `DASHBOARD_READONLY=1`; the local unrestricted dashboard is unaffected.

## Test plan

- `npm --workspace backend run typecheck`
- `node --import tsx --test backend/test/supervisor-read-allowlist.test.ts`
- `npx prettier --check backend/src/routes/supervisor-read-allowlist.ts backend/test/supervisor-read-allowlist.test.ts`
